### PR TITLE
Fixing openByDefault option on repeating groups

### DIFF
--- a/src/altinn-app-frontend/src/features/form/containers/GroupContainer.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/GroupContainer.tsx
@@ -220,18 +220,9 @@ export function GroupContainer({
         layoutElementId: id,
         remove: true,
         index: groupIndex,
+        leaveOpen: container.edit?.openByDefault,
       }),
     );
-
-    if (
-      container.edit?.openByDefault &&
-      groupIndex === 0 &&
-      repeatingGroups[id].index === 0
-    ) {
-      dispatch(
-        FormLayoutActions.updateRepeatingGroups({ layoutElementId: id }),
-      );
-    }
   };
 
   const onClickSave = () => {

--- a/src/altinn-app-frontend/src/features/form/layout/formLayoutTypes.ts
+++ b/src/altinn-app-frontend/src/features/form/layout/formLayoutTypes.ts
@@ -60,6 +60,7 @@ export interface IUpdateRepeatingGroups {
   layoutElementId: string;
   remove?: boolean;
   index?: number;
+  leaveOpen?: boolean;
 }
 
 export interface IUpdateRepeatingGroupsFulfilled {

--- a/src/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
+++ b/src/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
@@ -137,7 +137,7 @@ function* updateFocus({
 }
 
 export function* updateRepeatingGroupsSaga({
-  payload: { layoutElementId, remove, index },
+  payload: { layoutElementId, remove, index, leaveOpen },
 }: PayloadAction<IUpdateRepeatingGroups>) {
   try {
     const formLayoutState: ILayoutState = yield select(selectFormLayoutState);
@@ -279,6 +279,12 @@ export function* updateRepeatingGroupsSaga({
             (value) => value !== index,
           );
         updatedRepeatingGroups[layoutElementId].editIndex = -1;
+
+        if (leaveOpen && index === 0) {
+          updatedRepeatingGroups[layoutElementId].index = 0;
+          updatedRepeatingGroups[layoutElementId].editIndex = 0;
+        }
+
         yield put(
           FormLayoutActions.updateRepeatingGroupsFulfilled({
             repeatingGroups: updatedRepeatingGroups,

--- a/test/cypress/e2e/integration/app-frontend/group.js
+++ b/test/cypress/e2e/integration/app-frontend/group.js
@@ -9,60 +9,92 @@ const appFrontend = new AppFrontend();
 const mui = new Common();
 
 describe('Group', () => {
-  beforeEach(() => {
+  const init = () => {
     cy.navigateToTask3();
     cy.get(appFrontend.group.showGroupToContinue).should('be.visible');
-  });
+  };
 
   it('Dynamics on group', () => {
+    init();
     cy.get(appFrontend.group.addNewItem).should('not.exist');
     cy.get(appFrontend.group.showGroupToContinue).find('input').check();
     cy.get(appFrontend.group.addNewItem).should('exist').and('be.visible');
   });
 
-  it('Add and delete items on main and nested group', () => {
-    cy.get(appFrontend.group.showGroupToContinue).find('input').check();
-    cy.addItemToGroup(1, 2, 'automation');
-    cy.get(appFrontend.group.mainGroup)
-      .find(mui.tableBody)
-      .then((table) => {
-        cy.get(table).find(mui.tableElement).first().invoke('text').should('equal', '1');
-        cy.get(table).find(mui.tableElement).eq(1).invoke('text').should('equal', '2');
-        cy.get(table).find(mui.tableElement).find(mui.buttonIcon).should('be.visible').click();
+  [true, false].forEach((openByDefault) => {
+    it(`Add and delete items on main and nested group (openByDefault = ${openByDefault ? 'true' : 'false'})`, () => {
+      cy.intercept('**/api/layouts/group', (req) => {
+        req.reply(res => {
+          const modified = JSON.parse(res.body);
+          modified.repeating.data.layout = modified.repeating.data.layout.map((component) => {
+            if (component.edit && typeof component.edit.openByDefault === 'boolean') {
+              component.edit.openByDefault = openByDefault;
+            }
+            return component;
+          });
+
+          res.send(JSON.stringify(modified));
+        });
       });
-    cy.get(appFrontend.group.mainGroup)
-      .siblings(appFrontend.group.editContainer)
-      .find(appFrontend.group.next)
-      .should('be.visible')
-      .click();
-    cy.get(appFrontend.group.subGroup)
-      .find(mui.tableBody)
-      .then((table) => {
-        cy.get(table).find(mui.tableElement).first().invoke('text').should('equal', 'automation');
-        cy.get(table).find(mui.tableElement).find(mui.buttonIcon).should('be.visible').click();
-      });
-    cy.get(appFrontend.group.subGroup)
-      .siblings(appFrontend.group.editContainer)
-      .find(appFrontend.group.delete)
-      .should('be.visible')
-      .click();
-    cy.get(appFrontend.group.subGroup).find(mui.tableElement).eq(0).should('not.contain.text', 'automation');
-    cy.get(appFrontend.group.comments).should('not.exist');
-    cy.get(appFrontend.group.mainGroup)
-      .siblings(appFrontend.group.editContainer)
-      .find(appFrontend.group.back)
-      .should('be.visible')
-      .click();
-    cy.get(appFrontend.group.mainGroup)
-      .siblings(appFrontend.group.editContainer)
-      .find(appFrontend.group.delete)
-      .should('be.visible')
-      .click();
-    cy.get(appFrontend.group.saveMainGroup).should('not.exist');
-    cy.get(appFrontend.group.mainGroup).find(mui.tableElement).should('have.length', 0);
+      init();
+
+      cy.get(appFrontend.group.showGroupToContinue).find('input').check();
+      cy.addItemToGroup(1, 2, 'automation', openByDefault);
+      cy.get(appFrontend.group.mainGroup)
+        .find(mui.tableBody)
+        .then((table) => {
+          cy.get(table).find(mui.tableElement).first().invoke('text').should('equal', '1');
+          cy.get(table).find(mui.tableElement).eq(1).invoke('text').should('equal', '2');
+          cy.get(table).find(mui.tableElement).find(mui.buttonIcon).should('be.visible').click();
+        });
+      cy.get(appFrontend.group.mainGroup)
+        .siblings(appFrontend.group.editContainer)
+        .find(appFrontend.group.next)
+        .should('be.visible')
+        .click();
+      cy.get(appFrontend.group.subGroup)
+        .find(mui.tableBody)
+        .then((table) => {
+          cy.get(table).find(mui.tableElement).first().invoke('text').should('equal', 'automation');
+          cy.get(table).find(mui.tableElement).find(mui.buttonIcon).should('be.visible').click();
+        });
+      cy.get(appFrontend.group.subGroup)
+        .siblings(appFrontend.group.editContainer)
+        .find(appFrontend.group.delete)
+        .should('be.visible')
+        .click();
+
+      if (openByDefault) {
+        cy.get(appFrontend.group.subGroup).find(mui.tableElement).eq(0).should('not.contain.text', 'automation');
+        cy.get(appFrontend.group.comments).should('be.visible');
+      } else {
+        cy.get(appFrontend.group.subGroup).find(mui.tableElement).should('have.length', 0);
+        cy.get(appFrontend.group.comments).should('not.exist');
+      }
+
+      cy.get(appFrontend.group.mainGroup)
+        .siblings(appFrontend.group.editContainer)
+        .find(appFrontend.group.back)
+        .should('be.visible')
+        .click();
+      cy.get(appFrontend.group.mainGroup)
+        .siblings(appFrontend.group.editContainer)
+        .find(appFrontend.group.delete)
+        .should('be.visible')
+        .click();
+
+      if (openByDefault) {
+        cy.get(appFrontend.group.saveMainGroup).should('be.visible');
+        cy.get(appFrontend.group.mainGroup).find(mui.tableElement).should('have.length.greaterThan', 0);
+      } else {
+        cy.get(appFrontend.group.saveMainGroup).should('not.exist');
+        cy.get(appFrontend.group.mainGroup).find(mui.tableElement).should('have.length', 0);
+      }
+    });
   });
 
   it('Calculation on Item in Main Group should update value', () => {
+    init();
     cy.get(appFrontend.group.showGroupToContinue).find('input').check();
     cy.get(appFrontend.group.addNewItem).focus().should('be.visible').click();
     cy.get(appFrontend.group.currentValue).should('be.visible').type('1337').blur().tab();
@@ -72,6 +104,7 @@ describe('Group', () => {
   });
 
   it('Validation on group', () => {
+    init();
     cy.get(appFrontend.group.showGroupToContinue).find('input').check();
     cy.get(appFrontend.group.addNewItem).should('exist').and('be.visible').focus().click();
     cy.get(appFrontend.group.currentValue).should('be.visible').type('1').blur();

--- a/test/cypress/e2e/support/app-frontend.js
+++ b/test/cypress/e2e/support/app-frontend.js
@@ -115,8 +115,11 @@ Cypress.Commands.add('navigateToTask4', () => {
   });
 });
 
-Cypress.Commands.add('addItemToGroup', (oldValue, newValue, comment) => {
-  cy.get(appFrontend.group.addNewItem).should('be.visible').focus().click();
+Cypress.Commands.add('addItemToGroup', (oldValue, newValue, comment, openByDefault) => {
+  if (openByDefault !== true) {
+    cy.get(appFrontend.group.addNewItem).should('be.visible').focus().click();
+  }
+
   cy.get(appFrontend.group.currentValue).should('be.visible').type(oldValue).blur();
   cy.get(appFrontend.group.newValue).should('be.visible').type(newValue).blur();
   cy.get(appFrontend.group.mainGroup)
@@ -124,7 +127,13 @@ Cypress.Commands.add('addItemToGroup', (oldValue, newValue, comment) => {
     .find(appFrontend.group.next)
     .should('be.visible')
     .click();
-  cy.get(appFrontend.group.addNewItem).should('not.exist');
+
+  if (openByDefault === true || typeof openByDefault === 'undefined') {
+    cy.get(appFrontend.group.addNewItem).should('not.exist');
+  } else {
+    cy.get(appFrontend.group.addNewItem).click();
+  }
+
   cy.get(appFrontend.group.comments).should('be.visible').type(comment).blur();
   cy.get(appFrontend.group.saveSubGroup).should('be.visible').click().should('not.exist');
   cy.get(appFrontend.group.saveMainGroup).should('be.visible').click().should('not.exist');

--- a/test/cypress/e2e/support/index.d.ts
+++ b/test/cypress/e2e/support/index.d.ts
@@ -60,7 +60,7 @@ declare namespace Cypress {
      * Add an item to group component with an item in nested group
      * @example cy.addItemToGroup(1, 2, 'automation')
      */
-    addItemToGroup(oldValue: Number, newValue: Number, comment: string): Chainable<Element>;
+    addItemToGroup(oldValue: Number, newValue: Number, comment: string, openByDefault?:boolean): Chainable<Element>;
 
     /**
      * Test for WCAG violations of impact critical, serious, moderate


### PR DESCRIPTION
## Description
I accidentally broke the `openByDefault` edit option for repeating groups in #246 when I extended `updateRepeatingGroupsSaga` to possibly cancel a row removal (when attachments could not be deleted). Adding the functionality back in (with a single dispatched event, causing no races) and adding tests for it.

## Related Issue(s)
- #128

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- ~~[ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~
