### PR TITLE
Support pre-releases in workflow and generate a list of versions as a .json on CDN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,9 @@ jobs:
           mkdir -p ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR.$APP_MINOR.$APP_PATCH
           cp -fr ./app-frontend/src/altinn-app-frontend/dist/altinn-app-frontend.js ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR.$APP_MINOR.$APP_PATCH/altinn-app-frontend.js
           cp -fr ./app-frontend/src/altinn-app-frontend/dist/altinn-app-frontend.css ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR.$APP_MINOR.$APP_PATCH/altinn-app-frontend.css
-          cd cdn
+          cd cdn/toolkits/altinn-app-frontend
+          ls -1 | grep --perl-regexp '^[\d\.]+$' | sort --version-sort | jq --raw-input --slurp 'split("\n") | map(select(. != ""))' > index.json
+          cd ../..
           git config --global user.email "$AUTHOR_EMAIL"
           git config --global user.name "$AUTHOR_NAME"
           git add .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
           token: ${{secrets.ALTINN_CDN_TOKEN}}
           path: cdn
 
-      - name: Publish to CDN
+      - name: Prepare version number
         working-directory: app-frontend
         run: |
           echo Clone, copy, commit and push to Altinn-CDN
@@ -49,6 +49,11 @@ jobs:
           AUTHOR_EMAIL=$(git log -1 | grep Author | cut -d' ' -f3 | cut -d'<' -f2 | cut -d'>' -f1)
           COMMIT_ID=$(git rev-parse HEAD~0)
           git log -1 | grep -Ev "commit|Author|Date" > ./../commitmsg.txt
+
+      - name: Copy version
+        working-directory: app-frontend
+        if: "!github.event.release.prerelease"
+        run: |
           cd ..
           echo Copy Major Version
           mkdir -p ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR
@@ -62,8 +67,22 @@ jobs:
           mkdir -p ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR.$APP_MINOR.$APP_PATCH
           cp -fr ./app-frontend/src/altinn-app-frontend/dist/altinn-app-frontend.js ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR.$APP_MINOR.$APP_PATCH/altinn-app-frontend.js
           cp -fr ./app-frontend/src/altinn-app-frontend/dist/altinn-app-frontend.css ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR.$APP_MINOR.$APP_PATCH/altinn-app-frontend.css
-          cd cdn/toolkits/altinn-app-frontend
-          ls -1 | grep --perl-regexp '^[\d\.]+$' | sort --version-sort | jq --raw-input --slurp 'split("\n") | map(select(. != ""))' > index.json
+
+      - name: Copy version (pre-release)
+        working-directory: app-frontend
+        if: "github.event.release.prerelease"
+        run: |
+          cd ..
+          echo Copy Patch
+          mkdir -p ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR.$APP_MINOR.$APP_PATCH
+          cp -fr ./app-frontend/src/altinn-app-frontend/dist/altinn-app-frontend.js ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR.$APP_MINOR.$APP_PATCH/altinn-app-frontend.js
+          cp -fr ./app-frontend/src/altinn-app-frontend/dist/altinn-app-frontend.css ./cdn/toolkits/altinn-app-frontend/$APP_MAJOR.$APP_MINOR.$APP_PATCH/altinn-app-frontend.css
+
+      - name: Copy patch version and commit to CDN
+        working-directory: cdn
+        run: |
+          cd toolkits/altinn-app-frontend
+          ls -1 | grep --perl-regexp '^[\d\.]+(-[a-z]+)?$' | sort --version-sort | jq --raw-input --slurp 'split("\n") | map(select(. != ""))' > index.json
           cd ../..
           git config --global user.email "$AUTHOR_EMAIL"
           git config --global user.name "$AUTHOR_NAME"


### PR DESCRIPTION
## Description
Supporting pull request for an upcoming PR in studio, where a list of released versions would be helpful when building a selector for testing previous versions.

`jq` [should be available in ubuntu-latest](https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md#tools)

## ~~Fixes~~ Supports
- Altinn/altinn-studio/pull/8562

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
