### PR TITLE
Update README.md for PAT with z shell on mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ We are currently using Github registry to publish packages. This means you need 
 
 - Acquire a [GitHub PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token). The only permission you need to grant is read:packages.
 - Assign the PAT to the GITHUB_PACKAGES_PAT environment variable:
-  - Mac/Linux: add the line `export GITHUB_PACKAGES_PAT=<PAT>` to `~/.bash_profile` and restart the terminal
+  - Mac/Linux: add the line `export GITHUB_PACKAGES_PAT=<PAT>` to the `~/.bash_profile` file and restart the terminal
   - Windows: Execute `setx GITHUB_PACKAGES_PAT <PAT> /m` and restart the terminal
+
+If you are using z shell (default on macOS since v10.15 Catalina), you need to update the `~/.zshrc` file instead of file `~/.bash_profile` or `~/.profile.`. 
 
 ## Getting Started
 


### PR DESCRIPTION
Had problems using PAT for mac using the proposed guide and updated with what worked for me using z shell on mac.

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
