### PR TITLE
Make RepeatingGroupTable check optionsId and Options in same order

### DIFF
--- a/src/altinn-app-frontend/src/utils/formComponentUtils.ts
+++ b/src/altinn-app-frontend/src/utils/formComponentUtils.ts
@@ -128,17 +128,17 @@ export const getDisplayFormData = (
     if (component.type === 'Dropdown' || component.type === 'RadioButtons') {
       const selectionComponent = component as ISelectionComponentProps;
       let label: string;
-      if (selectionComponent?.options) {
-        label = selectionComponent.options.find(
-          (option: IOption) => option.value === formDataValue,
-        )?.label;
-      } else if (selectionComponent.optionsId) {
+      if (selectionComponent.optionsId) {
         label = options[
           getOptionLookupKey(
-            selectionComponent?.optionsId,
+            selectionComponent.optionsId,
             selectionComponent.mapping,
           )
         ].options?.find(
+          (option: IOption) => option.value === formDataValue,
+        )?.label;
+      } else if (selectionComponent.options) {
+        label = selectionComponent.options.find(
           (option: IOption) => option.value === formDataValue,
         )?.label;
       }


### PR DESCRIPTION
It seems like it should be "undefined behaviour" to specify both `options` and `optionsId` on a selection component. Currently most things work, so this change will make the behaviour consistent and pick the api options specified by `optionsId` first if present, also on `RepeatingGroupTable`.


## Related Issue(s)
- [Slack discussion](https://altinn.slack.com/archives/C02EVE4RU82/p1655812902474279)

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
