### PR TITLE
bug: avoid mutating redux state

### DIFF
--- a/src/altinn-app-frontend/src/components/base/FileUpload/FileUploadComponent.tsx
+++ b/src/altinn-app-frontend/src/components/base/FileUpload/FileUploadComponent.tsx
@@ -36,38 +36,10 @@ export function FileUploadComponent({
   hasCustomFileEndings,
   textResourceBindings
 }: IFileUploadProps) {
-  const [attachments, dispatch] = React.useReducer(reducer, []);
   const [validations, setValidations] = React.useState([]);
   const [showFileUpload, setShowFileUpload] = React.useState(false);
   const mobileView = useMediaQuery('(max-width:992px)'); // breakpoint on altinn-modal
-
-  function reducer(state, action) {
-    if (action.type === 'replace') {
-      return action.value;
-    }
-
-    if (action.type === 'add') {
-      return state.concat(action.value);
-    }
-
-    if (action.type === 'delete') {
-      const attachmentToDelete = state[action.index];
-      if (!attachmentToDelete.uploaded) {
-        return state;
-      }
-      attachmentToDelete.deleting = true;
-      const newList = state.slice();
-      newList[action.index] = attachmentToDelete;
-      return newList;
-    }
-    return state;
-  }
-
-  const currentAttachments: IAttachment[] = useAppSelector(state => state.attachments.attachments[id] || emptyArray);
-
-  React.useEffect(() => {
-    dispatch({ type: 'replace', value: currentAttachments });
-  }, [currentAttachments]);
+  const attachments: IAttachment[] = useAppSelector(state => state.attachments.attachments[id] || emptyArray);
 
   const getComponentValidations = (): IComponentValidations => {
     const validationMessages = {
@@ -175,7 +147,6 @@ export function FileUploadComponent({
   const handleDeleteFile = (index: number) => {
     const attachmentToDelete = attachments[index];
     const fileType = id; // component id used as filetype identifier for now, see issue #1364
-    dispatch({ type: 'delete', index });
     AttachmentDispatcher.deleteAttachment(
       attachmentToDelete,
       fileType,

--- a/src/altinn-app-frontend/src/components/base/FileUpload/FileUploadComponent.tsx
+++ b/src/altinn-app-frontend/src/components/base/FileUpload/FileUploadComponent.tsx
@@ -23,7 +23,7 @@ export interface IFileUploadProps extends IFileUploadGenericProps {
 export const bytesInOneMB = 1048576;
 export const emptyArray = [];
 
-export function FileUploadComponent({ 
+export function FileUploadComponent({
   id,
   componentValidations,
   readOnly,
@@ -39,7 +39,7 @@ export function FileUploadComponent({
   const [validations, setValidations] = React.useState([]);
   const [showFileUpload, setShowFileUpload] = React.useState(false);
   const mobileView = useMediaQuery('(max-width:992px)'); // breakpoint on altinn-modal
-  const attachments: IAttachment[] = useAppSelector(state => state.attachments.attachments[id] || emptyArray);
+  const attachments = useAppSelector(state => state.attachments.attachments[id] || emptyArray);
 
   const getComponentValidations = (): IComponentValidations => {
     const validationMessages = {
@@ -377,7 +377,7 @@ export function FileUploadComponent({
           hasValidationMessages={hasValidationMessages}
           hasCustomFileEndings={hasCustomFileEndings}
           validFileEndings={validFileEndings}
-          textResourceBindings={textResourceBindings}        
+          textResourceBindings={textResourceBindings}
       />
       )}
 

--- a/src/altinn-app-frontend/src/shared/resources/attachments/attachmentReducer.test.ts
+++ b/src/altinn-app-frontend/src/shared/resources/attachments/attachmentReducer.test.ts
@@ -1,0 +1,69 @@
+import attachmentReducer from './attachmentReducer';
+import type { IAttachmentState } from './attachmentReducer';
+import { DELETE_ATTACHMENT, DELETE_ATTACHMENT_FULFILLED, DELETE_ATTACHMENT_REJECTED } from './attachmentActionTypes';
+import type { IDeleteAttachmentAction, IDeleteAttachmentActionFulfilled, IDeleteAttachmentActionRejected } from './delete/deleteAttachmentActions';
+import { IAttachment } from '.';
+
+describe('attachmentReducer', () => {
+  it('should set deleting to true when DELETE_ATTACHMENT action is received', () => {
+    const state: IAttachmentState = {
+      attachments: {
+        someType: [
+          { id: 'someId', deleting: false, name: 'someName', size: 0, tags: [], uploaded: false, updating: false },
+        ],
+      },
+    };
+    const action: IDeleteAttachmentAction = {
+      type: DELETE_ATTACHMENT,
+      attachment: {
+        id: 'someId',
+        deleting: false,
+      } as IAttachment,
+      attachmentType: 'someType',
+      componentId: 'someComponentId',
+    };
+    const newState = attachmentReducer(state, action);
+    expect(newState.attachments.someType[0].deleting).toBeTruthy();
+  });
+
+  it('should set deleting to false when DELETE_ATTACHMENT_REJECTED action is received', () => {
+    const state: IAttachmentState = {
+      attachments: {
+        someType: [
+          { id: 'someId', deleting: true, name: 'someName', size: 0, tags: [], uploaded: false, updating: false },
+        ],
+      },
+    };;
+    const action: IDeleteAttachmentActionRejected = {
+      type: DELETE_ATTACHMENT_REJECTED,
+      attachment: {
+        id: 'someId',
+        deleting: true,
+      } as IAttachment,
+      attachmentType: 'someType',
+      componentId: 'someComponentId',
+    };
+    const newState = attachmentReducer(state, action);
+    expect(newState.attachments.someType[0].deleting).toBeFalsy();
+  });
+
+  it('should remove the attachment when DELETE_ATTACHMENT_FULFILLED action is received', () => {
+    const state: IAttachmentState = {
+      attachments: {
+        someType: [
+          { id: 'someId', deleting: true, name: 'someName', size: 0, tags: [], uploaded: false, updating: false },
+          { id: 'someOtherId', deleting: true, name: 'someName', size: 0, tags: [], uploaded: false, updating: false },
+        ],
+      },
+    };
+    const action: IDeleteAttachmentActionFulfilled = {
+      type: DELETE_ATTACHMENT_FULFILLED,
+      attachmentId: 'someId',
+      attachmentType: 'someType',
+      componentId: 'someComponentId',
+    };
+    const newState = attachmentReducer(state, action);
+    expect(newState.attachments.someType.length).toEqual(1);
+    expect(newState.attachments.someType[0].id).toEqual('someOtherId');
+  });
+});

--- a/src/altinn-app-frontend/src/shared/resources/attachments/attachmentReducer.ts
+++ b/src/altinn-app-frontend/src/shared/resources/attachments/attachmentReducer.ts
@@ -141,6 +141,23 @@ const attachmentReducer: Reducer<IAttachmentState> = (
       });
     }
 
+    case (AttachmentActionsTypes.DELETE_ATTACHMENT): {
+      const { attachment, attachmentType } =
+        action as deleteActions.IDeleteAttachmentAction;
+      const newAttachment = { ...attachment, deleting: true };
+      const index = state.attachments[attachmentType].findIndex((element) => element.id === attachment.id);
+      if (index < 0) {
+        return state;
+      }
+      return update<IAttachmentState>(state, {
+        attachments: {
+          [attachmentType]: {
+            [index]: { $set: newAttachment },
+          },
+        },
+      });
+    }
+
     case (AttachmentActionsTypes.DELETE_ATTACHMENT_FULFILLED): {
       const { attachmentId: id, attachmentType } = action as deleteActions.IDeleteAttachmentActionFulfilled;
       return update<IAttachmentState>(state, {

--- a/src/altinn-app-frontend/src/shared/resources/textResources/replace/replaceTextResourcesSagas.ts
+++ b/src/altinn-app-frontend/src/shared/resources/textResources/replace/replaceTextResourcesSagas.ts
@@ -12,13 +12,13 @@ import { ITextResourcesState } from '../textResourcesReducer';
 import { REPLACE_TEXT_RESOURCES } from './replaceTextResourcesActionTypes';
 import { buildInstanceContext } from 'altinn-shared/utils/instanceContext';
 
-export const InstanceSelector: (state: IRuntimeState) => IInstance = 
+export const InstanceSelector: (state: IRuntimeState) => IInstance =
   (state) => state.instanceData?.instance;
-export const FormDataSelector: (state: IRuntimeState) => IFormData = 
+export const FormDataSelector: (state: IRuntimeState) => IFormData =
   (state) => state.formData?.formData;
-export const ApplicationSettingsSelector: (state: IRuntimeState) => IApplicationSettings = 
+export const ApplicationSettingsSelector: (state: IRuntimeState) => IApplicationSettings =
   (state) => state.applicationSettings?.applicationSettings;
-export const TextResourcesSelector: (state: IRuntimeState) => ITextResourcesState = 
+export const TextResourcesSelector: (state: IRuntimeState) => ITextResourcesState =
   (state) => state.textResources;
 export const RepeatingGroupsSelector: (state: IRuntimeState) => IRepeatingGroups =
   (state) => state.formLayout.uiConfig.repeatingGroups;
@@ -32,10 +32,10 @@ export function* replaceTextResourcesSaga(): SagaIterator {
     const repeatingGroups: IRepeatingGroups = yield select(RepeatingGroupsSelector);
 
     const instanceContext: IInstanceContext = buildInstanceContext(instance);
-    
-    const dataSources: IDataSources = { 
-      dataModel: formData, 
-      applicationSettings:  applicationSettings, 
+
+    const dataSources: IDataSources = {
+      dataModel: formData,
+      applicationSettings: applicationSettings,
       instanceContext: instanceContext
     };
 

--- a/src/altinn-app-frontend/src/store/index.ts
+++ b/src/altinn-app-frontend/src/store/index.ts
@@ -14,7 +14,7 @@ export const setupStore = (preloadedState?: PreloadedState<RootState>) => {
     middleware: (getDefaultMiddleware) => getDefaultMiddleware({
       // TODO: enable once we have cleaned up our store
       serializableCheck: false,
-      immutableCheck: false,
+      immutableCheck: true,
     }).concat(middlewares),
     preloadedState
   });

--- a/src/shared/src/utils/language.test.ts
+++ b/src/shared/src/utils/language.test.ts
@@ -2,248 +2,235 @@ import 'jest';
 import { ITextResource, IDataSources, IDataSource, IApplicationSettings, IInstanceContext, IAltinnOrg, IAltinnOrgs, IApplication } from '../../src/types';
 import { getAppName, getAppOwner, getParsedLanguageFromText, replaceTextResourceParams } from './language';
 
-describe('>>> src/Altinn.Apps/AppFrontend/react/shared/src/utils/language.ts', () => {
-  let mockTextResources: ITextResource[];
-  let mockDataSources: IDataSources;
-  let mockDataSource: IDataSource;
-  let mockApplicationSettings: IApplicationSettings;
-  let mockInstanceContext: IInstanceContext;
-  let adjectiveValue: string;
-  let colorValue: string;
-  let animal0Value: string;
-  let animal1Value: string;
-  let homeBaseUrl: string;
-  let instanceOwnerPartyId: string;
+describe('language.ts', () => {
+  const adjectiveValue = 'awesome';
+  const colorValue = 'yellow';
+  const animal0Value = 'dog';
+  const animal1Value = 'cat';
+  const homeBaseUrl = 'https://www.testdirektoratet.no';
+  const instanceOwnerPartyId = '234323';
+  const mockDataSource: IDataSource = {
+    'model.text.adjective': adjectiveValue,
+    'model.text.color': colorValue,
+    'model.group[0].animal': animal0Value,
+    'model.group[1].animal': animal1Value,
+  };
+  const mockApplicationSettings: IApplicationSettings = {
+    'homeBaseUrl': homeBaseUrl,
+  };
+  const mockInstanceContext = {
+    instanceOwnerPartyId: instanceOwnerPartyId,
+  } as IInstanceContext;
+  const mockDataSources: IDataSources = {
+    dataModel: mockDataSource,
+    applicationSettings: mockApplicationSettings,
+    instanceContext: mockInstanceContext,
+  };
 
-  beforeEach(() => {
-    adjectiveValue = 'awesome';
-    colorValue = 'yellow';
-    animal0Value = 'dog';
-    animal1Value = 'cat';
-    homeBaseUrl = 'https://www.testdirektoratet.no';
-    instanceOwnerPartyId = '234323';
-    mockDataSource = {
-      'model.text.adjective': adjectiveValue,
-      'model.text.color': colorValue,
-      'model.group[0].animal': animal0Value,
-      'model.group[1].animal': animal1Value,
-    };
-    mockApplicationSettings = {
-      'homeBaseUrl': homeBaseUrl,
-    };
-    mockInstanceContext = {
-      instanceOwnerPartyId: instanceOwnerPartyId,
-    } as IInstanceContext;
-    mockDataSources = {
-      dataModel: mockDataSource,
-      applicationSettings: mockApplicationSettings,
-      instanceContext: mockInstanceContext,
-    };
-    mockTextResources = [];
-  });
+  describe('replaceTextResourceParams', () => {
+    it('should replace parameter for unparsed value', () => {
+      const mockTextResources: ITextResource[] = [
+        {
+          id: 'mockId1', value: 'This is an {0} text.', unparsedValue: 'This is an {0} text.', variables: [{ key: 'model.text.adjective', dataSource: 'dataModel.test' }],
+        },
+      ];
+      const replacedResources = replaceTextResourceParams(mockTextResources, mockDataSources);
+      const textResource = replacedResources.find((resource: ITextResource) => resource.id === 'mockId1');
+      expect(textResource.value).toEqual(`This is an ${adjectiveValue} text.`);
+    });
 
-  it('should replace parameter for unparsed value', () => {
-    mockTextResources = [
-      {
-        id: 'mockId1', value: 'This is an {0} text.', unparsedValue: 'This is an {0} text.', variables: [{ key: 'model.text.adjective', dataSource: 'dataModel.test' }],
-      },
-    ];
-    replaceTextResourceParams(mockTextResources, mockDataSources);
-    const textResource = mockTextResources.find((resource: ITextResource) => resource.id === 'mockId1');
-    expect(textResource.value).toEqual(`This is an ${adjectiveValue} text.`);
-  });
+    it('should replace multiple parameters', () => {
+      const mockTextResources: ITextResource[] = [
+        {
+          id: 'mockId1',
+          value: 'This is an {0} text, {1}.',
+          unparsedValue: 'This is an {0} text, {1}.',
+          variables: [
+            { key: 'model.text.adjective', dataSource: 'dataModel.test' },
+            { key: 'model.text.color', dataSource: 'dataModel.test' },
+          ],
+        },
+      ];
 
-  it('should replace multiple parameters', () => {
-    mockTextResources = [
-      {
-        id: 'mockId1',
-        value: 'This is an {0} text, {1}.',
-        unparsedValue: 'This is an {0} text, {1}.',
-        variables: [
-          { key: 'model.text.adjective', dataSource: 'dataModel.test' },
-          { key: 'model.text.color', dataSource: 'dataModel.test' },
-        ],
-      },
-    ];
+      const replacedResources = replaceTextResourceParams(mockTextResources, mockDataSources);
+      const textResource = replacedResources.find((resource) => resource.id === 'mockId1');
+      expect(textResource.value).toEqual(`This is an ${adjectiveValue} text, ${colorValue}.`);
+    });
 
-    replaceTextResourceParams(mockTextResources, mockDataSources);
-    const textResource = mockTextResources.find((resource) => resource.id === 'mockId1');
-    expect(textResource.value).toEqual(`This is an ${adjectiveValue} text, ${colorValue}.`);
-  });
+    it('should replace parameter for previously parsed value', () => {
+      const mockTextResources: ITextResource[] = [
+        {
+          id: 'mockId',
+          value: 'This is a green apple.',
+          unparsedValue: 'This is a {0} apple.',
+          variables: [
+            { key: 'model.text.color', dataSource: 'dataModel.test' }
+          ],
+        },
+      ];
+      const replacedResources = replaceTextResourceParams(mockTextResources, mockDataSources);
+      const textResource = replacedResources.find((resource: ITextResource) => resource.id === 'mockId');
+      expect(textResource.value).toEqual(`This is a ${colorValue} apple.`);
+    });
 
-  it('should replace parameter for previously parsed value', () => {
-    mockTextResources = [
-      {
-        id: 'mockId',
-        value: 'This is a green apple.',
-        unparsedValue: 'This is a {0} apple.',
-        variables: [
-          { key: 'model.text.color', dataSource: 'dataModel.test' }
-        ],
-      },
-    ];
-    replaceTextResourceParams(mockTextResources, mockDataSources);
-    const textResource = mockTextResources.find((resource: ITextResource) => resource.id === 'mockId');
-    expect(textResource.value).toEqual(`This is a ${colorValue} apple.`);
-  });
+    it('should replace parameter with text key', () => {
+      const mockTextResources: ITextResource[] = [
+        {
+          id: 'mockId',
+          value: 'This is a text with a missing param: {0}.',
+          unparsedValue: 'This is a text with a missing param: {0}.',
+          variables: [
+            { key: 'model.text.param', dataSource: 'dataModel.test' }
+          ],
+        },
+      ];
+      const replacedResources = replaceTextResourceParams(mockTextResources, mockDataSources);
+      const textResource = replacedResources.find((resource: ITextResource) => resource.id === 'mockId');
+      expect(textResource.value).toEqual('This is a text with a missing param: model.text.param.');
+    });
 
-  it('should replace parameter with text key', () => {
-    mockTextResources = [
-      {
-        id: 'mockId',
-        value: 'This is a text with a missing param: {0}.',
-        unparsedValue: 'This is a text with a missing param: {0}.',
-        variables: [
-          { key: 'model.text.param', dataSource: 'dataModel.test' }
-        ],
-      },
-    ];
-    replaceTextResourceParams(mockTextResources, mockDataSources);
-    const textResource = mockTextResources.find((resource: ITextResource) => resource.id === 'mockId');
-    expect(textResource.value).toEqual('This is a text with a missing param: model.text.param.');
-  });
+    it('should not replace the texts from invalid source', () => {
+      const mockTextResources: ITextResource[] = [
+        {
+          id: 'mockId',
+          value: 'This: {0} depends on an invalid source.',
+          unparsedValue: 'This: {0} depends on an invalid source.',
+          variables: [
+            { key: 'model.text.adjective', dataSource: 'api.invalidSource' }
+          ],
+        },
+      ];
+      const replacedResources = replaceTextResourceParams(mockTextResources, mockDataSources);
+      const textResource = replacedResources.find((resource: ITextResource) => resource.id === 'mockId');
+      expect(textResource.value).toEqual('This: {0} depends on an invalid source.');
+    });
 
-  it('should not replace the texts from invalid source', () => {
-    mockTextResources = [
-      {
-        id: 'mockId',
-        value: 'This: {0} depends on an invalid source.',
-        unparsedValue: 'This: {0} depends on an invalid source.',
-        variables: [
-          { key: 'model.text.adjective', dataSource: 'api.invalidSource' }
-        ],
-      },
-    ];
-    replaceTextResourceParams(mockTextResources, mockDataSources);
-    const textResource = mockTextResources.find((resource: ITextResource) => resource.id === 'mockId');
-    expect(textResource.value).toEqual('This: {0} depends on an invalid source.');
-  });
+    it('should not replace texts when no variable is defined', () => {
+      const mockTextResources: ITextResource[] = [
+        {
+          id: 'mockId',
+          value: 'mock value',
+          unparsedValue: 'mock value',
+          variables: undefined,
+        },
+      ];
+      const replacedResources = replaceTextResourceParams(mockTextResources, mockDataSources);
+      const textResource = replacedResources.find((resource: ITextResource) => resource.id === 'mockId');
+      expect(textResource.value).toEqual('mock value');
+    });
 
-  it('should not replace texts when no variable is defined', () => {
-    mockTextResources = [
-      {
-        id: 'mockId',
-        value: 'mock value',
-        unparsedValue: 'mock value',
-        variables: undefined,
-      },
-    ];
-    replaceTextResourceParams(mockTextResources, mockDataSources);
-    const textResource = mockTextResources.find((resource: ITextResource) => resource.id === 'mockId');
-    expect(textResource.value).toEqual('mock value');
-  });
+    it('should replace texts for repeating groups', () => {
+      const mockTextResources: ITextResource[] = [
+        {
+          id: 'mockId',
+          value: 'Hello, {0}!',
+          unparsedValue: 'Hello, {0}!',
+          variables: [
+            {
+              key: 'model.group[{0}].animal',
+              dataSource: 'dataModel.mockDataDource',
+            },
+          ],
+        },
+      ];
+      const mockRepeatingGroups = {
+        group1: {
+          index: 1,
+          dataModelBinding: 'model.group',
+        },
+      };
+      const replacedResources = replaceTextResourceParams(mockTextResources, mockDataSources, mockRepeatingGroups);
+      let textResource = replacedResources.find((resource) => resource.id === 'mockId-0');
+      expect(textResource.value).toEqual(`Hello, ${animal0Value}!`);
+      textResource = replacedResources.find((resource) => resource.id === 'mockId-1');
+      expect(textResource.value).toEqual(`Hello, ${animal1Value}!`);
+    });
 
-  it('should replace texts for repeating groups', () => {
-    mockTextResources = [
-      {
-        id: 'mockId',
-        value: 'Hello, {0}!',
-        unparsedValue: 'Hello, {0}!',
-        variables: [
-          {
-            key: 'model.group[{0}].animal',
-            dataSource: 'dataModel.mockDataDource',
-          },
-        ],
-      },
-    ];
-    const mockRepeatingGroups = {
-      group1: {
-        index: 1,
-        dataModelBinding: 'model.group',
-      },
-    };
-    replaceTextResourceParams(mockTextResources, mockDataSources, mockRepeatingGroups);
-    let textResource = mockTextResources.find((resource) => resource.id === 'mockId-0');
-    expect(textResource.value).toEqual(`Hello, ${animal0Value}!`);
-    textResource = mockTextResources.find((resource) => resource.id === 'mockId-1');
-    expect(textResource.value).toEqual(`Hello, ${animal1Value}!`);
-  });
+    it('should replace multiple references to same value', () => {
+      const mockTextResources: ITextResource[] = [
+        {
+          id: 'mockId',
+          value: 'This is a {0} apple. It will always be {0}. Yes, {0} is my favorite color.',
+          unparsedValue: 'This is a {0} apple. It will always be {0}. Yes, {0} is my favorite color.',
+          variables: [
+            { key: 'model.text.color', dataSource: 'dataModel.test' },
+          ],
+        },
+      ];
+      const replacedResources = replaceTextResourceParams(mockTextResources, mockDataSources);
+      const textResource = replacedResources.find((resource: ITextResource) => resource.id === 'mockId');
+      expect(textResource.value).toEqual(`This is a ${colorValue} apple. It will always be ${colorValue}. Yes, ${colorValue} is my favorite color.`);
+    });
 
-  it('should replace multiple references to same value', () => {
-    mockTextResources = [
-      {
-        id: 'mockId',
-        value: 'This is a {0} apple. It will always be {0}. Yes, {0} is my favorite color.',
-        unparsedValue: 'This is a {0} apple. It will always be {0}. Yes, {0} is my favorite color.',
-        variables: [
-          { key: 'model.text.color', dataSource: 'dataModel.test' },
-        ],
-      },
-    ];
-    replaceTextResourceParams(mockTextResources, mockDataSources);
-    const textResource = mockTextResources.find((resource: ITextResource) => resource.id === 'mockId');
-    expect(textResource.value).toEqual(`This is a ${colorValue} apple. It will always be ${colorValue}. Yes, ${colorValue} is my favorite color.`);
-  });
+    it('should replace text based on appsettings', () => {
+      const mockTextResources: ITextResource[] = [
+        {
+          id: 'mockId',
+          value: 'This is a [link]({0}).',
+          unparsedValue: 'This is a [link]({0}).',
+          variables: [
+            { key: 'homeBaseUrl', dataSource: 'applicationSettings' },
+          ],
+        },
+      ];
+      const replacedResources = replaceTextResourceParams(mockTextResources, mockDataSources);
+      const textResource = replacedResources.find((resource: ITextResource) => resource.id === 'mockId');
+      expect(textResource.value).toEqual(`This is a [link](${homeBaseUrl}).`);
+    });
 
-  it('should replace text based on appsettings', () => {
-    mockTextResources = [
-      {
-        id: 'mockId',
-        value: 'This is a [link]({0}).',
-        unparsedValue: 'This is a [link]({0}).',
-        variables: [
-          { key: 'homeBaseUrl', dataSource: 'applicationSettings' },
-        ],
-      },
-    ];
-    replaceTextResourceParams(mockTextResources, mockDataSources);
-    const textResource = mockTextResources.find((resource: ITextResource) => resource.id === 'mockId');
-    expect(textResource.value).toEqual(`This is a [link](${homeBaseUrl}).`);
-  });
+    it('should replace text with key when appsettings value is missing', () => {
+      const mockTextResources: ITextResource[] = [
+        {
+          id: 'mockId',
+          value: 'This is a [link]({0}).',
+          unparsedValue: 'This is a [link]({0}).',
+          variables: [
+            { key: 'doesnotexists', dataSource: 'applicationSettings' },
+          ],
+        },
+      ];
+      const replacedResources = replaceTextResourceParams(mockTextResources, mockDataSources);
+      const textResource = replacedResources.find((resource: ITextResource) => resource.id === 'mockId');
+      expect(textResource.value).toEqual(`This is a [link](doesnotexists).`);
+    });
 
-  it('should replace text with key when appsettings value is missing', () => {
-    mockTextResources = [
-      {
-        id: 'mockId',
-        value: 'This is a [link]({0}).',
-        unparsedValue: 'This is a [link]({0}).',
-        variables: [
-          { key: 'doesnotexists', dataSource: 'applicationSettings' },
-        ],
-      },
-    ];
-    replaceTextResourceParams(mockTextResources, mockDataSources);
-    const textResource = mockTextResources.find((resource: ITextResource) => resource.id === 'mockId');
-    expect(textResource.value).toEqual(`This is a [link](doesnotexists).`);
-  });
+    it('should replace text from instance context', () => {
+      const mockTextResources: ITextResource[] = [
+        {
+          id: 'mockId',
+          value: 'The instance owner party id is {0}',
+          unparsedValue: 'The instance owner party id is {0}',
+          variables: [
+            { key: 'instanceOwnerPartyId', dataSource: 'instanceContext' },
+          ],
+        },
+      ];
+      const replacedResources = replaceTextResourceParams(mockTextResources, mockDataSources);
+      const textResource = replacedResources.find((resource: ITextResource) => resource.id === 'mockId');
+      expect(textResource.value).toEqual(`The instance owner party id is ${instanceOwnerPartyId}`);
+    });
 
-  it('should replace text from instance context', () => {
-    mockTextResources = [
-      {
-        id: 'mockId',
-        value: 'The instance owner party id is {0}',
-        unparsedValue: 'The instance owner party id is {0}',
-        variables: [
-          { key: 'instanceOwnerPartyId', dataSource: 'instanceContext' },
-        ],
-      },
-    ];
-    replaceTextResourceParams(mockTextResources, mockDataSources);
-    const textResource = mockTextResources.find((resource: ITextResource) => resource.id === 'mockId');
-    expect(textResource.value).toEqual(`The instance owner party id is ${instanceOwnerPartyId}`);
-  });
-
-  it('should replace text in a reapeating group based on appsettings', () => {
-    mockTextResources = [
-      {
-        id: 'mockId',
-        value: 'This is a [link]({0}).',
-        unparsedValue: 'This is a [link]({0}).',
-        variables: [
-          { key: 'homeBaseUrl', dataSource: 'applicationSettings' },
-        ],
-      },
-    ];
-    const mockRepeatingGroups = {
-      group1: {
-        index: 1,
-        dataModelBinding: 'model.group',
-      },
-    };
-    replaceTextResourceParams(mockTextResources, mockDataSources, mockRepeatingGroups);
-    const textResource = mockTextResources.find((resource: ITextResource) => resource.id === 'mockId');
-    expect(textResource.value).toEqual(`This is a [link](${homeBaseUrl}).`);
+    it('should replace text in a reapeating group based on appsettings', () => {
+      const mockTextResources: ITextResource[] = [
+        {
+          id: 'mockId',
+          value: 'This is a [link]({0}).',
+          unparsedValue: 'This is a [link]({0}).',
+          variables: [
+            { key: 'homeBaseUrl', dataSource: 'applicationSettings' },
+          ],
+        },
+      ];
+      const mockRepeatingGroups = {
+        group1: {
+          index: 1,
+          dataModelBinding: 'model.group',
+        },
+      };
+      const replacedResources = replaceTextResourceParams(mockTextResources, mockDataSources, mockRepeatingGroups);
+      const textResource = replacedResources.find((resource: ITextResource) => resource.id === 'mockId');
+      expect(textResource.value).toEqual(`This is a [link](${homeBaseUrl}).`);
+    });
   });
 
   describe('getParsedLanguageFromText', () => {
@@ -260,14 +247,14 @@ describe('>>> src/Altinn.Apps/AppFrontend/react/shared/src/utils/language.ts', (
 
   describe('getAppName', () => {
     it('should return app name if defined by appName key', () => {
-        const textResources: ITextResource[] = [{
-          value: 'SomeAppName',
-          id: 'appName',
-        }];
+      const textResources: ITextResource[] = [{
+        value: 'SomeAppName',
+        id: 'appName',
+      }];
 
-        const result = getAppName(textResources, {} as IApplication, 'nb');
-        const expectedResult = 'SomeAppName';
-        expect(result).toEqual(expectedResult);
+      const result = getAppName(textResources, {} as IApplication, 'nb');
+      const expectedResult = 'SomeAppName';
+      expect(result).toEqual(expectedResult);
     });
 
     it('should return app name if defined by ServiceName key', () => {

--- a/src/shared/src/utils/language.ts
+++ b/src/shared/src/utils/language.ts
@@ -89,7 +89,7 @@ export function getTextResourceByKey(key: string, textResources: ITextResource[]
  * @param textResources the original text resources
  * @param dataSources the data sources
  * @param repeatingGroups the repeating groups
- * @returns a new array with replace values.
+ * @returns a new array with replaced values.
  */
 export function replaceTextResourceParams(
   textResources: ITextResource[],
@@ -156,7 +156,7 @@ export function replaceTextResourceParams(
     }
     return textResourceCopy;
   });
-  
+
   return mappedResources.concat(repeatingGroupResources);
 }
 

--- a/src/shared/src/utils/language.ts
+++ b/src/shared/src/utils/language.ts
@@ -84,69 +84,80 @@ export function getTextResourceByKey(key: string, textResources: ITextResource[]
   return textResource ? textResource.value : key;
 }
 
+/**
+ * Replaces all variables in text resources with values from relevant source.
+ * @param textResources the original text resources
+ * @param dataSources the data sources
+ * @param repeatingGroups the repeating groups
+ * @returns a new array with replace values.
+ */
 export function replaceTextResourceParams(
   textResources: ITextResource[],
   dataSources: IDataSources,
   repeatingGroups?: any,
 ): ITextResource[] {
-  let replaceValues: string[];
-  const resourcesWithVariables = textResources?.filter((resource) => resource.variables);
-  resourcesWithVariables?.forEach((resource) => {
-    const variableForRepeatingGroup = resource.variables.find((variable) => variable.key.indexOf('[{0}]') > -1);
-    if (repeatingGroups && variableForRepeatingGroup) {
-      const repeatingGroupId = Object.keys(repeatingGroups).find((groupId) => {
-        const id = variableForRepeatingGroup.key.split('[{0}]')[0];
-        return repeatingGroups[groupId].dataModelBinding === id;
-      });
-      const repeatingGroupIndex = repeatingGroups[repeatingGroupId]?.index;
+  const repeatingGroupResources: ITextResource[] = [];
+  const mappedResources = textResources.map((textResource: ITextResource) => {
+    const textResourceCopy = { ...textResource };
+    if (textResourceCopy.variables) {
+      const variableForRepeatingGroup = textResourceCopy.variables.find((variable) => variable.key.indexOf('[{0}]') > -1);
+      if (repeatingGroups && variableForRepeatingGroup) {
+        const repeatingGroupId = Object.keys(repeatingGroups).find((groupId) => {
+          const id = variableForRepeatingGroup.key.split('[{0}]')[0];
+          return repeatingGroups[groupId].dataModelBinding === id;
+        });
+        const repeatingGroupIndex = repeatingGroups[repeatingGroupId]?.index;
 
-      for (let i = 0; i <= repeatingGroupIndex; ++i) {
-        replaceValues = [];
-        resource.variables.forEach((variable) => {
-          if (variable.dataSource.startsWith('dataModel')) {
-            if (variable.key.indexOf('[{0}]') > -1) {
-              const keyWithIndex = variable.key.replace('{0}', `${i}`);
-              replaceValues.push(dataSources.dataModel[keyWithIndex] || '');
-            } else {
-              replaceValues.push(dataSources.dataModel[variable.key] || '');
+        for (let i = 0; i <= repeatingGroupIndex; ++i) {
+          const replaceValues: string[] = [];
+          textResourceCopy.variables.forEach((variable) => {
+            if (variable.dataSource.startsWith('dataModel')) {
+              if (variable.key.indexOf('[{0}]') > -1) {
+                const keyWithIndex = variable.key.replace('{0}', `${i}`);
+                replaceValues.push(dataSources.dataModel[keyWithIndex] || '');
+              } else {
+                replaceValues.push(dataSources.dataModel[variable.key] || '');
+              }
             }
+          });
+          const newValue = replaceParameters(textResourceCopy.unparsedValue, replaceValues);
+
+          if (textResourceCopy.repeating && textResourceCopy.id.endsWith(`-${i}`)) {
+            textResourceCopy.value = newValue;
+          } else if (!textResourceCopy.repeating && textResources.findIndex((r) => r.id === `${textResourceCopy.id}-${i}`) === -1) {
+            const newId = `${textResourceCopy.id}-${i}`;
+            repeatingGroupResources.push({
+              ...textResourceCopy,
+              id: newId,
+              value: newValue,
+              repeating: true,
+            });
+          }
+        }
+      } else {
+        const replaceValues: string[] = [];
+        textResourceCopy.variables.forEach((variable) => {
+          if (variable.dataSource.startsWith('dataModel')) {
+            replaceValues.push(dataSources.dataModel[variable.key] || variable.key);
+          }
+          else if (variable.dataSource === 'applicationSettings') {
+            replaceValues.push(dataSources.applicationSettings[variable.key] || variable.key);
+          }
+          else if (variable.dataSource === 'instanceContext') {
+            replaceValues.push(dataSources.instanceContext[variable.key] || variable.key);
           }
         });
-        const newValue = replaceParameters(resource.unparsedValue, replaceValues);
 
-        if (resource.repeating && resource.id.endsWith(`-${i}`)) {
-          resource.value = newValue;
-        } else if (!resource.repeating && textResources.findIndex((r) => r.id === `${resource.id}-${i}`) === -1) {
-          const newId = `${resource.id}-${i}`;
-          textResources.push({
-            ...resource,
-            id: newId,
-            value: newValue,
-            repeating: true,
-          });
+        const newValue = replaceParameters(textResourceCopy.unparsedValue, replaceValues);
+        if (textResourceCopy.value !== newValue) {
+          textResourceCopy.value = newValue;
         }
-      }
-    } else {
-      replaceValues = [];
-      resource.variables.forEach((variable) => {
-        if (variable.dataSource.startsWith('dataModel')) {
-          replaceValues.push(dataSources.dataModel[variable.key] || variable.key);
-        }
-        else if (variable.dataSource === 'applicationSettings') {
-          replaceValues.push(dataSources.applicationSettings[variable.key] || variable.key);
-        }
-        else if (variable.dataSource === 'instanceContext') {
-          replaceValues.push(dataSources.instanceContext[variable.key] || variable.key);
-        }
-      });
-
-      const newValue = replaceParameters(resource.unparsedValue, replaceValues);
-      if (resource.value !== newValue) {
-        resource.value = newValue;
       }
     }
+    return textResourceCopy;
   });
-  return textResources;
+  
+  return mappedResources.concat(repeatingGroupResources);
 }
 
 export function getAppOwner(
@@ -154,7 +165,7 @@ export function getAppOwner(
   orgs: IAltinnOrgs,
   org: string,
   userLanguage: string,
-  ) {
+) {
 
   const appOwner = getTextResourceByKey('appOwner', textResources);
   if (appOwner !== 'appOwner') {
@@ -176,20 +187,20 @@ export function getAppName(
   textResources: ITextResource[],
   applicationMetadata: IApplication,
   userLanguage: string
-  ) {
-    let appName = getTextResourceByKey(appNameKey, textResources);
-    if (appName === appNameKey) {
-      appName = getTextResourceByKey(oldAppNameKey, textResources);
-    }
+) {
+  let appName = getTextResourceByKey(appNameKey, textResources);
+  if (appName === appNameKey) {
+    appName = getTextResourceByKey(oldAppNameKey, textResources);
+  }
 
-    if (appName !== appNameKey && appName !== oldAppNameKey) {
-      return appName;
-    }
+  if (appName !== appNameKey && appName !== oldAppNameKey) {
+    return appName;
+  }
 
-    // if no text resource key is set, fetch from app metadata
-    if (applicationMetadata) {
-        return applicationMetadata.title[userLanguage] || applicationMetadata.title.nb;
-    }
+  // if no text resource key is set, fetch from app metadata
+  if (applicationMetadata) {
+    return applicationMetadata.title[userLanguage] || applicationMetadata.title.nb;
+  }
 
-    return undefined;
+  return undefined;
 }


### PR DESCRIPTION
## Description
- avoid mutating text resources in our redux store (just a pure copy existing logic but create new object instead of mutation)
  - cleanup of tests
- avoid mutating file upload state, removed duplicated local + global reducer as this caused issues
  - added tests for touched parts of code 
- enabled immutability check for our redux store to avoid such errors again

## Fixes
- Partially solves #159, where we get rid of logic that mutates text resource array which caused problems for #https://github.com/Altinn/app-frontend-react/pull/83, and might have caused other bugs elsewhere.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
