### PR TITLE
chore: disable SonarCloud scan for forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,7 @@ jobs:
         run: yarn test --coverage
 
       - name: SonarCloud Scan
+        if: github.event.repository.fork == false
         with:
           projectBaseDir: app-frontend
         uses: SonarSource/sonarcloud-github-action@master


### PR DESCRIPTION
## Description
Builds from forks always result in a failed check, because they do not have access to the `SONAR_TOKEN` secret. This is very annoying. We investigated possibilities to be able to run this check in a separate workflow which had access to the secret in #255 , but it turned out to be a bit complex, and not worth the trouble.

We should instead disable SonarCloud scan on forks, and if we want coverage checks (or other checks) from forks, we should add other tools to our pipeline (tools which ideally do not require any secrets, because then we get into the same problem again)

## Related Issue(s)
- #234 
- #300

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
