### PR TITLE
bug: race condition conditional rules

### DIFF
--- a/src/altinn-app-frontend/src/features/form/dynamics/formDynamicsSlice.ts
+++ b/src/altinn-app-frontend/src/features/form/dynamics/formDynamicsSlice.ts
@@ -37,6 +37,7 @@ const slice = createSagaSlice((mkAction: MkActionType<IFormDynamicState>) => ({
                 take(FormDataActions.fetchFulfilled),
                 take(FormDynamicsActions.fetchFulfilled),
                 take(FormRulesActions.fetchFulfilled),
+                take(FormLayoutActions.updateRepeatingGroupsFulfilled),
               ]);
               yield call(checkIfConditionalRulesShouldRunSaga);
             }


### PR DESCRIPTION
## Description
Solves a race condition [reported by SSB](https://altinn.slack.com/archives/C02EVE4RU82/p1662552278562939). For dynamics for repeating groups to work the repeating group state must be set before running the rules. This fix prevents the rules running before this init is completed.


## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
