### PR TITLE
Fixing bug causing misindexed repeating groups

### DIFF
--- a/src/altinn-app-frontend/src/utils/formLayout.test.ts
+++ b/src/altinn-app-frontend/src/utils/formLayout.test.ts
@@ -121,6 +121,46 @@ describe('formLayout', () => {
     expect(result).toEqual(expected);
   });
 
+  it('getRepeatingGroups should correctly handle out-of-order formData', () => {
+    const formData = {
+      'Group1[2].prop1': 'value-2-1',
+      'Group1[2].Group2[1].group2prop': 'group2-2-2-value',
+      'Group1[2].Group2[0].group2prop': 'group2-2-1-value',
+      'Group1[1].prop1': 'value-1-1',
+      'Group1[1].Group2[3].group2prop': 'group2-1-3-value',
+      'Group1[1].Group2[4].group2prop': 'group2-1-3-value',
+      'Group1[1].Group2[0].group2prop': 'group2-1-0-value',
+      'Group1[1].Group2[1].group2prop': 'group2-1-1-value',
+      'Group1[1].Group2[2].group2prop': 'group2-1-2-value',
+      'Group1[0].Group2[0].group2prop': 'group2-0-0-value',
+      'Group1[0].prop1': 'value-0-1',
+    };
+    const expected = {
+      Group1: {
+        index: 2,
+        dataModelBinding: 'Group1',
+        editIndex: -1,
+      },
+      'Group2-0': {
+        index: 0,
+        baseGroupId: 'Group2',
+        editIndex: -1,
+      },
+      'Group2-1': {
+        index: 4,
+        baseGroupId: 'Group2',
+        editIndex: -1,
+      },
+      'Group2-2': {
+        index: 1,
+        baseGroupId: 'Group2',
+        editIndex: -1,
+      },
+    };
+    const result = getRepeatingGroups(testLayout, formData);
+    expect(result).toEqual(expected);
+  });
+
   it('getRepeatingGroups should return correct count', () => {
     const testLayout: ILayout = [
       {

--- a/src/altinn-app-frontend/src/utils/formLayout.ts
+++ b/src/altinn-app-frontend/src/utils/formLayout.ts
@@ -98,9 +98,11 @@ export function getRepeatingGroups(formLayout: ILayout, formData: any) {
 
   filteredGroups.forEach((groupElement: ILayoutGroup) => {
     if (groupElement.maxCount > 1) {
-      const groupFormData = Object.keys(formData).filter((key) => {
-        return key.startsWith(groupElement.dataModelBindings.group);
-      });
+      const groupFormData = Object.keys(formData)
+        .filter((key) => {
+          return key.startsWith(groupElement.dataModelBindings.group);
+        })
+        .sort();
       if (groupFormData && groupFormData.length > 0) {
         const lastItem = groupFormData[groupFormData.length - 1];
         const match = lastItem.match(regex);
@@ -193,9 +195,11 @@ function getIndexForNestedRepeatingGroup(
     parentGroupBinding,
     `${parentGroupBinding}[${parentIndex}]`,
   );
-  const groupFormData = Object.keys(formData).filter((key) => {
-    return key.startsWith(indexedGroupBinding);
-  });
+  const groupFormData = Object.keys(formData)
+    .filter((key) => {
+      return key.startsWith(indexedGroupBinding);
+    })
+    .sort();
   if (groupFormData && groupFormData.length > 0) {
     const lastItem = groupFormData[groupFormData.length - 1];
     const match = lastItem.match(regex);


### PR DESCRIPTION
## Description
When adding formData to previous rows in a repeating group, and combined with a 303 response from the server causing repeating groups to be recalculated, you could end up with an issue where the repeating group index got overwritten with a lower value - seemingly deleting subsequent rows.

## Related Issue(s)
- #307

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- ~~[ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~
