### PR TITLE
Empty fields validation for multiPage repeating groups

### DIFF
--- a/src/altinn-app-frontend/package.json
+++ b/src/altinn-app-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "altinn-app-frontend",
-  "version": "3.36.0",
+  "version": "3.36.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/altinn-app-frontend/src/utils/validation.test.ts
+++ b/src/altinn-app-frontend/src/utils/validation.test.ts
@@ -1,30 +1,34 @@
-import { createElement } from 'react';
-import { getInitialStateMock } from '../../__mocks__/initialStateMock';
-import { getMockValidationState } from '../../__mocks__/validationStateMock';
+import {createElement} from 'react';
+import {getInitialStateMock} from '../../__mocks__/initialStateMock';
+import {getMockValidationState} from '../../__mocks__/validationStateMock';
 import * as oneOfOnRootSchema from '../../__mocks__/json-schema/one-of-on-root.json';
 import * as refOnRootSchema from '../../__mocks__/json-schema/ref-on-root.json';
 import * as complexSchema from '../../__mocks__/json-schema/complex.json';
 
 import type {
-  IValidationIssue,
-  IValidations,
-  IRepeatingGroups,
-  IRuntimeState,
   IComponentBindingValidation,
   IComponentValidations,
   ILayoutValidations,
+  IRepeatingGroups,
+  IRuntimeState,
+  IValidationIssue,
+  IValidations,
 } from 'src/types';
-import type { ILayoutComponent, ILayoutGroup } from 'src/features/form/layout';
-
-import { Severity } from 'src/types';
-import { getParsedLanguageFromKey } from '../../../shared/src';
-import { createRepeatingGroupComponents } from 'src/utils/formLayout';
-import { getParsedTextResourceByKey } from 'src/utils/textResource';
+import {Severity} from 'src/types';
+import type {ILayoutComponent, ILayoutGroup} from 'src/features/form/layout';
+import {getParsedLanguageFromKey} from '../../../shared/src';
+import {createRepeatingGroupComponents} from 'src/utils/formLayout';
+import {getParsedTextResourceByKey} from 'src/utils/textResource';
 import * as validation from './validation';
-import { mapToComponentValidations } from './validation';
+import {mapToComponentValidations} from './validation';
 
 describe('utils > validation', () => {
   let mockLayout: any;
+  let mockGroup1: any; // Repeating group
+  let mockGroup2: any; // Repeating group nested inside group1
+  let mockGroup3: any; // Repeating multiPage group
+  let mockComponent4: any; // Required input inside group1
+  let mockComponent5: any; // Non-required input inside group2
   let mockReduxFormat: any;
   let mockLayoutState: any;
   let mockJsonSchema: any;
@@ -51,6 +55,63 @@ describe('utils > validation', () => {
           pattern: 'Feil format eller verdi',
         },
       },
+    };
+
+    mockComponent4 = {
+      type: 'Input',
+      id: 'componentId_4',
+      dataModelBindings: {
+        simpleBinding: 'group_1.dataModelField_4',
+      },
+      required: true,
+      readOnly: false,
+      textResourceBindings: {},
+    };
+
+    mockComponent5 = {
+      type: 'Input',
+      id: 'componentId_5',
+      dataModelBindings: {
+        simpleBinding: 'group_1.group_2.dataModelField_5',
+      },
+      required: false,
+      readOnly: false,
+      textResourceBindings: {},
+    };
+
+    mockGroup2 = {
+      type: 'group',
+      id: 'group2',
+      dataModelBindings: {
+        group: 'group_1.group_2',
+      },
+      maxCount: 3,
+      children: [mockComponent5.id],
+    };
+
+    mockGroup1 = {
+      type: 'group',
+      id: 'group1',
+      dataModelBindings: {
+        group: 'group_1',
+      },
+      maxCount: 3,
+      children: [mockComponent4.id, mockGroup2.id],
+    };
+
+    mockGroup3 = {
+      type: 'group',
+      id: 'group3',
+      dataModelBindings: {
+        group: 'group_3',
+      },
+      maxCount: 2,
+      edit: {
+        multiPage: true,
+      },
+      children: [
+        // Add your own children (remember page prefixes!)
+      ],
     };
 
     mockLayout = {
@@ -85,34 +146,9 @@ describe('utils > validation', () => {
           readOnly: false,
           textResourceBindings: {},
         },
-        {
-          type: 'group',
-          id: 'group1',
-          dataModelBindings: {
-            group: 'group_1',
-          },
-          maxCount: 3,
-          children: ['componentId_4', 'group2'],
-        },
-        {
-          type: 'group',
-          id: 'group2',
-          dataModelBindings: {
-            group: 'group_1.group_2',
-          },
-          maxCount: 3,
-          children: ['componentId_5'],
-        },
-        {
-          type: 'Input',
-          id: 'componentId_4',
-          dataModelBindings: {
-            simpleBinding: 'group_1.dataModelField_4',
-          },
-          required: true,
-          readOnly: false,
-          textResourceBindings: {},
-        },
+        mockGroup1,
+        mockGroup2,
+        mockComponent4,
         {
           type: 'FileUpload',
           id: 'componentId_7',
@@ -120,16 +156,7 @@ describe('utils > validation', () => {
           maxNumberOfAttachments: '3',
           minNumberOfAttachments: '2',
         },
-        {
-          type: 'Input',
-          id: 'componentId_5',
-          dataModelBindings: {
-            simpleBinding: 'group_1.group_2.dataModelField_5',
-          },
-          required: false,
-          readOnly: false,
-          textResourceBindings: {},
-        },
+        mockComponent5,
         {
           type: 'AddressComponent',
           id: 'componentId_6',
@@ -740,22 +767,113 @@ describe('utils > validation', () => {
   });
 
   describe('validateEmptyFieldsForLayout', () => {
-    const withHidden = (hiddenFields:string[]) => validation.validateEmptyFieldsForLayout(
-      {},
-      mockLayout.FormLayout,
+    const _with = ({
+      formData = {},
+      formLayout = mockLayout.FormLayout,
+      hiddenFields = [],
+      repeatingGroups = {},
+    }) => validation.validateEmptyFieldsForLayout(
+      formData,
+      formLayout,
       mockLanguage.language,
       hiddenFields,
-      {}
+      repeatingGroups,
     );
-    const requiredField = 'required_in_group_simple';
+
+    const requiredFieldInSimpleGroup = 'required_in_group_simple';
+    const requiredError = {
+      simpleBinding: { errors: ['Feltet er påkrevd'], warnings: [] },
+    };
 
     it('should skip validation on required field in hidden group', () => {
-      expect(withHidden(['group_simple'])[requiredField]).toBeUndefined();
+      expect(_with({hiddenFields: ['group_simple']})[requiredFieldInSimpleGroup]).toBeUndefined();
+    });
+    it('should run validation on required field in visible group', () => {
+      expect(_with({hiddenFields: []})[requiredFieldInSimpleGroup]).toEqual(requiredError);
     });
 
-    it('should run validation on required field in visible group', () => {
-      expect(withHidden([])[requiredField]).toEqual({
-        simpleBinding: { errors: ['Feltet er påkrevd'], warnings: [] },
+    it('should validate successfully with no instances of repeating groups', () => {
+      expect(_with({
+        formLayout: [
+          mockGroup1,
+          mockGroup2,
+          mockComponent4,
+          {...mockComponent5, required: true},
+        ],
+        repeatingGroups: {},
+      })).toEqual({});
+    });
+
+    it('should support nested repeating groups', () => {
+      expect(_with({
+        formLayout: [
+          mockGroup1,
+          mockGroup2,
+          mockComponent4,
+          {...mockComponent5, required: true},
+        ],
+        repeatingGroups: {
+          group1: { index: 2 }, // Group1 has 3 instances
+          'group2-0': { index: 1 }, // Group2 has 2 instances inside the first instance of group1
+          'group2-1': { index: 0 }, // Group2 has 1 instance inside the second instance of group1
+          // Group2 has no instances inside the third instance of group1
+        },
+      })).toEqual({
+        'componentId_4-0': requiredError,
+        'componentId_4-1': requiredError,
+        'componentId_4-2': requiredError,
+        'componentId_5-0-0': requiredError,
+        'componentId_5-0-1': requiredError,
+        'componentId_5-1-0': requiredError,
+      });
+    });
+
+    it('should support repeating groups', () => {
+      expect(_with({
+        formLayout: [mockGroup1, mockGroup2, mockComponent4, mockComponent5],
+        repeatingGroups: {
+          group1: { index: 1 }, // Group1 has 2 instances
+        },
+      })).toEqual({
+        'componentId_4-0': requiredError,
+        'componentId_4-1': requiredError,
+      });
+    });
+
+    it('should support multiPage repeating groups', () => {
+      expect(_with({
+        formLayout: [
+          {...mockGroup3, children: [`0:${mockComponent4.id}`, `1:${mockComponent5.id}`]},
+          mockComponent4,
+          mockComponent5,
+        ],
+        repeatingGroups: {
+          group3: { index: 1 },
+        },
+      })).toEqual({
+        'componentId_4-0': requiredError,
+        'componentId_4-1': requiredError,
+      });
+    });
+
+    it('should support multiPage repeating and nesting groups', () => {
+      expect(_with({
+        formLayout: [
+          mockGroup1,
+          mockGroup2,
+          {...mockGroup3, children: [`0:${mockGroup1.id}`, `1:${mockGroup2.id}`]},
+          mockComponent4,
+          {...mockComponent5, required: true},
+        ],
+        repeatingGroups: {
+          group3: { index: 1 },
+          'group1': { index: 1 },
+          'group2-0': { index: 0 },
+        },
+      })).toEqual({
+        'componentId_4-0': requiredError,
+        'componentId_4-1': requiredError,
+        'componentId_5-0-0': requiredError,
       });
     });
   });

--- a/src/altinn-app-frontend/src/utils/validation.test.ts
+++ b/src/altinn-app-frontend/src/utils/validation.test.ts
@@ -1,26 +1,27 @@
-import {createElement} from 'react';
-import {getInitialStateMock} from '../../__mocks__/initialStateMock';
-import {getMockValidationState} from '../../__mocks__/validationStateMock';
+import { createElement } from 'react';
+import { getInitialStateMock } from '../../__mocks__/initialStateMock';
+import { getMockValidationState } from '../../__mocks__/validationStateMock';
 import * as oneOfOnRootSchema from '../../__mocks__/json-schema/one-of-on-root.json';
 import * as refOnRootSchema from '../../__mocks__/json-schema/ref-on-root.json';
 import * as complexSchema from '../../__mocks__/json-schema/complex.json';
 
 import type {
+  IValidationIssue,
+  IValidations,
+  IRepeatingGroups,
+  IRuntimeState,
   IComponentBindingValidation,
   IComponentValidations,
   ILayoutValidations,
-  IRepeatingGroups,
-  IRuntimeState,
-  IValidationIssue,
-  IValidations,
 } from 'src/types';
-import {Severity} from 'src/types';
-import type {ILayoutComponent, ILayoutGroup} from 'src/features/form/layout';
-import {getParsedLanguageFromKey} from '../../../shared/src';
-import {createRepeatingGroupComponents} from 'src/utils/formLayout';
-import {getParsedTextResourceByKey} from 'src/utils/textResource';
+import type { ILayoutComponent, ILayoutGroup } from 'src/features/form/layout';
+
+import { Severity } from 'src/types';
+import { getParsedLanguageFromKey } from '../../../shared/src';
+import { createRepeatingGroupComponents } from 'src/utils/formLayout';
+import { getParsedTextResourceByKey } from 'src/utils/textResource';
 import * as validation from './validation';
-import {mapToComponentValidations} from './validation';
+import { mapToComponentValidations } from './validation';
 
 describe('utils > validation', () => {
   let mockLayout: any;

--- a/src/altinn-app-frontend/src/utils/validation.ts
+++ b/src/altinn-app-frontend/src/utils/validation.ts
@@ -207,12 +207,12 @@ export function validateEmptyFieldsForLayout(
 ): ILayoutValidations {
   const validations: any = {};
   const allGroups = formLayout.filter((component) => component.type.toLowerCase() === 'group');
+  const childrenWithoutMultiPagePrefix = (group:ILayoutGroup) => group.edit?.multiPage
+    ? group.children.map((componentId) => componentId.replace(/^\d+:/g, ''))
+    : group.children;
+
   const fieldsInGroup = allGroups
-    .map((group: ILayoutGroup) => (
-      group.edit?.multiPage
-        ? group.children.map(componentId => componentId.replace(/^\d+:/g, ''))
-        : group.children
-    ))
+    .map(childrenWithoutMultiPagePrefix)
     .flat();
   const groupsToCheck = allGroups.filter(group => !hiddenFields.includes(group.id));
   const fieldsToCheck = formLayout.filter((component) => (
@@ -236,7 +236,7 @@ export function validateEmptyFieldsForLayout(
     const componentsToCheck = formLayout.filter((component) => {
       return (
         (component as ILayoutComponent).required &&
-        group.children?.indexOf(component.id) > -1
+        childrenWithoutMultiPagePrefix(group).indexOf(component.id) > -1
       );
     });
 

--- a/src/altinn-app-frontend/src/utils/validation.ts
+++ b/src/altinn-app-frontend/src/utils/validation.ts
@@ -208,7 +208,11 @@ export function validateEmptyFieldsForLayout(
   const validations: any = {};
   const allGroups = formLayout.filter((component) => component.type.toLowerCase() === 'group');
   const fieldsInGroup = allGroups
-    .map((group: ILayoutGroup) => group.children)
+    .map((group: ILayoutGroup) => (
+      group.edit?.multiPage
+        ? group.children.map(componentId => componentId.replace(/^\d+:/g, ''))
+        : group.children
+    ))
     .flat();
   const groupsToCheck = allGroups.filter(group => !hiddenFields.includes(group.id));
   const fieldsToCheck = formLayout.filter((component) => (


### PR DESCRIPTION
<!-- Thank you for contributing to Altinn:) We know this isn't the fun part, but please make sure you follow our [contributing guidelines](../CONTRIBUTING.md) and put the same effort into the pull request as you did into the code and it should soon find it's way to main. -->

## Description
Validation for empty fields broke when using `multiPage: true` in repeating groups. The validation missed the page number prefix in `group.children` and defaulted to validate as individual fields. Adding more unit tests for this and other layouts (such as repeating + nested + multiPage groups, although I haven't tested how that would work in the UI :wink:)

## Fixes
- Altinn/altinn-studio/issues/7478

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
- [ ] Changelog is updated with a separate linked PR
  - [x] [altinn-app-frontend](https://docs.altinn.studio/community/changelog/app-frontend/)- (if applicable)
  - [ ] [nuget-packages](https://docs.altinn.studio/community/changelog/app-nuget/) - (if applicable)
