### PR TITLE
chore: add env variable for PAT token so packages from github registry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,22 +16,30 @@ jobs:
         with:
           path: app-frontend
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
+
       - name: install node
         uses: actions/setup-node@v2
         with:
           node-version: '16'
+
       - name: install dependencies
         working-directory: app-frontend/src
+        env:
+          GITHUB_PACKAGES_PAT: ${{ secrets.GITHUB_TOKEN }}
         run: yarn --immutable
+
       - name: run build
         working-directory: app-frontend/src/altinn-app-frontend
         run: yarn build
+
       - name: run eslint
         working-directory: app-frontend/src
         run: yarn lint
+
       - name: run tests
         working-directory: app-frontend/src
         run: yarn test --coverage
+
       - name: SonarCloud Scan
         with:
           projectBaseDir: app-frontend

--- a/.github/workflows/cypress-altinn-app-frontend.yml
+++ b/.github/workflows/cypress-altinn-app-frontend.yml
@@ -38,6 +38,8 @@ jobs:
           node-version: '16'
 
       - name: Install altinn-app-frontend dependencies
+        env:
+          GITHUB_PACKAGES_PAT: ${{ secrets.GITHUB_TOKEN }}
         run: yarn --immutable
         working-directory: src
 
@@ -74,6 +76,8 @@ jobs:
           node-version: '16'
 
       - name: Install altinn-app-frontend dependencies
+        env:
+          GITHUB_PACKAGES_PAT: ${{ secrets.GITHUB_TOKEN }}
         run: yarn --immutable
         working-directory: src
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ jobs:
 
       - name: install dependencies
         working-directory: app-frontend/src
+        env:
+          GITHUB_PACKAGES_PAT: ${{ secrets.GITHUB_TOKEN }}
         run: yarn --immutable
 
       - name: run build

--- a/README.md
+++ b/README.md
@@ -4,10 +4,21 @@ React SPA used by applications developed in [altinn-studio](https://github.com/A
 
 ## Prerequisites
 
+### Node and Corepack
+
 - Latest [Node LTS release](https://nodejs.org/en/)
 - Enable [corepack](https://github.com/nodejs/corepack#default-installs) (execute `corepack enable` from a terminal after installing Node 16.9.0 or later)
 
 This project is using [`yarn`](https://yarnpkg.com/) instead of the default `npm` CLI. This means that you should execute package.json scripts with `yarn` instead of `npm`. F.ex instead of `npm run test` you should execute `yarn run test`. With `yarn`, the `run` keyword is optional, so you can also execute `yarn test`.
+
+### Setup Github PAT Token
+
+We are currently using Github registry to publish packages. This means you need to setup a PAT (Personal Access Token) on your machine.
+
+- Acquire a [GitHub PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token). The only permission you need to grant is read:packages.
+- Assign the PAT to the GITHUB_PACKAGES_PAT environment variable:
+  - Mac/Linux: add the line `export GITHUB_PACKAGES_PAT=<PAT>` to `~/.bash_profile` and restart the terminal
+  - Windows: Execute `setx GITHUB_PACKAGES_PAT <PAT> /m` and restart the terminal
 
 ## Getting Started
 

--- a/src/.yarnrc.yml
+++ b/src/.yarnrc.yml
@@ -1,13 +1,18 @@
 enableMessageNames: false
 
+npmScopes:
+  altinn:
+    npmRegistryServer: https://npm.pkg.github.com
+    npmAuthToken: ${GITHUB_PACKAGES_PAT:-}
+
 enableTelemetry: false
 
 nodeLinker: node-modules
 
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-workspace-tools.cjs
-    spec: "@yarnpkg/plugin-workspace-tools"
+    spec: '@yarnpkg/plugin-workspace-tools'
   - path: .yarn/plugins/@yarnpkg/plugin-interactive-tools.cjs
-    spec: "@yarnpkg/plugin-interactive-tools"
+    spec: '@yarnpkg/plugin-interactive-tools'
 
 yarnPath: .yarn/releases/yarn-3.2.0.cjs


### PR DESCRIPTION
<!-- Thank you for contributing to Altinn:) We know this isn't the fun part, but please make sure you follow our [contributing guidelines](../CONTRIBUTING.md) and put the same effort into the pull request as you did into the code and it should soon find it's way to main. -->

## Description
Add info about need for PAT token, and add this as environment variable for our build scripts

This is needed because we are currently using Github registry to publish our npm packages, and they require a PAT token to read from this registry. This is a prerequisite for using [@altinn/altinn-design-system](https://github.com/Altinn/altinn-design-system) package in this repo