### PR TITLE
Rendering checkboxes summary as string, when string is provided

### DIFF
--- a/src/altinn-app-frontend/src/components/summary/SummaryComponentSwitch.tsx
+++ b/src/altinn-app-frontend/src/components/summary/SummaryComponentSwitch.tsx
@@ -13,6 +13,8 @@ import SummaryBoilerplate from 'src/components/summary/SummaryBoilerplate';
 import {
   isFileUploadComponent,
   isFileUploadWithTagComponent,
+  isGroupComponent,
+  isCheckboxesComponent,
 } from 'src/utils/formLayout';
 
 export interface ISummaryComponentSwitch {
@@ -46,67 +48,67 @@ export default function SummaryComponentSwitch({
     return null;
   }
 
-  if (Object.keys(formComponent.dataModelBindings || {}).length === 0) {
-    if (isFileUploadComponent(formComponent)) {
-      return (
-        <>
-          <SummaryBoilerplate
-            {...change}
-            label={label}
-            hasValidationMessages={hasValidationMessages}
-          />
-          <AttachmentSummaryComponent componentRef={componentRef} />
-        </>
-      );
-    }
-    if (isFileUploadWithTagComponent(formComponent)) {
-      return (
-        <>
-          <SummaryBoilerplate
-            {...change}
-            label={label}
-            hasValidationMessages={hasValidationMessages}
-          />
-          <AttachmentWithTagSummaryComponent
-            componentRef={componentRef}
-            component={formComponent as ISelectionComponentProps}
-          />
-        </>
-      );
-    }
+  const hasDataBindings =
+    Object.keys(formComponent.dataModelBindings || {}).length === 0;
+
+  if (hasDataBindings && isFileUploadComponent(formComponent)) {
+    return (
+      <>
+        <SummaryBoilerplate
+          {...change}
+          label={label}
+          hasValidationMessages={hasValidationMessages}
+        />
+        <AttachmentSummaryComponent componentRef={componentRef} />
+      </>
+    );
   }
 
-  switch (formComponent.type) {
-    case 'Group':
-    case 'group': {
-      return (
-        <SummaryGroupComponent
+  if (hasDataBindings && isFileUploadWithTagComponent(formComponent)) {
+    return (
+      <>
+        <SummaryBoilerplate
           {...change}
-          {...groupProps}
+          label={label}
+          hasValidationMessages={hasValidationMessages}
+        />
+        <AttachmentWithTagSummaryComponent
           componentRef={componentRef}
+          component={formComponent as ISelectionComponentProps}
         />
-      );
-    }
-    case 'Checkboxes': {
-      return (
-        <MultipleChoiceSummary
-          {...change}
-          label={label}
-          hasValidationMessages={hasValidationMessages}
-          formData={formData}
-          readOnlyComponent={(formComponent as ILayoutComponent).readOnly}
-        />
-      );
-    }
-    default:
-      return (
-        <SingleInputSummary
-          {...change}
-          label={label}
-          hasValidationMessages={hasValidationMessages}
-          formData={formData}
-          readOnlyComponent={(formComponent as ILayoutComponent).readOnly}
-        />
-      );
+      </>
+    );
   }
+
+  if (isGroupComponent(formComponent)) {
+    return (
+      <SummaryGroupComponent
+        {...change}
+        {...groupProps}
+        componentRef={componentRef}
+      />
+    );
+  }
+
+  if (isCheckboxesComponent(formComponent) && typeof formData !== 'string') {
+    return (
+      <MultipleChoiceSummary
+        {...change}
+        label={label}
+        hasValidationMessages={hasValidationMessages}
+        formData={formData}
+        readOnlyComponent={(formComponent as ILayoutComponent).readOnly}
+      />
+    );
+  }
+
+  return (
+    <SingleInputSummary
+      {...change}
+      label={label}
+      hasValidationMessages={hasValidationMessages}
+      formData={formData}
+      readOnlyComponent={(formComponent as ILayoutComponent).readOnly}
+    />
+  );
 }

--- a/src/altinn-app-frontend/src/utils/formLayout.ts
+++ b/src/altinn-app-frontend/src/utils/formLayout.ts
@@ -18,6 +18,7 @@ import type {
   ILayoutGroup,
 } from '../features/form/layout';
 import type { IDatePickerProps } from 'src/components/base/DatepickerComponent';
+import type { ICheckboxContainerProps } from 'src/components/base/CheckboxesContainerComponent';
 
 interface SplitKey {
   baseComponentId: string;
@@ -467,4 +468,12 @@ export function isDatePickerComponent(
   component: ILayoutComponent | ILayoutGroup,
 ): component is IDatePickerProps & ILayoutComponent {
   return component.type.toLowerCase() === 'datepicker';
+}
+
+export function isCheckboxesComponent(
+  component: any,
+): component is ICheckboxContainerProps & ILayoutComponent {
+  return (
+    component && component.type && component.type.toLowerCase() === 'checkboxes'
+  );
 }


### PR DESCRIPTION
## Description
The summary page could end up rendering `Checkboxes` components by iterating each character and listing them line-by-line. This happens when the `formData` is provided as a string.

This quick-fix just renders the string instead, but we could also go the extra mile by hunting down why this happens and make sure `Checkboxes` components are always summarized with list inputs - although it is stored in `formData` as a comma-separated string.

## Related Issue(s)
- #257

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- ~~[ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~
