### PR TITLE
Fixing missing dependencies for hooks

### DIFF
--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -50,7 +50,11 @@
     "jsx-a11y/no-autofocus": ["off"],
     "@typescript-eslint/no-explicit-any": ["off"],
     "import/no-unresolved": ["off"],
-    "@typescript-eslint/no-unused-vars": ["error", { "ignoreRestSiblings": true }],
-    "@typescript-eslint/consistent-type-imports": ["warn"]
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      { "ignoreRestSiblings": true }
+    ],
+    "@typescript-eslint/consistent-type-imports": ["warn"],
+    "react-hooks/exhaustive-deps": ["error"]
   }
 }

--- a/src/altinn-app-frontend/src/components/advanced/AddressComponent.tsx
+++ b/src/altinn-app-frontend/src/components/advanced/AddressComponent.tsx
@@ -121,7 +121,7 @@ export function AddressComponent({
       validationErrors.houseNumber = null;
     }
     return validationErrors;
-  }, [houseNumber, language, zipCode]);
+  }, [houseNumber, language, zipCode, setPostPlace]);
 
   const onSaveField = React.useCallback(
     (key: AddressKeys, value: any) => {
@@ -135,7 +135,7 @@ export function AddressComponent({
         }
       }
     },
-    [validate, handleDataChange],
+    [validate, handleDataChange, setPostPlace],
   );
 
   React.useEffect(() => {
@@ -194,7 +194,14 @@ export function AddressComponent({
     return function cleanup() {
       source.cancel('ComponentWillUnmount');
     };
-  }, [formData.zipCode, language, source, onSaveField, validations]);
+  }, [
+    formData.zipCode,
+    language,
+    source,
+    onSaveField,
+    validations,
+    setPostPlace,
+  ]);
 
   const updateField = (
     key: AddressKeys,


### PR DESCRIPTION
## Description
Introduced in the recently merged #305, these hooks had missing dependencies. Changing the warning to be an error as well.

## Related Issue(s)
- #305

## Verification
- [x] **Your** code builds clean without any errors or warnings
- ~~[ ] Manual testing done (required)~~
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green - failing cypress tests because of changes in #330 (cypress tests verified to be working locally, on an older frontend-test version)

## Documentation
- ~~[ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~
