### PR TITLE
Better error messages for required fields

### DIFF
--- a/src/altinn-app-frontend/src/features/form/data/submit/submitFormDataSagas.ts
+++ b/src/altinn-app-frontend/src/features/form/data/submit/submitFormDataSagas.ts
@@ -57,6 +57,7 @@ function* submitFormSaga({ payload: { apiMode, stopWithWarnings } }: PayloadActi
       state.language.language,
       state.formLayout.uiConfig.hiddenFields,
       state.formLayout.uiConfig.repeatingGroups,
+      state.textResources.resources,
     );
 
     validations = mergeValidationObjects(validations, componentSpecificValidations);

--- a/src/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
+++ b/src/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
@@ -160,6 +160,7 @@ export function* updateCurrentViewSaga({ payload: {
         state.language.language,
         state.formLayout.uiConfig.hiddenFields,
         state.formLayout.uiConfig.repeatingGroups,
+        state.textResources.resources,
       );
       let validations = mergeValidationObjects(validationResult.validations, componentSpecificValidations, emptyFieldsValidations);
       const instanceId = state.instanceData.instance.id;

--- a/src/altinn-app-frontend/src/utils/databindings.test.ts
+++ b/src/altinn-app-frontend/src/utils/databindings.test.ts
@@ -4,6 +4,7 @@ import type { IMapping } from 'src/types';
 
 import {
   flattenObject,
+  getFormDataFromFieldKey,
   getKeyWithoutIndex,
   mapFormData,
   removeGroupData,
@@ -270,5 +271,32 @@ describe('utils/databindings.ts', () => {
         expect(mapFormData(formData, mapping)).toEqual(formData);
       },
     );
+  });
+
+  describe.only('getFormDataFromFieldKey', () => {
+    const formData = {
+      'field1': 'value1',
+      'group[0].field': 'someValue',
+      'group[1].field': 'another value',
+    }
+    it('should return correct form data for a field not in a group', () => {
+      const result = getFormDataFromFieldKey(
+        'simpleBinding',
+        { simpleBinding: 'field1' },
+        formData,
+      );
+      expect(result).toEqual('value1');
+    });
+
+    it('should return correct form data for a field in a group', () => {
+      const result = getFormDataFromFieldKey(
+        'simpleBinding',
+        { simpleBinding: 'group.field' },
+        formData,
+        'group',
+        1,
+      );
+      expect(result).toEqual('another value');
+    });
   });
 });

--- a/src/altinn-app-frontend/src/utils/databindings.ts
+++ b/src/altinn-app-frontend/src/utils/databindings.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-len */
 import { object } from 'dot-object';
 import { ILayout, ILayoutGroup } from 'src/features/form/layout';
-import { IMapping, IRepeatingGroup } from 'src/types';
+import { IDataModelBindings, IMapping, IRepeatingGroup } from 'src/types';
 import { getParentGroup } from './validation';
 import { IFormData } from 'src/features/form/data/formDataReducer';
 
@@ -156,4 +156,21 @@ export function mapFormData(formData: IFormData, mapping: IMapping) {
     mappedFormData[target] = formData[source];
   });
   return mappedFormData;
+}
+
+export function getFormDataFromFieldKey(
+  fieldKey: string,
+  dataModelBindings: IDataModelBindings,
+  formData: any,
+  groupDataBinding?: string,
+  index?: number,
+) {
+    let dataModelBindingKey = dataModelBindings[fieldKey];
+    if (groupDataBinding) {
+      dataModelBindingKey = dataModelBindingKey.replace(
+        groupDataBinding,
+        `${groupDataBinding}[${index}]`,
+      );
+    }
+    return formData[dataModelBindingKey];
 }

--- a/src/altinn-app-frontend/src/utils/formComponentUtils.test.ts
+++ b/src/altinn-app-frontend/src/utils/formComponentUtils.test.ts
@@ -20,6 +20,7 @@ import {
   isComponentValid,
   componentValidationsHandledByGenericComponent,
   componentHasValidationMessages,
+  getFieldName,
 } from './formComponentUtils';
 
 describe('formComponentUtils', () => {
@@ -477,5 +478,60 @@ describe('formComponentUtils', () => {
         const result = componentHasValidationMessages(validations);
         expect(result).toEqual(true);
       });
+  });
+
+  describe.only('getFieldName', () => {
+    const mockTextResources = [
+      { id: 'title', value: 'Component name'},
+      { id: 'short', value: 'name'},
+    ];
+    const mockLanguage = {
+      form_filler: {
+        error_required: 'Du må fylle ut {0}.',
+        address: 'Gateadresse',
+        postPlace: 'Poststed',
+        zipCode: 'Postnummer',
+      },
+      validation: {
+        generic_field: 'dette feltet',
+      },
+    };
+
+    it('should return field text from languages when fieldKey is present', () => {
+      const result = getFieldName(
+        { title: 'title' },
+        mockTextResources,
+        mockLanguage,
+        'address'
+      );
+      expect(result).toEqual('Gateadresse');
+    });
+
+    it('should return component shortName (textResourceBindings) when no fieldKey is present', () => {
+      const result = getFieldName(
+        { title: 'title', shortName: 'short' },
+        mockTextResources,
+        mockLanguage,
+      );
+      expect(result).toEqual('name');
+    });
+
+    it('should return component title (textResourceBindings) when no shortName (textResourceBindings) and no fieldKey is present', () => {
+      const result = getFieldName(
+        { title: 'title' },
+        mockTextResources,
+        mockLanguage,
+      );
+      expect(result).toEqual('Component name');
+    });
+
+    it('should return generic field name when fieldKey, shortName and title are all not available', () => {
+      const result = getFieldName(
+        { something: 'someTextKey' },
+        mockTextResources,
+        mockLanguage,
+      );
+      expect(result).toEqual('dette feltet');
+    });
   });
 });

--- a/src/altinn-app-frontend/src/utils/formComponentUtils.ts
+++ b/src/altinn-app-frontend/src/utils/formComponentUtils.ts
@@ -23,6 +23,7 @@ import {
 } from 'src/types';
 import { AsciiUnitSeparator } from './attachment';
 import { getOptionLookupKey } from './options';
+import { getTextFromAppOrDefault } from './textResource';
 
 export const componentValidationsHandledByGenericComponent = (
   dataModelBindings: any,
@@ -412,3 +413,25 @@ export const atleastOneTagExists = (attachments: IAttachment[]): boolean => {
 
   return totalTagCount !== undefined && totalTagCount >= 1;
 };
+
+export function getFieldName(
+  textResourceBindings: ITextResourceBindings,
+  textResources: ITextResource[],
+  language: ILanguage,
+  fieldKey?: string,
+): string {
+  if (fieldKey)
+  {
+    return getTextFromAppOrDefault(`form_filler.${fieldKey}`, textResources, language, null, true);
+  }
+
+  if (textResourceBindings.shortName) {
+    return getTextResourceByKey(textResourceBindings.shortName, textResources);
+  }
+
+  if (textResourceBindings.title) {
+    return getTextResourceByKey(textResourceBindings.title, textResources);
+  }
+
+  return getLanguageFromKey('validation.generic_field', language);
+}

--- a/src/altinn-app-frontend/src/utils/validation.test.ts
+++ b/src/altinn-app-frontend/src/utils/validation.test.ts
@@ -13,6 +13,7 @@ import type {
   IComponentBindingValidation,
   IComponentValidations,
   ILayoutValidations,
+  ITextResource,
 } from 'src/types';
 import type { ILayoutComponent, ILayoutGroup } from 'src/features/form/layout';
 
@@ -40,15 +41,22 @@ describe('utils > validation', () => {
   let mockLanguage: any;
   let mockFormAttachments: any;
   let mockDataElementValidations: IValidationIssue[];
+  let mockTextResources: ITextResource[];
 
   beforeEach(() => {
     mockLanguage = {
       language: {
         form_filler: {
-          error_required: 'Feltet er påkrevd',
+          error_required: 'Du må fylle ut {0}.',
           file_uploader_validation_error_file_number_1:
             'For å fortsette må du laste opp',
           file_uploader_validation_error_file_number_2: 'vedlegg',
+          address: 'Gateadresse',
+          postPlace: 'Poststed',
+          zipCode: 'Postnummer',
+        },
+        validation: {
+          generic_field: 'dette feltet',
         },
         validation_errors: {
           minLength: 'length must be bigger than {0}',
@@ -58,6 +66,33 @@ describe('utils > validation', () => {
       },
     };
 
+    mockTextResources = [
+      {
+        id: 'c1Title',
+        value: 'component_1'
+      },
+      {
+        id: 'c2Title',
+        value: 'component_2'
+      },
+      {
+        id: 'c3Title',
+        value: 'component_3'
+      },
+      {
+        id: 'c4Title',
+        value: 'component_4'
+      },
+      {
+        id: 'c5Title',
+        value: 'component_5'
+      },
+      {
+        id: 'c6Title',
+        value: 'component_6'
+      },
+    ];
+
     mockComponent4 = {
       type: 'Input',
       id: 'componentId_4',
@@ -66,7 +101,9 @@ describe('utils > validation', () => {
       },
       required: true,
       readOnly: false,
-      textResourceBindings: {},
+      textResourceBindings: {
+        title: 'c4Title',
+      },
     };
 
     mockComponent5 = {
@@ -77,7 +114,9 @@ describe('utils > validation', () => {
       },
       required: false,
       readOnly: false,
-      textResourceBindings: {},
+      textResourceBindings: {
+        title: 'c5Title',
+      },
     };
 
     mockGroup2 = {
@@ -125,7 +164,9 @@ describe('utils > validation', () => {
           },
           required: true,
           readOnly: false,
-          textResourceBindings: {},
+          textResourceBindings: {
+            title: 'c1Title',
+          },
         },
         {
           type: 'Input',
@@ -135,7 +176,9 @@ describe('utils > validation', () => {
           },
           required: true,
           readOnly: false,
-          textResourceBindings: {},
+          textResourceBindings: {
+            title: 'c2Title',
+          },
         },
         {
           type: 'TextArea',
@@ -145,7 +188,9 @@ describe('utils > validation', () => {
           },
           required: true,
           readOnly: false,
-          textResourceBindings: {},
+          textResourceBindings: {
+            title: 'c3Title',
+          },
         },
         mockGroup1,
         mockGroup2,
@@ -168,7 +213,9 @@ describe('utils > validation', () => {
           },
           required: true,
           readOnly: false,
-          textResourceBindings: {},
+          textResourceBindings: {
+            title: 'c6Title',
+          },
         },
         {
           type: 'Input',
@@ -644,23 +691,24 @@ describe('utils > validation', () => {
           mockLanguage.language,
           [],
           repeatingGroups,
+          mockTextResources,
         );
 
         const mockResult = {
           FormLayout: {
             componentId_3: {
-              simpleBinding: { errors: ['Feltet er påkrevd'], warnings: [] },
+              simpleBinding: { errors: ['Du må fylle ut component_3.'], warnings: [] },
             },
             'componentId_4-0': {
-              simpleBinding: { errors: ['Feltet er påkrevd'], warnings: [] },
+              simpleBinding: { errors: ['Du må fylle ut component_4.'], warnings: [] },
             },
             componentId_6: {
-              address: { errors: ['Feltet er påkrevd'], warnings: [] },
-              postPlace: { errors: ['Feltet er påkrevd'], warnings: [] },
-              zipCode: { errors: ['Feltet er påkrevd'], warnings: [] },
+              address: { errors: ['Du må fylle ut Gateadresse.'], warnings: [] },
+              postPlace: { errors: ['Du må fylle ut Poststed.'], warnings: [] },
+              zipCode: { errors: ['Du må fylle ut Postnummer.'], warnings: [] },
             },
             required_in_group_simple: { simpleBinding: {
-                errors: ['Feltet er påkrevd'],
+                errors: ['Du må fylle ut dette feltet.'],
                 warnings: [],
             }},
           },
@@ -683,20 +731,21 @@ describe('utils > validation', () => {
           mockLanguage.language,
           ['componentId_4-0'],
           repeatingGroups,
+          mockTextResources,
         );
 
         const mockResult = {
           FormLayout: {
             componentId_3: {
-              simpleBinding: { errors: ['Feltet er påkrevd'], warnings: [] },
+              simpleBinding: { errors: ['Du må fylle ut component_3.'], warnings: [] },
             },
             componentId_6: {
-              address: { errors: ['Feltet er påkrevd'], warnings: [] },
-              postPlace: { errors: ['Feltet er påkrevd'], warnings: [] },
-              zipCode: { errors: ['Feltet er påkrevd'], warnings: [] },
+              address: { errors: ['Du må fylle ut Gateadresse.'], warnings: [] },
+              postPlace: { errors: ['Du må fylle ut Poststed.'], warnings: [] },
+              zipCode: { errors: ['Du må fylle ut Postnummer.'], warnings: [] },
             },
             required_in_group_simple: { simpleBinding: {
-              errors: ['Feltet er påkrevd'],
+              errors: ['Du må fylle ut dette feltet.'],
               warnings: [],
             }}
           },
@@ -719,6 +768,7 @@ describe('utils > validation', () => {
           mockLanguage.language,
           [],
           repeatingGroups,
+          mockTextResources,
         );
 
         expect(componentSpesificValidations).toEqual({});
@@ -732,12 +782,14 @@ describe('utils > validation', () => {
         validations[component.id] = validation.validateEmptyField(
           mockFormData,
           component.dataModelBindings,
+          component.textResourceBindings,
+          mockTextResources,
           mockLanguage.language,
         );
 
         const mockResult = {
           componentId_3: {
-            simpleBinding: { errors: ['Feltet er påkrevd'], warnings: [] },
+            simpleBinding: { errors: ['Du må fylle ut component_3.'], warnings: [] },
           },
         };
 
@@ -752,14 +804,16 @@ describe('utils > validation', () => {
         validations[component.id] = validation.validateEmptyField(
           mockFormData,
           component.dataModelBindings,
+          component.textResourceBindings,
+          mockTextResources,
           mockLanguage.language,
         );
 
         const mockResult = {
           componentId_6: {
-            address: { errors: ['Feltet er påkrevd'], warnings: [] },
-            postPlace: { errors: ['Feltet er påkrevd'], warnings: [] },
-            zipCode: { errors: ['Feltet er påkrevd'], warnings: [] },
+            address: { errors: ['Du må fylle ut Gateadresse.'], warnings: [] },
+              postPlace: { errors: ['Du må fylle ut Poststed.'], warnings: [] },
+              zipCode: { errors: ['Du må fylle ut Postnummer.'], warnings: [] },
           },
         };
 
@@ -779,12 +833,19 @@ describe('utils > validation', () => {
       mockLanguage.language,
       hiddenFields,
       repeatingGroups,
+      mockTextResources,
     );
 
     const requiredFieldInSimpleGroup = 'required_in_group_simple';
-    const requiredError = {
-      simpleBinding: { errors: ['Feltet er påkrevd'], warnings: [] },
-    };
+    const requiredError = (name?: string) => {
+      const fieldName = name || 'dette feltet';
+      return {
+        simpleBinding: {
+          errors: [`Du må fylle ut ${fieldName}.`],
+          warnings: [],
+        },
+      };
+    }
 
     it('should pass validation on required field in hidden group', () => {
       expect(_with({hiddenFields: ['group_simple']})[requiredFieldInSimpleGroup]).toBeUndefined();
@@ -793,7 +854,7 @@ describe('utils > validation', () => {
       expect(_with({hiddenFields: [requiredFieldInSimpleGroup]})[requiredFieldInSimpleGroup]).toBeUndefined();
     });
     it('should mark as required with required field in visible group', () => {
-      expect(_with({hiddenFields: []})[requiredFieldInSimpleGroup]).toEqual(requiredError);
+      expect(_with({hiddenFields: []})[requiredFieldInSimpleGroup]).toEqual(requiredError());
     });
 
     it('should validate successfully with no instances of repeating groups', () => {
@@ -823,12 +884,12 @@ describe('utils > validation', () => {
           // Group2 has no instances inside the third instance of group1
         },
       })).toEqual({
-        'componentId_4-0': requiredError,
-        'componentId_4-1': requiredError,
-        'componentId_4-2': requiredError,
-        'componentId_5-0-0': requiredError,
-        'componentId_5-0-1': requiredError,
-        'componentId_5-1-0': requiredError,
+        'componentId_4-0': requiredError('component_4'),
+        'componentId_4-1': requiredError('component_4'),
+        'componentId_4-2': requiredError('component_4'),
+        'componentId_5-0-0': requiredError('component_5'),
+        'componentId_5-0-1': requiredError('component_5'),
+        'componentId_5-1-0': requiredError('component_5'),
       });
     });
 
@@ -839,8 +900,8 @@ describe('utils > validation', () => {
           group1: { index: 1 }, // Group1 has 2 instances
         },
       })).toEqual({
-        'componentId_4-0': requiredError,
-        'componentId_4-1': requiredError,
+        'componentId_4-0': requiredError('component_4'),
+        'componentId_4-1': requiredError('component_4'),
       });
     });
 
@@ -855,8 +916,8 @@ describe('utils > validation', () => {
           group3: { index: 1 },
         },
       })).toEqual({
-        'componentId_4-0': requiredError,
-        'componentId_4-1': requiredError,
+        'componentId_4-0': requiredError('component_4'),
+        'componentId_4-1': requiredError('component_4'),
       });
     });
 
@@ -875,9 +936,9 @@ describe('utils > validation', () => {
           'group2-0': { index: 0 },
         },
       })).toEqual({
-        'componentId_4-0': requiredError,
-        'componentId_4-1': requiredError,
-        'componentId_5-0-0': requiredError,
+        'componentId_4-0': requiredError('component_4'),
+        'componentId_4-1': requiredError('component_4'),
+        'componentId_5-0-0': requiredError('component_5'),
       });
     });
   });
@@ -1533,6 +1594,11 @@ describe('utils > validation', () => {
         formData: {
           formData: mockFormData,
         } as any,
+        textResources: {
+          error: null,
+          language: 'nb',
+          resources: mockTextResources,
+        }
       });
       const result: IValidations = validation.validateGroup('group1', state);
       expect(result).toEqual({
@@ -1540,7 +1606,7 @@ describe('utils > validation', () => {
           'componentId_4-0': {
             simpleBinding: {
               errors: [
-                'Feltet er påkrevd',
+                'Du må fylle ut component_4.',
                 getParsedLanguageFromKey(
                   `validation_errors.pattern`,
                   state.language.language,
@@ -1646,19 +1712,19 @@ describe('utils > validation', () => {
         FormLayout: {
           'group1-0': {
             simpleBinding: {
-              errors: ['Feltet er påkrevd'],
+              errors: ['Du må fylle ut dette feltet.'],
               warnings: [],
             },
           },
           'group1-1': {
             simpleBinding: {
-              errors: ['Feltet er påkrevd'],
+              errors: ['Du må fylle ut dette feltet.'],
               warnings: [],
             },
           },
           'componentId_4-1': {
             simpleBinding: {
-              errors: ['Feltet er påkrevd'],
+              errors: ['Du må fylle ut component_4.'],
               warnings: [],
             },
           },
@@ -1681,7 +1747,7 @@ describe('utils > validation', () => {
         FormLayout: {
           'group1-0': {
             simpleBinding: {
-              errors: ['Feltet er påkrevd'],
+              errors: ['Du må fylle ut dette feltet.'],
               warnings: [],
             },
           },
@@ -1695,13 +1761,13 @@ describe('utils > validation', () => {
         FormLayout: {
           'group1-0': {
             simpleBinding: {
-              errors: ['Feltet er påkrevd'],
+              errors: ['Du må fylle ut dette feltet.'],
               warnings: [],
             },
           },
           'group1-1': {
             simpleBinding: {
-              errors: ['Feltet er påkrevd'],
+              errors: ['Du må fylle ut dette feltet.'],
               warnings: [],
             },
           },
@@ -1736,7 +1802,7 @@ describe('utils > validation', () => {
         FormLayout: {
           'group1-0': {
             simpleBinding: {
-              errors: ['Feltet er påkrevd'],
+              errors: ['Du må fylle ut dette feltet.'],
               warnings: [],
             },
           },
@@ -1762,13 +1828,13 @@ describe('utils > validation', () => {
         FormLayout: {
           'group1-0': {
             simpleBinding: {
-              errors: ['Feltet er påkrevd'],
+              errors: ['Du må fylle ut dette feltet.'],
               warnings: [],
             },
           },
           'group2-0-0': {
             simpleBinding: {
-              errors: ['Feltet er påkrevd'],
+              errors: ['Du må fylle ut dette feltet.'],
               warnings: [],
             },
           },
@@ -1807,7 +1873,7 @@ describe('utils > validation', () => {
         FormLayout: {
           'group1-0': {
             simpleBinding: {
-              errors: ['Feltet er påkrevd'],
+              errors: ['Du må fylle ut dette feltet.'],
               warnings: [],
             },
           },
@@ -1833,25 +1899,25 @@ describe('utils > validation', () => {
         FormLayout: {
           'group1-0': {
             simpleBinding: {
-              errors: ['Feltet er påkrevd'],
+              errors: ['Du må fylle ut dette feltet.'],
               warnings: [],
             },
           },
           'group2-0-1': {
             simpleBinding: {
-              errors: ['Feltet er påkrevd'],
+              errors: ['Du må fylle ut dette feltet.'],
               warnings: [],
             },
           },
           'componentId_5-0-0': {
             simpleBinding: {
-              errors: ['Feltet er påkrevd 1'],
+              errors: ['Du må fylle ut  1'],
               warnings: [],
             },
           },
           'componentId_5-0-1': {
             simpleBinding: {
-              errors: ['Feltet er påkrevd 2'],
+              errors: ['Du må fylle ut  2'],
               warnings: [],
             },
           },
@@ -1885,19 +1951,19 @@ describe('utils > validation', () => {
         FormLayout: {
           'group1-0': {
             simpleBinding: {
-              errors: ['Feltet er påkrevd'],
+              errors: ['Du må fylle ut dette feltet.'],
               warnings: [],
             },
           },
           'group2-0-1': {
             simpleBinding: {
-              errors: ['Feltet er påkrevd'],
+              errors: ['Du må fylle ut dette feltet.'],
               warnings: [],
             },
           },
           'componentId_5-0-1': {
             simpleBinding: {
-              errors: ['Feltet er påkrevd'],
+              errors: ['Du må fylle ut dette feltet.'],
               warnings: [],
             },
           },
@@ -2193,7 +2259,7 @@ describe('utils > validation', () => {
       const validations: ILayoutValidations = {
         field: {
           'simple_binding': {
-            errors: ['Some random error', 'Feltet er påkrevd'],
+            errors: ['Some random error', 'Du må fylle ut dette feltet.'],
             warnings: [],
           }
         }
@@ -2202,7 +2268,7 @@ describe('utils > validation', () => {
       expect(result).toBeTruthy();
     });
     it('should return true when validations contain messages (react element) for missing fields', () => {
-      const node = createElement('span', {}, 'Feltet er påkrevd');
+      const node = createElement('span', {}, 'Du må fylle ut ');
       const validations: ILayoutValidations = {
         field: {
           'simple_binding': {
@@ -2223,9 +2289,9 @@ describe('utils > validation', () => {
           }
         }
       });
-      const shallow = ['Første linje', "\n", 'Feltet er påkrevd'];
-      const deep = ['Dette er feil:', ['Første linje', "\n", 'Feltet er påkrevd']];
-      const withNode = ['Dette er feil:', ['Første linje', "\n", createElement('span', {}, 'Feltet er påkrevd')]];
+      const shallow = ['Første linje', "\n", 'Du må fylle ut '];
+      const deep = ['Dette er feil:', ['Første linje', "\n", 'Du må fylle ut ']];
+      const withNode = ['Dette er feil:', ['Første linje', "\n", createElement('span', {}, 'Du må fylle ut ')]];
       expect(validation.missingFieldsInLayoutValidations(validations(shallow), mockLanguage.language)).toBeTruthy();
       expect(validation.missingFieldsInLayoutValidations(validations(deep), mockLanguage.language)).toBeTruthy();
       expect(validation.missingFieldsInLayoutValidations(validations(withNode), mockLanguage.language)).toBeTruthy();

--- a/src/shared/src/language/texts/en.ts
+++ b/src/shared/src/language/texts/en.ts
@@ -41,7 +41,7 @@ export function en() {
       back_to_summary: 'Return to summary',
       error_report_header: 'There is a problem',
       error_report_description: 'The form contains errors that prevent it from being submitted. Try submitting again once the errors are corrected.',
-      error_required: 'Field is required',
+      error_required: 'You have to fill out {0}.',
       file_upload_valid_file_format_all: 'all',
       file_uploader_add_attachment: 'Add more attachments',
       file_uploader_drag: 'Drag and drop or',
@@ -75,6 +75,11 @@ export function en() {
       required_label: '*',
       summary_item_change: 'Change',
       summary_go_to_correct_page: 'Go to the correct page in the form',
+      address: 'Street Address',
+      careOf: 'C/O or other additional address',
+      houseNumber: 'House Number',
+      postPlace: 'Post Place',
+      zipCode: 'Zip Code',
     },
     navigation: {
       main: 'App navigation',
@@ -214,6 +219,14 @@ export function en() {
       log_out: 'Log out',
       profile_icon_aria_label: 'Profile icon button',
     },
+    soft_validation: {
+      info_title: 'Information',
+      warning_title: 'Note',
+      success_title: 'How great!'
+    },
+    validation: {
+      generic_field: 'this field',
+    },
     validation_errors: {
       min: 'Minimum valid value is {0}',
       max: 'Maximum valid value is {0}',
@@ -224,10 +237,5 @@ export function en() {
       required: 'Field is required',
       enum: 'Only the values {0} are permitted',
     },
-    soft_validation: {
-      info_title: 'Information',
-      warning_title: 'Note',
-      success_title: 'How great!'
-    }
   };
 }

--- a/src/shared/src/language/texts/nb.ts
+++ b/src/shared/src/language/texts/nb.ts
@@ -41,7 +41,7 @@ export function nb() {
       back_to_summary: 'Tilbake til oppsummering',
       error_report_header: 'Det er feil i skjema',
       error_report_description: 'Skjemaet inneholder feil eller mangler som hindrer oss fra å sende det inn. Når du har rettet feilene, kan du sende inn skjemaet på nytt.',
-      error_required: 'Feltet er påkrevd',
+      error_required: 'Du må fylle ut {0}.',
       file_upload_valid_file_format_all: 'alle',
       file_uploader_add_attachment: 'Legg til flere vedlegg',
       file_uploader_drag: 'Dra og slipp eller',
@@ -75,6 +75,11 @@ export function nb() {
       required_label: '*',
       summary_item_change: 'Endre',
       summary_go_to_correct_page: 'Gå til riktig side i skjema',
+      address: 'Gateadresse',
+      careOf: 'C/O eller annen tilleggsadresse',
+      houseNumber: 'Bolignummer',
+      postPlace: 'Poststed',
+      zipCode: 'Postnr',
     },
     navigation: {
       main: 'Appnavigasjon',
@@ -214,6 +219,14 @@ export function nb() {
       log_out: 'Logg ut',
       profile_icon_aria_label: 'Profil ikon knapp',
     },
+    soft_validation: {
+      info_title: 'Lurt å tenke på',
+      warning_title: 'OBS',
+      success_title: 'Så flott!'
+    },
+    validation: {
+      generic_field: 'dette feltet',
+    },
     validation_errors: {
       min: 'Minste gyldig verdi er {0}',
       max: 'Største gyldig verdi er {0}',
@@ -224,10 +237,5 @@ export function nb() {
       required: 'Feltet er påkrevd',
       enum: 'Kun verdiene {0} er tillatt',
     },
-    soft_validation: {
-      info_title: 'Lurt å tenke på',
-      warning_title: 'OBS',
-      success_title: 'Så flott!'
-    }
   };
 }

--- a/src/shared/src/language/texts/nn.ts
+++ b/src/shared/src/language/texts/nn.ts
@@ -40,7 +40,7 @@ export function nn() {
       back_to_summary: 'Attende til samandrag',
       error_report_header: 'Det er feil i skjema',
       error_report_description: 'Skjemaet inneheld feil eller manglar som hindrar oss frå å sende det inn. Når du har retta feila, kan du sende inn skjemaet på nytt.',
-      error_required: 'Feltet er påkravd',
+      error_required: 'Du må fylle ut {0}.',
       file_upload_valid_file_format_all: 'alle',
       file_uploader_add_attachment: 'Legg til fleire vedlegg',
       file_uploader_drag: 'Dra og slepp eller',
@@ -74,6 +74,11 @@ export function nn() {
       required_label: '*',
       summary_item_change: 'Endre',
       summary_go_to_correct_page: 'Gå til riktig side i skjema',
+      address: 'Gateadresse',
+      careOf: 'C/O eller annan tilleggsadresse',
+      houseNumber: 'Bustadnummer',
+      postPlace: 'Poststed',
+      zipCode: 'Postnr',
     },
     navigation: {
       main: 'Appnavigasjon',
@@ -211,6 +216,14 @@ export function nn() {
       log_out: 'Logg ut',
       profile_icon_aria_label: 'Profil ikon knapp',
     },
+    soft_validation: {
+      info_title: 'Lurt å tenke på',
+      warning_title: 'OBS',
+      success_title: 'Så flott!'
+    },
+    validation: {
+      generic_field: 'dette feltet',
+    },
     validation_errors: {
       min: 'Minste gyldige verdi er {0}',
       max: 'Største gyldige verdi er {0}',
@@ -221,10 +234,5 @@ export function nn() {
       required: 'Feltet er påkravd',
       enum: 'Kun verdiane {0} er tillatne',
     },
-    soft_validation: {
-      info_title: 'Lurt å tenke på',
-      warning_title: 'OBS',
-      success_title: 'Så flott!'
-    }
   };
 }


### PR DESCRIPTION
## Description
Implemented new error messages for required fields where field name (title) is used in the message. 
Added option for setting a `shortName` property on component dataModelBinding to handle cases where component title is too long to be useful in the error message.

## Related Issue(s)
- #130 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
