### PR TITLE
Fixing failing cypress test for FileUploadWithTag

### DIFF
--- a/src/altinn-app-frontend/src/components/base/FileUpload/FileUploadWithTag/EditWindowComponent.tsx
+++ b/src/altinn-app-frontend/src/components/base/FileUpload/FileUploadWithTag/EditWindowComponent.tsx
@@ -75,7 +75,10 @@ export function EditWindowComponent(props: EditWindowProps): JSX.Element {
     props.setEditIndex(-1);
   };
 
-  const saveIsDisabled = props.attachment.uploaded === false || props.readOnly;
+  const saveIsDisabled =
+    props.attachment.updating === true ||
+    props.attachment.uploaded === false ||
+    props.readOnly;
 
   return (
     <div
@@ -160,7 +163,7 @@ export function EditWindowComponent(props: EditWindowProps): JSX.Element {
                   ? props.attachment.tags[0]
                   : null
               }
-              disabled={props.attachment.updating ? true : props.readOnly}
+              disabled={saveIsDisabled}
               className={classNames(
                 classes.select,
                 'custom-select a-custom-select',

--- a/src/altinn-app-frontend/src/components/base/FileUpload/FileUploadWithTag/FileUploadWithTagComponent.tsx
+++ b/src/altinn-app-frontend/src/components/base/FileUpload/FileUploadWithTag/FileUploadWithTagComponent.tsx
@@ -121,7 +121,7 @@ export function FileUploadWithTagComponent({
         message: `${getLanguageFromKey(
           'form_filler.file_uploader_validation_error_no_chosen_tag',
           language,
-        )} ${getTextResource(textResourceBindings.tagTitle)
+        )} ${(getTextResource(textResourceBindings.tagTitle) || '')
           .toString()
           .toLowerCase()}.`,
       });


### PR DESCRIPTION
## Description
The root cause of this round of cypress test problems was caused by the backend being a little slow to respond when uploading the attachment. Because of this, when cypress used the dropdown to select a tag for an uploaded attachment (which seems entirely valid even though the attachment hasn't been uploaded yet), it stored this state using the `tmpAttachmentId`. When the attachment had finished uploading, this tag was stored on the wrong id. This adds a quick-fix where you can't use the select/dropdown until the attachment is fully uploaded.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- ~~[ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~