### PR TITLE
Fixing release script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,32 +53,33 @@ jobs:
           git log -1 | grep -Ev "commit|Author|Date" > ./../commitmsg.txt
 
       - name: Copy version
-        working-directory: app-frontend
+        working-directory: cdn
         if: "!github.event.release.prerelease"
         run: |
           echo altinn-app-frontend version: ${{ steps.prepare.outputs.APP_FULL }}
-          cd ..
           echo Copy Major Version
-          mkdir -p ./cdn/toolkits/altinn-app-frontend/${{ steps.prepare.outputs.APP_MAJOR }}
-          git rm ./cdn/toolkits/altinn-app-frontend/${{ steps.prepare.outputs.APP_MAJOR }}/*
-          cp -fr ./app-frontend/src/altinn-app-frontend/dist/* ./cdn/toolkits/altinn-app-frontend/${{ steps.prepare.outputs.APP_MAJOR }}/
+          test -e toolkits/altinn-app-frontend/${{ steps.prepare.outputs.APP_MAJOR }} && git rm -r toolkits/altinn-app-frontend/${{ steps.prepare.outputs.APP_MAJOR }}
+          mkdir -p toolkits/altinn-app-frontend/${{ steps.prepare.outputs.APP_MAJOR }}
+          cp -fr ../app-frontend/src/altinn-app-frontend/dist/* toolkits/altinn-app-frontend/${{ steps.prepare.outputs.APP_MAJOR }}/
           echo Copy Minor Version
-          mkdir -p ./cdn/toolkits/altinn-app-frontend/${{ steps.prepare.outputs.APP_MAJOR_MINOR }}
-          git rm ./cdn/toolkits/altinn-app-frontend/${{ steps.prepare.outputs.APP_MAJOR_MINOR }}/*
-          cp -fr ./app-frontend/src/altinn-app-frontend/dist/* ./cdn/toolkits/altinn-app-frontend/${{ steps.prepare.outputs.APP_MAJOR_MINOR }}/
+          test -e toolkits/altinn-app-frontend/${{ steps.prepare.outputs.APP_MAJOR_MINOR }} && git rm -r toolkits/altinn-app-frontend/${{ steps.prepare.outputs.APP_MAJOR_MINOR }}
+          mkdir -p toolkits/altinn-app-frontend/${{ steps.prepare.outputs.APP_MAJOR_MINOR }}
+          cp -fr ../app-frontend/src/altinn-app-frontend/dist/* toolkits/altinn-app-frontend/${{ steps.prepare.outputs.APP_MAJOR_MINOR }}/
           echo Copy Patch
+          test -e toolkits/altinn-app-frontend/${{ steps.prepare.outputs.APP_FULL }} && git rm -r toolkits/altinn-app-frontend/${{ steps.prepare.outputs.APP_FULL }}
           mkdir -p ./cdn/toolkits/altinn-app-frontend/${{ steps.prepare.outputs.APP_FULL }}
-          cp -fr ./app-frontend/src/altinn-app-frontend/dist/* ./cdn/toolkits/altinn-app-frontend/${{ steps.prepare.outputs.APP_FULL }}/
+          cp -fr ../app-frontend/src/altinn-app-frontend/dist/* toolkits/altinn-app-frontend/${{ steps.prepare.outputs.APP_FULL }}/
 
       - name: Copy version (pre-release)
-        working-directory: app-frontend
+        working-directory: cdn
         if: "github.event.release.prerelease"
         run: |
           echo altinn-app-frontend version: ${{ steps.prepare.outputs.APP_FULL }}
           cd ..
           echo Copy Patch
-          mkdir -p ./cdn/toolkits/altinn-app-frontend/${{ steps.prepare.outputs.APP_FULL }}
-          cp -fr ./app-frontend/src/altinn-app-frontend/dist/* ./cdn/toolkits/altinn-app-frontend/${{ steps.prepare.outputs.APP_FULL }}/
+          test -e toolkits/altinn-app-frontend/${{ steps.prepare.outputs.APP_FULL }} && git rm -r toolkits/altinn-app-frontend/${{ steps.prepare.outputs.APP_FULL }}
+          mkdir -p toolkits/altinn-app-frontend/${{ steps.prepare.outputs.APP_FULL }}
+          cp -fr ../app-frontend/src/altinn-app-frontend/dist/* toolkits/altinn-app-frontend/${{ steps.prepare.outputs.APP_FULL }}/
 
       - name: Copy patch version and commit to CDN
         working-directory: cdn


### PR DESCRIPTION
## Description
Release script got broken in #430, because of two oversights:
1. Git gets confused when told to perform operations from a working directory not in git (even though the relative path points to a checked out repo).
2. Removing `*` in a folder produces an error when the folder is empty

Rant: I would love for these scripts to be more easily testable locally

## Related Issue(s)
- #430

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
