### PR TITLE
Make labelGrid work for radio buttons.

### DIFF
--- a/src/altinn-app-frontend/src/components/GenericComponent.tsx
+++ b/src/altinn-app-frontend/src/components/GenericComponent.tsx
@@ -56,40 +56,40 @@ const useStyles = makeStyles((theme) => ({
   },
   xs: {
     'border-bottom': '1px dashed #949494',
-    '& > div:nth-child(2)':{
-      paddingLeft: theme.spacing(3/2) // Half the spacing of <Grid in <Form
-    }
+    '& .innerGrid': {
+      paddingLeft: theme.spacing(3 / 2), // Half the spacing of <Grid in <Form
+    },
   },
   sm: {
     [theme.breakpoints.up('sm')]: {
       'border-bottom': '1px dashed #949494',
-      '& > div:nth-child(2)':{
-        paddingLeft: theme.spacing(3/2)
-      }
+      '& .innerGrid': {
+        paddingLeft: theme.spacing(3 / 2),
+      },
     },
   },
   md: {
     [theme.breakpoints.up('md')]: {
       'border-bottom': '1px dashed #949494',
-      '& > div:nth-child(2)':{
-        paddingLeft: theme.spacing(3/2)
-      }
+      '& .innerGrid': {
+        paddingLeft: theme.spacing(3 / 2),
+      },
     },
   },
   lg: {
     [theme.breakpoints.up('lg')]: {
       'border-bottom': '1px dashed #949494',
-      '& > div:nth-child(2)':{
-        paddingLeft: theme.spacing(3/2)
-      }
+      '& .innerGrid': {
+        paddingLeft: theme.spacing(3 / 2),
+      },
     },
   },
   xl: {
     [theme.breakpoints.up('xl')]: {
       'border-bottom': '1px dashed #949494',
-      '& > div:nth-child(2)':{
-        paddingLeft: theme.spacing(3/2)
-      }
+      '& .innerGrid': {
+        paddingLeft: theme.spacing(3 / 2),
+      },
     },
   },
 }));
@@ -304,6 +304,46 @@ export function GenericComponent(props: IGenericComponentProps) {
     'NavigationBar',
   ];
 
+  let component = (
+    <>
+      <RenderComponent.Tag {...componentProps} />
+
+      {componentValidationsHandledByGenericComponent(
+        props.dataModelBindings,
+        props.type,
+      ) &&
+        hasValidationMessages &&
+        renderValidationMessagesForComponent(
+          componentValidations?.simpleBinding,
+          props.id,
+        )}
+    </>
+  );
+
+  if (!noLabelComponents.includes(props.type)) {
+    component = (
+      <>
+        <Grid item={true} {...gridToProps(props.grid?.labelGrid)}>
+          <RenderLabelScoped
+            props={props}
+            passThroughProps={passThroughProps}
+            language={language}
+            texts={texts}
+          />
+          <RenderDescription key={`description-${props.id}`} />
+        </Grid>
+        <Grid
+          item={true}
+          className="innerGrid"
+          id={`form-content-${id}`}
+          {...gridToProps(props.grid?.innerGrid)}
+        >
+          {component}
+        </Grid>
+      </>
+    );
+  }
+
   return (
     <Grid
       item={true}
@@ -322,46 +362,7 @@ export function GenericComponent(props: IGenericComponentProps) {
       )}
       alignItems='baseline'
     >
-      {!noLabelComponents.includes(props.type) && (
-        <Grid
-          item={true}
-          xs={props.grid?.labelGrid?.xs || 12}
-          sm={props.grid?.labelGrid?.sm || false}
-          md={props.grid?.labelGrid?.md || false}
-          lg={props.grid?.labelGrid?.lg || false}
-          xl={props.grid?.labelGrid?.xl || false}
-        >
-          <RenderLabelScoped
-            props={props}
-            passThroughProps={passThroughProps}
-            language={language}
-            texts={texts}
-          />
-          <RenderDescription key={`description-${props.id}`} />
-        </Grid>
-      )}
-      <Grid
-        key={`form-content-${props.id}`}
-        item={true}
-        id={`form-content-${props.id}`}
-        xs={props.grid?.innerGrid?.xs || 12}
-        sm={props.grid?.innerGrid?.sm || false}
-        md={props.grid?.innerGrid?.md || false}
-        lg={props.grid?.innerGrid?.lg || false}
-        xl={props.grid?.innerGrid?.xl || false}
-      >
-        <RenderComponent.Tag {...componentProps} />
-
-        {componentValidationsHandledByGenericComponent(
-          props.dataModelBindings,
-          props.type,
-        ) &&
-          hasValidationMessages &&
-          renderValidationMessagesForComponent(
-            componentValidations?.simpleBinding,
-            props.id,
-          )}
-      </Grid>
+      {component}
     </Grid>
   );
 }
@@ -385,6 +386,14 @@ const RenderLabelScoped = (props: IRenderLabelProps) => {
     />
   );
 };
+
+export const gridToProps = (gridStyling: IGridStyling) => ({
+  xs: gridStyling?.xs || 12,
+  sm: gridStyling?.sm || false,
+  md: gridStyling?.md || false,
+  lg: gridStyling?.lg || false,
+  xl: gridStyling?.xl || false,
+});
 
 const gridToHiddenProps = (
   labelGrid: IGridStyling,

--- a/src/altinn-app-frontend/src/components/base/RadioButtonsContainerComponent.tsx
+++ b/src/altinn-app-frontend/src/components/base/RadioButtonsContainerComponent.tsx
@@ -4,7 +4,7 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Radio, { RadioProps } from '@material-ui/core/Radio';
 import RadioGroup from '@material-ui/core/RadioGroup';
 import { makeStyles } from '@material-ui/core/styles';
-import { FormLabel } from '@material-ui/core';
+import { FormLabel, Grid } from '@material-ui/core';
 import cn from 'classnames';
 
 import { renderValidationMessagesForComponent } from '../../utils/render';
@@ -16,6 +16,7 @@ import { getOptionLookupKey } from 'src/utils/options';
 import { AltinnSpinner } from 'altinn-shared/components';
 import { shouldUseRowLayout } from 'src/utils/layout';
 import { useGetOptions } from '../hooks';
+import { gridToProps } from '../GenericComponent';
 
 export interface IRadioButtonsContainerProps extends IComponentProps {
   validationMessages?: any;
@@ -87,6 +88,7 @@ export const RadioButtonContainerComponent = ({
   layout,
   legend,
   title,
+  grid,
   shouldFocus,
   getTextResource,
   validationMessages,
@@ -142,47 +144,52 @@ export const RadioButtonContainerComponent = ({
   const RenderLegend = legend;
 
   return (
-    <FormControl component='fieldset'>
-      <FormLabel component='legend' classes={{ root: cn(classes.legend) }}>
-        <RenderLegend />
-      </FormLabel>
-      {fetchingOptions ? (
-        <AltinnSpinner />
-      ) : (
-        <RadioGroup
-          aria-label={title}
-          name={title}
-          value={selected}
-          onBlur={handleBlur}
-          onChange={handleChange}
-          row={shouldUseRowLayout({
-            layout,
-            optionsCount: calculatedOptions.length,
-          })}
-          id={id}
-        >
-          {calculatedOptions.map((option: any, index: number) => (
-            <React.Fragment key={index}>
-              <FormControlLabel
-                control={
-                  <StyledRadio
-                    autoFocus={shouldFocus && selected === option.value}
-                  />
-                }
-                label={getTextResource(option.label)}
-                value={option.value}
-                classes={{ root: cn(classes.margin) }}
-              />
-              {validationMessages &&
-                selected === option.value &&
-                renderValidationMessagesForComponent(
-                  validationMessages.simpleBinding,
-                  id,
-                )}
-            </React.Fragment>
-          ))}
-        </RadioGroup>
-      )}
+    <FormControl component='fieldset' style={{ display: 'contents' }}>
+      <Grid item={true} {...gridToProps(grid?.labelGrid)}>
+        <FormLabel component='legend' classes={{ root: cn(classes.legend) }}>
+          <RenderLegend />
+        </FormLabel>
+      </Grid>
+
+      <Grid item={true} className="innerGrid" {...gridToProps(grid?.innerGrid)}>
+        {fetchingOptions ? (
+          <AltinnSpinner />
+        ) : (
+          <RadioGroup
+            aria-label={title}
+            name={title}
+            value={selected}
+            onBlur={handleBlur}
+            onChange={handleChange}
+            row={shouldUseRowLayout({
+              layout,
+              optionsCount: calculatedOptions.length,
+            })}
+            id={id}
+          >
+            {calculatedOptions.map((option: any, index: number) => (
+              <React.Fragment key={index}>
+                <FormControlLabel
+                  control={
+                    <StyledRadio
+                      autoFocus={shouldFocus && selected === option.value}
+                    />
+                  }
+                  label={getTextResource(option.label)}
+                  value={option.value}
+                  classes={{ root: cn(classes.margin) }}
+                />
+                {validationMessages &&
+                  selected === option.value &&
+                  renderValidationMessagesForComponent(
+                    validationMessages.simpleBinding,
+                    id,
+                  )}
+              </React.Fragment>
+            ))}
+          </RadioGroup>
+        )}
+      </Grid>
     </FormControl>
   );
 };


### PR DESCRIPTION
Some schemas with many questions, benefit from having the answers on the right side and label on the left. I implemented this in https://github.com/Altinn/altinn-studio/pull/7027, ([docs](https://docs.altinn.studio/app/development/ux/styling/#innergrid-og-labelgrid)), but just found out that it did not work for `RadioButtons` or other components designated as [`noLabelComponents`](https://github.com/Altinn/app-frontend-react/blob/28244732ba9c978019be3e9e6153d639548e705c/src/altinn-app-frontend/src/components/GenericComponent.tsx#L292-L305).

![image](https://user-images.githubusercontent.com/131616/171837604-ee1ea955-bbba-4f1c-b9d4-f7335140f03d.png)

### Notes for review
* The radio button is wrapped in a `<fieldset>` tag, that makes it somewhat harder to work with the grid system.
* I had to use a `class="innerGrid"` (not jss) to add correct padding to the content element.
* One might consider dropping the padding, and rather align the checkboxes to the right of the screen.
* I changed the html for all `noLabelComponents` to have 1 less nested <div, for no particular reason, other than that it looked correct.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green
