### PR TITLE
Bug: Dynamics/hidden fields in summaries of nested repeating groups

### DIFF
--- a/src/altinn-app-frontend/src/utils/databindings.test.ts
+++ b/src/altinn-app-frontend/src/utils/databindings.test.ts
@@ -113,7 +113,7 @@ describe('utils/databindings.ts', () => {
   });
 
   describe('getKeyIndex', () => {
-    it('should work', () => {
+    it('should return key indexes from string', () => {
       expect(getKeyIndex('Group[1].Group2[0].group2prop')).toEqual([1, 0]);
     });
   });

--- a/test/cypress/e2e/fixtures/texts.json
+++ b/test/cypress/e2e/fixtures/texts.json
@@ -26,5 +26,11 @@
   "uploadWithTag": "Last opp vedlegg og knytte den mot en tag",
   "uplodDocs": "Last opp eventuell dokumentasjon for ditt nye navn",
   "zeroIsNotValid": "0 er ikke en gyldig verdi",
-  "finishedUploading": "Ferdig lastet"
+  "finishedUploading": "Ferdig lastet",
+  "nestedOptionsToggle": "Vis tillegg",
+  "nestedOptions": "Tilleggsopsjoner",
+  "nestedOption1": "Opsjon 11",
+  "nestedOption2": "Opsjon 1",
+  "nestedOption3": "Opsjon 111",
+  "change": "Endre"
 }

--- a/test/cypress/e2e/integration/app-frontend/summary.js
+++ b/test/cypress/e2e/integration/app-frontend/summary.js
@@ -91,7 +91,7 @@ describe('Summary', () => {
       });
   });
 
-  it('is possible to view summary of repeating group', () => {
+  it.only('is possible to view summary of repeating group', () => {
     cy.completeTask3Form();
     cy.get(appFrontend.group.mainGroupSummary)
       .should('be.visible').and('have.length', 1)
@@ -108,7 +108,33 @@ describe('Summary', () => {
         cy.get(item).eq(4).should('contain.text', 'attachment-in-multi2.pdf');
         cy.get(item).eq(5).should('contain.text', 'attachment-in-nested.pdf');
         cy.get(item).eq(5).should('contain.text', 'automation');
-        cy.get(item).eq(5).should('not.contain.text', 'Tilleggsopsjoner');
+        cy.get(item).eq(5).should('contain.text', texts.nestedOptionsToggle);
+        cy.get(item).eq(5).should('not.contain.text', texts.nestedOptions);
+
+        // Go back to the repeating group in order to set nested options
+        cy.get(item).eq(5).find('button').first().should('contain.text', texts.change).click();
+      });
+
+    // Check to show a couple of nested options, then go back to the summary
+    cy.get(appFrontend.group.rows[0].editBtn).click();
+    cy.get(appFrontend.group.mainGroup)
+      .siblings(appFrontend.group.editContainer)
+      .find(appFrontend.group.next).click();
+    cy.get(appFrontend.group.rows[0].nestedGroup.rows[0].nestedDynamics).click();
+    cy.get(appFrontend.group.rows[0].nestedGroup.rows[0].nestedOptions[1]).click();
+    cy.get(appFrontend.group.rows[0].nestedGroup.rows[0].nestedOptions[2]).click();
+    cy.get(appFrontend.group.rows[0].nestedGroup.saveBtn).click();
+    cy.get(appFrontend.group.saveMainGroup).click();
+    cy.contains(mui.button, texts.backToSummary).click();
+
+    cy.get(appFrontend.group.mainGroupSummary)
+      .should('be.visible').and('have.length', 1)
+      .first()
+      .children(mui.gridItem).should('have.length', 6)
+      .then((item) => {
+        cy.get(item).eq(5).should('contain.text', texts.nestedOptionsToggle);
+        cy.get(item).eq(5).should('contain.text', texts.nestedOptions);
+        cy.get(item).eq(5).should('contain.text', `${texts.nestedOption2}, ${texts.nestedOption3}`);
       });
   });
 });

--- a/test/cypress/e2e/integration/app-frontend/summary.js
+++ b/test/cypress/e2e/integration/app-frontend/summary.js
@@ -108,6 +108,7 @@ describe('Summary', () => {
         cy.get(item).eq(4).should('contain.text', 'attachment-in-multi2.pdf');
         cy.get(item).eq(5).should('contain.text', 'attachment-in-nested.pdf');
         cy.get(item).eq(5).should('contain.text', 'automation');
+        cy.get(item).eq(5).should('not.contain.text', 'Tilleggsopsjoner');
       });
   });
 });

--- a/test/cypress/e2e/pageobjects/app-frontend.js
+++ b/test/cypress/e2e/pageobjects/app-frontend.js
@@ -160,6 +160,12 @@ export default class AppFrontend {
         nestedGroup: {
           rows: [0, 1].map((subIdx) => ({
             uploadTagMulti: makeUploaderSelectors('subUploader', `${idx}-${subIdx}`, 2, true),
+            nestedDynamics: `#nestedDynamics-${idx}-${subIdx} input[type=checkbox]`,
+            nestedOptions: [
+              `#nestedOptions-${idx}-${subIdx} input[type=checkbox]:nth(0)`,
+              `#nestedOptions-${idx}-${subIdx} input[type=checkbox]:nth(1)`,
+              `#nestedOptions-${idx}-${subIdx} input[type=checkbox]:nth(2)`,
+            ],
             editBtn: `#group-subGroup-${idx}-table-body > tr:nth-child(${subIdx + 1}) > td:last-of-type > button`
           })),
           groupContainer: `#group-subGroup-${idx}`,


### PR DESCRIPTION
## Description
This fix involves three distinct changes:

1. Using a Set instead of iterating the hidden fields to reduce it to a subset. While the group children filter works, it does not filter nested children, so this didn't seem to have the desired effect on nested groups. I assume the filtering is done for performance reasons, so using a Set for this seems more ideal (lookups are cheap, at least).
2. Making sure we check for the full nested dashed path when testing if the field should be hidden. Without this, nested dynamics have no effect when showing a summary.
3. Moving the code so that loops continue earlier when hidden fields are found. Previously it would run the iteration almost to the end before scrapping the result if the field was hidden, which is a bit wasteful. This shouldn't have an effect on the core problem, but should slightly improve performance.

## Related Issue(s)
- #311

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- ~~[ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~
