### PR TITLE
Checking for validation errors inside arrays recursively

### DIFF
--- a/src/altinn-app-frontend/package.json
+++ b/src/altinn-app-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "altinn-app-frontend",
-  "version": "3.36.1",
+  "version": "3.36.2",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/altinn-app-frontend/src/utils/validation.test.ts
+++ b/src/altinn-app-frontend/src/utils/validation.test.ts
@@ -2124,5 +2124,22 @@ describe('utils > validation', () => {
       const result = validation.missingFieldsInLayoutValidations(validations, mockLanguage.language);
       expect(result).toBeTruthy();
     });
+    it('should return true when validations contain arrays with error message for missing fields', () => {
+      const validations = (err:any[]):ILayoutValidations => ({
+        field: {
+          'simple_binding': {
+            errors: ['Some random error', err],
+            warnings: [],
+          }
+        }
+      });
+      const shallow = ['Første linje', "\n", 'Feltet er påkrevd'];
+      const deep = ['Dette er feil:', ['Første linje', "\n", 'Feltet er påkrevd']];
+      const withNode = ['Dette er feil:', ['Første linje', "\n", createElement('span', {}, 'Feltet er påkrevd')]];
+      expect(validation.missingFieldsInLayoutValidations(validations(shallow), mockLanguage.language)).toBeTruthy();
+      expect(validation.missingFieldsInLayoutValidations(validations(deep), mockLanguage.language)).toBeTruthy();
+      expect(validation.missingFieldsInLayoutValidations(validations(withNode), mockLanguage.language)).toBeTruthy();
+    });
+
   });
 });

--- a/src/altinn-app-frontend/src/utils/validation.ts
+++ b/src/altinn-app-frontend/src/utils/validation.ts
@@ -1677,6 +1677,16 @@ export function missingFieldsInLayoutValidations(
 ): boolean {
   let result = false;
   const requiredMessage = getLanguageFromKey('form_filler.error_required', language);
+  const lookForRequiredMsg = (e: any) => {
+    if (typeof(e) === 'string') {
+      return e.includes(requiredMessage);
+    }
+    if (Array.isArray(e)) {
+      return e.findIndex(lookForRequiredMsg) > -1;
+    }
+    return (e?.props?.children as string).includes(requiredMessage);
+  };
+
   Object.keys(layoutValidations).forEach((component: string) => {
     if (!layoutValidations[component]) return;
     if (result) return;
@@ -1685,12 +1695,7 @@ export function missingFieldsInLayoutValidations(
       if (result) return;
 
       const errors = layoutValidations[component][binding].errors;
-      result = (errors && errors.length > 0 && errors.findIndex((e: any) => {
-        if (typeof(e) === 'string') {
-          return e.includes(requiredMessage);
-        }
-        return (e?.props?.children as string).includes(requiredMessage);
-      }) > -1)
+      result = (errors && errors.length > 0 && errors.findIndex(lookForRequiredMsg) > -1)
     })
   });
 


### PR DESCRIPTION
## Description
In the linked issue, the error was caused by an error message being an array mixed with react elements and strings. Checking inside these to look for the required message as well.

## Fixes
- Altinn/altinn-studio/issues/8481

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
- [ ] Changelog is updated with a separate linked PR
  - [ ] [altinn-app-frontend](https://docs.altinn.studio/community/changelog/app-frontend/)- (if applicable)
  - [ ] [nuget-packages](https://docs.altinn.studio/community/changelog/app-nuget/) - (if applicable)
