### PR TITLE
Fix bug with repeating groups only showing 9 rows

### DIFF
--- a/src/altinn-app-frontend/src/utils/formLayout.test.ts
+++ b/src/altinn-app-frontend/src/utils/formLayout.test.ts
@@ -234,6 +234,51 @@ describe('getRepeatingGroups', () => {
     const result = getRepeatingGroups(testLayout, formData);
     expect(result).toEqual(expected);
   });
+  it('should return correct index from unordered formdata', () => {
+    const testLayout: ILayout = [
+      {
+        id: 'Group1',
+        type: 'Group',
+        dataModelBindings: {
+          group: 'Group1',
+        },
+        children: ['field1'],
+        maxCount: 99,
+      } as ILayoutGroup,
+      {
+        id: 'field1',
+        type: 'Input',
+        textResourceBindings: {
+          title: 'Title',
+        },
+        readOnly: false,
+        required: false,
+        disabled: false,
+      } as ILayoutComponent,
+    ];
+    const formData = {
+      'Group1[0].prop': 'value-0',
+      'Group1[1].prop': 'value-1',
+      'Group1[12].prop': 'value-1',
+      'Group1[2].prop': 'value-2',
+      'Group1[3].prop': 'value-3',
+      'Group1[4].prop': 'value-0',
+      'Group1[5].prop': 'value-1',
+      'Group1[6].prop': 'value-2',
+      'Group1[7].prop': 'value-3',
+      'Group1[8].prop': 'value-3',
+      'Group1[9].prop': 'value-3',
+    };
+    const expected = {
+      Group1: {
+        index: 12,
+        dataModelBinding: 'Group1',
+        editIndex: -1,
+      },
+    };
+    const result = getRepeatingGroups(testLayout, formData);
+    expect(result).toEqual(expected);
+  });
 });
 
 describe('removeRepeatingGroupFromUIConfig', () => {

--- a/src/altinn-app-frontend/src/utils/formLayout.test.ts
+++ b/src/altinn-app-frontend/src/utils/formLayout.test.ts
@@ -123,6 +123,53 @@ describe('getRepeatingGroups', () => {
     expect(result).toEqual(expected);
   });
 
+  it('should handle nested groups with index above 9', () => {
+    const formData = {
+      'Group1[0].prop1': 'value-0-1',
+      'Group1[0].Group2[0].group2prop': 'group2-0-0-value',
+      'Group1[1].prop1': 'value-1-1',
+      'Group1[1].Group2[0].group2prop': 'group2-1-0-value',
+      'Group1[1].Group2[1].group2prop': 'group2-1-1-value',
+      'Group1[1].Group2[2].group2prop': 'group2-1-2-value',
+      'Group1[1].Group2[3].group2prop': 'group2-1-3-value',
+      'Group1[1].Group2[4].group2prop': 'group2-1-3-value',
+      'Group1[1].Group2[5].group2prop': 'group2-1-3-value',
+      'Group1[1].Group2[6].group2prop': 'group2-1-3-value',
+      'Group1[1].Group2[7].group2prop': 'group2-1-3-value',
+      'Group1[1].Group2[8].group2prop': 'group2-1-3-value',
+      'Group1[1].Group2[9].group2prop': 'group2-1-3-value',
+      'Group1[1].Group2[10].group2prop': 'group2-1-3-value',
+      'Group1[2].prop1': 'value-2-1',
+      'Group1[2].Group2[0].group2prop': 'group2-2-1-value',
+      'Group1[2].Group2[1].group2prop': 'group2-2-2-value',
+    };
+    const expected = {
+      Group1: {
+        index: 2,
+        dataModelBinding: 'Group1',
+        editIndex: -1,
+      },
+      'Group2-0': {
+        index: 0,
+        baseGroupId: 'Group2',
+        editIndex: -1,
+      },
+      'Group2-1': {
+        index: 10,
+        baseGroupId: 'Group2',
+        editIndex: -1,
+      },
+      'Group2-2': {
+        index: 1,
+        baseGroupId: 'Group2',
+        editIndex: -1,
+      },
+    };
+
+    const result = getRepeatingGroups(testLayout, formData);
+    expect(result).toEqual(expected);
+  });
+
   it('should correctly handle out-of-order formData', () => {
     const formData = {
       'Group1[2].prop1': 'value-2-1',

--- a/src/altinn-app-frontend/src/utils/formLayout.ts
+++ b/src/altinn-app-frontend/src/utils/formLayout.ts
@@ -102,10 +102,14 @@ export function getRepeatingGroups(formLayout: ILayout, formData: any) {
         })
         .sort();
       if (groupFormData && groupFormData.length > 0) {
-        const lastItem = groupFormData[groupFormData.length - 1];
-        const match = lastItem.match(regex);
-        if (match && match[1]) {
-          const index = parseInt(match[1], 10);
+        const maxIndex = Math.max(
+          ...groupFormData.map((formDataKey) => {
+            const match = formDataKey.match(regex);
+            return parseInt(match[1], 10);
+          }),
+        );
+        if (maxIndex) {
+          const index = maxIndex;
           repeatingGroups[groupElement.id] = {
             index,
             dataModelBinding: groupElement.dataModelBindings?.group,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixed a bug with repeating groups where it would only show max 9 rows, even if you had a much larger datamodel. 
We discovered the bug when implementing the Likert component with rows above 10.

I reproduced the bug in a test and fixed it!

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
