### PR TITLE
Fixing code using lookbehind + lookahead, for Safari

### DIFF
--- a/src/altinn-app-frontend/src/utils/databindings.test.ts
+++ b/src/altinn-app-frontend/src/utils/databindings.test.ts
@@ -8,6 +8,7 @@ import {
   getKeyWithoutIndex,
   mapFormData,
   removeGroupData,
+  getKeyIndex,
 } from './databindings';
 
 describe('utils/databindings.ts', () => {
@@ -109,6 +110,12 @@ describe('utils/databindings.ts', () => {
         disabled: false,
       },
     ];
+  });
+
+  describe('getKeyIndex', () => {
+    it('should work', () => {
+      expect(getKeyIndex('Group[1].Group2[0].group2prop')).toEqual([1, 0]);
+    });
   });
 
   describe('flattenObject', () => {

--- a/src/altinn-app-frontend/src/utils/databindings.ts
+++ b/src/altinn-app-frontend/src/utils/databindings.ts
@@ -72,8 +72,8 @@ export function getKeyWithoutIndex(keyWithIndex: string): string {
  * as an array => [0, 1]
  */
 export function getKeyIndex(keyWithIndex: string): number[] {
-  const match = keyWithIndex.match(/(?<=\[)\d+(?=])]/g) || [];
-  return match.map((n) => parseInt(n, 10));
+  const match = keyWithIndex.match(/\[\d+]/g) || [];
+  return match.map((n) => parseInt(n.replace('[', '').replace(']', ''), 10));
 }
 
 /**


### PR DESCRIPTION
## Description
The offending code caused Safari to crash on load.

## Related Issue(s)
- #312

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- ~~[ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~
