### PR TITLE
Fixing flaky options test

### DIFF
--- a/test/cypress/e2e/integration/app-frontend/options.js
+++ b/test/cypress/e2e/integration/app-frontend/options.js
@@ -6,17 +6,30 @@ import AppFrontend from '../../pageobjects/app-frontend';
 const appFrontend = new AppFrontend();
 
 describe('Options', () => {
-  // disabled until https://github.com/Altinn/altinn-studio/issues/8255 is solved
-  it.skip('is possible to retrieve options dynamically', () => {
+  it('is possible to retrieve options dynamically', () => {
     cy.navigateToChangeName();
-    // Case: options are dynamicly refetched based on what the user selects as source
+    // Case: options are dynamically refetched based on what the user selects as source
     cy.get(appFrontend.changeOfName.sources).should('be.visible');
-    cy.get(appFrontend.changeOfName.reference).should('be.visible').select('nordmann').should('have.value', 'nordmann');
+
+    // Make sure we wait until the option is visible, as it's not instant
+    cy.get(appFrontend.changeOfName.reference)
+      .get(`option[value=nordmann]`)
+      .should('be.visible');
+
+    cy.get(appFrontend.changeOfName.reference)
+      .select('nordmann')
+      .should('have.value', 'nordmann');
 
     //Secure options
-    cy.get(appFrontend.changeOfName.reference2).should('be.visible').select('1').and('have.value', '1');
+    cy.get(appFrontend.changeOfName.reference2)
+      .get('option[value=1]')
+      .should('be.visible');
+    cy.get(appFrontend.changeOfName.reference2)
+      .should('be.visible')
+      .select('1')
+      .and('have.value', '1');
 
-    // Select a different source, expect previous selction to be cleared and
+    // Select a different source, expect previous selection to be cleared and
     // new value to be selectable in the reference option
     cy.get(appFrontend.changeOfName.sources).select('digdir');
     cy.get(appFrontend.changeOfName.reference).should('be.visible').and('have.value', '');

--- a/test/cypress/e2e/support/index.d.ts
+++ b/test/cypress/e2e/support/index.d.ts
@@ -1,3 +1,4 @@
+/// <reference types="cypress" />
 declare namespace Cypress {
   interface Chainable {
     /**


### PR DESCRIPTION
## Description
The `options` cypress test was flaky. The root cause of this was assumed to be the way `preselectedOptionIndex` is implemented, as the first dropdown component (`source`) is first rendered once before it figures out it should be pre-selecting an option. The component will then set its data and render again shortly after. When this field value is then a dependency for a second dropdown with a list of options (`reference`), the list of options would first get fetched with `source=undefined` (during the first render) and then right after it would fetch options with `source=something`. Only then can the second dropdown (queried in this test) contain the expected option.

For cypress, this meant that it would find the element it was looking for (and verify it was visible), but then try to select an option before the XHR had finished fetching relevant options. Even if we fixed the minor issue where there is a first round of rendering (and a useless XHR to fetch options) before the correct `preselectedOptionIndex` is chosen, the test would still be flaky as it would have had to wait for the XHR to finish before the expected option was available.

The solution here is [in the cypress docs](https://docs.cypress.io/guides/core-concepts/retry-ability#Commands-vs-assertions); we have to make sure cypress waits until the expected option is found.

## Fixes
- Altinn/altinn-studio/issues/8255

## Verification
- [X] **Your** code builds clean without any errors or warnings
- ~~[ ] Manual testing done (required)~~
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- ~~[ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~
- ~~[ ] Changelog is updated with a separate linked PR~~
  - ~~[ ] [altinn-app-frontend](https://docs.altinn.studio/community/changelog/app-frontend/)- (if applicable)~~
  - ~~[ ] [nuget-packages](https://docs.altinn.studio/community/changelog/app-nuget/) - (if applicable)~~
