### PR TITLE
Type duplication cleanup in actions

### DIFF
--- a/src/altinn-app-frontend/src/components/base/FileUpload/FileUploadWithTag/FileUploadWithTagComponent.tsx
+++ b/src/altinn-app-frontend/src/components/base/FileUpload/FileUploadWithTag/FileUploadWithTagComponent.tsx
@@ -112,7 +112,7 @@ export function FileUploadWithTagComponent({
   const setAttachmentTag = (attachment: IAttachment, optionValue: string) => {
     const option = options?.find((o) => o.value === optionValue);
     if (option !== undefined) {
-      AttachmentDispatcher.updateAttachment(attachment, id, option.value, id);
+      AttachmentDispatcher.updateAttachment(attachment, id, option.value);
     } else {
       console.error(`Could not find option for ${optionValue}`);
     }

--- a/src/altinn-app-frontend/src/features/form/dynamics/formDynamicsActions.ts
+++ b/src/altinn-app-frontend/src/features/form/dynamics/formDynamicsActions.ts
@@ -1,32 +1,13 @@
-import { Action, ActionCreatorsMapObject, bindActionCreators } from 'redux';
-import { store } from '../../../store';
+import { bindActionCreators } from 'redux';
+import { store } from 'src/store';
 
 import * as ApiActions from './api/apiActions';
 import * as ConditionalRenderActions from './conditionalRendering/conditionalRenderingActions';
 import * as FetchDynamicActions from './fetch/fetchFormDynamicsActions';
 
-export interface IFormDynamicsActions extends ActionCreatorsMapObject {
-  checkIfApiShouldFetch: (
-    updatedComponentId: string,
-    updatedDataField: string,
-    updatedData: string,
-    repeating: boolean,
-    dataModelGroup?: string,
-    index?: number,
-  ) => ApiActions.ICheckIfApiShouldFetchAction;
-  checkIfConditionalRulesShouldRun: (
-    repeatingContainerId?: string,
-  ) => ConditionalRenderActions.ICheckIfConditionalRulesShouldRun;
-  fetchFormDynamics: () => Action;
-  fetchFormDynamicsFulfilled: (
-    apis: any,
-    roleConnections: any,
-    conditionalRendering: any,
-  ) => FetchDynamicActions.IFetchServiceConfigFulfilled;
-  fetchFormDynamicsRejected: (error: Error) => FetchDynamicActions.IFetchServiceConfigRejected;
-}
+export type IFormDynamicsActions = typeof actions;
 
-const actions: IFormDynamicsActions = {
+const actions = {
   checkIfApiShouldFetch: ApiActions.checkIfApiShouldFetch,
   checkIfConditionalRulesShouldRun: ConditionalRenderActions.checkIfConditionalRulesShouldRun,
   fetchFormDynamics: FetchDynamicActions.fetchServiceConfig,

--- a/src/altinn-app-frontend/src/features/form/rules/rulesActions.ts
+++ b/src/altinn-app-frontend/src/features/form/rules/rulesActions.ts
@@ -1,14 +1,10 @@
-import { Action, ActionCreatorsMapObject, bindActionCreators } from 'redux';
-import { store } from '../../../store';
+import { bindActionCreators } from 'redux';
+import { store } from 'src/store';
 import * as FetchRuleModel from './fetch/fetchRulesActions';
 
-export interface IFormRulesActions extends ActionCreatorsMapObject {
-  fetchRuleModel: () => Action;
-  fetchRuleModelFulfilled: (formData: any) => FetchRuleModel.IFetchRuleModelFulfilled;
-  fetchRuleModelRejected: (error: Error) => FetchRuleModel.IFetchRuleModelRejected;
-}
+export type IFormRulesActions = typeof actions;
 
-const actions: IFormRulesActions = {
+const actions = {
   fetchRuleModel: FetchRuleModel.fetchRuleModelAction,
   fetchRuleModelFulfilled: FetchRuleModel.fetchRuleModelFulfilledAction,
   fetchRuleModelRejected: FetchRuleModel.fetchRuleModelRejectedAction,

--- a/src/altinn-app-frontend/src/features/instantiate/instantiation/actions/index.ts
+++ b/src/altinn-app-frontend/src/features/instantiate/instantiation/actions/index.ts
@@ -1,15 +1,10 @@
-import { Action, ActionCreatorsMapObject, bindActionCreators } from 'redux';
-import { store } from '../../../../store';
+import { bindActionCreators } from 'redux';
+import { store } from 'src/store';
 import * as InstantiateActions from './instantiate';
 
-export interface IInstantiationActions extends ActionCreatorsMapObject {
-  instantiate: (org: string, app: string) => InstantiateActions.IInstantiate;
-  instantiateFulfilled: (instanceId: string) => InstantiateActions.IInstantiateFulfilled;
-  instantiateRejected: (error: Error) => InstantiateActions.IInstantiateRejected;
-  instantiateToggle: () => Action;
-}
+export type IInstantiationActions = typeof actions;
 
-const actions: IInstantiationActions = {
+const actions = {
   instantiate: InstantiateActions.instantiate,
   instantiateFulfilled: InstantiateActions.instantiateFulfilled,
   instantiateRejected: InstantiateActions.instantiateRejected,

--- a/src/altinn-app-frontend/src/shared/resources/applicationMetadata/actions/index.ts
+++ b/src/altinn-app-frontend/src/shared/resources/applicationMetadata/actions/index.ts
@@ -1,20 +1,11 @@
-import { Action, ActionCreatorsMapObject, bindActionCreators } from 'redux';
-import { IApplicationMetadata } from '..';
-import { store } from '../../../../store';
+import { bindActionCreators } from 'redux';
+import { store } from 'src/store';
 
 import * as getActions from './get';
 
-export interface IApplicationMetadataActions extends ActionCreatorsMapObject {
-  getApplicationMetadata: () => Action;
-  getApplicationMetadataFulfilled: (
-    applicationMetadata: IApplicationMetadata,
-  ) => getActions.IGetApplicationMetadataFulfilled;
-  getApplicationMetadataRejected: (
-    error: Error,
-  ) => getActions.IGetApplicationMetadataRejected;
-}
+export type IApplicationMetadataActions = typeof actions;
 
-const actions: IApplicationMetadataActions = {
+const actions = {
   getApplicationMetadata: getActions.getApplicationMetadata,
   getApplicationMetadataFulfilled: getActions.getApplicationMetadataFulfilled,
   getApplicationMetadataRejected: getActions.getApplicationMetadataRejected,

--- a/src/altinn-app-frontend/src/shared/resources/attachments/attachmentActions.ts
+++ b/src/altinn-app-frontend/src/shared/resources/attachments/attachmentActions.ts
@@ -1,66 +1,14 @@
-import { Action, ActionCreatorsMapObject, bindActionCreators } from 'redux';
-import { IAttachment, IAttachments } from '.';
-import { store } from '../../../store';
+import { bindActionCreators } from 'redux';
+import { store } from 'src/store';
 
 import * as deleteActions from './delete/deleteAttachmentActions';
 import * as mapActions from './map/mapAttachmentsActions';
 import * as uploadActions from './upload/uploadAttachmentActions';
 import * as updateActions from './update/updateAttachmentActions';
 
-export interface IAttachmentActions extends ActionCreatorsMapObject {
-  uploadAttachment: (
-    file: File,
-    fileType: string,
-    attachmentId: string,
-    componentId: string,
-  ) => uploadActions.IUploadAttachmentAction;
-  uploadAttachmentFulfilled: (
-    attachment: IAttachment,
-    fileType: string,
-    tmpAttachmentId: string,
-    componentId: string,
-  ) => uploadActions.IUploadAttachmentActionFulfilled;
-  uploadAttachmentRejected: (
-    attachmentId: string,
-    attachmentType: string,
-    componentId: string,
-  ) => uploadActions.IUploadAttachmentActionRejected;
-  updateAttachment: (
-    attachment: IAttachment,
-    attachmentType: string,
-    tag: string,
-    componentId: string,
-  ) => updateActions.IUpdateAttachmentAction;
-  updateAttachmentFulfilled: (
-    attachment: IAttachment,
-    attachmentType: string,
-  ) => updateActions.IUpdateAttachmentActionFulfilled;
-  updateAttachmentRejected: (
-    attachment: IAttachment,
-    attachmentType: string,
-    tag: string,
-  ) => updateActions.IUpdateAttachmentActionRejected;
-  deleteAttachment: (
-    attachment: IAttachment,
-    attachmentType: string,
-    componentId: string,
-  ) => deleteActions.IDeleteAttachmentAction;
-  deleteAttachmentFulfilled: (
-    attachmentId: string,
-    attachmentType: string,
-    componentId: string,
-  ) => deleteActions.IDeleteAttachmentActionFulfilled;
-  deleteAttachmentRejected: (
-    attachment: IAttachment,
-    attachmentType: string,
-    componentId: string,
-  ) => deleteActions.IDeleteAttachmentActionRejected;
-  mapAttachments: () => Action;
-  mapAttachmentsFulfilled: (attachments: IAttachments) => mapActions.IMapAttachmentsActionFulfilled;
-  mapAttachmentsRejected: (error: Error) => mapActions.IMapAttachmentsActionRejected;
-}
+export type IAttachmentActions = typeof actions;
 
-const actions: IAttachmentActions = {
+const actions = {
   uploadAttachment: uploadActions.uploadAttachment,
   uploadAttachmentFulfilled: uploadActions.uploadAttachmentFulfilled,
   uploadAttachmentRejected: uploadActions.uploadAttachmentRejected,

--- a/src/altinn-app-frontend/src/shared/resources/instanceData/instanceDataActions.ts
+++ b/src/altinn-app-frontend/src/shared/resources/instanceData/instanceDataActions.ts
@@ -1,15 +1,11 @@
-import { ActionCreatorsMapObject, bindActionCreators } from 'redux';
-import { store } from '../../../store';
+import { bindActionCreators } from 'redux';
+import { store } from 'src/store';
 
 import * as GetInstanceData from './get/getInstanceDataActions';
 
-export interface IInstanceDataActions extends ActionCreatorsMapObject {
-  getInstanceData: (instanceOwner: string, instanceId: string) => GetInstanceData.IGetInstanceData;
-  getInstanceDataFulfilled: (instanceData: any) => GetInstanceData.IGetInstanceDataFulfilled;
-  getInstanceDataRejected: (error: Error) => GetInstanceData.IGetInstanceDataRejected;
-}
+export type IInstanceDataActions = typeof actions;
 
-const actions: IInstanceDataActions = {
+const actions = {
   getInstanceData: GetInstanceData.getInstanceData,
   getInstanceDataFulfilled: GetInstanceData.getInstanceDataFulfilled,
   getInstanceDataRejected: GetInstanceData.getInstanceDataRejected,

--- a/src/altinn-app-frontend/src/shared/resources/language/languageActions.ts
+++ b/src/altinn-app-frontend/src/shared/resources/language/languageActions.ts
@@ -1,20 +1,11 @@
-import { ILanguage } from 'altinn-shared/types';
-import { Action, ActionCreatorsMapObject, bindActionCreators } from 'redux';
-import { store } from '../../../store';
+import { bindActionCreators } from 'redux';
+import { store } from 'src/store';
 
 import * as FetchLanguage from './fetch/fetchLanguageActions';
 
-export interface ILanguageActions extends ActionCreatorsMapObject {
-  fetchLanguage: () => Action;
-  fetchLanguageFulfilled: (
-    language: ILanguage,
-  ) => FetchLanguage.IFetchLanguageFulfilled;
-  fetchLanguageRecjeted: (
-    error: Error,
-  ) => FetchLanguage.IFetchLanguageRejected;
-}
+export type ILanguageActions = typeof actions;
 
-const actions: ILanguageActions = {
+const actions = {
   fetchLanguage: FetchLanguage.fetchLanguage,
   fetchLanguageFulfilled: FetchLanguage.fetchLanguageFulfilled,
   fetchLanguageRecjeted: FetchLanguage.fetchLanguageRejected,

--- a/src/altinn-app-frontend/src/shared/resources/options/optionsActions.ts
+++ b/src/altinn-app-frontend/src/shared/resources/options/optionsActions.ts
@@ -1,25 +1,11 @@
-import { Action, ActionCreatorsMapObject, bindActionCreators } from 'redux';
-import { IOptionData } from 'src/types';
-import { store } from '../../../store';
+import { bindActionCreators } from 'redux';
+import { store } from 'src/store';
 
 import * as FetchOptions from './fetch/fetchOptionsActions';
 
-export interface IOptionsActions extends ActionCreatorsMapObject {
-  fetchOptions: () => Action;
-  fetchingOptions: (
-    optionsKey: string,
-  ) => FetchOptions.IFetchingOptionsAction;
-  fetchOptionsFulfilled: (
-    optionsKey: string,
-    optionData: IOptionData,
-  ) => FetchOptions.IFetchOptionsFulfilledAction;
-  fetchOptionsRejected: (
-    optionsKey: string,
-    error: Error,
-  ) => FetchOptions.IFetchOptionsRejectedAction;
-}
+export type IOptionsActions = typeof actions;
 
-const actions: IOptionsActions = {
+const actions = {
   fetchOptions: FetchOptions.fetchOptions,
   fetchingOptions: FetchOptions.fetchingOptions,
   fetchOptionsFulfilled: FetchOptions.fetchOptionsFulfilled,

--- a/src/altinn-app-frontend/src/shared/resources/orgs/orgsActions.ts
+++ b/src/altinn-app-frontend/src/shared/resources/orgs/orgsActions.ts
@@ -1,16 +1,11 @@
-import { IAltinnOrgs } from 'altinn-shared/types';
-import { ActionCreatorsMapObject, bindActionCreators } from 'redux';
-import { store } from '../../../store';
+import { bindActionCreators } from 'redux';
+import { store } from 'src/store';
 
 import * as Fetchorgs from './fetch/fetchOrgsActions';
 
-export interface IOrgsActions extends ActionCreatorsMapObject {
-  fetchOrgs: () => Fetchorgs.IFetchOrgs;
-  fetchOrgsFulfilled: (orgs: IAltinnOrgs) => Fetchorgs.IFetchOrgsFulfilled;
-  fetchOrgsRejected: (error: Error) => Fetchorgs.IFetchOrgsRejected;
-}
+export type IOrgsActions = typeof actions;
 
-const actions: IOrgsActions = {
+const actions = {
   fetchOrgs: Fetchorgs.fetchOrgs,
   fetchOrgsFulfilled: Fetchorgs.fetchOrgsFulfilled,
   fetchOrgsRejected: Fetchorgs.fetchOrgsRejected,

--- a/src/altinn-app-frontend/src/shared/resources/party/partyActions.ts
+++ b/src/altinn-app-frontend/src/shared/resources/party/partyActions.ts
@@ -1,20 +1,11 @@
-import { Action, ActionCreatorsMapObject, bindActionCreators } from 'redux';
-import { IParty } from 'altinn-shared/types';
-import { store } from '../../../store';
+import { bindActionCreators } from 'redux';
+import { store } from 'src/store';
 import * as GetPartiesActions from './getParties/getPartiesActions';
 import * as SelectPartyActions from './selectParty/selectPartyActions';
 
-export interface IPartyActions extends ActionCreatorsMapObject {
-  getParties: () => Action;
-  getPartiesFulfilled: (parties: IParty[]) => GetPartiesActions.IGetPartiesFulfilled;
-  getPartiesRejected: (error: Error) => GetPartiesActions.IGetPartiesRejected;
-  getCurrentParty: () => Action;
-  selectParty: (party: IParty, redirect: boolean) => SelectPartyActions.ISelectParty;
-  selectPartyFulfilled: (party: IParty) => SelectPartyActions.ISelectPartyFulfilled;
-  selectPartyRejected: (error: Error) => SelectPartyActions.ISelectPartyRejected;
-}
+export type IPartyActions = typeof actions;
 
-const actions: IPartyActions = {
+const actions = {
   getParties: GetPartiesActions.getParties,
   getPartiesFulfilled: GetPartiesActions.getPartiesFulfilled,
   getPartiesRejected: GetPartiesActions.getPartiesRejected,

--- a/src/altinn-app-frontend/src/shared/resources/process/processDispatcher.ts
+++ b/src/altinn-app-frontend/src/shared/resources/process/processDispatcher.ts
@@ -1,31 +1,19 @@
-import { Action, ActionCreatorsMapObject, bindActionCreators } from 'redux';
-import { store } from '../../../store';
-import { ProcessTaskType } from '../../../types';
+import { bindActionCreators } from 'redux';
+import { store } from 'src/store';
 import * as CompleteProcessActions from './completeProcess/completeProcessActions';
 import * as GetProcessStateActions from './getProcessState/getProcessStateActions';
 import * as CheckProcessUpdatedActions from './checkProcessUpdated/checkProcessUpdatedActions';
 
 /**
- * Define a interface describing the the different Actions available
+ * Define a interface describing the different Actions available
  * and which datamodel those actions expect.
  */
-export interface IProcessDispatchers extends ActionCreatorsMapObject {
-  getProcessState: () => Action;
-  getProcessStateFulfilled:
-    (processStep: ProcessTaskType, taskId: string) => GetProcessStateActions.IGetProcessStateFulfilled;
-  getProcessStateRejected: (result: Error) => GetProcessStateActions.IGetProcessStateRejected;
-  completeProcess: () => Action;
-  completeProcessFulfilled:
-    (processStep: ProcessTaskType, taskId: string) => CompleteProcessActions.ICompleteProcessFulfilled;
-  completeProcessRejected: (error: Error) => CompleteProcessActions.ICompleteProcessRejected;
-  checkProcessUpdated: () => Action;
-}
+export type IProcessDispatchers = typeof actions;
 
 /**
  * Define mapping between action and Action dispatcher method
  */
-
-const actions: IProcessDispatchers = {
+const actions = {
   getProcessState: GetProcessStateActions.getProcessStateAction,
   getProcessStateFulfilled: GetProcessStateActions.getProcessStateFulfilledAction,
   getProcessStateRejected: GetProcessStateActions.getProcessStateRejectedAction,

--- a/src/altinn-app-frontend/src/shared/resources/profile/profileActions.ts
+++ b/src/altinn-app-frontend/src/shared/resources/profile/profileActions.ts
@@ -1,17 +1,10 @@
-import { ActionCreatorsMapObject, bindActionCreators } from 'redux';
-import { IProfile } from 'altinn-shared/types';
-import { store } from '../../../store';
+import { bindActionCreators } from 'redux';
+import { store } from 'src/store';
 import * as FetchProfileActions from './fetch/fetchProfileActions';
 
-export interface IProfileActions extends ActionCreatorsMapObject {
-  fetchProfile: (url: string) => FetchProfileActions.IFetchProfile;
-  fetchProfileFulfilled: (
-    profile: IProfile,
-  ) => FetchProfileActions.IFetchProfileFulfilled;
-  fetchProfileRejected: (error: Error) => FetchProfileActions.IFetchProfileRejected;
-}
+export type IProfileActions = typeof actions;
 
-const actions: IProfileActions = {
+const actions = {
   fetchProfile: FetchProfileActions.fetchProfile,
   fetchProfileFulfilled: FetchProfileActions.fetchProfileFulfilled,
   fetchProfileRejected: FetchProfileActions.fetchProfileRejected,

--- a/src/altinn-app-frontend/src/shared/resources/textResources/textResourcesActions.ts
+++ b/src/altinn-app-frontend/src/shared/resources/textResources/textResourcesActions.ts
@@ -1,22 +1,12 @@
-import { Action, ActionCreatorsMapObject, bindActionCreators } from 'redux';
-import { ITextResource } from 'src/types';
+import { bindActionCreators } from 'redux';
 import * as FetchActions from './fetch/fetchTextResourcesActions';
 import * as ReplaceActions from './replace/replaceTextResoucesActions';
 
-import { store } from '../../../store';
+import { store } from 'src/store';
 
-export interface ITextResourcesActions extends ActionCreatorsMapObject {
-  fetchTextResources: () => Action;
-  fetchTextResourcesFulfilled:
-    (language: string, resources: ITextResource[]) => FetchActions.IFetchTextResourcesFulfilled;
-  fetchTextResourcesRejected: (error: Error) => FetchActions.IFetchTextResourcesRejected;
-  replaceTextResources: () => Action;
-  replaceTextResourcesFulfilled:
-    (language: string, resources: ITextResource[]) => ReplaceActions.IReplaceTextResourcesFulfilled;
-  replaceTextResourcesRejected: (error: Error) => ReplaceActions.IReplaceTextResourcesRejected;
-}
+export type ITextResourcesActions = typeof actions;
 
-const actions: ITextResourcesActions = {
+const actions = {
   fetchTextResources: FetchActions.fetchTextResources,
   fetchTextResourcesFulfilled: FetchActions.fetchFormResourceFulfilled,
   fetchTextResourcesRejected: FetchActions.fetchFormResourceRejected,


### PR DESCRIPTION
## Description
The duplication of types (most significantly action arguments) meant that code would be difficult to follow from the IDE, and it could lead to bugs if not properly maintained. This quick-and-easy change makes it a little bit better until this code is converted to redux-toolkit in the future.

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- ~~[ ] Relevant automated test added (if you find this hard, leave it and we'll help out)~~
- [X] All ***type checking*** run green

## Documentation
- ~~[ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~
- ~~[ ] Changelog is updated with a separate linked PR~~
  - ~~[ ] [altinn-app-frontend](https://docs.altinn.studio/community/changelog/app-frontend/)- (if applicable)~~
  - ~~[ ] [nuget-packages](https://docs.altinn.studio/community/changelog/app-nuget/) - (if applicable)~~
