### PR TITLE
BugFix: Show menu icon when user doesn't have ssn or org number

### DIFF
--- a/src/shared/src/components/organisms/AltinnAppHeader.test.tsx
+++ b/src/shared/src/components/organisms/AltinnAppHeader.test.tsx
@@ -17,7 +17,7 @@ describe('organisms/AltinnAppHeader', () => {
     name: 'Bedrift',
   } as IParty;
 
-  const anonymousUser = {
+  const selfIdentifiedUser = {
     childParties: null,
     isDeleted: false,
     name: 'uidp_brxzt8pt992',
@@ -62,7 +62,7 @@ describe('organisms/AltinnAppHeader', () => {
   });
 
   it('should render private icon for user without ssn or org number', () => {
-    renderComponent(anonymousUser);
+    renderComponent(selfIdentifiedUser);
     const profileButton = screen.getByRole('button', {
       name: /profilikon meny/i,
     });

--- a/src/shared/src/components/organisms/AltinnAppHeader.test.tsx
+++ b/src/shared/src/components/organisms/AltinnAppHeader.test.tsx
@@ -61,7 +61,7 @@ describe('organisms/AltinnAppHeader', () => {
     );
   });
 
-  it('should render fallback to private icon', () => {
+  it('should render private icon for user without ssn or org number', () => {
     renderComponent(anonymousUser);
     const profileButton = screen.getByRole('button', {
       name: /profilikon meny/i,

--- a/src/shared/src/components/organisms/AltinnAppHeader.test.tsx
+++ b/src/shared/src/components/organisms/AltinnAppHeader.test.tsx
@@ -16,6 +16,21 @@ describe('organisms/AltinnAppHeader', () => {
     partyId: '54321',
     name: 'Bedrift',
   } as IParty;
+
+  const anonymousUser = {
+    childParties: null,
+    isDeleted: false,
+    name: 'uidp_brxzt8pt992',
+    onlyHierarchyElementWithNoAccess: false,
+    orgNumber: '',
+    organization: null,
+    partyId: '52057791',
+    partyTypeName: 3,
+    person: null,
+    ssn: '',
+    unitType: null,
+  } as IParty;
+
   const headerBackgroundColor = 'blue';
   const logoColor = 'blue';
   const language = {
@@ -38,6 +53,16 @@ describe('organisms/AltinnAppHeader', () => {
 
   it('should render private icon when party is person', () => {
     renderComponent(partyPerson);
+    const profileButton = screen.getByRole('button', {
+      name: /profilikon meny/i,
+    });
+    expect(profileButton.firstChild.firstChild).toHaveClass(
+      'fa-private-circle-big',
+    );
+  });
+
+  it('should render fallback to private icon', () => {
+    renderComponent(anonymousUser);
     const profileButton = screen.getByRole('button', {
       name: /profilikon meny/i,
     });

--- a/src/shared/src/components/organisms/AltinnAppHeaderMenu.tsx
+++ b/src/shared/src/components/organisms/AltinnAppHeaderMenu.tsx
@@ -56,22 +56,14 @@ function AltinnAppHeaderMenu(props: IAltinnAppHeaderMenuProps) {
         className={classes.iconButton}
         id='profile-icon-button'
       >
-        {party.ssn && (
-          <AltinnIcon
-            iconClass='fa fa-private-circle-big'
-            iconColor={logoColor}
-            iconSize={31}
-            margin='0px 0px 0px 5px'
-          />
-        )}
-        {party.orgNumber && (
-          <AltinnIcon
-            iconClass='fa fa-corp-circle-big'
-            iconColor={logoColor}
-            iconSize={31}
-            margin='0px 0px 0px 5px'
-          />
-        )}
+        <AltinnIcon
+          iconClass={`fa ${
+            party.orgNumber ? 'fa fa-corp-circle-big' : 'fa-private-circle-big'
+          }`}
+          iconColor={logoColor}
+          iconSize={31}
+          margin='0px 0px 0px 5px'
+        />
       </IconButton>
       <Menu
         id='profile-menu'

--- a/src/shared/src/components/organisms/AltinnAppHeaderMenu.tsx
+++ b/src/shared/src/components/organisms/AltinnAppHeaderMenu.tsx
@@ -58,7 +58,7 @@ function AltinnAppHeaderMenu(props: IAltinnAppHeaderMenuProps) {
       >
         <AltinnIcon
           iconClass={`fa ${
-            party.orgNumber ? 'fa fa-corp-circle-big' : 'fa-private-circle-big'
+            party.orgNumber ? 'fa-corp-circle-big' : 'fa-private-circle-big'
           }`}
           iconColor={logoColor}
           iconSize={31}

--- a/src/shared/src/types/index.ts
+++ b/src/shared/src/types/index.ts
@@ -149,7 +149,7 @@ export interface IOrganisation {
 export interface IParty {
   partyId: string;
   partyTypeName: number;
-  orgNumber: number;
+  orgNumber: number | string;
   ssn: string;
   unitType: string;
   name: string;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Shows the private person icon as a fallback if ssn or orgNumber is not present in user party.

## Related Issue(s)
- #58 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
