### PR TITLE
Cleaning up some warnings from tests and React runtime

### DIFF
--- a/src/altinn-app-frontend/src/components/base/DatepickerComponent.test.tsx
+++ b/src/altinn-app-frontend/src/components/base/DatepickerComponent.test.tsx
@@ -226,6 +226,7 @@ describe('DatepickerComponent', () => {
   });
 
   it('should show error message when typed date is on an invalid format and call handleDataChange with empty value if formdata is present', async () => {
+    jest.spyOn(console, 'warn').mockImplementation();
     const handleDataChange = jest.fn();
     render({ handleDataChange, formData: { simpleBinding: '12.12.2022' } });
 
@@ -241,6 +242,7 @@ describe('DatepickerComponent', () => {
     fireEvent.blur(inputField);
 
     expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(console.warn).toHaveBeenCalledTimes(1);
 
     expect(
       screen.getByText('date_picker.invalid_date_message'),

--- a/src/altinn-app-frontend/src/components/base/DatepickerComponent.test.tsx
+++ b/src/altinn-app-frontend/src/components/base/DatepickerComponent.test.tsx
@@ -59,6 +59,7 @@ describe('DatepickerComponent', () => {
   });
 
   it('should not show calendar initially, and show calendar when clicking calendar button', async () => {
+    jest.spyOn(console, 'error').mockImplementation();
     render();
 
     expect(getCalendarYearHeader('queryByRole')).not.toBeInTheDocument();
@@ -67,6 +68,12 @@ describe('DatepickerComponent', () => {
 
     expect(getCalendarYearHeader()).toBeInTheDocument();
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(console.error).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringMatching(
+        /Material-UI: The `fade` color utility was renamed to `alpha` to better describe its functionality/,
+      ),
+    );
   });
 
   it('should not show calendar initially, and show calendar in a dialog when clicking calendar button, and screen size is mobile sized', async () => {
@@ -243,6 +250,11 @@ describe('DatepickerComponent', () => {
 
     expect(screen.getByRole('alert')).toBeInTheDocument();
     expect(console.warn).toHaveBeenCalledTimes(1);
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringMatching(
+        /Deprecation warning: value provided is not in a recognized RFC2822 or ISO format. moment construction falls back to js Date/,
+      ),
+    );
 
     expect(
       screen.getByText('date_picker.invalid_date_message'),

--- a/src/altinn-app-frontend/src/components/base/ImageComponent.tsx
+++ b/src/altinn-app-frontend/src/components/base/ImageComponent.tsx
@@ -57,7 +57,7 @@ export function ImageComponent(props: IImageProps) {
     <Grid
       container
       direction='row'
-      justify={align}
+      justifyContent={align}
     >
       <Grid item={true}>
         {renderSvg ? (

--- a/src/altinn-app-frontend/src/components/base/ParagraphComponent.test.tsx
+++ b/src/altinn-app-frontend/src/components/base/ParagraphComponent.test.tsx
@@ -58,4 +58,19 @@ describe('ParagraphComponent', () => {
 
     expect(shallowParagraphComponent.find('HelpTextContainer')).toHaveLength(1);
   });
+
+  it('should render in a <div> instead of a <p> when a header text is supplied', () => {
+    const shallowParagraphComponent = shallow(
+      <ParagraphComponent
+        id={mockId}
+        text={<h3>Hello world</h3>}
+        language={mockLanguage}
+        getTextResource={mockGetTextResource}
+        textResourceBindings={mockTextResourceBindings}
+        {...({} as IComponentProps)}
+      />,
+    );
+
+    expect(shallowParagraphComponent).toMatchSnapshot();
+  });
 });

--- a/src/altinn-app-frontend/src/components/base/ParagraphComponent.test.tsx
+++ b/src/altinn-app-frontend/src/components/base/ParagraphComponent.test.tsx
@@ -1,6 +1,7 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import * as renderer from 'react-test-renderer';
+import { render } from '@testing-library/react';
 
 import type { ITextResourceBindings } from 'src/features/form/layout';
 import type { IComponentProps } from 'src/components';
@@ -59,8 +60,8 @@ describe('ParagraphComponent', () => {
     expect(shallowParagraphComponent.find('HelpTextContainer')).toHaveLength(1);
   });
 
-  it('should render in a <div> instead of a <p> when a header text is supplied', () => {
-    const shallowParagraphComponent = shallow(
+  it('should render in a <div> when a header text is supplied', () => {
+    const { container } = render(
       <ParagraphComponent
         id={mockId}
         text={<h3>Hello world</h3>}
@@ -71,6 +72,27 @@ describe('ParagraphComponent', () => {
       />,
     );
 
-    expect(shallowParagraphComponent).toMatchSnapshot();
+    expect(container.querySelector('#mock-id').tagName).toEqual('DIV');
+  });
+
+  it('should render in a <p> when regular text content is supplied', () => {
+    const { container } = render(
+      <ParagraphComponent
+        id={mockId}
+        text={
+          <>
+            Hello world with line
+            <br />
+            break
+          </>
+        }
+        language={mockLanguage}
+        getTextResource={mockGetTextResource}
+        textResourceBindings={mockTextResourceBindings}
+        {...({} as IComponentProps)}
+      />,
+    );
+
+    expect(container.querySelector('#mock-id').tagName).toEqual('P');
   });
 });

--- a/src/altinn-app-frontend/src/components/base/ParagraphComponent.tsx
+++ b/src/altinn-app-frontend/src/components/base/ParagraphComponent.tsx
@@ -34,6 +34,11 @@ const useStyles = makeStyles({
 
 export function ParagraphComponent(props: IComponentProps) {
   const classes = useStyles();
+  const isHeader =
+    typeof props.text === 'object' &&
+    typeof (props.text as any).type === 'string' &&
+    (props.text as any).type.match(/^h\d+$/);
+
   return (
     <Grid
       container={true}
@@ -42,6 +47,7 @@ export function ParagraphComponent(props: IComponentProps) {
     >
       <Grid item={true}>
         <Typography
+          component={isHeader ? 'div' : 'p'}
           id={props.id}
           className={`${classes.spacing} ${classes.typography}`}
         >

--- a/src/altinn-app-frontend/src/components/base/__snapshots__/ParagraphComponent.test.tsx.snap
+++ b/src/altinn-app-frontend/src/components/base/__snapshots__/ParagraphComponent.test.tsx.snap
@@ -16,3 +16,25 @@ exports[`ParagraphComponent should match snapshot 1`] = `
   </div>
 </div>
 `;
+
+exports[`ParagraphComponent should render in a <div> instead of a <p> when a header text is supplied 1`] = `
+<WithStyles(ForwardRef(Grid))
+  alignItems="center"
+  container={true}
+  direction="row"
+>
+  <WithStyles(ForwardRef(Grid))
+    item={true}
+  >
+    <WithStyles(ForwardRef(Typography))
+      className="makeStyles-spacing-1 makeStyles-typography-2"
+      component="div"
+      id="mock-id"
+    >
+      <h3>
+        Hello world
+      </h3>
+    </WithStyles(ForwardRef(Typography))>
+  </WithStyles(ForwardRef(Grid))>
+</WithStyles(ForwardRef(Grid))>
+`;

--- a/src/altinn-app-frontend/src/components/base/__snapshots__/ParagraphComponent.test.tsx.snap
+++ b/src/altinn-app-frontend/src/components/base/__snapshots__/ParagraphComponent.test.tsx.snap
@@ -16,25 +16,3 @@ exports[`ParagraphComponent should match snapshot 1`] = `
   </div>
 </div>
 `;
-
-exports[`ParagraphComponent should render in a <div> instead of a <p> when a header text is supplied 1`] = `
-<WithStyles(ForwardRef(Grid))
-  alignItems="center"
-  container={true}
-  direction="row"
->
-  <WithStyles(ForwardRef(Grid))
-    item={true}
-  >
-    <WithStyles(ForwardRef(Typography))
-      className="makeStyles-spacing-1 makeStyles-typography-2"
-      component="div"
-      id="mock-id"
-    >
-      <h3>
-        Hello world
-      </h3>
-    </WithStyles(ForwardRef(Typography))>
-  </WithStyles(ForwardRef(Grid))>
-</WithStyles(ForwardRef(Grid))>
-`;

--- a/src/altinn-app-frontend/src/utils/dateHelpers.test.ts
+++ b/src/altinn-app-frontend/src/utils/dateHelpers.test.ts
@@ -21,12 +21,19 @@ describe('/utils/dateFlagParser.ts', () => {
   });
 
   describe('getISOString(...)', () => {
-    test.each(['', undefined, null, 'abcdef'])(
+    test.each(['', undefined, null])(
       'should return undefined if input date is %p',
       (date) => {
         expect(getISOString(date)).toBeUndefined();
       },
     );
+
+    it('should return undefined if input date is "abcdef"', () => {
+      jest.spyOn(console, 'warn').mockImplementation();
+
+      expect(getISOString('abcdef')).toBeUndefined();
+      expect(console.warn).toHaveBeenCalledTimes(1);
+    });
 
     it('should return ISO string if input date is valid ISO string', () => {
       const validISOString = '2020-12-13T12:00:00Z';

--- a/src/altinn-app-frontend/src/utils/dateHelpers.test.ts
+++ b/src/altinn-app-frontend/src/utils/dateHelpers.test.ts
@@ -33,6 +33,11 @@ describe('/utils/dateFlagParser.ts', () => {
 
       expect(getISOString('abcdef')).toBeUndefined();
       expect(console.warn).toHaveBeenCalledTimes(1);
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringMatching(
+          /Deprecation warning: value provided is not in a recognized RFC2822 or ISO format. moment construction falls back to js Date/,
+        ),
+      );
     });
 
     it('should return ISO string if input date is valid ISO string', () => {

--- a/src/altinn-app-frontend/src/utils/validation.test.ts
+++ b/src/altinn-app-frontend/src/utils/validation.test.ts
@@ -515,6 +515,25 @@ describe('utils > validation', () => {
         code: '',
       },
     ];
+
+    /**
+     * Silences deprecation warning about jsPropertySyntax from Ajv, so we don't pollute our test runner output with
+     * these warnings. We already know about the deprecation of jsPropertySyntax, and our tests will fail if/when
+     * AJV decides to completely remove support for this syntax.
+     *
+     * @see createValidator
+     */
+    const oldConsoleWarn = console.warn;
+    console.warn = (...args: any[]) => {
+      if (
+        typeof args[0] === 'string' &&
+        args[0].match(/DEPRECATED: option jsPropertySyntax/)
+      ) {
+        return;
+      }
+
+      oldConsoleWarn(...args);
+    };
   });
 
   describe('getErrorCount', () => {

--- a/src/altinn-app-frontend/src/utils/validation.ts
+++ b/src/altinn-app-frontend/src/utils/validation.ts
@@ -81,7 +81,17 @@ export function createValidator(schema: any): ISchemaValidator {
   const ajvOptions: Options = {
     allErrors: true,
     coerceTypes: true,
+
+    /**
+     * This option is deprecated in AJV, but continues to work for now. We have unit tests that will fail if the
+     * functionality is removed from AJV. The jsPropertySyntax (ex. 'Path.To.Array[0].Item') was replaced with JSON
+     * pointers in v7 (ex. '/Path/To/Array/0/Item'). If the option to keep the old syntax is removed at some point,
+     * we'll have to implement a translator ourselves, as we'll need this format to equal our data model bindings.
+     *
+     * @see https://github.com/ajv-validator/ajv/issues/1577#issuecomment-832216719
+     */
     jsPropertySyntax: true,
+
     strict: false,
     strictTypes: false,
     strictTuples: false,


### PR DESCRIPTION
## Description
This silences some knows warnings in unit tests, and tests for them instead of outputting them to the console. In addition, it cleans up some warnings shown in the console when running some apps.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- ~~[ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~
