### PR TITLE
Adding an element for the PDF generator to know when the page has loaded

### DIFF
--- a/src/altinn-app-frontend/src/features/confirm/containers/Confirm.tsx
+++ b/src/altinn-app-frontend/src/features/confirm/containers/Confirm.tsx
@@ -9,6 +9,7 @@ import {
 } from 'src/common/hooks';
 import { ValidationActions } from 'src/features/form/validation/validationSlice';
 import { selectAppName } from 'src/selectors/language';
+import { ReadyForPrint } from 'src/shared/components/ReadyForPrint';
 import { InstanceDataActions } from 'src/shared/resources/instanceData/instanceDataSlice';
 import { ProcessActions } from 'src/shared/resources/process/processSlice';
 import { getValidationUrl } from 'src/utils/appUrlHelper';
@@ -191,6 +192,7 @@ const Confirm = () => {
             pdf={getInstancePdf(instance.data)}
           />
           <SubmitButton />
+          <ReadyForPrint />
         </>
       )}
     </div>

--- a/src/altinn-app-frontend/src/features/feedback/Feedback.tsx
+++ b/src/altinn-app-frontend/src/features/feedback/Feedback.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { createTheme, MuiThemeProvider, Typography } from '@material-ui/core';
 
 import { useAppDispatch, useAppSelector } from 'src/common/hooks';
+import { ReadyForPrint } from 'src/shared/components/ReadyForPrint';
 import { ProcessActions } from 'src/shared/resources/process/processSlice';
 import { getTextFromAppOrDefault } from 'src/utils/textResource';
 
@@ -34,6 +35,7 @@ export default function Feedback() {
           {getTextFromAppOrDefault('feedback.body', textResources, language)}
         </Typography>
       </MuiThemeProvider>
+      <ReadyForPrint />
     </div>
   );
 }

--- a/src/altinn-app-frontend/src/features/form/containers/Form.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/Form.tsx
@@ -10,6 +10,7 @@ import { DisplayGroupContainer } from 'src/features/form/containers/DisplayGroup
 import { mapGroupComponents } from 'src/features/form/containers/formUtils';
 import { GroupContainer } from 'src/features/form/containers/GroupContainer';
 import { PanelGroupContainer } from 'src/features/form/containers/PanelGroupContainer';
+import { ReadyForPrint } from 'src/shared/components/ReadyForPrint';
 import {
   extractBottomButtons,
   hasRequiredFields,
@@ -150,6 +151,7 @@ export function Form() {
         )}
         <ErrorReport components={errorReportComponents} />
       </Grid>
+      <ReadyForPrint />
     </>
   );
 }

--- a/src/altinn-app-frontend/src/features/instantiate/containers/InstanceSelection.tsx
+++ b/src/altinn-app-frontend/src/features/instantiate/containers/InstanceSelection.tsx
@@ -9,6 +9,7 @@ import {
 } from '@material-ui/core';
 
 import { useAppSelector } from 'src/common/hooks';
+import { ReadyForPrint } from 'src/shared/components/ReadyForPrint';
 import { getInstanceUiUrl } from 'src/utils/appUrlHelper';
 import type { ISimpleInstance } from 'src/types';
 
@@ -175,49 +176,52 @@ export default function InstanceSelection({
   };
 
   return (
-    <Grid
-      container
-      id='instance-selection-container'
-    >
-      <Grid item>
-        <Typography
-          variant='h2'
-          id='instance-selection-header'
-        >
-          {getLanguageFromKey('instance_selection.header', language)}
-        </Typography>
-      </Grid>
+    <>
       <Grid
-        item
-        id='instance-selection-description'
+        container
+        id='instance-selection-container'
       >
-        <Typography
-          variant='body1'
+        <Grid item>
+          <Typography
+            variant='h2'
+            id='instance-selection-header'
+          >
+            {getLanguageFromKey('instance_selection.header', language)}
+          </Typography>
+        </Grid>
+        <Grid
+          item
+          id='instance-selection-description'
+        >
+          <Typography
+            variant='body1'
+            style={marginTop12}
+          >
+            {getLanguageFromKey('instance_selection.description', language)}
+          </Typography>
+        </Grid>
+        <Grid
+          item
+          style={marginTop26}
+        >
+          {mobileView && renderMobileTable()}
+          {!mobileView && renderTable()}
+        </Grid>
+        <Grid
+          item
           style={marginTop12}
         >
-          {getLanguageFromKey('instance_selection.description', language)}
-        </Typography>
+          <AltinnButton
+            btnText={getLanguageFromKey(
+              'instance_selection.new_instance',
+              language,
+            )}
+            onClickFunction={onNewInstance}
+            id='new-instance-button'
+          />
+        </Grid>
       </Grid>
-      <Grid
-        item
-        style={marginTop26}
-      >
-        {mobileView && renderMobileTable()}
-        {!mobileView && renderTable()}
-      </Grid>
-      <Grid
-        item
-        style={marginTop12}
-      >
-        <AltinnButton
-          btnText={getLanguageFromKey(
-            'instance_selection.new_instance',
-            language,
-          )}
-          onClickFunction={onNewInstance}
-          id='new-instance-button'
-        />
-      </Grid>
-    </Grid>
+      <ReadyForPrint />
+    </>
   );
 }

--- a/src/altinn-app-frontend/src/features/instantiate/containers/InstantiationContainer.tsx
+++ b/src/altinn-app-frontend/src/features/instantiate/containers/InstantiationContainer.tsx
@@ -4,6 +4,7 @@ import { Grid, makeStyles } from '@material-ui/core';
 
 import { useAppSelector } from 'src/common/hooks';
 import Header from 'src/shared/components/altinnAppHeader';
+import { ReadyForPrint } from 'src/shared/components/ReadyForPrint';
 import { changeBodyBackground } from 'src/utils/bodyStyling';
 
 import { AltinnAppTheme } from 'altinn-shared/theme';
@@ -48,6 +49,7 @@ export function InstantiationContainer({
         type={type}
       />
       <main id='main-content'>{children}</main>
+      <ReadyForPrint />
     </Grid>
   );
 }

--- a/src/altinn-app-frontend/src/features/receipt/containers/ReceiptContainer.tsx
+++ b/src/altinn-app-frontend/src/features/receipt/containers/ReceiptContainer.tsx
@@ -8,6 +8,7 @@ import {
   useInstanceIdParams,
 } from 'src/common/hooks';
 import { selectAppName } from 'src/selectors/language';
+import { ReadyForPrint } from 'src/shared/components/ReadyForPrint';
 import { InstanceDataActions } from 'src/shared/resources/instanceData/instanceDataSlice';
 import { getTextFromAppOrDefault } from 'src/utils/textResource';
 
@@ -209,6 +210,7 @@ const ReceiptContainer = () => {
               )}`}
             />
           )}
+          <ReadyForPrint />
         </>
       )}
     </div>

--- a/src/altinn-app-frontend/src/shared/components/ReadyForPrint.tsx
+++ b/src/altinn-app-frontend/src/shared/components/ReadyForPrint.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+
+/**
+ * This element only serves to let our PDF generator know the app is ready and have rendered its content.
+ * It should be included in the app DOM for every possible execution path, except those where we're showing
+ * loading indicators to the user while waiting for content to get ready.
+ */
+export function ReadyForPrint() {
+  const [imagesLoaded, setImagesLoaded] = React.useState(false);
+
+  React.useLayoutEffect(() => {
+    const promises = [];
+
+    const imageLoadPromise = (img: HTMLImageElement) => {
+      return new Promise((res) => {
+        img.addEventListener('load', res);
+        img.addEventListener('error', res);
+      });
+    };
+
+    document.querySelectorAll('img').forEach((image) => {
+      image.complete || promises.push(imageLoadPromise(image));
+    });
+
+    Promise.all(promises).then(() => {
+      // All images have loaded (or failed to load), but they haven't always been painted/caused a re-render. A request
+      // for an animation frame reserves you a slot to execute some code _before the next repaint_, but that might be
+      // the repaint where the image was supposed to render. When we call it twice, we're guaranteed to output our
+      // element after all images have been rendered.
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          setImagesLoaded(true);
+        });
+      });
+    });
+  }, []);
+
+  if (!imagesLoaded) {
+    return;
+  }
+
+  return (
+    <div
+      style={{ display: 'none' }}
+      id='readyForPrint'
+    />
+  );
+}


### PR DESCRIPTION
## Description
This element should be injected everywhere in our app at the points where all content has been loaded and the DOM is ready for the user (i.e., after all our loading placeholders). This element (`#readyForPrint`) can be listened for by the PDF generator to know when the page can be printed to a PDF.

As it's notoriously hard to test these things, and I'm not sure how (or even if) we should include this in our Cypress test suite, I opened up the debugger in Chrome and pasted this code inside a file to make sure we trigger a breakpoint (which freezes rendering) when the `readyForPrint` element appears on the page. It's not pretty, but it's what made me find the issue with images that have to be loaded.

```typescript
let iterations = 0;
let found = false;
setInterval(() => {
  iterations++;
  const elmFound = !!document.getElementById('readyForPrint');
  if (!found && elmFound) {
    found = true;
    console.log(
      'Found readyForPrint after',
      iterations,
      'iterations',
      document.readyState,
    );
    debugger;
  } else if (found && !elmFound) {
    found = false;
    iterations = 0;
  }
}, 5);
```

I'm not sure about the naming - maybe we should use a more generic name like `altinnAppReady` instead?

## Related Issue(s)
- #388

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- ~~[ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~
