### PR TITLE
chore: dont create a new version for every merge to master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: Build PR
+    name: Build
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -39,47 +39,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      - name: Checkout Altinn-CDN repository
-        if: github.ref == 'refs/heads/main'
-        uses: actions/checkout@v3
-        with:
-          repository: 'Altinn/altinn-cdn'
-          token: ${{secrets.ALTINN_CDN_TOKEN}}
-          path: cdn
-      - name: Publish to CDN
-        if: github.ref == 'refs/heads/main'
-        working-directory: app-frontend
-        run: |
-          echo Clone, copy, commit and push to Altinn-CDN
-          APP_VERSION=$(jq '.version' ./src/altinn-app-frontend/package.json)
-          APP_MAJOR=$(echo $APP_VERSION | tr --delete '"' | cut -d'.' -f1)
-          APP_MINOR=$(echo $APP_VERSION | tr --delete '"' | cut -d'.' -f2)
-          APP_PATCH=$(echo $APP_VERSION | tr --delete '"' | cut -d'.' -f3)
-          echo altinn-app-frontend version: $APP_MAJOR.$APP_MINOR.$APP_PATCH
-          AUTHOR_FULL=$(git log -1 | grep Author)
-          AUTHOR_NAME=$(git log -1 | grep Author | cut -d' ' -f2)
-          AUTHOR_EMAIL=$(git log -1 | grep Author | cut -d' ' -f3 | cut -d'<' -f2 | cut -d'>' -f1)
-          COMMIT_ID=$(git rev-parse HEAD~0)
-          git log -1 | grep -Ev "commit|Author|Date" > ./../commitmsg.txt
-          cd ..
-          echo Copy Major Version
-          mkdir -p ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR
-          cp -fr ./app-frontend/src/altinn-app-frontend/dist/altinn-app-frontend.js ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR/altinn-app-frontend.js
-          cp -fr ./app-frontend/src/altinn-app-frontend/dist/altinn-app-frontend.css ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR/altinn-app-frontend.css
-          echo Copy Minor Version
-          mkdir -p ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR.$APP_MINOR
-          cp -fr ./app-frontend/src/altinn-app-frontend/dist/altinn-app-frontend.js ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR.$APP_MINOR/altinn-app-frontend.js
-          cp -fr ./app-frontend/src/altinn-app-frontend/dist/altinn-app-frontend.css ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR.$APP_MINOR/altinn-app-frontend.css
-          echo Copy Patch
-          mkdir -p ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR.$APP_MINOR.$APP_PATCH
-          cp -fr ./app-frontend/src/altinn-app-frontend/dist/altinn-app-frontend.js ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR.$APP_MINOR.$APP_PATCH/altinn-app-frontend.js
-          cp -fr ./app-frontend/src/altinn-app-frontend/dist/altinn-app-frontend.css ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR.$APP_MINOR.$APP_PATCH/altinn-app-frontend.css
-          cd cdn
-          git config --global user.email "$AUTHOR_EMAIL"
-          git config --global user.name "$AUTHOR_NAME"
-          git add .
-          echo "$AUTHOR_FULL updated altinn-app-frontend to $APP_MAJOR.$APP_MINOR.$APP_PATCH" > ./../commit1.txt
-          echo "based on commit https://github.com/Altinn/altinn-studio/commit/$COMMIT_ID" > ./../commit2.txt
-          cat ./../commit1.txt ./../commit2.txt ./../commitmsg.txt > ./../commit.txt
-          git commit -F ./../commit.txt
-          git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,90 @@
+name: Create release
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: "The type of release (one of 'patch', 'minor', or 'major')"
+        required: true
+        default: patch
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Build
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          path: app-frontend
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
+
+      - name: install node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+
+      - name: install dependencies
+        working-directory: app-frontend/src
+        run: yarn --immutable
+
+      - name: Prepare release version
+        working-directory: app-frontend/src/altinn-app-frontend
+        # This step runs if the trigger is run via github action
+        if: ${{ ! github.event.after }}
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          yarn release ${{ github.event.inputs.release_type }}
+          echo "release_version=`git describe`" >> $GITHUB_ENV
+          git push --follow-tags
+
+      - name: run build
+        working-directory: app-frontend/src/altinn-app-frontend
+        run: yarn build
+
+      - name: Checkout Altinn-CDN repository
+        if: github.ref == 'refs/heads/main'
+        uses: actions/checkout@v3
+        with:
+          repository: 'Altinn/altinn-cdn'
+          token: ${{secrets.ALTINN_CDN_TOKEN}}
+          path: cdn
+
+      - name: Publish to CDN
+        if: github.ref == 'refs/heads/main'
+        working-directory: app-frontend
+        run: |
+          echo Clone, copy, commit and push to Altinn-CDN
+          APP_VERSION=$(jq '.version' ./src/altinn-app-frontend/package.json)
+          APP_MAJOR=$(echo $APP_VERSION | tr --delete '"' | cut -d'.' -f1)
+          APP_MINOR=$(echo $APP_VERSION | tr --delete '"' | cut -d'.' -f2)
+          APP_PATCH=$(echo $APP_VERSION | tr --delete '"' | cut -d'.' -f3)
+          echo altinn-app-frontend version: $APP_MAJOR.$APP_MINOR.$APP_PATCH
+          AUTHOR_FULL=$(git log -1 | grep Author)
+          AUTHOR_NAME=$(git log -1 | grep Author | cut -d' ' -f2)
+          AUTHOR_EMAIL=$(git log -1 | grep Author | cut -d' ' -f3 | cut -d'<' -f2 | cut -d'>' -f1)
+          COMMIT_ID=$(git rev-parse HEAD~0)
+          git log -1 | grep -Ev "commit|Author|Date" > ./../commitmsg.txt
+          cd ..
+          echo Copy Major Version
+          mkdir -p ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR
+          cp -fr ./app-frontend/src/altinn-app-frontend/dist/altinn-app-frontend.js ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR/altinn-app-frontend.js
+          cp -fr ./app-frontend/src/altinn-app-frontend/dist/altinn-app-frontend.css ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR/altinn-app-frontend.css
+          echo Copy Minor Version
+          mkdir -p ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR.$APP_MINOR
+          cp -fr ./app-frontend/src/altinn-app-frontend/dist/altinn-app-frontend.js ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR.$APP_MINOR/altinn-app-frontend.js
+          cp -fr ./app-frontend/src/altinn-app-frontend/dist/altinn-app-frontend.css ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR.$APP_MINOR/altinn-app-frontend.css
+          echo Copy Patch
+          mkdir -p ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR.$APP_MINOR.$APP_PATCH
+          cp -fr ./app-frontend/src/altinn-app-frontend/dist/altinn-app-frontend.js ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR.$APP_MINOR.$APP_PATCH/altinn-app-frontend.js
+          cp -fr ./app-frontend/src/altinn-app-frontend/dist/altinn-app-frontend.css ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR.$APP_MINOR.$APP_PATCH/altinn-app-frontend.css
+          cd cdn
+          git config --global user.email "$AUTHOR_EMAIL"
+          git config --global user.name "$AUTHOR_NAME"
+          git add .
+          echo "$AUTHOR_FULL updated altinn-app-frontend to $APP_MAJOR.$APP_MINOR.$APP_PATCH" > ./../commit1.txt
+          echo "based on commit https://github.com/Altinn/altinn-studio/commit/$COMMIT_ID" > ./../commit2.txt
+          cat ./../commit1.txt ./../commit2.txt ./../commitmsg.txt > ./../commit.txt
+          git commit -F ./../commit.txt
+          git push


### PR DESCRIPTION
## Description
This will stop creating a new release to CDN on every merge to master. This is problematic because we need to manually remember to update package.json to avoid overwriting whats already published.

Creating a new release will now require that we go to Actions in Github, and run the `release` pipeline. Here you will need to input `major`, `minor` or `patch` to decide which type of version to bump.

This approach is similar to what we do in https://github.com/Altinn/altinn-design-system and https://github.com/Altinn/figma-design-tokens repos, so you can have a look at the action in one of those repos to see how it will work.

We can always improve it further later, but I think its important that we get away from the current error-prone situation 😁
