### PR TITLE
Cypress: Increasing file watcher limits for fork PRs

### DIFF
--- a/.github/workflows/cypress-altinn-app-frontend.yml
+++ b/.github/workflows/cypress-altinn-app-frontend.yml
@@ -51,7 +51,8 @@ jobs:
         working-directory: test/cypress
 
       - name: Verify cypress and run tests
-        run: "yarn run cy:verify\n
+        run: "
+          yarn run cy:verify\n
           export CYPRESS_PROJECT_ID=y2jhp6\n
           export CYPRESS_RECORD_KEY=${{ secrets.CYPRESS_RECORD_KEY }}\n
           export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}\n
@@ -84,6 +85,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Increase file watchers
+        run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
 
       - uses: actions/setup-node@v2
         with:

--- a/.github/workflows/cypress-altinn-app-frontend.yml
+++ b/.github/workflows/cypress-altinn-app-frontend.yml
@@ -51,12 +51,21 @@ jobs:
         working-directory: test/cypress
 
       - name: Verify cypress and run tests
-        run: |
-          yarn run cy:verify
-          export CYPRESS_PROJECT_ID=y2jhp6
-          export CYPRESS_RECORD_KEY=${{ secrets.CYPRESS_RECORD_KEY }}
-          export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
-          ./node_modules/.bin/start-server-and-test 'cd $GITHUB_WORKSPACE/src/altinn-app-frontend && yarn start --no-hot' http://localhost:8080/altinn-app-frontend.js 'yarn run test:all:headless --env environment=tt02,testUserName=tt02testuser,testUserPwd=${{ secrets.CYPRESS_ALTINN_USERPWD }} --record --parallel --tag "altinn-app-frontend" --group altinn-app-frontend --ci-build-id $GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT'
+        run: "yarn run cy:verify\n
+          export CYPRESS_PROJECT_ID=y2jhp6\n
+          export CYPRESS_RECORD_KEY=${{ secrets.CYPRESS_RECORD_KEY }}\n
+          export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}\n
+          ./node_modules/.bin/start-server-and-test
+            'cd $GITHUB_WORKSPACE/src/altinn-app-frontend && yarn start --no-hot'
+            http://localhost:8080/altinn-app-frontend.js
+            'yarn run test:all:headless
+              --env environment=tt02,testUserName=tt02testuser,testUserPwd=${{ secrets.CYPRESS_ALTINN_USERPWD }}
+              --record
+              --parallel
+              --tag \"altinn-app-frontend\"
+              --group altinn-app-frontend
+              --ci-build-id $GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT'
+        "
         working-directory: test/cypress
 
       - uses: actions/upload-artifact@v3
@@ -91,9 +100,15 @@ jobs:
         working-directory: test/cypress
 
       - name: Verify cypress and run tests
-        run: |
-          yarn run cy:verify
-          ./node_modules/.bin/start-server-and-test 'cd $GITHUB_WORKSPACE/src/altinn-app-frontend && yarn start --no-hot' http://localhost:8080/altinn-app-frontend.js 'yarn run test:all:headless --config watchForFileChanges=false --env environment=tt02,testUserName=testuserexternal,testUserPwd=r@h74Rz7XYQJ'
+        run: "
+          yarn run cy:verify\n
+          ./node_modules/.bin/start-server-and-test
+            'cd $GITHUB_WORKSPACE/src/altinn-app-frontend && yarn start --no-hot'
+            http://localhost:8080/altinn-app-frontend.js
+            'yarn run test:all:headless
+              --config watchForFileChanges=false
+              --env environment=tt02,testUserName=testuserexternal,testUserPwd=r@h74Rz7XYQJ'
+        "
         working-directory: test/cypress
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/cypress-altinn-app-frontend.yml
+++ b/.github/workflows/cypress-altinn-app-frontend.yml
@@ -7,12 +7,14 @@ on:
       - 'src/altinn-app-frontend/**'
       - 'src/shared/**'
       - 'test/cypress/**'
+      - '.github/workflows/cypress-altinn-app-frontend.yml'
   pull_request:
     branches: [main]
     paths:
       - 'src/altinn-app-frontend/**'
       - 'src/shared/**'
       - 'test/cypress/**'
+      - '.github/workflows/cypress-altinn-app-frontend.yml'
 
   workflow_dispatch:
 


### PR DESCRIPTION
## Description
Cypress tests for #326 fails, as the max file watchers haven't been increased for fork PRs.

## Related Issue(s)
- #326

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- ~~[ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~
