### PR TITLE
chore: treat 0.x.x versions as major changes, so they are not grouped in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,13 +5,9 @@
   ],
   "packageRules": [
     {
-      "matchPackagePatterns": [
-        "*"
-      ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
+      "matchCurrentVersion": ">=1.0.0",
+      "matchPackagePatterns": ["*"],
+      "matchUpdateTypes": ["minor", "patch"],
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch"
     }

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base", "schedule:earlyMondays"],
+  "extends": ["config:base", "schedule:earlyMondays", "npm:unpublishSafe"],
   "packageRules": [
     {
       "matchCurrentVersion": ">=1.0.0",

--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
-  ],
+  "extends": ["config:base", "schedule:earlyMondays"],
   "packageRules": [
     {
       "matchCurrentVersion": ">=1.0.0",


### PR DESCRIPTION
## Description
- Do not group any 0.x.x dependency together with minor/patch PR, because these could contain breaking changes acoording to the semver spec.
- Add schedule for when renovate should create PR's
- Add delay for when a new version is published, before renovate creates a PR to update it. The delay is currently 3 days. See https://docs.renovatebot.com/presets-npm/

## Related Issue(s)
- #274 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
