### PR TITLE
wcag: moved width from width-prop to css style

### DIFF
--- a/src/altinn-app-frontend/package.json
+++ b/src/altinn-app-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "altinn-app-frontend",
-  "version": "3.34.0",
+  "version": "3.34.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/altinn-app-frontend/src/components/base/ImageComponent.tsx
+++ b/src/altinn-app-frontend/src/components/base/ImageComponent.tsx
@@ -19,7 +19,7 @@ export interface IImagesrc {
   nb: string;
   nn?: string;
   en?: string;
-  [language: string]:string;
+  [language: string]: string;
 }
 
 const useStyles = makeStyles({
@@ -56,11 +56,13 @@ export function ImageComponent(props: IImageProps) {
               type='image/svg+xml'
               id={props.id}
               data={imgSrc}
-              width={width}
             >
               <img
                 src={imgSrc}
                 alt={altText}
+                style={{
+                  width: width,
+                }}
               />
             </object>
           )
@@ -69,18 +71,20 @@ export function ImageComponent(props: IImageProps) {
               id={props.id}
               src={imgSrc}
               alt={altText}
-              width={width}
+              style={{
+                width: width,
+              }}
             />
           )
         }
       </Grid>
       {props.textResourceBindings?.help &&
-      <Grid item={true} className={classes.spacing}>
-        <HelpTextContainer
-          language={props.language}
-          helpText={props.getTextResource(props.textResourceBindings.help)}
-        />
-      </Grid>
+        <Grid item={true} className={classes.spacing}>
+          <HelpTextContainer
+            language={props.language}
+            helpText={props.getTextResource(props.textResourceBindings.help)}
+          />
+        </Grid>
       }
     </Grid>
   );


### PR DESCRIPTION
## Description
Solves part of #14 regarding widths defined in percentage of width used in the img.width prop. Moved to style.
Read more here: https://rocketvalidator.com/html-validation/bad-value-x-for-attribute-width-on-element-img-expected-a-digit-but-saw-instead


## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
- [x] Changelog is updated with a separate linked PR
  - [x] [altinn-app-frontend](https://docs.altinn.studio/community/changelog/app-frontend/)- https://github.com/Altinn/altinn-studio-docs/pull/485

