### PR TITLE
chore: attempt to skip SonarCloud run on external PR's

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,10 @@ jobs:
         run: yarn test --coverage
 
       - name: SonarCloud Scan
-        if: github.event.repository.fork == false
+        if: |
+          github.repository_owner == 'Altinn' &&
+          (github.event_name != 'pull_request' && github.event.repository.fork == false) ||
+          (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
         with:
           projectBaseDir: app-frontend
         uses: SonarSource/sonarcloud-github-action@master


### PR DESCRIPTION
## Description
Currently, fork PR's still try to run SonarCloud scan, which will not work since they will not have access to the required secret. This should skip it for external PRs. 
