### PR TITLE
chore: remove invalid condition in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     name: Build
-    if: github.ref == 'refs/heads/main'
     steps:
       - name: checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Related to https://github.com/Altinn/app-frontend-react/pull/89 , which had an incorrect condition to only run on refs/heads/main . This will not work, since the ref will be a tag instead.