### PR TITLE
Uploading all files to CDN on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,9 +60,11 @@ jobs:
           cd ..
           echo Copy Major Version
           mkdir -p ./cdn/toolkits/altinn-app-frontend/${{ steps.prepare.outputs.APP_MAJOR }}
+          git rm ./cdn/toolkits/altinn-app-frontend/${{ steps.prepare.outputs.APP_MAJOR }}/*
           cp -fr ./app-frontend/src/altinn-app-frontend/dist/* ./cdn/toolkits/altinn-app-frontend/${{ steps.prepare.outputs.APP_MAJOR }}/
           echo Copy Minor Version
           mkdir -p ./cdn/toolkits/altinn-app-frontend/${{ steps.prepare.outputs.APP_MAJOR_MINOR }}
+          git rm ./cdn/toolkits/altinn-app-frontend/${{ steps.prepare.outputs.APP_MAJOR_MINOR }}/*
           cp -fr ./app-frontend/src/altinn-app-frontend/dist/* ./cdn/toolkits/altinn-app-frontend/${{ steps.prepare.outputs.APP_MAJOR_MINOR }}/
           echo Copy Patch
           mkdir -p ./cdn/toolkits/altinn-app-frontend/${{ steps.prepare.outputs.APP_FULL }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,16 +60,13 @@ jobs:
           cd ..
           echo Copy Major Version
           mkdir -p ./cdn/toolkits/altinn-app-frontend/${{ steps.prepare.outputs.APP_MAJOR }}
-          cp -fr ./app-frontend/src/altinn-app-frontend/dist/altinn-app-frontend.js ./cdn/toolkits/altinn-app-frontend/${{ steps.prepare.outputs.APP_MAJOR }}/altinn-app-frontend.js
-          cp -fr ./app-frontend/src/altinn-app-frontend/dist/altinn-app-frontend.css ./cdn/toolkits/altinn-app-frontend/${{ steps.prepare.outputs.APP_MAJOR }}/altinn-app-frontend.css
+          cp -fr ./app-frontend/src/altinn-app-frontend/dist/* ./cdn/toolkits/altinn-app-frontend/${{ steps.prepare.outputs.APP_MAJOR }}/
           echo Copy Minor Version
           mkdir -p ./cdn/toolkits/altinn-app-frontend/${{ steps.prepare.outputs.APP_MAJOR_MINOR }}
-          cp -fr ./app-frontend/src/altinn-app-frontend/dist/altinn-app-frontend.js ./cdn/toolkits/altinn-app-frontend/${{ steps.prepare.outputs.APP_MAJOR_MINOR }}/altinn-app-frontend.js
-          cp -fr ./app-frontend/src/altinn-app-frontend/dist/altinn-app-frontend.css ./cdn/toolkits/altinn-app-frontend/${{ steps.prepare.outputs.APP_MAJOR_MINOR }}/altinn-app-frontend.css
+          cp -fr ./app-frontend/src/altinn-app-frontend/dist/* ./cdn/toolkits/altinn-app-frontend/${{ steps.prepare.outputs.APP_MAJOR_MINOR }}/
           echo Copy Patch
           mkdir -p ./cdn/toolkits/altinn-app-frontend/${{ steps.prepare.outputs.APP_FULL }}
-          cp -fr ./app-frontend/src/altinn-app-frontend/dist/altinn-app-frontend.js ./cdn/toolkits/altinn-app-frontend/${{ steps.prepare.outputs.APP_FULL }}/altinn-app-frontend.js
-          cp -fr ./app-frontend/src/altinn-app-frontend/dist/altinn-app-frontend.css ./cdn/toolkits/altinn-app-frontend/${{ steps.prepare.outputs.APP_FULL }}/altinn-app-frontend.css
+          cp -fr ./app-frontend/src/altinn-app-frontend/dist/* ./cdn/toolkits/altinn-app-frontend/${{ steps.prepare.outputs.APP_FULL }}/
 
       - name: Copy version (pre-release)
         working-directory: app-frontend
@@ -79,8 +76,7 @@ jobs:
           cd ..
           echo Copy Patch
           mkdir -p ./cdn/toolkits/altinn-app-frontend/${{ steps.prepare.outputs.APP_FULL }}
-          cp -fr ./app-frontend/src/altinn-app-frontend/dist/altinn-app-frontend.js ./cdn/toolkits/altinn-app-frontend/${{ steps.prepare.outputs.APP_FULL }}/altinn-app-frontend.js
-          cp -fr ./app-frontend/src/altinn-app-frontend/dist/altinn-app-frontend.css ./cdn/toolkits/altinn-app-frontend/${{ steps.prepare.outputs.APP_FULL }}/altinn-app-frontend.css
+          cp -fr ./app-frontend/src/altinn-app-frontend/dist/* ./cdn/toolkits/altinn-app-frontend/${{ steps.prepare.outputs.APP_FULL }}/
 
       - name: Copy patch version and commit to CDN
         working-directory: cdn


### PR DESCRIPTION
## Description
This should add all files from the `dist` folder to CDN, not just the js/css file. The only obvious weakness is that it will not delete previous files no longer part of the `dist` folder.

## Related Issue(s)
- #429

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- ~~[ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~
