### PR TITLE
Extend build action to push new app-frontend version to CDN on main branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,38 +10,46 @@ jobs:
   build:
     runs-on: ubuntu-latest
     name: Build PR
-    defaults:
-      run:
-        working-directory: src
     steps:
       - name: checkout
         uses: actions/checkout@v3
         with:
+          path: app-frontend
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
       - name: install node
         uses: actions/setup-node@v2
         with:
           node-version: '16'
       - name: install dependencies
+        working-directory: app-frontend/src
         run: yarn --immutable
       - name: run build
+        working-directory: app-frontend/src/altinn-app-frontend
         run: yarn build
-        working-directory: src/altinn-app-frontend
       - name: run eslint
+        working-directory: app-frontend/src
         run: yarn lint
       - name: run tests
+        working-directory: app-frontend/src
         run: yarn test --coverage
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      - name: Publish to CDN (main branch only)
+      - name: Checkout Altinn-CDN repository
         # if: github.ref == 'refs/heads/main'
-        working-directory: src
+        uses: actions/checkout@v3
+        with:
+          repository: 'Altinn/altinn-cdn'
+          token: ${{secrets.ALTINN_CDN_TOKEN}}
+          path: cdn
+      - name: Publish to CDN
+        # if: github.ref == 'refs/heads/main'
+        working-directory: app-frontend
         run: |
           echo Clone, copy, commit and push to Altinn-CDN
-          APP_VERSION=$(jq '.version' ./altinn-app-frontend/package.json)
+          APP_VERSION=$(jq '.version' ./app-frontend/src/altinn-app-frontend/package.json)
           APP_MAJOR=$(echo $APP_VERSION | tr --delete '"' | cut -d'.' -f1)
           APP_MINOR=$(echo $APP_VERSION | tr --delete '"' | cut -d'.' -f2)
           APP_PATCH=$(echo $APP_VERSION | tr --delete '"' | cut -d'.' -f3)
@@ -50,22 +58,21 @@ jobs:
           AUTHOR_NAME=$(git log -1 | grep Author | cut -d' ' -f2)
           AUTHOR_EMAIL=$(git log -1 | grep Author | cut -d' ' -f3 | cut -d'<' -f2 | cut -d'>' -f1)
           COMMIT_ID=$(git rev-parse HEAD~0)
-          git log -1 | grep -Ev "commit|Author|Date" > ./../../commitmsg.txt
-          cd ../..
-          git clone https://$(${{secrets.ALTINN_CDN_TOKEN}})@github.com/Altinn/altinn-cdn.git
+          git log -1 | grep -Ev "commit|Author|Date" > ./../commitmsg.txt
+          cd ..
           echo Copy Major Version
-          mkdir -p ./altinn-cdn/toolkits/altinn-app-frontend/$APP_MAJOR
-          cp -fr ./app-frontend-react/src/altinn-app-frontend/dist/altinn-app-frontend.js ./altinn-cdn/toolkits/altinn-app-frontend/$APP_MAJOR/altinn-app-frontend.js
-          cp -fr ./app-frontend-react/src/altinn-app-frontend/dist/altinn-app-frontend.css ./altinn-cdn/toolkits/altinn-app-frontend/$APP_MAJOR/altinn-app-frontend.css
+          mkdir -p ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR
+          cp -fr ./app-frontend-react/src/altinn-app-frontend/dist/altinn-app-frontend.js ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR/altinn-app-frontend.js
+          cp -fr ./app-frontend-react/src/altinn-app-frontend/dist/altinn-app-frontend.css ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR/altinn-app-frontend.css
           echo Copy Minor Version
-          mkdir -p ./altinn-cdn/toolkits/altinn-app-frontend/$APP_MAJOR.$APP_MINOR
-          cp -fr ./app-frontend-react/src/altinn-app-frontend/dist/altinn-app-frontend.js ./altinn-cdn/toolkits/altinn-app-frontend/$APP_MAJOR.$APP_MINOR/altinn-app-frontend.js
-          cp -fr ./app-frontend-react/src/altinn-app-frontend/dist/altinn-app-frontend.css ./altinn-cdn/toolkits/altinn-app-frontend/$APP_MAJOR.$APP_MINOR/altinn-app-frontend.css
+          mkdir -p ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR.$APP_MINOR
+          cp -fr ./app-frontend-react/src/altinn-app-frontend/dist/altinn-app-frontend.js ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR.$APP_MINOR/altinn-app-frontend.js
+          cp -fr ./app-frontend-react/src/altinn-app-frontend/dist/altinn-app-frontend.css ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR.$APP_MINOR/altinn-app-frontend.css
           echo Copy Patch
-          mkdir -p ./altinn-cdn/toolkits/altinn-app-frontend/$APP_MAJOR.$APP_MINOR.$APP_PATCH
-          cp -fr ./app-frontend-react/src/altinn-app-frontend/dist/altinn-app-frontend.js ./altinn-cdn/toolkits/altinn-app-frontend/$APP_MAJOR.$APP_MINOR.$APP_PATCH/altinn-app-frontend.js
-          cp -fr ./app-frontend-react/src/altinn-app-frontend/dist/altinn-app-frontend.css ./altinn-cdn/toolkits/altinn-app-frontend/$APP_MAJOR.$APP_MINOR.$APP_PATCH/altinn-app-frontend.css
-          cd altinn-cdn
+          mkdir -p ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR.$APP_MINOR.$APP_PATCH
+          cp -fr ./app-frontend-react/src/altinn-app-frontend/dist/altinn-app-frontend.js ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR.$APP_MINOR.$APP_PATCH/altinn-app-frontend.js
+          cp -fr ./app-frontend-react/src/altinn-app-frontend/dist/altinn-app-frontend.css ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR.$APP_MINOR.$APP_PATCH/altinn-app-frontend.css
+          cd cdn
           git config --global user.email "$AUTHOR_EMAIL"
           git config --global user.name "$AUTHOR_NAME"
           git add .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,6 +81,5 @@ jobs:
           echo "$AUTHOR_FULL updated altinn-app-frontend to $APP_MAJOR.$APP_MINOR.$APP_PATCH" > ./../commit1.txt
           echo "based on commit https://github.com/Altinn/altinn-studio/commit/$COMMIT_ID" > ./../commit2.txt
           cat ./../commit1.txt ./../commit2.txt ./../commitmsg.txt > ./../commit.txt
-
-# git commit -F ./../commit.txt
-# git push
+          git commit -F ./../commit.txt
+          git push

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
         working-directory: app-frontend
         run: |
           echo Clone, copy, commit and push to Altinn-CDN
-          APP_VERSION=$(jq '.version' ./app-frontend/src/altinn-app-frontend/package.json)
+          APP_VERSION=$(jq '.version' ./src/altinn-app-frontend/package.json)
           APP_MAJOR=$(echo $APP_VERSION | tr --delete '"' | cut -d'.' -f1)
           APP_MINOR=$(echo $APP_VERSION | tr --delete '"' | cut -d'.' -f2)
           APP_PATCH=$(echo $APP_VERSION | tr --delete '"' | cut -d'.' -f3)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       - name: Publish to CDN (main branch only)
-        if: github.ref == 'refs/heads/main'
+        # if: github.ref == 'refs/heads/main'
         working-directory: src
         run: |
           echo Clone, copy, commit and push to Altinn-CDN

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,16 +63,16 @@ jobs:
           cd ..
           echo Copy Major Version
           mkdir -p ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR
-          cp -fr ./app-frontend-react/src/altinn-app-frontend/dist/altinn-app-frontend.js ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR/altinn-app-frontend.js
-          cp -fr ./app-frontend-react/src/altinn-app-frontend/dist/altinn-app-frontend.css ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR/altinn-app-frontend.css
+          cp -fr ./app-frontend/src/altinn-app-frontend/dist/altinn-app-frontend.js ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR/altinn-app-frontend.js
+          cp -fr ./app-frontend/src/altinn-app-frontend/dist/altinn-app-frontend.css ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR/altinn-app-frontend.css
           echo Copy Minor Version
           mkdir -p ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR.$APP_MINOR
-          cp -fr ./app-frontend-react/src/altinn-app-frontend/dist/altinn-app-frontend.js ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR.$APP_MINOR/altinn-app-frontend.js
-          cp -fr ./app-frontend-react/src/altinn-app-frontend/dist/altinn-app-frontend.css ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR.$APP_MINOR/altinn-app-frontend.css
+          cp -fr ./app-frontend/src/altinn-app-frontend/dist/altinn-app-frontend.js ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR.$APP_MINOR/altinn-app-frontend.js
+          cp -fr ./app-frontend/src/altinn-app-frontend/dist/altinn-app-frontend.css ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR.$APP_MINOR/altinn-app-frontend.css
           echo Copy Patch
           mkdir -p ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR.$APP_MINOR.$APP_PATCH
-          cp -fr ./app-frontend-react/src/altinn-app-frontend/dist/altinn-app-frontend.js ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR.$APP_MINOR.$APP_PATCH/altinn-app-frontend.js
-          cp -fr ./app-frontend-react/src/altinn-app-frontend/dist/altinn-app-frontend.css ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR.$APP_MINOR.$APP_PATCH/altinn-app-frontend.css
+          cp -fr ./app-frontend/src/altinn-app-frontend/dist/altinn-app-frontend.js ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR.$APP_MINOR.$APP_PATCH/altinn-app-frontend.js
+          cp -fr ./app-frontend/src/altinn-app-frontend/dist/altinn-app-frontend.css ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR.$APP_MINOR.$APP_PATCH/altinn-app-frontend.css
           cd cdn
           git config --global user.email "$AUTHOR_EMAIL"
           git config --global user.name "$AUTHOR_NAME"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,27 +26,28 @@ jobs:
       - name: run build
         working-directory: app-frontend/src/altinn-app-frontend
         run: yarn build
-      # - name: run eslint
-      #   working-directory: app-frontend/src
-      #   run: yarn lint
-      # - name: run tests
-      #   working-directory: app-frontend/src
-      #   run: yarn test --coverage
-      # - name: SonarCloud Scan
-      #   working-directory: app-frontend
-      #   uses: SonarSource/sonarcloud-github-action@master
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #     SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      - name: run eslint
+        working-directory: app-frontend/src
+        run: yarn lint
+      - name: run tests
+        working-directory: app-frontend/src
+        run: yarn test --coverage
+      - name: SonarCloud Scan
+        with:
+          projectBaseDir: app-frontend
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       - name: Checkout Altinn-CDN repository
-        # if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         uses: actions/checkout@v3
         with:
           repository: 'Altinn/altinn-cdn'
           token: ${{secrets.ALTINN_CDN_TOKEN}}
           path: cdn
       - name: Publish to CDN
-        # if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         working-directory: app-frontend
         run: |
           echo Clone, copy, commit and push to Altinn-CDN
@@ -80,5 +81,6 @@ jobs:
           echo "$AUTHOR_FULL updated altinn-app-frontend to $APP_MAJOR.$APP_MINOR.$APP_PATCH" > ./../commit1.txt
           echo "based on commit https://github.com/Altinn/altinn-studio/commit/$COMMIT_ID" > ./../commit2.txt
           cat ./../commit1.txt ./../commit2.txt ./../commitmsg.txt > ./../commit.txt
+
 # git commit -F ./../commit.txt
 # git push

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,3 +36,41 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      - name: Publish to CDN (main branch only)
+        if: github.ref == 'refs/heads/main'
+        working-directory: src
+        run: |
+          echo Clone, copy, commit and push to Altinn-CDN
+          APP_VERSION=$(jq '.version' ./altinn-app-frontend/package.json)
+          APP_MAJOR=$(echo $APP_VERSION | tr --delete '"' | cut -d'.' -f1)
+          APP_MINOR=$(echo $APP_VERSION | tr --delete '"' | cut -d'.' -f2)
+          APP_PATCH=$(echo $APP_VERSION | tr --delete '"' | cut -d'.' -f3)
+          echo altinn-app-frontend version: $APP_MAJOR.$APP_MINOR.$APP_PATCH
+          AUTHOR_FULL=$(git log -1 | grep Author)
+          AUTHOR_NAME=$(git log -1 | grep Author | cut -d' ' -f2)
+          AUTHOR_EMAIL=$(git log -1 | grep Author | cut -d' ' -f3 | cut -d'<' -f2 | cut -d'>' -f1)
+          COMMIT_ID=$(git rev-parse HEAD~0)
+          git log -1 | grep -Ev "commit|Author|Date" > ./../../commitmsg.txt
+          cd ../..
+          git clone https://$(${{secrets.ALTINN_CDN_TOKEN}})@github.com/Altinn/altinn-cdn.git
+          echo Copy Major Version
+          mkdir -p ./altinn-cdn/toolkits/altinn-app-frontend/$APP_MAJOR
+          cp -fr ./app-frontend-react/src/altinn-app-frontend/dist/altinn-app-frontend.js ./altinn-cdn/toolkits/altinn-app-frontend/$APP_MAJOR/altinn-app-frontend.js
+          cp -fr ./app-frontend-react/src/altinn-app-frontend/dist/altinn-app-frontend.css ./altinn-cdn/toolkits/altinn-app-frontend/$APP_MAJOR/altinn-app-frontend.css
+          echo Copy Minor Version
+          mkdir -p ./altinn-cdn/toolkits/altinn-app-frontend/$APP_MAJOR.$APP_MINOR
+          cp -fr ./app-frontend-react/src/altinn-app-frontend/dist/altinn-app-frontend.js ./altinn-cdn/toolkits/altinn-app-frontend/$APP_MAJOR.$APP_MINOR/altinn-app-frontend.js
+          cp -fr ./app-frontend-react/src/altinn-app-frontend/dist/altinn-app-frontend.css ./altinn-cdn/toolkits/altinn-app-frontend/$APP_MAJOR.$APP_MINOR/altinn-app-frontend.css
+          echo Copy Patch
+          mkdir -p ./altinn-cdn/toolkits/altinn-app-frontend/$APP_MAJOR.$APP_MINOR.$APP_PATCH
+          cp -fr ./app-frontend-react/src/altinn-app-frontend/dist/altinn-app-frontend.js ./altinn-cdn/toolkits/altinn-app-frontend/$APP_MAJOR.$APP_MINOR.$APP_PATCH/altinn-app-frontend.js
+          cp -fr ./app-frontend-react/src/altinn-app-frontend/dist/altinn-app-frontend.css ./altinn-cdn/toolkits/altinn-app-frontend/$APP_MAJOR.$APP_MINOR.$APP_PATCH/altinn-app-frontend.css
+          cd altinn-cdn
+          git config --global user.email "$AUTHOR_EMAIL"
+          git config --global user.name "$AUTHOR_NAME"
+          git add .
+          echo "$AUTHOR_FULL updated altinn-app-frontend to $APP_MAJOR.$APP_MINOR.$APP_PATCH" > ./../commit1.txt
+          echo "based on commit https://github.com/Altinn/altinn-studio/commit/$COMMIT_ID" > ./../commit2.txt
+          cat ./../commit1.txt ./../commit2.txt ./../commitmsg.txt > ./../commit.txt
+# git commit -F ./../commit.txt
+# git push

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,17 +26,18 @@ jobs:
       - name: run build
         working-directory: app-frontend/src/altinn-app-frontend
         run: yarn build
-      - name: run eslint
-        working-directory: app-frontend/src
-        run: yarn lint
-      - name: run tests
-        working-directory: app-frontend/src
-        run: yarn test --coverage
-      - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      # - name: run eslint
+      #   working-directory: app-frontend/src
+      #   run: yarn lint
+      # - name: run tests
+      #   working-directory: app-frontend/src
+      #   run: yarn test --coverage
+      # - name: SonarCloud Scan
+      #   working-directory: app-frontend
+      #   uses: SonarSource/sonarcloud-github-action@master
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #     SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       - name: Checkout Altinn-CDN repository
         # if: github.ref == 'refs/heads/main'
         uses: actions/checkout@v3

--- a/src/altinn-app-frontend/package.json
+++ b/src/altinn-app-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "altinn-app-frontend",
-  "version": "3.33.4",
+  "version": "3.33.5",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
When running the build action on main branch, it will now deploy a new version of app-frontend to CDN, similar to the old pipeline we had in AzureDevOps.