### PR TITLE
Smart un-uppercasing for required field validations

### DIFF
--- a/src/altinn-app-frontend/src/utils/formComponentUtils.test.ts
+++ b/src/altinn-app-frontend/src/utils/formComponentUtils.test.ts
@@ -634,7 +634,7 @@ describe('formComponentUtils', () => {
         mockLanguage,
         'address',
       );
-      expect(result).toEqual('Gateadresse');
+      expect(result).toEqual('gateadresse');
     });
 
     it('should return component shortName (textResourceBindings) when no fieldKey is present', () => {

--- a/src/altinn-app-frontend/src/utils/formComponentUtils.test.ts
+++ b/src/altinn-app-frontend/src/utils/formComponentUtils.test.ts
@@ -14,6 +14,7 @@ import {
   isNotAttachmentError,
   parseFileUploadComponentWithTagValidationObject,
   selectComponentTexts,
+  smart_unucfirst,
 } from 'src/utils/formComponentUtils';
 import type { IFormData } from 'src/features/form/data';
 import type {
@@ -651,7 +652,7 @@ describe('formComponentUtils', () => {
         textResources,
         mockLanguage,
       );
-      expect(result).toEqual('Component name');
+      expect(result).toEqual('component name');
     });
 
     it('should return generic field name when fieldKey, shortName and title are all not available', () => {
@@ -661,6 +662,34 @@ describe('formComponentUtils', () => {
         mockLanguage,
       );
       expect(result).toEqual('dette feltet');
+    });
+  });
+
+  describe('smart_unucfirst', () => {
+    it.each([
+      { input: 'Fornavn', expected: 'fornavn' },
+      { input: 'fornavn', expected: 'fornavn' },
+      { input: 'Postnummer', expected: 'postnummer' },
+      { input: 'AlfabeteT', expected: 'alfabeteT' },
+      {
+        input: 'Den dominikanske Republikk',
+        expected: 'den dominikanske Republikk',
+      },
+      {
+        input: 'Den Dominikanske Republikk',
+        expected: 'Den Dominikanske Republikk',
+      },
+      { input: 'Sas', expected: 'sas' },
+      { input: 'SAS', expected: 'SAS' },
+      { input: 'SERIOUSLY', expected: 'SERIOUSLY' },
+      { input: 'ÆØÅ', expected: 'ÆØÅ' },
+      { input: 'Grünerløkka', expected: 'grünerløkka' },
+      { input: 'D.o.B.', expected: 'D.o.B.' },
+      { input: 'SaaB', expected: 'SaaB' },
+      { input: 'S.a.a.B', expected: 'S.a.a.B' },
+      { input: '¿Cómo te llamas?', expected: '¿cómo te llamas?' },
+    ])('Should convert $input to $expected', ({ input, expected }) => {
+      expect(smart_unucfirst(input)).toEqual(expected);
     });
   });
 

--- a/src/altinn-app-frontend/src/utils/formComponentUtils.test.ts
+++ b/src/altinn-app-frontend/src/utils/formComponentUtils.test.ts
@@ -14,7 +14,7 @@ import {
   isNotAttachmentError,
   parseFileUploadComponentWithTagValidationObject,
   selectComponentTexts,
-  smart_unucfirst,
+  smartLowerCaseFirst,
 } from 'src/utils/formComponentUtils';
 import type { IFormData } from 'src/features/form/data';
 import type {
@@ -665,7 +665,7 @@ describe('formComponentUtils', () => {
     });
   });
 
-  describe('smart_unucfirst', () => {
+  describe('smartLowerCaseFirst', () => {
     it.each([
       { input: 'Fornavn', expected: 'fornavn' },
       { input: 'fornavn', expected: 'fornavn' },
@@ -689,7 +689,7 @@ describe('formComponentUtils', () => {
       { input: 'S.a.a.B', expected: 'S.a.a.B' },
       { input: '¿Cómo te llamas?', expected: '¿cómo te llamas?' },
     ])('Should convert $input to $expected', ({ input, expected }) => {
-      expect(smart_unucfirst(input)).toEqual(expected);
+      expect(smartLowerCaseFirst(input)).toEqual(expected);
     });
   });
 

--- a/src/altinn-app-frontend/src/utils/formComponentUtils.ts
+++ b/src/altinn-app-frontend/src/utils/formComponentUtils.ts
@@ -521,7 +521,7 @@ export function getFieldName(
   fieldKey?: string,
 ): string {
   if (fieldKey) {
-    return smart_unucfirst(
+    return smartLowerCaseFirst(
       getTextFromAppOrDefault(
         `form_filler.${fieldKey}`,
         textResources,
@@ -537,7 +537,7 @@ export function getFieldName(
   }
 
   if (textResourceBindings.title) {
-    return smart_unucfirst(
+    return smartLowerCaseFirst(
       getTextResourceByKey(textResourceBindings.title, textResources),
     );
   }
@@ -548,7 +548,7 @@ export function getFieldName(
 /**
  * Un-uppercase the first letter of a string
  */
-export function unucfirst(text: string, firstLetterIndex = 0): string {
+export function lowerCaseFirst(text: string, firstLetterIndex = 0): string {
   if (firstLetterIndex > 0) {
     return (
       text.substring(0, firstLetterIndex) +
@@ -563,7 +563,7 @@ export function unucfirst(text: string, firstLetterIndex = 0): string {
  * Un-uppercase the first letter of a string, but be smart about it (avoiding it when the string is an
  * uppercase abbreviation, etc).
  */
-export function smart_unucfirst(text: string): string {
+export function smartLowerCaseFirst(text: string): string {
   const uc = text.toUpperCase();
   const lc = text.toLowerCase();
 
@@ -591,10 +591,10 @@ export function smart_unucfirst(text: string): string {
     }
 
     if (letters >= 5) {
-      // We've seen enough, looks like normal ucfirst text
-      return unucfirst(text, firstLetterIdx);
+      // We've seen enough, looks like normal text with an uppercase first letter
+      return lowerCaseFirst(text, firstLetterIdx);
     }
   }
 
-  return unucfirst(text, firstLetterIdx);
+  return lowerCaseFirst(text, firstLetterIdx);
 }

--- a/src/altinn-app-frontend/src/utils/formComponentUtils.ts
+++ b/src/altinn-app-frontend/src/utils/formComponentUtils.ts
@@ -535,8 +535,64 @@ export function getFieldName(
   }
 
   if (textResourceBindings.title) {
-    return getTextResourceByKey(textResourceBindings.title, textResources);
+    return smart_unucfirst(
+      getTextResourceByKey(textResourceBindings.title, textResources),
+    );
   }
 
   return getLanguageFromKey('validation.generic_field', language);
+}
+
+/**
+ * Un-uppercase the first letter of a string
+ */
+export function unucfirst(text: string, firstLetterIndex = 0): string {
+  if (firstLetterIndex > 0) {
+    return (
+      text.substring(0, firstLetterIndex) +
+      text[firstLetterIndex].toLowerCase() +
+      text.substring(firstLetterIndex + 1)
+    );
+  }
+  return text[firstLetterIndex].toLowerCase() + text.substring(1);
+}
+
+/**
+ * Un-uppercase the first letter of a string, but be smart about it (avoiding it when the string is an
+ * uppercase abbreviation, etc).
+ */
+export function smart_unucfirst(text: string): string {
+  const uc = text.toUpperCase();
+  const lc = text.toLowerCase();
+
+  let letters = 0;
+  let firstLetterIdx = 0;
+  for (let i = 0; i < text.length; i++) {
+    if (uc[i] === lc[i]) {
+      // This is not a letter, or could not be case-converted, skip it
+      continue;
+    }
+    letters++;
+
+    if (letters === 1) {
+      if (text[i] === lc[i]) {
+        // First letter is lower case already, return early
+        return text;
+      }
+
+      firstLetterIdx = i;
+      continue;
+    }
+
+    if (text[i] !== lc[i]) {
+      return text;
+    }
+
+    if (letters >= 5) {
+      // We've seen enough, looks like normal ucfirst text
+      return unucfirst(text, firstLetterIdx);
+    }
+  }
+
+  return unucfirst(text, firstLetterIdx);
 }

--- a/src/altinn-app-frontend/src/utils/formComponentUtils.ts
+++ b/src/altinn-app-frontend/src/utils/formComponentUtils.ts
@@ -521,12 +521,14 @@ export function getFieldName(
   fieldKey?: string,
 ): string {
   if (fieldKey) {
-    return getTextFromAppOrDefault(
-      `form_filler.${fieldKey}`,
-      textResources,
-      language,
-      null,
-      true,
+    return smart_unucfirst(
+      getTextFromAppOrDefault(
+        `form_filler.${fieldKey}`,
+        textResources,
+        language,
+        null,
+        true,
+      ),
     );
   }
 

--- a/src/altinn-app-frontend/src/utils/validation.test.ts
+++ b/src/altinn-app-frontend/src/utils/validation.test.ts
@@ -734,9 +734,9 @@ describe('utils > validation', () => {
             },
           },
           componentId_6: {
-            address: { errors: ['Du må fylle ut Gateadresse'], warnings: [] },
-            postPlace: { errors: ['Du må fylle ut Poststed'], warnings: [] },
-            zipCode: { errors: ['Du må fylle ut Postnummer'], warnings: [] },
+            address: { errors: ['Du må fylle ut gateadresse'], warnings: [] },
+            postPlace: { errors: ['Du må fylle ut poststed'], warnings: [] },
+            zipCode: { errors: ['Du må fylle ut postnummer'], warnings: [] },
           },
           required_in_group_simple: {
             simpleBinding: {
@@ -776,9 +776,9 @@ describe('utils > validation', () => {
             },
           },
           componentId_6: {
-            address: { errors: ['Du må fylle ut Gateadresse'], warnings: [] },
-            postPlace: { errors: ['Du må fylle ut Poststed'], warnings: [] },
-            zipCode: { errors: ['Du må fylle ut Postnummer'], warnings: [] },
+            address: { errors: ['Du må fylle ut gateadresse'], warnings: [] },
+            postPlace: { errors: ['Du må fylle ut poststed'], warnings: [] },
+            zipCode: { errors: ['Du må fylle ut postnummer'], warnings: [] },
           },
           required_in_group_simple: {
             simpleBinding: {
@@ -852,9 +852,9 @@ describe('utils > validation', () => {
 
       const mockResult = {
         componentId_6: {
-          address: { errors: ['Du må fylle ut Gateadresse'], warnings: [] },
-          postPlace: { errors: ['Du må fylle ut Poststed'], warnings: [] },
-          zipCode: { errors: ['Du må fylle ut Postnummer'], warnings: [] },
+          address: { errors: ['Du må fylle ut gateadresse'], warnings: [] },
+          postPlace: { errors: ['Du må fylle ut poststed'], warnings: [] },
+          zipCode: { errors: ['Du må fylle ut postnummer'], warnings: [] },
         },
       };
 

--- a/test/cypress/e2e/fixtures/texts.json
+++ b/test/cypress/e2e/fixtures/texts.json
@@ -15,7 +15,7 @@
   "missingRights": "Du mangler rettigheter for å se denne tjenesten",
   "next": "Neste",
   "requiredField": "Feltet er påkrevd",
-  "requiredFieldLastName": "Du må fylle ut Nytt etternavn",
+  "requiredFieldLastName": "Du må fylle ut nytt etternavn",
   "requiredFieldDateFrom": "Du må fylle ut Dato for navneendring",
   "securityReasons": "Av sikkerhetshensyn vil verken innholdet i tjenesten eller denne meldingen være synlig i Altinn etter at du har forlatt denne siden",
   "selectNewReportee": "Velg ny aktør under",


### PR DESCRIPTION
## Description
After the introduction of better error messages for required fields (`You have to fill out {0}`), I've been slightly irked by these error messages falling back to the `title` text binding (if no `shortName` exists), but keeping the uppercase first letter these titles usually have. This produces error messages like `You have to fill out First name` instead of the more natural `You have to fill out first name`.

It might not be advisable to simply un-uppercase the first letter all the time, as the title text might be an all-uppercase abbreviation, etc. This impulsive PR nobody asked for tries to solve this by looking at the first 5 non-symbol letters in the string in order to decide if it should uncapitalize the first letter.

Demo of what this does (here inside the unfinished #346, with warning colors):

![ucfirst](https://user-images.githubusercontent.com/700139/180160632-b6fc019e-6cf4-4ee7-a326-38eb4a5bcaa0.gif)

Note: This was an early draft of this PR, and the behaviour has slightly changed after recording. The error `Du må fylle ut dato for navneendring` now actually reads `Du må fylle ut Dato for navneendring` (still capitalized), because this field has a `shortName` key defined (although it is still capitalized on the first letter for some reason).

Very open to discussion on this stunt! I'm not sure if we want to touch these strings, but I was hoping it is slightly better in most cases than just keeping the `title` as-is.

## Related Issue(s)
- #230 
- #130

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
