### PR TITLE
fix flaky cypress test

### DIFF
--- a/test/cypress/e2e/integration/app-frontend/summary.js
+++ b/test/cypress/e2e/integration/app-frontend/summary.js
@@ -96,6 +96,7 @@ describe('Summary', () => {
     cy.get(appFrontend.group.mainGroupSummary).should('be.visible').and('have.length', 1);
     cy.get(appFrontend.group.mainGroupSummary)
       .first()
+      .should('be.visible').and('have.length', 1)
       .children(mui.gridItem)
       .then((item) => {
         cy.get(item).should('have.length', 4);


### PR DESCRIPTION
## Description
Verify that element actually is rendered before running the cypress evaluation. Caused flaky behavior.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
