### PR TITLE
Style fixes for #100

### DIFF
--- a/src/altinn-app-frontend/src/components/GenericComponent.tsx
+++ b/src/altinn-app-frontend/src/components/GenericComponent.tsx
@@ -307,12 +307,12 @@ export function GenericComponent<Type extends ComponentExceptGroup>(
     ...passThroughProps,
   } as IComponentProps & ILayoutComponent<Type>;
 
-  const noLabelComponents = [
+  const noLabelComponents: ComponentTypes[] = [
     'Header',
     'Paragraph',
     'Image',
-    'Submit',
-    'ThirdParty',
+    'NavigationButtons',
+    'Custom',
     'AddressComponent',
     'Button',
     'Checkboxes',

--- a/src/altinn-app-frontend/src/components/message/ErrorReport.tsx
+++ b/src/altinn-app-frontend/src/components/message/ErrorReport.tsx
@@ -37,10 +37,10 @@ const useStyles = makeStyles((theme) => ({
     },
     '& > li > button': {
       textAlign: 'left',
-      borderBottom: theme.sharedStyles.noLinkBorderBottom,
+      borderBottom: '2px solid transparent',
     },
     '& > li > button:hover': {
-      borderBottom: theme.sharedStyles.linkBorderBottom,
+      borderBottom: `2px solid black`,
     },
   },
   buttonAsInvisibleLink: {
@@ -126,7 +126,9 @@ const ErrorReport = ({ components }: IErrorReportProps) => {
               <ul className={classes.errorList}>
                 {errorsUnmapped.map((error: string, index: number) => (
                   <li key={`unmapped-${index}`}>
-                    {getParsedLanguageFromText(error)}
+                    {getParsedLanguageFromText(error, {
+                      disallowedTags: ['a'],
+                    })}
                   </li>
                 ))}
                 {errorsMapped.map((error) => (
@@ -136,7 +138,9 @@ const ErrorReport = ({ components }: IErrorReportProps) => {
                       onClick={handleErrorClick(error)}
                       onKeyDown={handleErrorClick(error)}
                     >
-                      {getParsedLanguageFromText(error.message)}
+                      {getParsedLanguageFromText(error.message, {
+                        disallowedTags: ['a'],
+                      })}
                     </button>
                   </li>
                 ))}

--- a/src/shared/src/theme/altinnAppTheme.tsx
+++ b/src/shared/src/theme/altinnAppTheme.tsx
@@ -41,7 +41,6 @@ const AltinnAppTheme = {
   sharedStyles: {
     boxShadow: '0px 0px 4px rgba(0, 0, 0, 0.25)',
     linkBorderBottom: '1px solid #0062BA',
-    noLinkBorderBottom: '1px solid transparent',
     mainPaddingLeft: 73,
     fontWeight: {
       medium: 500,

--- a/src/shared/src/utils/language.ts
+++ b/src/shared/src/utils/language.ts
@@ -54,20 +54,27 @@ export const getParsedLanguageFromKey = (
 
 export const getParsedLanguageFromText = (
   text: string,
-  allowedTags?: string[],
-  allowedAttr?: string[],
+  options?: {
+    allowedTags?: string[];
+    allowedAttr?: string[];
+    disallowedTags?: string[];
+  },
 ) => {
   const dirty = marked.parse(text);
-  const options: DOMPurify.Config = {};
-  if (allowedTags) {
-    options.ALLOWED_TAGS = allowedTags;
+  const actualOptions: DOMPurify.Config = {};
+  if (options && options.allowedTags) {
+    actualOptions.ALLOWED_TAGS = options.allowedTags;
   }
 
-  if (allowedAttr) {
-    options.ALLOWED_ATTR = allowedAttr;
+  if (options && options.allowedAttr) {
+    actualOptions.ALLOWED_ATTR = options.allowedAttr;
   }
 
-  const clean = DOMPurify.sanitize(dirty, options);
+  if (options && options.disallowedTags) {
+    actualOptions.FORBID_TAGS = options.disallowedTags;
+  }
+
+  const clean = DOMPurify.sanitize(dirty, actualOptions);
   return parseHtmlToReact(clean.toString().trim(), parseOptions);
 };
 


### PR DESCRIPTION
## Description
As requested, changing the underline to be `2px black`, and also removing potential links from markdown text in error messages when shown in `ErrorReport`.

Before:
![image](https://user-images.githubusercontent.com/1464915/183883848-c485a83b-d428-4af8-80a6-feb1861b2c61.png) 

After:
![image](https://user-images.githubusercontent.com/700139/183935217-6077da78-5e7a-4236-98e9-6096b170c213.png) 

## Related Issue(s)
- #100

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- ~~[ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~
