### PR TITLE
Keep focus styling on edit button when editing group

### DIFF
--- a/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupTable.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupTable.tsx
@@ -110,6 +110,10 @@ const useStyles = makeStyles({
       outline: `2px dotted ${theme.altinnPalette.primary.blueDark}`,
     },
   },
+  editButtonActivated: {
+    background: theme.altinnPalette.primary.blueLighter,
+    outline: `2px dotted ${theme.altinnPalette.primary.blueDark}`,
+  },
   deleteButton: {
     color: theme.altinnPalette.primary.red,
     fontWeight: 700,
@@ -358,7 +362,11 @@ export function RepeatingGroupTable({
                         key={`edit-${index}`}
                       >
                         <IconButton
-                          className={classes.tableEditButton}
+                          className={`${classes.tableEditButton} ${
+                            editIndex === index
+                              ? classes.editButtonActivated
+                              : ''
+                          }`}
                           onClick={() => onClickEdit(index)}
                         >
                           <i
@@ -434,6 +442,7 @@ export function RepeatingGroupTable({
                     key={index}
                     items={items}
                     valid={!rowHasErrors}
+                    editIndex={editIndex}
                     onEditClick={() => onClickEdit(index)}
                     onDeleteClick={() => onClickRemove(index)}
                     editIconNode={

--- a/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupTable.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupTable.tsx
@@ -9,6 +9,7 @@ import {
   TableRow,
   useMediaQuery,
 } from '@material-ui/core';
+import cn from 'classnames';
 
 import {
   getFormDataForComponentInRepeatingGroup,
@@ -362,11 +363,9 @@ export function RepeatingGroupTable({
                         key={`edit-${index}`}
                       >
                         <IconButton
-                          className={`${classes.tableEditButton} ${
-                            editIndex === index
-                              ? classes.editButtonActivated
-                              : ''
-                          }`}
+                          className={cn(classes.tableEditButton, {
+                            [classes.editButtonActivated]: editIndex === index,
+                          })}
                           onClick={() => onClickEdit(index)}
                         >
                           <i

--- a/src/shared/src/components/molecules/AltinnMobileTableItem.tsx
+++ b/src/shared/src/components/molecules/AltinnMobileTableItem.tsx
@@ -11,6 +11,7 @@ import {
 } from '@material-ui/core';
 import React from 'react';
 import theme from '../../theme/altinnStudioTheme';
+import cn from 'classnames';
 
 export interface IMobileTableItem {
   key: React.Key;
@@ -199,10 +200,9 @@ export default function AltinnMobileTableItem({
                     align='right'
                   >
                     <IconButton
-                      className={`${classes.tableEditButton}
-                      ${
-                        editIndex === index ? classes.editButtonActivated : ''
-                      }`}
+                      className={cn(classes.tableEditButton, {
+                        [classes.editButtonActivated]: editIndex === index,
+                      })}
                       onClick={onEditClick}
                       data-testid='edit-button'
                     >

--- a/src/shared/src/components/molecules/AltinnMobileTableItem.tsx
+++ b/src/shared/src/components/molecules/AltinnMobileTableItem.tsx
@@ -21,6 +21,7 @@ export interface IMobileTableItem {
 export interface IAltinnMobileTableItemProps {
   items: IMobileTableItem[];
   valid?: boolean;
+  editIndex?: number;
   onEditClick: () => void;
   onDeleteClick?: () => void;
   deleteIconNode?: React.ReactNode;
@@ -69,14 +70,31 @@ const useStyles = makeStyles({
       margin: '0',
       padding: '0',
       borderRadius: '50%',
+      outlineOffset: '-2px',
     },
     '&:hover': {
       background: 'none',
-      outline: `2px dotted ${theme.altinnPalette.primary.blueDark}`,
+      outline: `1px dotted ${theme.altinnPalette.primary.blueDark}`,
     },
     '&:focus': {
       background: theme.altinnPalette.primary.blueLighter,
       outline: `2px dotted ${theme.altinnPalette.primary.blueDark}`,
+    },
+  },
+  editButtonActivated: {
+    background: theme.altinnPalette.primary.blueLighter,
+    outline: `2px dotted ${theme.altinnPalette.primary.blueDark}`,
+    '@media (max-width: 768px)': {
+      fontSize: '2.5rem',
+      height: '3rem',
+      width: '3rem',
+      margin: '0',
+      padding: '0',
+      borderRadius: '50%',
+    },
+    '&:hover': {
+      background: 'none',
+      outline: `1px dotted ${theme.altinnPalette.primary.blueDark}`,
     },
   },
   deleteButton: {
@@ -136,6 +154,7 @@ const useStyles = makeStyles({
 export default function AltinnMobileTableItem({
   items,
   valid = true,
+  editIndex,
   onEditClick,
   onDeleteClick,
   editIconNode,
@@ -180,7 +199,10 @@ export default function AltinnMobileTableItem({
                     align='right'
                   >
                     <IconButton
-                      className={classes.tableEditButton}
+                      className={`${classes.tableEditButton}
+                      ${
+                        editIndex === index ? classes.editButtonActivated : ''
+                      }`}
                       onClick={onEditClick}
                       data-testid='edit-button'
                     >


### PR DESCRIPTION
Add active css class for editbutton in repeating groups and apply it to the button with the index that is currently being edited. 

## Related Issue(s)
#324 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
