### PR TITLE
chore: fix unstable tests

### DIFF
--- a/src/altinn-app-frontend/setupTests.ts
+++ b/src/altinn-app-frontend/setupTests.ts
@@ -1,12 +1,12 @@
-import Enzyme from "enzyme";
-import Adapter from "@wojtekmaj/enzyme-adapter-react-17";
-import "jest";
-import "@testing-library/jest-dom/extend-expect";
+import Enzyme from 'enzyme';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
+import 'jest';
+import '@testing-library/jest-dom/extend-expect';
 
-import type { IAltinnWindow } from "src/types";
+import type { IAltinnWindow } from 'src/types';
 
 // https://jestjs.io/docs/manual-mocks#mocking-methods-which-are-not-implemented-in-jsdom
-Object.defineProperty(window, "matchMedia", {
+Object.defineProperty(window, 'matchMedia', {
   writable: true,
   value: jest.fn().mockImplementation((query) => ({
     matches: false,
@@ -22,10 +22,8 @@ Object.defineProperty(window, "matchMedia", {
 
 // org and app is assigned to window object, so to avoid 'undefined' in tests, they need to be set
 const altinnWindow = window as Window as IAltinnWindow;
-altinnWindow.org = "ttd";
-altinnWindow.app = "test";
-// Increase timeout for longer tests
-jest.setTimeout(10000);
+altinnWindow.org = 'ttd';
+altinnWindow.app = 'test';
 
 Enzyme.configure({
   adapter: new Adapter(),

--- a/src/altinn-app-frontend/setupTests.ts
+++ b/src/altinn-app-frontend/setupTests.ts
@@ -24,6 +24,7 @@ Object.defineProperty(window, 'matchMedia', {
 const altinnWindow = window as Window as IAltinnWindow;
 altinnWindow.org = 'ttd';
 altinnWindow.app = 'test';
+jest.setTimeout(10000);
 
 Enzyme.configure({
   adapter: new Adapter(),

--- a/src/altinn-app-frontend/src/features/form/containers/GroupContainerLikert.test.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/GroupContainerLikert.test.tsx
@@ -24,7 +24,7 @@ describe('GroupContainer', () => {
 
     it('should render table with one selected row', () => {
       const mockQuestions = defaultMockQuestions.map((mock, index) => {
-        if (index === 2) {
+        if (index === 1) {
           // Set one answer to selected
           return { ...mock, answer: '2' };
         }
@@ -36,11 +36,11 @@ describe('GroupContainer', () => {
 
     it('should render table with two selected row', () => {
       const mockQuestions = defaultMockQuestions.map((mock, index) => {
-        if (index === 2) {
+        if (index === 1) {
           // Set one answer to selected
           return { ...mock, answer: '2' };
         }
-        if (index === 4) {
+        if (index === 2) {
           // Set one answer to selected
           return { ...mock, answer: '1' };
         }
@@ -82,14 +82,14 @@ describe('GroupContainer', () => {
           edit: {
             mode: 'likert',
             filter: [
-              { key: 'start', value: '2' },
-              { key: 'stop', value: '4' },
+              { key: 'start', value: '1' },
+              { key: 'stop', value: '3' },
             ],
           },
         },
       });
 
-      validateTableLayout(defaultMockQuestions.slice(2, 4));
+      validateTableLayout(defaultMockQuestions.slice(1, 3));
     });
 
     it('should render table view and click radiobuttons', async () => {
@@ -263,14 +263,14 @@ describe('GroupContainer', () => {
           edit: {
             mode: 'likert',
             filter: [
-              { key: 'start', value: '2' },
-              { key: 'stop', value: '4' },
+              { key: 'start', value: '1' },
+              { key: 'stop', value: '3' },
             ],
           },
         },
       });
 
-      validateRadioLayout(defaultMockQuestions.slice(2, 4));
+      validateRadioLayout(defaultMockQuestions.slice(1, 3));
     });
   });
 });

--- a/src/altinn-app-frontend/src/features/form/containers/GroupContainerLikert.test.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/GroupContainerLikert.test.tsx
@@ -21,6 +21,7 @@ describe('GroupContainer', () => {
       });
       validateTableLayout(defaultMockQuestions);
     });
+
     it('should render table with one selected row', () => {
       const mockQuestions = defaultMockQuestions.map((mock, index) => {
         if (index === 2) {
@@ -32,6 +33,7 @@ describe('GroupContainer', () => {
       render({ mockQuestions });
       validateTableLayout(mockQuestions);
     });
+
     it('should render table with two selected row', () => {
       const mockQuestions = defaultMockQuestions.map((mock, index) => {
         if (index === 2) {
@@ -47,6 +49,7 @@ describe('GroupContainer', () => {
       render({ mockQuestions });
       validateTableLayout(mockQuestions);
     });
+
     it('should render table with start binding', () => {
       render({
         likertContainerProps: {
@@ -59,6 +62,7 @@ describe('GroupContainer', () => {
 
       validateTableLayout(defaultMockQuestions.slice(2));
     });
+
     it('should render table with end binding', () => {
       render({
         likertContainerProps: {
@@ -71,6 +75,7 @@ describe('GroupContainer', () => {
 
       validateTableLayout(defaultMockQuestions.slice(0, 3));
     });
+
     it('should render table with start and end binding', () => {
       render({
         likertContainerProps: {
@@ -86,8 +91,9 @@ describe('GroupContainer', () => {
 
       validateTableLayout(defaultMockQuestions.slice(2, 4));
     });
+
     it('should render table view and click radiobuttons', async () => {
-      const { mockStorDispatch } = render();
+      const { mockStoreDispatch } = render();
       validateTableLayout(defaultMockQuestions);
 
       const rad1 = screen.getByRole('radiogroup', {
@@ -104,30 +110,31 @@ describe('GroupContainer', () => {
       const btn2 = within(rad2).getByRole('radio', {
         name: /Dårlig/i,
       });
-      mockStorDispatch.mockClear();
+      mockStoreDispatch.mockClear();
       expect(btn1).not.toBeChecked();
       await userEvent.click(btn1);
-      expect(mockStorDispatch).toHaveBeenCalledWith(
+      expect(mockStoreDispatch).toHaveBeenCalledWith(
         createFormDataUpdateAction(0, '1'),
       );
-      mockStorDispatch.mockClear();
+      mockStoreDispatch.mockClear();
       expect(btn2).not.toBeChecked();
       await userEvent.click(btn2);
 
-      expect(mockStorDispatch).toHaveBeenCalledWith(
+      expect(mockStoreDispatch).toHaveBeenCalledWith(
         createFormDataUpdateAction(1, '3'),
       );
     });
 
     it('should render standard view and use keyboard to navigate', async () => {
-      const { mockStorDispatch } = render();
+      const { mockStoreDispatch } = render();
       validateTableLayout(defaultMockQuestions);
       await userEvent.tab();
       await userEvent.keyboard('[Space]');
-      expect(mockStorDispatch).toHaveBeenCalledWith(
+      expect(mockStoreDispatch).toHaveBeenCalledWith(
         createFormDataUpdateAction(0, '1'),
       );
     });
+
     it('should support nested binding for question text in data model', async () => {
       const extraTextResources = defaultMockQuestions.map((question, i) => ({
         value: question.Question,
@@ -140,6 +147,7 @@ describe('GroupContainer', () => {
       render({ mockQuestions, extraTextResources });
       validateTableLayout(defaultMockQuestions);
     });
+
     it('should render error message', async () => {
       render({
         validations: createFormError(1),
@@ -147,6 +155,7 @@ describe('GroupContainer', () => {
       expect(screen.getByRole('alert')).toHaveTextContent('Feltet er påkrevd');
       screen.getByText(/En av radene er ikke fylt ut riktig/i);
     });
+
     it('should render 2 alerts', async () => {
       render({
         validations: { ...createFormError(1), ...createFormError(2) },
@@ -154,6 +163,7 @@ describe('GroupContainer', () => {
       expect(screen.getAllByRole('alert')).toHaveLength(2);
       screen.getByText(/En av radene er ikke fylt ut riktig/i);
     });
+
     it('should display title and description', async () => {
       render({
         likertContainerProps: {
@@ -183,8 +193,9 @@ describe('GroupContainer', () => {
         screen.getByRole('group', { name: /Likert test title/i }),
       ).toHaveAccessibleDescription('This is a test description');
     });
+
     it('should render mobile view and click radiobuttons', async () => {
-      const { mockStorDispatch } = render({ mobileView: true });
+      const { mockStoreDispatch } = render({ mobileView: true });
       validateRadioLayout(defaultMockQuestions);
       const rad1 = screen.getByRole('radiogroup', {
         name: /Hvordan trives du på skolen/i,
@@ -195,10 +206,10 @@ describe('GroupContainer', () => {
 
       expect(btn1).not.toBeChecked();
       await userEvent.click(btn1);
-      expect(mockStorDispatch).toHaveBeenCalledWith(
+      expect(mockStoreDispatch).toHaveBeenCalledWith(
         createFormDataUpdateAction(0, '1'),
       );
-      mockStorDispatch.mockClear();
+      mockStoreDispatch.mockClear();
 
       const rad2 = screen.getByRole('radiogroup', {
         name: /Har du det bra/i,
@@ -210,10 +221,11 @@ describe('GroupContainer', () => {
 
       expect(btn2).not.toBeChecked();
       await userEvent.click(btn2);
-      expect(mockStorDispatch).toHaveBeenCalledWith(
+      expect(mockStoreDispatch).toHaveBeenCalledWith(
         createFormDataUpdateAction(1, '3'),
       );
     });
+
     it('should render mobile view with selected values', () => {
       const mockQuestions = defaultMockQuestions.map((mock, index) => {
         if (index === 2) {

--- a/src/altinn-app-frontend/src/features/form/containers/GroupContainerLikert.test.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/GroupContainerLikert.test.tsx
@@ -6,6 +6,7 @@ import {
   render,
   validateRadioLayout,
   validateTableLayout,
+  questionsWithAnswers,
 } from 'src/features/form/containers/GroupContainerLikertTestUtils';
 import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -23,31 +24,34 @@ describe('GroupContainer', () => {
     });
 
     it('should render table with one selected row', () => {
-      const mockQuestions = defaultMockQuestions.map((mock, index) => {
-        if (index === 1) {
-          // Set one answer to selected
-          return { ...mock, answer: '2' };
-        }
-        return mock;
+      const questions = questionsWithAnswers({
+        questions: defaultMockQuestions,
+        selectedAnswers: [{ questionIndex: 1, answerValue: '2' }],
       });
-      render({ mockQuestions });
-      validateTableLayout(mockQuestions);
+      render({ mockQuestions: questions });
+
+      validateTableLayout(questions);
     });
 
     it('should render table with two selected row', () => {
-      const mockQuestions = defaultMockQuestions.map((mock, index) => {
-        if (index === 1) {
-          // Set one answer to selected
-          return { ...mock, answer: '2' };
-        }
-        if (index === 2) {
-          // Set one answer to selected
-          return { ...mock, answer: '1' };
-        }
-        return mock;
+      const selectedAnswers = [
+        {
+          questionIndex: 1,
+          answerValue: '2',
+        },
+        {
+          questionIndex: 2,
+          answerValue: '1',
+        },
+      ];
+
+      const questions = questionsWithAnswers({
+        questions: defaultMockQuestions,
+        selectedAnswers,
       });
-      render({ mockQuestions });
-      validateTableLayout(mockQuestions);
+
+      render({ mockQuestions: questions });
+      validateTableLayout(questions);
     });
 
     it('should render table with start binding', () => {
@@ -227,19 +231,17 @@ describe('GroupContainer', () => {
     });
 
     it('should render mobile view with selected values', () => {
-      const mockQuestions = defaultMockQuestions.map((mock, index) => {
-        if (index === 2) {
-          // Set one answer to selected
-          return { ...mock, Answer: '2' };
-        }
-        return mock;
+      const questions = questionsWithAnswers({
+        questions: defaultMockQuestions,
+        selectedAnswers: [{ questionIndex: 2, answerValue: '2' }],
       });
-      render({ mockQuestions, mobileView: true });
-      validateRadioLayout(mockQuestions);
+
+      render({ mockQuestions: questions, mobileView: true });
+      validateRadioLayout(questions);
 
       // Validate that radio is selected
       const selectedRow = screen.getByRole('radiogroup', {
-        name: mockQuestions[2].Question,
+        name: questions[2].Question,
       });
 
       const selectedRadio = within(selectedRow).getByRole('radio', {

--- a/src/altinn-app-frontend/src/features/form/containers/GroupContainerLikertTestUtils.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/GroupContainerLikertTestUtils.tsx
@@ -48,6 +48,16 @@ export const mockOptions = [
   },
 ];
 
+export const questionsWithAnswers = ({ questions, selectedAnswers }) => {
+  const questionsCopy = [...questions];
+
+  selectedAnswers.forEach((answer) => {
+    questionsCopy[answer.questionIndex].Answer = answer.answerValue;
+  });
+
+  return questionsCopy;
+};
+
 const createLikertContainer = (props: Partial<ILayoutGroup>): ILayoutGroup => {
   return {
     id: 'likert-repeating-group-id',
@@ -270,6 +280,7 @@ export const validateTableLayout = (questions: IQuestion[]) => {
 
 export const validateRadioLayout = (questions: IQuestion[]) => {
   expect(screen.getAllByRole('radiogroup')).toHaveLength(questions.length);
+
   for (const question of questions) {
     const row = screen.getByRole('radiogroup', {
       name: question.Question,

--- a/src/altinn-app-frontend/src/features/form/containers/GroupContainerLikertTestUtils.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/GroupContainerLikertTestUtils.tsx
@@ -262,9 +262,10 @@ export const validateTableLayout = (questions: IQuestion[]) => {
   screen.getByRole('table');
 
   for (const option of mockOptions) {
-    screen.getByRole('columnheader', {
+    const columnHeader = screen.getByRole('columnheader', {
       name: new RegExp(option.label),
     });
+    expect(columnHeader).toBeInTheDocument();
   }
 
   validateRadioLayout(questions);
@@ -276,12 +277,18 @@ export const validateRadioLayout = (questions: IQuestion[]) => {
     const row = screen.getByRole('radiogroup', {
       name: question.Question,
     });
+
     for (const option of mockOptions) {
-      const radio = within(row).getByRole('radio', {
-        name: new RegExp(option.label),
-      });
+      // Ideally we should use `getByRole` selector here, but the tests that use this function
+      // generates a DOM of several hundred nodes, and `getByRole` is quite slow since it has to traverse
+      // the entire tree. Doing that in a loop (within another loop) on hundreds of nodes is not a good idea.
+      // ref: https://github.com/testing-library/dom-testing-library/issues/698
+      const radio = within(row).getByDisplayValue(option.value);
+
       if (question.Answer && option.value === question.Answer) {
         expect(radio).toBeChecked();
+      } else {
+        expect(radio).not.toBeChecked();
       }
     }
   }

--- a/src/altinn-app-frontend/src/features/form/containers/GroupContainerLikertTestUtils.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/GroupContainerLikertTestUtils.tsx
@@ -241,8 +241,8 @@ export const render = ({
   });
 
   const mockStore = setupStore(preloadedState);
-  const mockStorDispatch = jest.fn();
-  mockStore.dispatch = mockStorDispatch;
+  const mockStoreDispatch = jest.fn();
+  mockStore.dispatch = mockStoreDispatch;
   setScreenWidth(mobileView ? 600 : 1200);
   renderWithProviders(
     <GroupContainer
@@ -255,7 +255,7 @@ export const render = ({
     },
   );
 
-  return { mockStorDispatch };
+  return { mockStoreDispatch };
 };
 
 export const validateTableLayout = (questions: IQuestion[]) => {

--- a/src/altinn-app-frontend/src/features/form/containers/GroupContainerLikertTestUtils.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/GroupContainerLikertTestUtils.tsx
@@ -15,9 +15,6 @@ export const defaultMockQuestions = [
   { Question: 'Hvordan trives du på skolen?', Answer: '' },
   { Question: 'Har du det bra?', Answer: '' },
   { Question: 'Hvor god er du i matte?', Answer: '' },
-  { Question: 'Hvor god er du i javascript?', Answer: '' },
-  { Question: 'Hvor god er du i css?', Answer: '' },
-  { Question: 'Hvordan trives du ute i skogen?', Answer: '' },
 ];
 
 const groupBinding = 'Questions';


### PR DESCRIPTION
## Description
We recently had some unstable tests, due to tests taking more than the allotted time to execute (10 seconds pr test). This was caused by using `getByRole` query, which is not great on a large DOM tree (~600 nodes) in a loop within a loop. The slowest test in this group now takes ~3500ms which is still not _great_, but I think good enough for now 🙂 When running the whole test suite, it takes longer (6-7000ms), which is why I have kept the increased jest timeout of 10000ms.

- Decreased test data set
	-  This is to reduce the generated DOM size, to improve the general test performance
- Changed from `getByRole` to `getByDisplayValue` in the innermost loop to improve test performance
- Fixed issue in test data where answers were added with incorrect casing in the key. This was not caught by any tests, because of a missing `expect` statement.
	- Add function to get "questions with answer", to ensure that answers are added with the proper key with correct casing (`Answer`)
	- Add extra expect to validateRadioLayout which will fail the test when answers are added with incorrect key casing (`answer`)

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
