### PR TITLE
Checking for classref, not only applogic for formData

### DIFF
--- a/src/altinn-app-frontend/src/utils/appMetadata.test.ts
+++ b/src/altinn-app-frontend/src/utils/appMetadata.test.ts
@@ -1,10 +1,11 @@
-import type { IApplication, IData, IInstance } from '../../../shared/src/types';
+import type { IApplication, IData, IDataType, IInstance } from '../../../shared/src/types';
 import type { ILayoutSets } from 'src/types';
 
 import {
   getCurrentDataTypeForApplication,
   getCurrentTaskData,
   getCurrentTaskDataElementId,
+  getDataTaskDataTypeId,
   getLayoutSetIdForApplication,
   isStatelessApp,
 } from './appMetadata';
@@ -30,6 +31,14 @@ describe('utils/appmetadata.ts', () => {
           autoCreate: true,
           classRef: 'Altinn.App.Models.StatelessV1',
         },
+        taskId: 'Task_1',
+        maxCount: 1,
+        minCount: 1,
+      },
+      {
+        id: 'type-with-no-classRef',
+        allowedContentTypes: ['application/xml'],
+        appLogic: {},
         taskId: 'Task_1',
         maxCount: 1,
         minCount: 1,
@@ -120,7 +129,7 @@ describe('utils/appmetadata.ts', () => {
       const expected = 'Stateless';
       expect(result).toEqual(expected);
     });
-    
+
     it('should return correct data type if instance not set', () => {
       const statelessApplication = {
         ...application,
@@ -202,6 +211,62 @@ describe('utils/appmetadata.ts', () => {
         (e) => e.id === 'datamodel-data-guid',
       );
       expect(result).toEqual(expected);
+    });
+  });
+
+  describe('getDataTaskDataTypeId', () => {
+    it('should return data task type id from element that has appLogic.schemaRef and connected taskId', () => {
+      const dataTypes: IDataType[] = [
+        {
+          id: 'ref-data-as-pdf',
+          allowedContentTypes: ['application/pdf'],
+          maxCount: 0,
+          minCount: 0
+        },
+        {
+          id: 'type-with-no-schemaRef',
+          allowedContentTypes: ['application/xml'],
+          maxCount: 0,
+          minCount: 0,
+          appLogic: {},
+          taskId: 'Task_1'
+        },
+        {
+          id: 'type-with-schemaRef',
+          allowedContentTypes: ['application/xml'],
+          maxCount: 0,
+          minCount: 0,
+          appLogic: {
+            classRef: 'Altinn.Skjema'
+          },
+          taskId: 'Task_1'
+        },
+      ];
+
+      const result = getDataTaskDataTypeId('Task_1', dataTypes);
+      expect(result).toBe('type-with-schemaRef');
+    });
+
+    it('should not return data task type id if element has appLogic and connected taskId but is missing schemaRef', () => {
+      const dataTypes: IDataType[] = [
+        {
+          id: 'ref-data-as-pdf',
+          allowedContentTypes: ['application/pdf'],
+          maxCount: 0,
+          minCount: 0
+        },
+        {
+          id: 'simpel-model',
+          allowedContentTypes: ['application/xml'],
+          maxCount: 0,
+          minCount: 0,
+          appLogic: {},
+          taskId: 'Task_1'
+        },
+      ];
+
+      const result = getDataTaskDataTypeId('Task_1', dataTypes);
+      expect(result).toBe(undefined);
     });
   });
 });

--- a/src/altinn-app-frontend/src/utils/appMetadata.ts
+++ b/src/altinn-app-frontend/src/utils/appMetadata.ts
@@ -1,14 +1,14 @@
-import { IApplication, IInstance } from 'altinn-shared/types';
+import { IApplication, IDataType, IInstance } from 'altinn-shared/types';
 import { ILayoutSets } from 'src/types';
 import { getLayoutsetForDataElement } from './layout';
 
-export function getDataTaskDataTypeId(taskId: string, dataTypes: any[]): string {
+export function getDataTaskDataTypeId(taskId: string, dataTypes: IDataType[]): string {
   if (!dataTypes || dataTypes.length === 0) {
     return null;
   }
 
   const result = dataTypes.find((dataType) => {
-    return dataType.appLogic !== null && dataType.appLogic.classRef !== null && dataType.taskId === taskId;
+    return dataType.appLogic?.classRef && dataType.taskId === taskId;
   });
   return result?.id;
 }
@@ -91,7 +91,7 @@ export function isStatelessApp(application: IApplication) {
 export const getCurrentTaskDataElementId = (appMetaData: IApplication, instance: IInstance) => {
   const currentTaskId = instance.process.currentTask.elementId;
   const appLogicDataType =
-    appMetaData.dataTypes.find((element) => element.appLogic !== null && element.appLogic.classRef !== null && element.taskId === currentTaskId);
+    appMetaData.dataTypes.find((element) => element.appLogic?.classRef && element.taskId === currentTaskId);
   const currentTaskDataElement = instance.data.find((element) => element.dataType === appLogicDataType.id);
   return currentTaskDataElement.id;
 };

--- a/src/altinn-app-frontend/src/utils/appMetadata.ts
+++ b/src/altinn-app-frontend/src/utils/appMetadata.ts
@@ -8,7 +8,7 @@ export function getDataTaskDataTypeId(taskId: string, dataTypes: any[]): string 
   }
 
   const result = dataTypes.find((dataType) => {
-    return dataType.appLogic !== null && dataType.taskId === taskId;
+    return dataType.appLogic !== null && dataType.appLogic.classRef !== null && dataType.taskId === taskId;
   });
   return result?.id;
 }
@@ -91,7 +91,7 @@ export function isStatelessApp(application: IApplication) {
 export const getCurrentTaskDataElementId = (appMetaData: IApplication, instance: IInstance) => {
   const currentTaskId = instance.process.currentTask.elementId;
   const appLogicDataType =
-    appMetaData.dataTypes.find((element) => element.appLogic !== null && element.taskId === currentTaskId);
+    appMetaData.dataTypes.find((element) => element.appLogic !== null && element.appLogic.classRef !== null && element.taskId === currentTaskId);
   const currentTaskDataElement = instance.data.find((element) => element.dataType === appLogicDataType.id);
   return currentTaskDataElement.id;
 };

--- a/src/altinn-app-frontend/src/utils/validation.test.ts
+++ b/src/altinn-app-frontend/src/utils/validation.test.ts
@@ -1503,7 +1503,9 @@ describe('utils > validation', () => {
           applicationMetadata: {
             dataTypes: [
               {
-                appLogic: {},
+                appLogic: {
+                  classRef: 'Altinn.App.Models.Skjema'
+                },
                 taskId: 'default',
                 maxCount: 0,
                 minCount: 0,
@@ -1584,7 +1586,9 @@ describe('utils > validation', () => {
           applicationMetadata: {
             dataTypes: [
               {
-                appLogic: {},
+                appLogic: {
+                  classRef: 'Altinn.App.Models.Skjema'
+                },
                 taskId: 'default',
                 maxCount: 0,
                 minCount: 0,

--- a/src/shared/src/types/index.ts
+++ b/src/shared/src/types/index.ts
@@ -32,7 +32,7 @@ export interface IAltinnOrgs {
 export interface IApplicationLogic {
   allowAnonymousOnStateless?: boolean;
   autoCreate?: boolean;
-  classRef: string;
+  classRef?: string;
   schemaRef?: string;
 }
 

--- a/src/shared/src/utils/applicationMetaDataUtils.ts
+++ b/src/shared/src/utils/applicationMetaDataUtils.ts
@@ -1,6 +1,6 @@
 import { IApplication, IInstance } from '../types';
 
 export const getCurrentTaskData = (appMetaData: IApplication, instance: IInstance) => {
-  const defaultDatatype = appMetaData.dataTypes.find((element) => element.appLogic !== null);
+  const defaultDatatype = appMetaData.dataTypes.find((element) => element.appLogic !== null && element.appLogic.classRef !== null );
   return instance.data.find((element) => element.dataType === defaultDatatype.id);
 };


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
A weakness in frontend implementation came to show during development of support of auto deletion of dataelements. 
When identifying a dataelement that has a jsonSchema, we should not only check that applogic exists. 
## Related Issue(s)
- Altinn/app-template-dotnet#66

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
~~- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~
