### PR TITLE
Bug/225 browser back button not navigating in app

### DIFF
--- a/src/altinn-app-frontend/src/App.tsx
+++ b/src/altinn-app-frontend/src/App.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Route, Switch } from 'react-router-dom';
+import * as React from 'react';
+import { Route, Switch, useLocation, useRouteMatch } from 'react-router-dom';
 
 import { useAppDispatch, useAppSelector } from 'src/common/hooks';
 import Entrypoint from 'src/features/entrypoint/Entrypoint';
@@ -29,9 +29,11 @@ export const App = () => {
 
   const allowAnonymousSelector = makeGetAllowAnonymousSelector();
   const allowAnonymous = useAppSelector(allowAnonymousSelector);
-
   const [ready, setReady] = React.useState(false);
-
+  const instancePath = '/instance/:partyId/:instanceGuid';
+  const match = useRouteMatch<string>(instancePath);
+  const matchUrl = match?.url || '';
+  const location = useLocation();
   React.useEffect(() => {
     function setUpEventListeners() {
       window.addEventListener('mousemove', refreshJwtToken);
@@ -92,23 +94,21 @@ export const App = () => {
   if (!ready) {
     return null;
   }
-
   return (
     <Switch>
       <Route
-        path='/'
-        exact={true}
+        path={`/`}
+        exact={!!matchUrl || location.pathname.includes('/partyselection/')}
       >
         <Entrypoint allowAnonymous={allowAnonymous} />
       </Route>
       <Route
         path='/partyselection/:errorCode?'
-        exact={true}
+        exact
         component={PartySelection}
       />
       <Route
-        path='/instance/:partyId/:instanceGuid'
-        exact={true}
+        path={instancePath}
         component={ProcessWrapper}
       />
     </Switch>

--- a/src/altinn-app-frontend/src/common/hooks/index.ts
+++ b/src/altinn-app-frontend/src/common/hooks/index.ts
@@ -16,5 +16,7 @@ export const usePrevious = (value: any) => {
   });
   return ref.current;
 };
+
 export { useAppSelector } from './useAppSelector';
 export { useAppDispatch } from './useAppDispatch';
+export { useFormLayoutHistoryAndMatchInstanceLocation } from './useFormLayoutHistory';

--- a/src/altinn-app-frontend/src/common/hooks/useFormLayoutHistory.test.tsx
+++ b/src/altinn-app-frontend/src/common/hooks/useFormLayoutHistory.test.tsx
@@ -1,0 +1,322 @@
+import React, { type PropsWithChildren, useState } from 'react';
+import {
+  type RouterProps,
+  Link,
+  MemoryRouter,
+  Route,
+  Switch,
+  useHistory,
+  useLocation,
+} from 'react-router-dom';
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { useAppDispatch } from 'src/common/hooks/useAppDispatch';
+import { useFormLayoutHistoryAndMatchInstanceLocation } from 'src/common/hooks/useFormLayoutHistory';
+
+jest.mock('./useAppDispatch');
+describe('useFormLayoutHistory', () => {
+  const instanceIdExample = '123456/75154373-aed4-41f7-95b4-e5b5115c2edc';
+  let setViewFunc: (arg: string) => void;
+  let browserHistory: RouterProps['history'];
+  let dispatchFunction: jest.Mock;
+  beforeEach(() => {
+    dispatchFunction = jest.fn(
+      ({ payload: { newView } }: { payload: { newView: string } }) => {
+        setViewFunc(newView);
+      },
+    );
+    (useAppDispatch as jest.Mock).mockImplementation(() => dispatchFunction);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+  const setBrowserHistory = (h: RouterProps['history']) => {
+    browserHistory = h;
+  };
+
+  const MockPage = function ({
+    children,
+    prevPage,
+    nextPage,
+  }: PropsWithChildren<{
+    prevPage?: string;
+    nextPage?: string;
+  }>) {
+    return (
+      <div>
+        <header>{window.location.pathname}</header>
+        <main>{children}</main>
+        <footer>
+          {prevPage && (
+            <button onClick={() => setViewFunc(prevPage)}>Prev</button>
+          )}
+          {nextPage && (
+            <button onClick={() => setViewFunc(nextPage)}>Next</button>
+          )}
+          {nextPage && <Link to={nextPage}>Next</Link>}
+        </footer>
+      </div>
+    );
+  };
+  const MockRouteLayout = function ({ currentView }: { currentView: string }) {
+    const location = useLocation();
+    const { matchRootUrl } = useFormLayoutHistoryAndMatchInstanceLocation({
+      activePageId: currentView,
+    });
+    return (
+      <>
+        <div>
+          <button onClick={browserHistory.goBack}>History back</button>
+          <button onClick={browserHistory.goForward}>History forward</button>
+          <p>location {location.pathname}</p>
+          <p>match {matchRootUrl}</p>
+          <p>currentView {currentView}</p>
+        </div>
+        <Route
+          exact
+          path={`${matchRootUrl}/page1`}
+        >
+          <MockPage nextPage={'page2'}>First route</MockPage>
+        </Route>
+        <Route
+          exact
+          path={`${matchRootUrl}/page2`}
+        >
+          <MockPage
+            prevPage={'page1'}
+            nextPage={'page3'}
+          >
+            Second route
+          </MockPage>
+        </Route>
+        <Route
+          exact
+          path={`${matchRootUrl}/page3`}
+        >
+          <MockPage
+            prevPage={'page2'}
+            nextPage={'page4'}
+          >
+            Third route
+          </MockPage>
+        </Route>
+        <Route
+          exact
+          path={`${matchRootUrl}/page4`}
+        >
+          <MockPage prevPage={'page3'}>
+            Fourth route
+            <button onClick={() => browserHistory.go(-3)}>
+              History 3 back
+            </button>
+          </MockPage>
+        </Route>
+      </>
+    );
+  };
+
+  function TheSwitch({ currentView }: { currentView: string }) {
+    const history = useHistory();
+    setBrowserHistory(history);
+    return (
+      <Switch>
+        <Route
+          path='/instance/:partyId/:instanceGuid/:pageId'
+          exact
+        >
+          <MockRouteLayout currentView={currentView} />
+        </Route>
+        <Route
+          path='/instance/:partyId/:instanceGuid'
+          exact
+        >
+          <MockRouteLayout currentView={currentView} />
+        </Route>
+        <Route
+          path={'/:pageId'}
+          exact
+        >
+          <MockRouteLayout currentView={currentView} />
+        </Route>
+        <Route
+          path={''}
+          exact
+        >
+          <MockRouteLayout currentView={currentView} />
+        </Route>
+      </Switch>
+    );
+  }
+
+  function Everything({
+    defaultPage,
+    initialEntries,
+  }: {
+    defaultPage: string;
+    initialEntries?: string[];
+  }) {
+    const [currentView, setCurrentView] = useState(defaultPage);
+    setViewFunc = setCurrentView;
+    return (
+      <MemoryRouter initialEntries={initialEntries}>
+        <TheSwitch currentView={currentView} />
+      </MemoryRouter>
+    );
+  }
+
+  const renderLayout = (defaultPage = '', initialEntries) => {
+    render(
+      <Everything
+        defaultPage={defaultPage}
+        initialEntries={initialEntries}
+      />,
+    );
+  };
+  const NEXT_BUTTON = () => screen.getByRole('button', { name: /next/i });
+  const PREV_BUTTON = () => screen.getByRole('button', { name: /prev/i });
+  const NEXT_LINK = () => screen.getByRole('link', { name: /next/i });
+
+  const BROWSER_BACK = () =>
+    screen.getByRole('button', { name: /History back/i });
+  const BROWSER_FORWARD = () =>
+    screen.getByRole('button', { name: /History forward/i });
+  describe('initialRoute=""', () => {
+    const commonTests = (expectedLocation: string) => {
+      expect(screen.getByText('currentView page1')).toBeInTheDocument();
+      expect(screen.getByText('First route')).toBeInTheDocument();
+      expect(
+        screen.getByText(`location ${expectedLocation}`),
+      ).toBeInTheDocument();
+    };
+    test('should direct the user to the "activePage" when user has instanceId', async () => {
+      renderLayout('page1', [`/instance/${instanceIdExample}`]);
+      commonTests(`/instance/${instanceIdExample}/page1`);
+    });
+    test('should direct to the "activePage" without instance', async () => {
+      renderLayout('page1', ['']);
+      commonTests('/page1');
+    });
+  });
+
+  describe('initialRoute="/page3" (direct link to form layout page)', () => {
+    const commonTests = (baseUrl) => {
+      renderLayout('', [`${baseUrl}page3`]);
+      expect(dispatchFunction).toHaveBeenCalled();
+      expect(screen.getByText('currentView page3')).toBeInTheDocument();
+      expect(screen.getByText('Third route')).toBeInTheDocument();
+      expect(screen.getByText(`location ${baseUrl}page3`)).toBeInTheDocument();
+      expect(browserHistory.length).toBe(1);
+    };
+    test('should work with instanceId', async () => {
+      const baseUrl = `/instance/${instanceIdExample}/`;
+      commonTests(baseUrl);
+    });
+    test('should work without instanceId ', async () => {
+      const baseRoute = `/`;
+      commonTests(baseRoute);
+    });
+  });
+
+  describe('directing the user to a default page in the form', () => {
+    const commonTests = (baseUrl) => {
+      renderLayout('page4', [`${baseUrl}page2`]);
+      expect(screen.getByText('currentView page4')).toBeInTheDocument();
+      expect(screen.getByText('Fourth route')).toBeInTheDocument();
+      expect(screen.getByText(`location ${baseUrl}page4`)).toBeInTheDocument();
+    };
+    test('should work with InstanceId', async () => {
+      const baseUrl = `/instance/${instanceIdExample}/`;
+      commonTests(baseUrl);
+    });
+    test('should work without InstanceId', async () => {
+      const baseUrl = `/`;
+      commonTests(baseUrl);
+    });
+  });
+  describe('vigorous navigation', () => {
+    const commonTests = async (baseUrl) => {
+      renderLayout('page1', [baseUrl]);
+      const user = userEvent.setup();
+      expect(screen.getByText('currentView page1')).toBeInTheDocument();
+      expect(screen.getByText('First route')).toBeInTheDocument();
+      expect(browserHistory.length).toBe(1);
+      await user.click(NEXT_BUTTON());
+      expect(screen.getByText('currentView page2')).toBeInTheDocument();
+      expect(screen.getByText('Second route')).toBeInTheDocument();
+      await user.click(NEXT_BUTTON());
+      expect(screen.getByText('currentView page3')).toBeInTheDocument();
+      expect(screen.getByText('Third route')).toBeInTheDocument();
+      await user.click(NEXT_BUTTON());
+      expect(screen.getByText('currentView page4')).toBeInTheDocument();
+      expect(screen.getByText('Fourth route')).toBeInTheDocument();
+      await user.click(PREV_BUTTON());
+      expect(screen.getByText('currentView page3')).toBeInTheDocument();
+      expect(screen.getByText('Third route')).toBeInTheDocument();
+      expect(browserHistory.length).toBe(5);
+      await user.click(BROWSER_BACK());
+      expect(dispatchFunction).toHaveBeenCalledWith({
+        payload: { newView: 'page4' },
+        type: 'formLayout/updateCurrentView',
+      });
+      expect(screen.getByText('currentView page4')).toBeInTheDocument();
+      await user.click(BROWSER_BACK());
+      expect(screen.getByText('currentView page3')).toBeInTheDocument();
+      await user.click(BROWSER_BACK());
+      expect(screen.getByText('currentView page2')).toBeInTheDocument();
+      expect(screen.getByText('Second route')).toBeInTheDocument();
+      expect(browserHistory.length).toBe(5); // history should be the same
+      await user.click(PREV_BUTTON());
+      expect(browserHistory.length).toBe(3); // history should change on new entry
+      await user.click(NEXT_BUTTON());
+      await user.click(NEXT_BUTTON());
+      await user.click(NEXT_BUTTON());
+      expect(screen.getByText('currentView page4')).toBeInTheDocument();
+      expect(screen.getByText('Fourth route')).toBeInTheDocument();
+      await user.click(screen.getByRole('button', { name: 'History 3 back' }));
+      expect(screen.getByText('currentView page1')).toBeInTheDocument();
+      expect(screen.getByText('First route')).toBeInTheDocument();
+      expect(browserHistory.length).toBe(6);
+      await user.click(BROWSER_FORWARD());
+      expect(screen.getByText('currentView page2')).toBeInTheDocument();
+      expect(screen.getByText('Second route')).toBeInTheDocument();
+      await user.click(BROWSER_FORWARD());
+      await user.click(BROWSER_FORWARD());
+      expect(screen.getByText('currentView page4')).toBeInTheDocument();
+      expect(screen.getByText('Fourth route')).toBeInTheDocument();
+    };
+    test('should work with InstanceId', async () => {
+      const baseUrl = `/instance/${instanceIdExample}`;
+      await commonTests(baseUrl);
+    });
+    test('should work without instance', async () => {
+      const baseUrl = ``;
+      await commonTests(baseUrl);
+    });
+  });
+  describe('navigate from a random page inside the form', () => {
+    const commonTests = async (baseUrl) => {
+      renderLayout('', [`${baseUrl}page3`]);
+      const user = userEvent.setup();
+      expect(screen.getByText('currentView page3')).toBeInTheDocument();
+      expect(screen.getByText('Third route')).toBeInTheDocument();
+      await user.click(PREV_BUTTON());
+      expect(screen.getByText('currentView page2')).toBeInTheDocument();
+      expect(screen.getByText('Second route')).toBeInTheDocument();
+      expect(browserHistory.length).toBe(2);
+      await user.click(NEXT_LINK());
+      expect(dispatchFunction).toHaveBeenCalled();
+      expect(screen.getByText(`location ${baseUrl}page3`)).toBeInTheDocument();
+    };
+    test('should work with InstanceId', async () => {
+      const baseUrl = `/instance/${instanceIdExample}/`;
+      await commonTests(baseUrl);
+    });
+    test('should work without instance', async () => {
+      const baseUrl = `/`;
+      await commonTests(baseUrl);
+    });
+  });
+});

--- a/src/altinn-app-frontend/src/common/hooks/useFormLayoutHistory.ts
+++ b/src/altinn-app-frontend/src/common/hooks/useFormLayoutHistory.ts
@@ -1,0 +1,117 @@
+import { useCallback, useEffect } from 'react';
+import { useHistory, useRouteMatch } from 'react-router-dom';
+
+import { useAppDispatch } from 'src/common/hooks/useAppDispatch';
+import { FormLayoutActions } from 'src/features/form/layout/formLayoutSlice';
+import type { IUpdateCurrentView } from 'src/features/form/layout/formLayoutTypes';
+
+enum HistoryAction {
+  BackOrForward = 'POP',
+}
+
+/**
+ * @param activePageId the formLayout page id that is currently active in the app
+ * @return matchRootUrl: Matches the location pathname of the history root. If not, an empty string.
+ */
+export const useFormLayoutHistoryAndMatchInstanceLocation = ({
+  activePageId,
+}: {
+  activePageId: string;
+}): { matchRootUrl: string } => {
+  const matchRoot = useRouteMatch<string>('/instance/:partyId/:instanceGuid');
+  const matchRootUrl = matchRoot?.url || '';
+  const dispatch = useAppDispatch();
+  const doDispatch = useCallback(
+    (payload: IUpdateCurrentView) => {
+      dispatch(FormLayoutActions.updateCurrentView(payload));
+    },
+    [dispatch],
+  );
+  useFormLayoutHistory({
+    renderedPageId: activePageId,
+    renderFunc: doDispatch,
+    pathToRoute: matchRootUrl,
+  });
+  return { matchRootUrl };
+};
+
+function useFormLayoutHistory({
+  renderedPageId,
+  renderFunc,
+  pathToRoute,
+}: {
+  pathToRoute: string;
+  renderedPageId: string;
+  renderFunc: (IUpdateCurrentView) => void;
+}) {
+  const history = useHistory();
+  useEffect(() => {
+    return formLayoutHistory({
+      history,
+      renderedPageId,
+      renderFunc,
+      pathToRoute,
+    });
+  }, [history, renderedPageId, renderFunc, pathToRoute]);
+}
+
+function formLayoutHistory({
+  history,
+  renderedPageId,
+  renderFunc,
+  pathToRoute,
+}: {
+  history;
+  pathToRoute: string;
+  renderedPageId: string;
+  renderFunc: (IUpdateCurrentView) => void;
+}) {
+  const pageIdFromLocation = getPageIdFromLocation(
+    history.location,
+    pathToRoute,
+  );
+  const browserIsOnRootPath = pageIdFromLocation === '';
+  if (renderedPageId) {
+    // When the application has rendered a view and the location path should reflect this.
+    if (browserIsOnRootPath) {
+      // The location path should be changed to the rendered page
+      history.replace(`${pathToRoute}/${renderedPageId}`);
+      return;
+    }
+    if (renderedPageId !== pageIdFromLocation) {
+      // Put the rendered pageId in the path
+      history.push(`${pathToRoute}/${renderedPageId}`);
+    }
+    return listenForHistoryAction(
+      {
+        action: HistoryAction.BackOrForward,
+        history,
+      },
+      (location) => {
+        const newView = getPageIdFromLocation(location, pathToRoute);
+        if (newView && newView !== renderedPageId) {
+          renderFunc({ newView });
+        }
+      },
+    );
+  }
+  if (!browserIsOnRootPath) {
+    // The application has not rendered a view and a request is sent for a specific page. I.e. direct link.
+    renderFunc({ newView: pageIdFromLocation });
+  }
+}
+
+function getPageIdFromLocation({ pathname }, removePath) {
+  if (pathname === removePath) {
+    return '';
+  }
+  return pathname.replace(`${removePath}/`, '');
+}
+
+function listenForHistoryAction({ history, action }, callBack) {
+  return history.listen((location, historyAction) => {
+    if (historyAction === action) {
+      callBack(location, historyAction);
+    }
+  });
+}

--- a/src/altinn-app-frontend/src/features/form/containers/Form.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/Form.tsx
@@ -1,8 +1,12 @@
 import React from 'react';
+import { Route } from 'react-router-dom';
 
 import Grid from '@material-ui/core/Grid';
 
-import { useAppSelector } from 'src/common/hooks';
+import {
+  useAppSelector,
+  useFormLayoutHistoryAndMatchInstanceLocation,
+} from 'src/common/hooks';
 import { SummaryComponent } from 'src/components/summary/SummaryComponent';
 import MessageBanner from 'src/features/form/components/MessageBanner';
 import { DisplayGroupContainer } from 'src/features/form/containers/DisplayGroupContainer';
@@ -17,6 +21,8 @@ import type {
   ILayoutComponent,
   ILayoutGroup,
 } from 'src/features/form/layout';
+
+import { AltinnContentLoader } from 'altinn-shared/components';
 
 export function renderLayoutComponent(
   layoutComponent: ILayoutComponent | ILayoutGroup,
@@ -105,6 +111,9 @@ export function Form() {
   const validations = useAppSelector(
     (state) => state.formValidations.validations,
   );
+  const { matchRootUrl } = useFormLayoutHistoryAndMatchInstanceLocation({
+    activePageId: currentView,
+  });
 
   React.useEffect(() => {
     setCurrentLayout(currentView);
@@ -141,9 +150,12 @@ export function Form() {
       setFilteredLayout(componentsToRender);
     }
   }, [layout]);
+  if (!currentView) {
+    return <AltinnContentLoader />;
+  }
 
   return (
-    <div>
+    <Route path={`${matchRootUrl}/:pageId`}>
       {hasRequiredFields(layout) && (
         <MessageBanner
           language={language}
@@ -162,7 +174,7 @@ export function Form() {
             return renderLayoutComponent(component, layout);
           })}
       </Grid>
-    </div>
+    </Route>
   );
 }
 


### PR DESCRIPTION
## Description
I changed the behavior of how the form url changes where it now puts the page id at he end of the route.
By doing so we get to listen to history-changes and re-render the Form component based on the page id inside the formLayout.

Tested in Firefox.

## Related Issue(s)
- #225 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## NOTE
The below steps (in Norwegian) do reproduce am error. However, the issue seems to be related to not being able to access pages after the allowed pages after the page order has been updated or switching layout sets:

> 1. Du har tidligere instanser, velg en fra listen eller start en ny. Jeg startet en ny.
>  2. Velkommen til frontend-test, noen beskrivelser, en knapp for å starte. Jeg trykker på knappen. (Tror URL sier /formLayout på dette tidspunktet)
>  3. Skjema for å endre navn. Jeg fyller ut skjemaet.
> 4. Oppsummeringsside for endring av navn. Jeg trykker neste.
> 5. Side for repeterende grupper.
> 6. Side for å fylle ut et tekstfelt (innmelder?).
> 7. Oppsummeringsside for repeterende grupper.
> Hvis du står på steg 4 og trykker tilbake, kommer du til steg 3, men hvis du står på steg 3 og går tilbake fikk jeg en feilmelding (appen kræsjet). Samme hvis jeg stod på steg 5, 6 eller 7 og prøvde å gå tilbake til steg 4.