### PR TITLE
chore: remove invalid eslint-disable statements

### DIFF
--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -52,10 +52,7 @@
     "import/no-unresolved": ["off"],
     "@typescript-eslint/no-unused-vars": [
       "error",
-      {
-        "argsIgnorePattern": "^_action$",
-        "ignoreRestSiblings": true
-      }
+      { "ignoreRestSiblings": true }
     ],
     "@typescript-eslint/consistent-type-imports": ["warn"],
     "react-hooks/exhaustive-deps": ["error"]

--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -52,7 +52,10 @@
     "import/no-unresolved": ["off"],
     "@typescript-eslint/no-unused-vars": [
       "error",
-      { "ignoreRestSiblings": true }
+      {
+        "argsIgnorePattern": "^_action$",
+        "ignoreRestSiblings": true
+      }
     ],
     "@typescript-eslint/consistent-type-imports": ["warn"],
     "react-hooks/exhaustive-deps": ["error"]

--- a/src/altinn-app-frontend/package.json
+++ b/src/altinn-app-frontend/package.json
@@ -30,7 +30,7 @@
     "ajv-formats": "^2.1.1",
     "axios": "^0.27.2",
     "dot-object": "^2.1.4",
-    "jsonpointer": "5.0.0",
+    "jsonpointer": "5.0.1",
     "moment": "^2.29.3",
     "react": "^17.0.2",
     "react-content-loader": "^6.2.0",

--- a/src/altinn-app-frontend/src/components/GenericComponent.tsx
+++ b/src/altinn-app-frontend/src/components/GenericComponent.tsx
@@ -251,14 +251,12 @@ export function GenericComponent(props: IGenericComponentProps) {
   };
 
   const RenderDescription = () => {
-    // eslint-disable-next-line react/prop-types
     if (!props.textResourceBindings?.description) {
       return null;
     }
 
     return (
       <Description
-        // eslint-disable-next-line react/prop-types
         key={`description-${props.id}`}
         description={texts.description}
         id={id}
@@ -270,7 +268,6 @@ export function GenericComponent(props: IGenericComponentProps) {
   const RenderLegend = () => {
     return (
       <Legend
-        // eslint-disable-next-line react/prop-types
         key={`legend-${props.id}`}
         labelText={texts.title}
         descriptionText={texts.description}

--- a/src/altinn-app-frontend/src/components/base/ButtonComponent.tsx
+++ b/src/altinn-app-frontend/src/components/base/ButtonComponent.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable react/prop-types */
-import * as React from 'react';
+import React from 'react';
 import { getLanguageFromKey } from 'altinn-shared/utils/language';
 import { AltinnLoader } from 'altinn-shared/components';
 import type { IAltinnWindow } from '../../types';

--- a/src/altinn-app-frontend/src/features/confirm/containers/Confirm.tsx
+++ b/src/altinn-app-frontend/src/features/confirm/containers/Confirm.tsx
@@ -17,7 +17,10 @@ import {
   getInstancePdf,
 } from 'altinn-shared/utils/attachmentsUtils';
 import { ProcessActions } from 'src/shared/resources/process/processSlice';
-import type { IAltinnWindow } from '../../../types';
+import type {
+  IAltinnWindow,
+  IPartyIdInterfaceGuidParams,
+} from '../../../types';
 import { get } from '../../../utils/networking';
 import { getValidationUrl } from '../../../utils/appUrlHelper';
 import { ValidationActions } from '../../form/validation/validationSlice';
@@ -83,11 +86,6 @@ export const returnConfirmSummaryObject = ({
   };
 };
 
-interface IParams {
-  partyId: string;
-  instanceGuid: string;
-}
-
 const Confirm = () => {
   const dispatch = useAppDispatch();
   const applicationMetadata = useAppSelector(
@@ -101,7 +99,7 @@ const Confirm = () => {
     (state) => state.textResources.resources,
   );
 
-  const { partyId, instanceGuid }: IParams = useParams();
+  const { partyId, instanceGuid }: IPartyIdInterfaceGuidParams = useParams();
 
   const isLoading = !instance || !parties;
 

--- a/src/altinn-app-frontend/src/features/form/components/Label.tsx
+++ b/src/altinn-app-frontend/src/features/form/components/Label.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable react/prop-types */
-import * as React from 'react';
+import React from 'react';
 import { Grid } from '@material-ui/core';
 import type { ILabelSettings } from 'src/types';
 import { HelpTextContainer } from './HelpTextContainer';

--- a/src/altinn-app-frontend/src/features/form/components/Legend.tsx
+++ b/src/altinn-app-frontend/src/features/form/components/Legend.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable react/prop-types */
-import * as React from 'react';
+import React from 'react';
 import type { ILabelSettings } from 'src/types';
 import { LayoutStyle } from 'src/types';
 import Description from './Description';

--- a/src/altinn-app-frontend/src/features/form/components/RepeatingGroupAddButton.tsx
+++ b/src/altinn-app-frontend/src/features/form/components/RepeatingGroupAddButton.tsx
@@ -1,6 +1,3 @@
-/* eslint-disable no-undef */
-/* eslint-disable react/no-array-index-key */
-/* eslint-disable max-len */
 import React from 'react';
 import { Grid, makeStyles, createTheme } from '@material-ui/core';
 import altinnAppTheme from 'altinn-shared/theme/altinnAppTheme';

--- a/src/altinn-app-frontend/src/features/form/containers/DisplayGroupContainer.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/DisplayGroupContainer.tsx
@@ -1,5 +1,5 @@
 import { Grid, Typography, makeStyles } from '@material-ui/core';
-import * as React from 'react';
+import React from 'react';
 import { useAppSelector } from 'src/common/hooks';
 import { makeGetHidden } from 'src/selectors/getLayoutData';
 import { getTextFromAppOrDefault } from 'src/utils/textResource';
@@ -8,7 +8,6 @@ import type { ILayout, ILayoutComponent, ILayoutGroup } from '../layout';
 export interface IDisplayGroupContainer {
   container: ILayoutGroup;
   components: (ILayoutComponent | ILayoutGroup)[];
-  // eslint-disable-next-line no-undef
   renderLayoutComponent: (
     components: ILayoutComponent | ILayoutGroup,
     layout: ILayout,

--- a/src/altinn-app-frontend/src/features/form/containers/Form.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/Form.tsx
@@ -1,6 +1,5 @@
-/* eslint-disable no-undef */
 import Grid from '@material-ui/core/Grid';
-import * as React from 'react';
+import React from 'react';
 import { SummaryComponent } from 'src/components/summary/SummaryComponent';
 import type { ILayout, ILayoutComponent, ILayoutGroup } from '../layout';
 import { GroupContainer } from './GroupContainer';

--- a/src/altinn-app-frontend/src/features/form/data/fetch/fetchFormDataSagas.ts
+++ b/src/altinn-app-frontend/src/features/form/data/fetch/fetchFormDataSagas.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import type { SagaIterator } from 'redux-saga';
 import { call, select, takeLatest, all, take, put } from 'redux-saga/effects';
 import { get } from 'altinn-shared/utils';

--- a/src/altinn-app-frontend/src/features/form/data/formDataSlice.ts
+++ b/src/altinn-app-frontend/src/features/form/data/formDataSlice.ts
@@ -66,9 +66,6 @@ const formDataSlice = createSlice({
       state.isSaving = false;
       state.ignoreWarnings = true;
     },
-    // The _action parameter is unused, but these parameters are used by TypeScript to infer the payload type for
-    // this action, so we need to keep it here even if we only read it in the saga.
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     update: (state, _action: PayloadAction<IUpdateFormData>) => {
       state.hasSubmitted = false;
       state.ignoreWarnings = false;

--- a/src/altinn-app-frontend/src/features/form/data/formDataSlice.ts
+++ b/src/altinn-app-frontend/src/features/form/data/formDataSlice.ts
@@ -66,6 +66,9 @@ const formDataSlice = createSlice({
       state.isSaving = false;
       state.ignoreWarnings = true;
     },
+    // The _action parameter is unused, but these parameters are used by TypeScript to infer the payload type for
+    // this action, so we need to keep it here even if we only read it in the saga.
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     update: (state, _action: PayloadAction<IUpdateFormData>) => {
       state.hasSubmitted = false;
       state.ignoreWarnings = false;

--- a/src/altinn-app-frontend/src/features/form/data/submit/submitFormDataSagas.ts
+++ b/src/altinn-app-frontend/src/features/form/data/submit/submitFormDataSagas.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import type { SagaIterator } from 'redux-saga';
 import { call, put as sagaPut, select, takeLatest } from 'redux-saga/effects';
 import { get, put } from 'altinn-shared/utils';
@@ -52,7 +51,6 @@ const UIConfigSelector: (store: IRuntimeStore) => IUiConfig = (
 ) => store.formLayout.uiConfig;
 export const allowAnonymousSelector = makeGetAllowAnonymousSelector();
 
-// eslint-disable-next-line consistent-return
 function* submitFormSaga({
   payload: { apiMode, stopWithWarnings },
 }: PayloadAction<ISubmitDataAction>): SagaIterator {
@@ -192,7 +190,6 @@ function* handleCalculationUpdate(changedFields) {
   if (!changedFields) {
     return false;
   }
-  // eslint-disable-next-line no-restricted-syntax
   for (const fieldKey of Object.keys(changedFields)) {
     yield sagaPut(
       FormDataActions.update({
@@ -207,17 +204,16 @@ function* handleCalculationUpdate(changedFields) {
   return true;
 }
 
-// eslint-disable-next-line consistent-return
 export function* saveFormDataSaga(): SagaIterator {
   try {
     const state: IRuntimeState = yield select();
     // updates the default data element
     const application = state.applicationMetadata.applicationMetadata;
     const model = convertDataBindingToModel(
-      filterOutInvalidData(
-        state.formData.formData,
-        state.formValidations.invalidDataTypes || [],
-      ),
+      filterOutInvalidData({
+        data: state.formData.formData,
+        invalidKeys: state.formValidations.invalidDataTypes,
+      }),
     );
 
     if (isStatelessApp(application)) {

--- a/src/altinn-app-frontend/src/features/form/datamodel/fetch/fetchFormDatamodelSagas.ts
+++ b/src/altinn-app-frontend/src/features/form/datamodel/fetch/fetchFormDatamodelSagas.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import type { SagaIterator } from 'redux-saga';
 import { call, select, all, take, put } from 'redux-saga/effects';
 import { getJsonSchemaUrl } from 'src/utils/appUrlHelper';

--- a/src/altinn-app-frontend/src/features/form/dynamics/index.ts
+++ b/src/altinn-app-frontend/src/features/form/dynamics/index.ts
@@ -6,8 +6,7 @@ export interface IFormDynamicState {
 }
 
 export interface IRuleConnection {
-  // eslint-disable-next-line @typescript-eslint/ban-types
-  inputParams: Object;
+  inputParams: IParameters;
   outParams: {
     outParam0?: string;
   };

--- a/src/altinn-app-frontend/src/features/form/layout/formLayoutSagas.ts
+++ b/src/altinn-app-frontend/src/features/form/layout/formLayoutSagas.ts
@@ -18,7 +18,6 @@ import {
   watchUpdateFileUploaderWithTagChosenOptionsSaga,
 } from './update/updateFormLayoutSagas';
 
-// eslint-disable-next-line func-names
 export default function* (): SagaIterator {
   yield fork(watchFetchFormLayoutSaga);
   yield fork(watchUpdateFocusSaga);

--- a/src/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
+++ b/src/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import type { PayloadAction } from '@reduxjs/toolkit';
 import type { SagaIterator } from 'redux-saga';
 import {

--- a/src/altinn-app-frontend/src/shared/containers/ProcessWrapper.tsx
+++ b/src/altinn-app-frontend/src/shared/containers/ProcessWrapper.tsx
@@ -1,9 +1,10 @@
-import * as React from 'react';
+import React from 'react';
+import { useParams } from 'react-router-dom';
 import {
   AltinnContentLoader,
   AltinnContentIconFormData,
 } from 'altinn-shared/components';
-import type { IAltinnWindow } from '../../types';
+import type { IAltinnWindow, IPartyIdInterfaceGuidParams } from '../../types';
 import { ProcessTaskType } from '../../types';
 import Presentation from './Presentation';
 import { Form } from '../../features/form/containers/Form';
@@ -26,14 +27,8 @@ const style = {
   marginTop: '2.5rem',
 };
 
-const ProcessWrapper = (props) => {
-  const {
-    // eslint-disable-next-line react/prop-types
-    match: {
-      // eslint-disable-next-line react/prop-types
-      params: { partyId, instanceGuid },
-    },
-  } = props;
+const ProcessWrapper = () => {
+  const { partyId, instanceGuid }: IPartyIdInterfaceGuidParams = useParams();
 
   const dispatch = useAppDispatch();
 

--- a/src/altinn-app-frontend/src/shared/resources/options/optionsSagas.ts
+++ b/src/altinn-app-frontend/src/shared/resources/options/optionsSagas.ts
@@ -1,4 +1,3 @@
-/* eslint-disable func-names */
 import type { SagaIterator } from 'redux-saga';
 import { fork } from 'redux-saga/effects';
 import {

--- a/src/altinn-app-frontend/src/shared/resources/queue/infoTask/infoTaskQueueSaga.ts
+++ b/src/altinn-app-frontend/src/shared/resources/queue/infoTask/infoTaskQueueSaga.ts
@@ -53,7 +53,6 @@ export function* startInitialInfoTaskQueueSaga(): SagaIterator {
     });
 
     let formData = {};
-    // eslint-disable-next-line no-restricted-syntax
     for (const dataElementId of dataElements) {
       const fetchedData = yield call(
         get,

--- a/src/altinn-app-frontend/src/types/index.ts
+++ b/src/altinn-app-frontend/src/types/index.ts
@@ -316,3 +316,8 @@ export interface IFetchSpecificOptionSaga {
   secure?: boolean;
   instanceId?: string;
 }
+
+export interface IPartyIdInterfaceGuidParams {
+  partyId: string;
+  instanceGuid: string;
+}

--- a/src/altinn-app-frontend/src/utils/databindings.test.ts
+++ b/src/altinn-app-frontend/src/utils/databindings.test.ts
@@ -9,6 +9,7 @@ import {
   mapFormData,
   removeGroupData,
   getKeyIndex,
+  filterOutInvalidData,
 } from './databindings';
 
 describe('utils/databindings.ts', () => {
@@ -321,6 +322,46 @@ describe('utils/databindings.ts', () => {
         1,
       );
       expect(result).toEqual('another value');
+    });
+  });
+
+  describe('filterOutInvalidData', () => {
+    it('should remove keys listed in the invalidKeys object', () => {
+      const formData = {
+        field1: 'value1',
+        'group[0].field': 'someValue',
+        'group[1].field': 'another value',
+      };
+      const result = filterOutInvalidData({
+        data: formData,
+        invalidKeys: ['group[0].field'],
+      });
+
+      expect(result).toEqual({
+        field1: 'value1',
+        'group[1].field': 'another value',
+      });
+    });
+
+    [undefined, null].forEach((value) => {
+      it(`should not crash when invalidKeys is ${value}`, () => {
+        const formData = {
+          field1: 'value1',
+          'group[0].field': 'someValue',
+          'group[1].field': 'another value',
+        };
+
+        const result = filterOutInvalidData({
+          data: formData,
+          invalidKeys: value,
+        });
+
+        expect(result).toEqual({
+          field1: 'value1',
+          'group[0].field': 'someValue',
+          'group[1].field': 'another value',
+        });
+      });
     });
   });
 });

--- a/src/altinn-app-frontend/src/utils/databindings.ts
+++ b/src/altinn-app-frontend/src/utils/databindings.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import { object } from 'dot-object';
 import type {
   ILayout,
@@ -28,11 +27,23 @@ export function convertDataBindingToModel(formData: any): any {
   return object({ ...formData });
 }
 
-export function filterOutInvalidData(data: any, invalidKeys: string[]) {
+export function filterOutInvalidData({
+  data,
+  invalidKeys = [],
+}: {
+  data: IFormData;
+  invalidKeys: string[];
+}) {
+  if (!invalidKeys) {
+    return data;
+  }
+
   const result = {};
   Object.keys(data).forEach((key) => {
-    // eslint-disable-next-line no-prototype-builtins
-    if (data.hasOwnProperty(key) && !invalidKeys.includes(key)) {
+    if (
+      Object.prototype.hasOwnProperty.call(data, key) &&
+      !invalidKeys.includes(key)
+    ) {
       result[key] = data[key];
     }
   });
@@ -228,7 +239,6 @@ export function deleteGroupData(
       ),
     )
     .forEach((key) => {
-      // eslint-disable-next-line no-param-reassign
       delete data[key];
       if (shiftData) {
         const newKey = key.replace(
@@ -237,7 +247,6 @@ export function deleteGroupData(
             ? `${keyStart}[${index - 1}]`
             : `${keyStart}-${index - 1}`,
         );
-        // eslint-disable-next-line no-param-reassign
         data[newKey] = prevData[key];
       }
     });

--- a/src/altinn-app-frontend/src/utils/validation.ts
+++ b/src/altinn-app-frontend/src/utils/validation.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-restricted-syntax */
-/* eslint-disable max-len */
 import {
   getLanguageFromKey,
   getParsedLanguageFromKey,
@@ -39,7 +37,6 @@ import {
   getFormDataFromFieldKey,
   getKeyWithoutIndex,
 } from './databindings';
-// eslint-disable-next-line import/no-cycle
 import { matchLayoutComponent, setupGroupComponents } from './layout';
 import {
   createRepeatingGroupComponents,
@@ -809,8 +806,6 @@ export function getSchemaPart(schemaPath: string, jsonSchema: object): any {
   try {
     // want to transform path example format to to /properties/model/properties/person/properties/name
     const pointer = schemaPath.substr(1).split('/').slice(0, -1).join('/');
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore typings for JsonPointer are incorrect, this ignore can be removed when PR is merged/released https://github.com/janl/node-jsonpointer/pull/54
     return JsonPointer.compile(pointer).get(jsonSchema);
   } catch (error) {
     console.error(error);
@@ -976,7 +971,6 @@ export function mapToComponentValidations(
       ? `${layoutComponent.id}-${index}`
       : layoutComponent.id;
     if (!validations[layoutId]) {
-      // eslint-disable-next-line no-param-reassign
       validations[layoutId] = {};
     }
     if (validations[layoutId][componentId]) {
@@ -992,13 +986,11 @@ export function mapToComponentValidations(
           errorMessage,
         );
       } else {
-        // eslint-disable-next-line no-param-reassign
         validations[layoutId][componentId][dataModelFieldKey] = {
           errors: [errorMessage],
         };
       }
     } else {
-      // eslint-disable-next-line no-param-reassign
       validations[layoutId][componentId] = {
         [dataModelFieldKey]: {
           errors: [errorMessage],
@@ -1742,7 +1734,6 @@ export function removeGroupValidationsByIndex(
         const newKey = `${id}-${i - 1}`;
         delete result[currentLayout][key];
         result[currentLayout][newKey] = validations[currentLayout][key];
-        // eslint-disable-next-line no-loop-func
         children?.forEach((element) => {
           let childKey;
           let shiftKey;

--- a/src/altinn-app-frontend/styleguide/wrapper.tsx
+++ b/src/altinn-app-frontend/styleguide/wrapper.tsx
@@ -1,19 +1,19 @@
-/* eslint-disable react/prop-types */
-import { createTheme, MuiThemeProvider } from "@material-ui/core/styles";
-import * as React from "react";
+import { createTheme, MuiThemeProvider } from '@material-ui/core/styles';
+import React from 'react';
 
-import altinnTheme from "../../shared/src/theme/altinnStudioTheme";
+import altinnTheme from '../../shared/src/theme/altinnStudioTheme';
 const theme = createTheme(altinnTheme);
 
-// import injectTapEventPlugin from 'react-tap-event-plugin';
-// injectTapEventPlugin();
-
-export default class Wrapper extends React.Component {
-  public render() {
-    return (
-      <MuiThemeProvider theme={theme}>
-        <div>{this.props.children}</div>
-      </MuiThemeProvider>
-    );
-  }
+interface IWrapperProps {
+  children: React.ReactNode;
 }
+
+const Wrapper = ({ children }: IWrapperProps) => {
+  return (
+    <MuiThemeProvider theme={theme}>
+      <div>{children}</div>
+    </MuiThemeProvider>
+  );
+};
+
+export default Wrapper;

--- a/src/shared/src/components/molecules/AltinnInformationPaper.tsx
+++ b/src/shared/src/components/molecules/AltinnInformationPaper.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef */
 import { createTheme, Paper } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import * as React from 'react';

--- a/src/shared/styleguide/wrapper.tsx
+++ b/src/shared/styleguide/wrapper.tsx
@@ -1,19 +1,19 @@
-/* eslint-disable react/prop-types */
 import { createTheme, MuiThemeProvider } from '@material-ui/core/styles';
-import * as React from 'react';
+import React from 'react';
 import altinnTheme from '../src/theme/altinnStudioTheme';
 
 const theme = createTheme(altinnTheme);
 
-// import injectTapEventPlugin from 'react-tap-event-plugin';
-// injectTapEventPlugin();
-
-export default class Wrapper extends React.Component {
-  public render() {
-    return (
-      <MuiThemeProvider theme={theme}>
-        <div>{this.props.children}</div>
-      </MuiThemeProvider>
-    );
-  }
+interface IWrapperProps {
+  children: React.ReactNode;
 }
+
+const Wrapper = ({ children }: IWrapperProps) => {
+  return (
+    <MuiThemeProvider theme={theme}>
+      <div>{children}</div>
+    </MuiThemeProvider>
+  );
+};
+
+export default Wrapper;

--- a/src/yarn.lock
+++ b/src/yarn.lock
@@ -4288,7 +4288,7 @@ __metadata:
     jest: ^28.1.1
     jest-environment-jsdom: ^28.1.1
     jest-junit: ^13.2.0
-    jsonpointer: 5.0.0
+    jsonpointer: 5.0.1
     mini-css-extract-plugin: ^2.6.1
     moment: ^2.29.3
     msw: ^0.42.1
@@ -10365,10 +10365,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonpointer@npm:5.0.0":
-  version: 5.0.0
-  resolution: "jsonpointer@npm:5.0.0"
-  checksum: c7ec0b6bb596b81de687bc12945586bbcdc80dfb54919656d2690d76334f796a936270067ee9f1b5bbc2d9ecc551afb366ac35e6685aa61f07b5b68d1e5e857d
+"jsonpointer@npm:5.0.1":
+  version: 5.0.1
+  resolution: "jsonpointer@npm:5.0.1"
+  checksum: 0b40f712900ad0c846681ea2db23b6684b9d5eedf55807b4708c656f5894b63507d0e28ae10aa1bddbea551241035afe62b6df0800fc94c2e2806a7f3adecd7c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description
- ~I propose to allow unused arguments named `_action`. This should of course be used only when needed, as the example in a saga where its used for TS infering types (see commit [`00ba52d` (#342)](https://github.com/Altinn/app-frontend-react/pull/342/commits/00ba52dfadee0c52931d48710e8e2a1d243d5a62) for details). By allowing this, we dont need to add `eslint-disable-next-line` whenever doing this, explaining why its needed.~ Not going to include this after all, as it will not be needed (ref: https://github.com/Altinn/app-frontend-react/pull/342#commitcomment-78491931). We can always add something like this back if we see the need for it.
- Removal of all `eslint-disable` statements, except one, [where a console.log is used](https://github.com/Altinn/app-frontend-react/blob/v3.46.0/src/altinn-app-frontend/src/features/instantiate/containers/PartySelection.tsx#L196-L197). Perhaps we can remove this (and the console.log) as well? Not really sure what value this statement gives.
- `filterOutInvalidData` function was rewritten a bit as a result of this. Tests for this did not exist, but are now added and was tested with old code before rewrite.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
