### PR TITLE
Cypress: Fuzzing and redux logging

### DIFF
--- a/.github/workflows/cypress-altinn-app-frontend.yml
+++ b/.github/workflows/cypress-altinn-app-frontend.yml
@@ -60,6 +60,7 @@ jobs:
         working-directory: test/cypress
 
       - uses: actions/upload-artifact@v3
+        if: failure()
         with:
           name: redux-state-history
           path: test/cypress/redux-history/*.json
@@ -96,6 +97,7 @@ jobs:
         working-directory: test/cypress
 
       - uses: actions/upload-artifact@v3
+        if: failure()
         with:
           name: redux-state-history
           path: test/cypress/redux-history/*.json

--- a/.github/workflows/cypress-altinn-app-frontend.yml
+++ b/.github/workflows/cypress-altinn-app-frontend.yml
@@ -59,6 +59,11 @@ jobs:
           ./node_modules/.bin/start-server-and-test 'cd $GITHUB_WORKSPACE/src/altinn-app-frontend && yarn start --no-hot' http://localhost:8080/altinn-app-frontend.js 'yarn run test:all:headless --env environment=tt02,testUserName=tt02testuser,testUserPwd=${{ secrets.CYPRESS_ALTINN_USERPWD }} --record --parallel --tag "altinn-app-frontend" --group altinn-app-frontend --ci-build-id $GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT'
         working-directory: test/cypress
 
+      - uses: actions/upload-artifact@v3
+        with:
+          name: redux-state-history
+          path: test/cypress/redux-history/*.json
+
   altinn-app-frontend-test-on-fork-pr:
     if: |
      github.repository_owner == 'Altinn' &&
@@ -89,3 +94,8 @@ jobs:
           yarn run cy:verify
           ./node_modules/.bin/start-server-and-test 'cd $GITHUB_WORKSPACE/src/altinn-app-frontend && yarn start --no-hot' http://localhost:8080/altinn-app-frontend.js 'yarn run test:all:headless --config watchForFileChanges=false --env environment=tt02,testUserName=testuserexternal,testUserPwd=r@h74Rz7XYQJ'
         working-directory: test/cypress
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: redux-state-history
+          path: test/cypress/redux-history/*.json

--- a/src/altinn-app-frontend/src/components/hooks/useDelayedSavedState.ts
+++ b/src/altinn-app-frontend/src/components/hooks/useDelayedSavedState.ts
@@ -48,6 +48,11 @@ export function useDelayedSavedState(
   return {
     value: immediateState,
     setValue: (newValue, saveImmediately) => {
+      if (newValue === 'a') {
+        // TODO: Remove this, obviously
+        throw new Error('blergh');
+      }
+
       setImmediateState(newValue);
       if (newValue !== formValue) {
         if (saveImmediately) {

--- a/src/altinn-app-frontend/src/components/hooks/useDelayedSavedState.ts
+++ b/src/altinn-app-frontend/src/components/hooks/useDelayedSavedState.ts
@@ -48,11 +48,6 @@ export function useDelayedSavedState(
   return {
     value: immediateState,
     setValue: (newValue, saveImmediately) => {
-      if (newValue === 'a') {
-        // TODO: Remove this, obviously
-        throw new Error('blergh');
-      }
-
       setImmediateState(newValue);
       if (newValue !== formValue) {
         if (saveImmediately) {

--- a/src/altinn-app-frontend/src/store/index.ts
+++ b/src/altinn-app-frontend/src/store/index.ts
@@ -11,14 +11,14 @@ export const sagaMiddleware: SagaMiddleware<any> = createSagaMiddleware();
 const middlewares = [sagaMiddleware, appApi.middleware];
 
 export const setupStore = (preloadedState?: PreloadedState<RootState>) => {
+  const isDev = process.env.NODE_ENV !== 'production';
   const innerStore = configureStore({
     reducer: reducers,
-    devTools: process.env.NODE_ENV !== 'production',
+    devTools: isDev,
     middleware: (getDefaultMiddleware) =>
       getDefaultMiddleware({
-        // TODO: enable once we have cleaned up our store
-        serializableCheck: false,
-        immutableCheck: true,
+        serializableCheck: isDev,
+        immutableCheck: isDev,
       }).concat(middlewares),
     preloadedState,
   });

--- a/src/altinn-app-frontend/src/store/index.ts
+++ b/src/altinn-app-frontend/src/store/index.ts
@@ -9,9 +9,17 @@ import { appApi } from 'src/services/AppApi';
 
 export const sagaMiddleware: SagaMiddleware<any> = createSagaMiddleware();
 const middlewares = [sagaMiddleware, appApi.middleware];
+const actionLog = [];
 
 export const setupStore = (preloadedState?: PreloadedState<RootState>) => {
   const isDev = process.env.NODE_ENV !== 'production';
+  if (isDev && (window as any).Cypress) {
+    middlewares.push(() => (next) => (action) => {
+      actionLog.push(action);
+      return next(action);
+    });
+  }
+
   const innerStore = configureStore({
     reducer: reducers,
     devTools: isDev,
@@ -35,20 +43,9 @@ if (process.env.NODE_ENV === 'development') {
   // in the app itself.
   (window as any).reduxStore = store;
 
-  // Adds a function that does approximately what the export function from redux-devtools does:
-  // https://github.com/reduxjs/redux-devtools/blob/b82de745928211cd9b7daa7a61b197ad9e11ec36/extension/src/browser/extension/inject/pageScript.ts#L220-L226
-  (window as any).getRecordedStateHistory = () => {
-    const liftedState = (store as any).liftedStore.getState();
-    const actionsById = liftedState.actionsById;
-    const payload: any[] = [];
-    liftedState.stagedActionIds.slice(1).forEach((id) => {
-      payload.push(actionsById[id].action);
-    });
-    return {
-      payload: JSON.stringify(payload),
-      preloadedState: JSON.stringify(store.getState()),
-    };
-  };
+  // Expose a log containing all dispatched actions. This is useful when Cypress tests fail, so that we can gather
+  // the logged actions to re-construct the redux state history using the redux devtools.
+  (window as any).reduxActionLog = actionLog;
 }
 
 export type RootState = ReturnType<typeof reducers>;

--- a/test/cypress/.gitignore
+++ b/test/cypress/.gitignore
@@ -27,3 +27,6 @@ downloads/
 !/.yarn/versions
 
 .env
+
+# Redux state history saved when tests fail
+/redux-history

--- a/test/cypress/e2e/fixtures/texts.json
+++ b/test/cypress/e2e/fixtures/texts.json
@@ -17,7 +17,7 @@
   "next": "Neste",
   "requiredField": "Feltet er påkrevd",
   "requiredFieldLastName": "Du må fylle ut nytt etternavn",
-  "requiredFieldDateFrom": "Du må fylle ut Dato for navneendring",
+  "requiredFieldDateFrom": "Du må fylle ut dato for navneendring",
   "securityReasons": "Av sikkerhetshensyn vil verken innholdet i tjenesten eller denne meldingen være synlig i Altinn etter at du har forlatt denne siden",
   "selectNewReportee": "Velg ny aktør under",
   "startingSoon": "Hold deg fast, nå starter vi!",

--- a/test/cypress/e2e/support/index.js
+++ b/test/cypress/e2e/support/index.js
@@ -15,28 +15,30 @@ before(() => {
 const failedCaseTable = {};
 afterEach(function () {
   if (this.currentTest.state === 'failed') {
+    const testName = this.currentTest.fullTitle();
+
+    // Remember the test case retry times
+    if (failedCaseTable[testName]) {
+      failedCaseTable[testName] += 1;
+    } else {
+      failedCaseTable[testName] = 1;
+    }
+
+    const title = this.currentTest.title.replace(/\s+/, '-').replace(/[^a-zA-Z\-0-9_]/, '');
+    const specBaseName = Cypress.spec.relative.split(/[\\\/]/).pop().split('.')[0];
+    const attempt = `failed${failedCaseTable[testName]}`;
+    const fileName = `redux-${specBaseName}-${title}-${attempt}.json`;
+
     cy.window().then((win) => {
-      const testName = this.currentTest.fullTitle();
-
-      // Remember the test case retry times
-      if (failedCaseTable[testName]) {
-        failedCaseTable[testName] += 1;
-      } else {
-        failedCaseTable[testName] = 1;
+      if (win.reduxActionLog && win.reduxStore) {
+        // This object does approximately what the export function from redux-devtools does:
+        // https://github.com/reduxjs/redux-devtools/blob/b82de745928211cd9b7daa7a61b197ad9e11ec36/extension/src/browser/extension/inject/pageScript.ts#L220-L226
+        const history = {
+          payload: JSON.stringify(win.reduxActionLog),
+          preloadedState: JSON.stringify(win.reduxStore.getState()),
+        };
+        cy.writeFile(`redux-history/${fileName}`, JSON.stringify(history, null, 2));
       }
-
-      if (!win.getRecordedStateHistory) {
-        console.error('Failed to get redux history: function not accessible');
-        return;
-      }
-
-      const title = this.currentTest.title.replace(/\s+/, '-').replace(/[^a-zA-Z\-0-9_]/, '');
-      const specBaseName = Cypress.spec.relative.split(/[\\\/]/).pop().split('.')[0];
-      const attempt = `failed${failedCaseTable[testName]}`;
-      const fileName = `redux-${specBaseName}-${title}-${attempt}.json`;
-
-      const history = win.getRecordedStateHistory();
-      cy.writeFile('redux-history/' + fileName, JSON.stringify(history, null, 2));
     });
   }
 });

--- a/test/cypress/e2e/support/index.js
+++ b/test/cypress/e2e/support/index.js
@@ -10,9 +10,33 @@ import chaiExtensions from './chai-extensions';
 
 before(() => {
   chai.use(chaiExtensions);
-  Cypress.on('uncaught:exception', (e, runnable) => {
-    console.log('error', e);
-    console.log('runnable', runnable);
-    return false;
-  });
+});
+
+const failedCaseTable = {};
+afterEach(function () {
+  if (this.currentTest.state === 'failed') {
+    cy.window().then((win) => {
+      const testName = this.currentTest.fullTitle();
+
+      // Remember the test case retry times
+      if (failedCaseTable[testName]) {
+        failedCaseTable[testName] += 1;
+      } else {
+        failedCaseTable[testName] = 1;
+      }
+
+      if (!win.getRecordedStateHistory) {
+        console.error('Failed to get redux history: function not accessible');
+        return;
+      }
+
+      const title = this.currentTest.title.replace(/\s+/, '-').replace(/[^a-zA-Z\-0-9_]/, '');
+      const specBaseName = Cypress.spec.relative.split(/[\\\/]/).pop().split('.')[0];
+      const attempt = `failed${failedCaseTable[testName]}`;
+      const fileName = `redux-${specBaseName}-${title}-${attempt}.json`;
+
+      const history = win.getRecordedStateHistory();
+      cy.writeFile('redux-history/' + fileName, JSON.stringify(history, null, 2));
+    });
+  }
 });

--- a/test/cypress/e2e/support/start-app-instance.js
+++ b/test/cypress/e2e/support/start-app-instance.js
@@ -12,6 +12,25 @@ Cypress.Commands.add('startAppInstance', (appName, anonymous=false) => {
     },
   };
 
+  if (Cypress.env('responseFuzzing') === 'on') {
+    const [min, max] = [10, 1000];
+    cy.log(`Response fuzzing on, will delay responses randomly between ${min}ms and ${max}ms`);
+
+    const rand = () => {
+      return Math.floor(Math.random() * (max - min + 1) + min);
+    };
+
+    const randomDelays = (req) => {
+      req.on('response', (res) => {
+        res.setDelay(rand());
+      });
+    };
+    cy.intercept('**/api/**', randomDelays);
+    cy.intercept('**/instances/**', randomDelays);
+  } else {
+    cy.log(`Response fuzzing off, enable with --env responseFuzzing=on`);
+  }
+
   cy.visit('/', visitOptions);
   if (Cypress.env('environment') === 'local') {
     if (anonymous) {


### PR DESCRIPTION
## Description
Multiple adjustments to Cypress testing.

1. Adding an option called `responseFuzzing`. When enabled, all API responses from the backend will be artificially delayed a random amount of time, simulating a slow network, I/O load on the backend, etc. This also causes dispatched events in the frontend to sometimes be fulfilled out-of-order, and can thus be used to bring to light any issues where our functionality implicitly relied on server response times in order to update the redux state correctly (like what happened in #365 and #87). Running this right now causes multiple cypress tests to fail, so it's evident we have more problems like this.
2. (Not included in code here, but still relevant to these changes.) I added `crossorigin` to the `<script>` tags in all tested apps, so that Cypress is able to gather error details from the app when something fails.
3. Adding a way to extract the log of redux actions and save it a test artifact we can download from github after the action runs. This can be imported into redux devtools and help us figure out what went wrong in the order of actions. This is especially useful when the fuzzing tests fail, as they can be very difficult to reproduce otherwise. 

## Related Issue(s)
- #365
- #87

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
