### PR TITLE
chore: update sonar.exclusions list

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,7 +2,6 @@ sonar.projectKey=Altinn_app-frontend-react
 sonar.organization=altinn
 
 sonar.sources=src
-sonar.exclusions=**/webpack.config.*.js,**/node_modules,**/dist,**/*.test.ts?,**/setupTests.ts
+sonar.exclusions=**/webpack.config.*.js,**/node_modules,**/dist,**/*.test.ts*,**/setupTests.ts,**/__mocks__/**,src/types/**
 
 sonar.javascript.lcov.reportPaths=src/altinn-app-frontend/coverage/lcov.info,src/shared/coverage/lcov.info
-sonar.coverage.exclusions=**/__mocks__/**,src/types/**

--- a/src/shared/src/utils/urlHelper.test.ts
+++ b/src/shared/src/utils/urlHelper.test.ts
@@ -149,12 +149,12 @@ describe('Shared urlHelper.ts', () => {
 
     // Test with non-standard port
     expect(
-      makeUrlRelativeIfSameDomain('http://altinn3local.no:8080/', {
+      makeUrlRelativeIfSameDomain('https://altinn3local.no:8080/', {
         hostname: 'altinn3local.no',
       } as Location),
     ).toBe('/');
     expect(
-      makeUrlRelativeIfSameDomain('http://altinn3local.no:8080/', {
+      makeUrlRelativeIfSameDomain('https://altinn3local.no:8080/', {
         hostname: 'altinn3local.no',
       } as Location),
     ).toBe('/');

--- a/src/shared/src/utils/urlHelper.ts
+++ b/src/shared/src/utils/urlHelper.ts
@@ -8,8 +8,8 @@ export const getApplicationMetadataUrl = (): string => {
 };
 
 export const altinnAppsIllustrationHelpCircleSvgUrl = 'https://altinncdn.no/img/illustration-help-circle.svg';
-export const altinnAppsImgLogoBlueSvgUrl = 'http://altinncdn.no/img/a-logo-blue.svg';
-export const altinnDocsUrl = 'http://docs.altinn.studio/';
+export const altinnAppsImgLogoBlueSvgUrl = 'https://altinncdn.no/img/a-logo-blue.svg';
+export const altinnDocsUrl = 'https://docs.altinn.studio/';
 export const altinnStudioDocsUrl = 'https://altinn.github.io/docs/altinn-studio/';
 export const altinnImgLogoHeaderUrl = 'https://altinncdn.no/img/altinn_logo_header.png';
 export const dataModelUploadPageUrl = `${origin}/designer/${org}/${app}#/datamodel`;


### PR DESCRIPTION
Sonarcloud config was incorrect, and test files were still counted when measuring code coverage, and duplications. This should fix it 🤞

Also fixed a couple links that were using http instead of https which SonarCloud also complained about.