### PR TITLE
chore: remove step to create testfiles in external PR pipeline

### DIFF
--- a/.github/workflows/cypress-altinn-app-frontend.yml
+++ b/.github/workflows/cypress-altinn-app-frontend.yml
@@ -81,10 +81,6 @@ jobs:
         run: yarn --immutable
         working-directory: test/cypress
 
-      - name: Create test files
-        run: yarn run create:testfiles
-        working-directory: test/cypress/e2e/fixtures
-
       - name: Verify cypress and run tests
         run: |
           yarn run cy:verify


### PR DESCRIPTION
## Description
The testfiles are checked into git, as part of a change in #182 and the workflow for internal PR's was updated, but external PR step was missed.

## Related Issue(s)
- #182
