### PR TITLE
bug: fixed stateless cache key + bug if cached key does no longer exist

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,4 +5,4 @@ sonar.sources=src
 sonar.exclusions=**/webpack.config.*.js,**/node_modules,**/dist,**/*.test.ts?,**/setupTests.ts
 
 sonar.javascript.lcov.reportPaths=src/altinn-app-frontend/coverage/lcov.info,src/shared/coverage/lcov.info
-sonar.coverage.exclusions=**/__mocks__/**,src/types/**
+sonar.coverage.exclusions=**/__mocks__/**,src/types/**,**/*.test.ts?

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,7 +2,7 @@ sonar.projectKey=Altinn_app-frontend-react
 sonar.organization=altinn
 
 sonar.sources=src
-sonar.exclusions=**/webpack.config.*.js,**/node_modules,**/dist,**/*.test.ts?,**/setupTests.ts
+sonar.exclusions=**/webpack.config.*.js,**/node_modules,**/dist,**/*.test.ts*,,**/setupTests.ts
 
 sonar.javascript.lcov.reportPaths=src/altinn-app-frontend/coverage/lcov.info,src/shared/coverage/lcov.info
-sonar.coverage.exclusions=**/__mocks__/**,src/types/**,**/*.test.ts?
+sonar.coverage.exclusions=**/__mocks__/**,src/types/**

--- a/src/altinn-app-frontend/package.json
+++ b/src/altinn-app-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "altinn-app-frontend",
-  "version": "3.34.2",
+  "version": "3.34.3",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/altinn-app-frontend/src/features/form/layout/fetch/fetchFormLayoutSagas.test.ts
+++ b/src/altinn-app-frontend/src/features/form/layout/fetch/fetchFormLayoutSagas.test.ts
@@ -1,0 +1,114 @@
+import { expectSaga } from "redux-saga-test-plan";
+import { applicationMetadataSelector, fetchLayoutSaga, instanceSelector, layoutSetsSelector } from "./fetchFormLayoutSagas";
+import * as networking from '../../../../utils/networking';
+import type { IApplication, IInstance } from "altinn-shared/types";
+import { select } from "redux-saga/effects";
+import { FormLayoutActions } from '../formLayoutSlice';
+
+describe('features / form / layout / fetch / fetchFormLayoutSagas', () => {
+
+  describe('fetchLayoutSaga', () => {
+    const instance = {
+      id: 'some-instance-id'
+    } as IInstance;
+    const application = {
+      id: 'someOrg/someApp'
+    } as IApplication;
+
+    it('should call relevant actions when layout is fetched successfully', () => {
+      const mockResponse = {
+        page1: {
+          data: {
+            layout: []
+          }
+        }
+      };
+      jest.spyOn(networking, 'get').mockResolvedValue(mockResponse);
+
+      return expectSaga(fetchLayoutSaga)
+        .provide([
+          [select(layoutSetsSelector), undefined],
+          [select(instanceSelector), instance],
+          [select(applicationMetadataSelector), application]
+        ])
+        .put(FormLayoutActions.setCurrentViewCacheKey({ key: instance.id }))
+        .put(FormLayoutActions.fetchLayoutFulfilled({ layouts: { page1: [] }, navigationConfig: { page1: undefined } }))
+        .put(FormLayoutActions.updateAutoSave({ autoSave: undefined }))
+        .put(FormLayoutActions.updateCurrentView({ newView: 'page1', skipPageCaching: true }))
+        .run();
+    });
+
+    it('should call fetchLayoutRejected when fetching layout fails', () => {
+      jest.spyOn(networking, 'get').mockRejectedValue(new Error('some error'));
+
+      return expectSaga(fetchLayoutSaga)
+        .provide([
+          [select(layoutSetsSelector), undefined],
+          [select(instanceSelector), instance],
+          [select(applicationMetadataSelector), application]
+        ])
+        .put(FormLayoutActions.fetchLayoutRejected({ error: new Error('some error') }))
+        .run();
+    });
+
+    it('should set current view to cached key if key exists in fetched layout', () => {
+      const mockResponse = {
+        page1: {
+          data: {
+            layout: []
+          }
+        },
+        page2: {
+          data: {
+            layout: []
+          }
+        },
+      };
+      jest.spyOn(networking, 'get').mockResolvedValue(mockResponse);
+      jest.spyOn(window.localStorage.__proto__, 'getItem');
+      window.localStorage.__proto__.getItem = jest.fn().mockReturnValue('page2');
+
+      return expectSaga(fetchLayoutSaga)
+        .provide([
+          [select(layoutSetsSelector), undefined],
+          [select(instanceSelector), instance],
+          [select(applicationMetadataSelector), application]
+        ])
+        .put(FormLayoutActions.setCurrentViewCacheKey({ key: instance.id }))
+        .put(FormLayoutActions.fetchLayoutFulfilled({ layouts: { page1: [], page2: [] }, navigationConfig: { page1: undefined, page2: undefined } }))
+        .put(FormLayoutActions.updateAutoSave({ autoSave: undefined }))
+        .put(FormLayoutActions.updateCurrentView({ newView: 'page2', skipPageCaching: true }))
+        .run();
+    });
+    
+    it('should set current view to first page in layout if a cached key exists but no longer exists in layout order', () => {
+      const mockResponse = {
+        page1: {
+          data: {
+            layout: []
+          }
+        },
+        page2: {
+          data: {
+            layout: []
+          }
+        },
+      };
+      jest.spyOn(networking, 'get').mockResolvedValue(mockResponse);
+      jest.spyOn(window.localStorage.__proto__, 'getItem');
+      window.localStorage.__proto__.getItem = jest.fn().mockReturnValue('page3');
+
+      return expectSaga(fetchLayoutSaga)
+        .provide([
+          [select(layoutSetsSelector), undefined],
+          [select(instanceSelector), instance],
+          [select(applicationMetadataSelector), application]
+        ])
+        .put(FormLayoutActions.setCurrentViewCacheKey({ key: instance.id }))
+        .put(FormLayoutActions.fetchLayoutFulfilled({ layouts: { page1: [], page2: [] }, navigationConfig: { page1: undefined, page2: undefined } }))
+        .put(FormLayoutActions.updateAutoSave({ autoSave: undefined }))
+        .put(FormLayoutActions.updateCurrentView({ newView: 'page1', skipPageCaching: true }))
+        .run();
+    });
+  });
+});

--- a/src/altinn-app-frontend/src/features/form/layout/fetch/fetchFormLayoutSagas.ts
+++ b/src/altinn-app-frontend/src/features/form/layout/fetch/fetchFormLayoutSagas.ts
@@ -33,10 +33,16 @@ function* fetchLayoutSaga(): SagaIterator {
     } else {
       const orderedLayoutKeys = Object.keys(layoutResponse).sort();
 
-      // use instance id as cache key for current page
-      const currentViewCacheKey = instance?.id || 'stateless';
+      // use instance id (or application id for stateless) as cache key for current page
+      const currentViewCacheKey = instance?.id || applicationMetadata.id;
       yield put(Actions.setCurrentViewCacheKey({ key: currentViewCacheKey }));
-      firstLayoutKey = localStorage.getItem(currentViewCacheKey) || orderedLayoutKeys[0];
+
+      const lastVisitedPage = localStorage.getItem(currentViewCacheKey);
+      if (lastVisitedPage && orderedLayoutKeys.includes(lastVisitedPage)) {
+        firstLayoutKey = lastVisitedPage;
+      } else {
+        firstLayoutKey = orderedLayoutKeys[0];
+      }
 
       orderedLayoutKeys.forEach((key) => {
         layouts[key] = layoutResponse[key].data.layout;

--- a/src/altinn-app-frontend/src/features/form/layout/fetch/fetchFormLayoutSagas.ts
+++ b/src/altinn-app-frontend/src/features/form/layout/fetch/fetchFormLayoutSagas.ts
@@ -11,11 +11,11 @@ import { ILayoutSettings, IRuntimeState, ILayoutSets } from '../../../../types';
 import { ILayouts } from '../index';
 import { getLayoutSetIdForApplication } from '../../../../utils/appMetadata';
 
-const layoutSetsSelector = (state: IRuntimeState) => state.formLayout.layoutsets;
-const instanceSelector = (state: IRuntimeState) => state.instanceData.instance;
-const applicationMetadataSelector = (state: IRuntimeState) => state.applicationMetadata.applicationMetadata;
+export const layoutSetsSelector = (state: IRuntimeState) => state.formLayout.layoutsets;
+export const instanceSelector = (state: IRuntimeState) => state.instanceData.instance;
+export const applicationMetadataSelector = (state: IRuntimeState) => state.applicationMetadata.applicationMetadata;
 
-function* fetchLayoutSaga(): SagaIterator {
+export function* fetchLayoutSaga(): SagaIterator {
   try {
     const layoutSets: ILayoutSets = yield select(layoutSetsSelector);
     const instance: IInstance = yield select(instanceSelector);

--- a/src/altinn-app-frontend/src/features/form/layout/formLayoutSlice.test.ts
+++ b/src/altinn-app-frontend/src/features/form/layout/formLayoutSlice.test.ts
@@ -103,7 +103,7 @@ describe('features > form > layout > layoutSlice.ts', () => {
       expect(nextState.uiConfig.currentView).toEqual('page2');
     });
   
-    it('should set curretnView to first page in settings.pages.order if key is cached in localStorage but does not exist in order', () => {
+    it('should set currentView to first page in settings.pages.order if key is cached in localStorage but does not exist in order', () => {
       jest.spyOn(window.localStorage.__proto__, 'getItem');
       window.localStorage.__proto__.getItem = jest.fn().mockReturnValue('page3');
       

--- a/src/altinn-app-frontend/src/features/form/layout/formLayoutSlice.test.ts
+++ b/src/altinn-app-frontend/src/features/form/layout/formLayoutSlice.test.ts
@@ -62,4 +62,68 @@ describe('features > form > layout > layoutSlice.ts', () => {
       expect(nextState.error).toEqual(null);
     });
   });
+
+  describe('fetchFormLayoutSettingsFulfilled', () => {
+    it('should set currentView to first page in settings.pages.order if no key is cached in localStorage', () => {
+      const settings = {
+        pages: {
+          order: ['page1', 'page2'],
+        },
+      };
+      const nextState = reducer(
+        initialState,
+        FormLayoutActions.fetchLayoutSettingsFulfilled({
+          settings,
+        }),
+      );
+
+      expect(nextState.uiConfig.currentView).toEqual('page1');
+    });
+
+    it('should set currentView to cached key in localStorage if key exists in settings.pages.order', () => {
+      jest.spyOn(window.localStorage.__proto__, 'getItem');
+      window.localStorage.__proto__.getItem = jest.fn().mockReturnValue('page2');
+      
+      const settings = {
+        pages: {
+          order: ['page1', 'page2'],
+        },
+      };
+      const nextState = reducer(
+        {...initialState,
+          uiConfig: {
+            ...initialState.uiConfig,
+            currentViewCacheKey: 'some-cache-key'
+        }},
+        FormLayoutActions.fetchLayoutSettingsFulfilled({
+          settings,
+        }),
+      );
+  
+      expect(nextState.uiConfig.currentView).toEqual('page2');
+    });
+  
+    it('should set curretnView to first page in settings.pages.order if key is cached in localStorage but does not exist in order', () => {
+      jest.spyOn(window.localStorage.__proto__, 'getItem');
+      window.localStorage.__proto__.getItem = jest.fn().mockReturnValue('page3');
+      
+      const settings = {
+        pages: {
+          order: ['page1', 'page2'],
+        },
+      };
+      const nextState = reducer(
+        {...initialState,
+          uiConfig: {
+            ...initialState.uiConfig,
+            currentViewCacheKey: 'some-cache-key'
+        }},
+        FormLayoutActions.fetchLayoutSettingsFulfilled({
+          settings,
+        }),
+      );
+  
+      expect(nextState.uiConfig.currentView).toEqual('page1');
+    })
+  });
 });

--- a/src/altinn-app-frontend/src/features/form/layout/formLayoutSlice.ts
+++ b/src/altinn-app-frontend/src/features/form/layout/formLayoutSlice.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import { createAction, createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { ILayoutSets, IUiConfig } from 'src/types';
 import { ILayouts } from './index';
@@ -62,8 +61,14 @@ const formLayoutSlice = createSlice({
         if (settings.pages.order) {
           state.uiConfig.layoutOrder = settings.pages.order;
           if (state.uiConfig.currentViewCacheKey) {
-            state.uiConfig.currentView = localStorage.getItem(state.uiConfig.currentViewCacheKey)
-              || settings.pages.order[0];
+            let currentView: string;
+            const lastVisitedPage = localStorage.getItem(state.uiConfig.currentViewCacheKey);
+            if (lastVisitedPage && settings.pages.order.includes(lastVisitedPage)) {
+              currentView = lastVisitedPage;
+            } else {
+              currentView = settings.pages.order[0];
+            }
+            state.uiConfig.currentView = currentView;
           } else {
             state.uiConfig.currentView = settings.pages.order[0];
           }

--- a/test/cypress/e2e/integration/app-frontend/options.js
+++ b/test/cypress/e2e/integration/app-frontend/options.js
@@ -6,7 +6,8 @@ import AppFrontend from '../../pageobjects/app-frontend';
 const appFrontend = new AppFrontend();
 
 describe('Options', () => {
-  it('is possible to retrieve options dynamically', () => {
+  // disabled until https://github.com/Altinn/altinn-studio/issues/8255 is solved
+  it.skip('is possible to retrieve options dynamically', () => {
     cy.navigateToChangeName();
     // Case: options are dynamicly refetched based on what the user selects as source
     cy.get(appFrontend.changeOfName.sources).should('be.visible');


### PR DESCRIPTION
<!-- Thank you for contributing to Altinn:) We know this isn't the fun part, but please make sure you follow our [contributing guidelines](../CONTRIBUTING.md) and put the same effort into the pull request as you did into the code and it should soon find it's way to main. -->

## Description

Git tired of running into this bug when testing locally so I just fixed it.

- bug: now uses application.id (org/app) as key for persiting selected page in local storage for stateless apps
- bug: now defaults to first page in page order if the cached key no longer exists (for both stateless + instance)
- sonarcloud: fixed glob for excluding test files

## Fixes
- https://github.com/Altinn/altinn-studio/issues/7897
- https://github.com/Altinn/altinn-studio/issues/6975

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
- [ ] Changelog is updated with a separate linked PR
  - [ ] [altinn-app-frontend](https://docs.altinn.studio/community/changelog/app-frontend/)- (if applicable)
  - [ ] [nuget-packages](https://docs.altinn.studio/community/changelog/app-nuget/) - (if applicable)
