### PR TITLE
chore: upgrade to latest design system package

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,17 +11,6 @@ React SPA used by applications developed in [altinn-studio](https://github.com/A
 
 This project is using [`yarn`](https://yarnpkg.com/) instead of the default `npm` CLI. This means that you should execute package.json scripts with `yarn` instead of `npm`. F.ex instead of `npm run test` you should execute `yarn run test`. With `yarn`, the `run` keyword is optional, so you can also execute `yarn test`.
 
-### Setup Github PAT Token
-
-We are currently using Github registry to publish packages. This means you need to setup a PAT (Personal Access Token) on your machine.
-
-- Acquire a [GitHub PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token). The only permission you need to grant is read:packages.
-- Assign the PAT to the GITHUB_PACKAGES_PAT environment variable:
-  - Mac/Linux: add the line `export GITHUB_PACKAGES_PAT=<PAT>` to the `~/.bash_profile` file and restart the terminal
-  - Windows: Execute `setx GITHUB_PACKAGES_PAT <PAT> /m` and restart the terminal
-
-If you are using z shell (default on macOS since v10.15 Catalina), you need to update the `~/.zshrc` file instead of file `~/.bash_profile` or `~/.profile.`. 
-
 ## Getting Started
 
 These instructions will get you a copy of the project up and running on your local machine for development and testing purposes.

--- a/src/.yarnrc.yml
+++ b/src/.yarnrc.yml
@@ -1,10 +1,5 @@
 enableMessageNames: false
 
-npmScopes:
-  altinn:
-    npmRegistryServer: https://npm.pkg.github.com
-    npmAuthToken: ${GITHUB_PACKAGES_PAT:-}
-
 enableTelemetry: false
 
 nodeLinker: node-modules

--- a/src/altinn-app-frontend/package.json
+++ b/src/altinn-app-frontend/package.json
@@ -18,7 +18,7 @@
   "author": "Altinn",
   "license": "3-Clause BSD",
   "dependencies": {
-    "@altinn/altinn-design-system": "^0.5.6",
+    "@altinn/altinn-design-system": "^0.5.7",
     "@babel/polyfill": "^7.12.1",
     "@date-io/moment": "1.3.13",
     "@material-ui/core": "^4.12.4",

--- a/src/yarn.lock
+++ b/src/yarn.lock
@@ -12,11 +12,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@altinn/altinn-design-system@npm:^0.5.6":
-  version: 0.5.6
-  resolution: "@altinn/altinn-design-system@npm:0.5.6::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40Altinn%2Faltinn-design-system%2F0.5.6%2F990461254766d5a449bccf731fdc6940f48ba589"
+"@altinn/altinn-design-system@npm:^0.5.7":
+  version: 0.5.7
+  resolution: "@altinn/altinn-design-system@npm:0.5.7"
   dependencies:
-    "@altinn/figma-design-tokens": ^0.3.0
+    "@altinn/figma-design-tokens": ^2.0.2
     "@react-hookz/web": ^15.0.1
     leaflet: ^1.8.0
     react-leaflet: ^4.0.1
@@ -24,14 +24,14 @@ __metadata:
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: b862e88a5cecc961fd18b405df6db4107003f18037d51245f034e050ed32313cb838ac994b05723e5d2c7d060d17c39ee318532602e388da79c3619bb5fd9290
+  checksum: cd20759989247d9c9ca4a4bc5080916a8bf056de69295256d482e85142f177ef11192165f1ba93826b4f51bc7f1d3b48d2e0bdb94b29c2aebf20c0b39070b92a
   languageName: node
   linkType: hard
 
-"@altinn/figma-design-tokens@npm:^0.3.0":
-  version: 0.3.0
-  resolution: "@altinn/figma-design-tokens@npm:0.3.0::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40altinn%2Ffigma-design-tokens%2F0.3.0%2Fc97036531b1b29622f09e601f9a3c9f8f49b36a5d97649f656bad4411a9fe674"
-  checksum: 72a0fa141e08d93912ff87714d98e5a5537ba0fb5cfb0bdad8e59e6fd05f37efa60bcb171f6ecb7c7901b24e2473d9b3b576dccae141c876d3bd3f536905e2ba
+"@altinn/figma-design-tokens@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "@altinn/figma-design-tokens@npm:2.0.2"
+  checksum: 60cc5076962e94743a083ff00180a8315c8e4469ffd0776af3f438b434f49e46045498fa95bc073e340191c4f0f9e156643275a860c466fa64505c8c82fb278d
   languageName: node
   linkType: hard
 
@@ -4407,7 +4407,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "altinn-app-frontend@workspace:altinn-app-frontend"
   dependencies:
-    "@altinn/altinn-design-system": ^0.5.6
+    "@altinn/altinn-design-system": ^0.5.7
     "@babel/core": ^7.18.10
     "@babel/polyfill": ^7.12.1
     "@babel/preset-env": ^7.18.10


### PR DESCRIPTION
## Description
- new version is published on npm feed instead of github, so we no longer need to set up a PAT
