### PR TITLE
Implementing missing loading state for app tasks

### DIFF
--- a/src/altinn-app-frontend/__mocks__/initialStateMock.ts
+++ b/src/altinn-app-frontend/__mocks__/initialStateMock.ts
@@ -50,6 +50,7 @@ export function getInitialStateMock(
       instantiating: null,
     },
     isLoading: {
+      appTask: null,
       dataTask: false,
       stateless: null,
     },

--- a/src/altinn-app-frontend/src/features/entrypoint/Entrypoint.test.tsx
+++ b/src/altinn-app-frontend/src/features/entrypoint/Entrypoint.test.tsx
@@ -33,6 +33,7 @@ describe('Entrypoint', () => {
         return {
           ...state,
           isLoading: {
+            appTask: null,
             stateless: false,
             dataTask: null,
           },

--- a/src/altinn-app-frontend/src/shared/containers/ProcessWrapper.tsx
+++ b/src/altinn-app-frontend/src/shared/containers/ProcessWrapper.tsx
@@ -24,7 +24,9 @@ const ProcessWrapper = () => {
   const instantiating = useAppSelector(
     (state) => state.instantiation.instantiating,
   );
-  const isLoading = useAppSelector((state) => state.isLoading.dataTask);
+  const isLoading = useAppSelector(
+    (state) => state.isLoading.dataTask || state.isLoading.appTask,
+  );
   const { hasApiErrors } = useApiErrorCheck();
   const { dispatch, process, appOwner, appName } = useProcess();
 

--- a/src/altinn-app-frontend/src/shared/resources/isLoading/isLoadingSlice.test.ts
+++ b/src/altinn-app-frontend/src/shared/resources/isLoading/isLoadingSlice.test.ts
@@ -20,7 +20,7 @@ describe('isLoadingSlice', () => {
 
   it('handles finishDataTaskIsLoading action', () => {
     const nextState = slice.reducer(
-      { dataTask: true, stateless: true },
+      { appTask: true, dataTask: true, stateless: true },
       IsLoadingActions.finishDataTaskIsLoading,
     );
     expect(nextState.dataTask).toBeFalsy();

--- a/src/altinn-app-frontend/src/shared/resources/isLoading/isLoadingSlice.ts
+++ b/src/altinn-app-frontend/src/shared/resources/isLoading/isLoadingSlice.ts
@@ -1,14 +1,26 @@
+import { all, put, take } from 'redux-saga/effects';
+import type { SagaIterator } from 'redux-saga';
+
+import { FormLayoutActions } from 'src/features/form/layout/formLayoutSlice';
+import { ApplicationMetadataActions } from 'src/shared/resources/applicationMetadata/applicationMetadataSlice';
+import { ApplicationSettingsActions } from 'src/shared/resources/applicationSettings/applicationSettingsSlice';
 import { watcherFinishDataTaskIsloadingSaga } from 'src/shared/resources/isLoading/dataTask/dataTaskIsLoadingSagas';
 import { watcherFinishStatelessIsLoadingSaga } from 'src/shared/resources/isLoading/stateless/statelessIsLoadingSagas';
+import { LanguageActions } from 'src/shared/resources/language/languageSlice';
+import { OrgsActions } from 'src/shared/resources/orgs/orgsSlice';
+import { QueueActions } from 'src/shared/resources/queue/queueSlice';
+import { TextResourcesActions } from 'src/shared/resources/textResources/textResourcesSlice';
 import { createSagaSlice } from 'src/shared/resources/utils/sagaSlice';
 import type { MkActionType } from 'src/shared/resources/utils/sagaSlice';
 
 export interface IIsLoadingState {
+  appTask: boolean;
   dataTask: boolean;
   stateless: boolean;
 }
 
 export const initialState: IIsLoadingState = {
+  appTask: null,
   dataTask: null,
   stateless: null,
 };
@@ -18,6 +30,34 @@ const isLoadingSlice = createSagaSlice(
     name: 'isLoading',
     initialState,
     actions: {
+      startAppTaskIsLoading: mkAction<void>({
+        reducer: (state) => {
+          state.appTask = true;
+        },
+      }),
+      finishAppTaskIsLoading: mkAction<void>({
+        saga: () =>
+          function* (): SagaIterator {
+            while (true) {
+              yield take(QueueActions.startInitialAppTaskQueue);
+              yield all([
+                take(
+                  ApplicationSettingsActions.fetchApplicationSettingsFulfilled,
+                ),
+                take(TextResourcesActions.fetchFulfilled),
+                take(LanguageActions.fetchLanguageFulfilled),
+                take(ApplicationMetadataActions.getFulfilled),
+                take(FormLayoutActions.fetchSetsFulfilled),
+                take(OrgsActions.fetchFulfilled),
+              ]);
+
+              yield put(IsLoadingActions.finishAppTaskIsLoading());
+            }
+          },
+        reducer: (state) => {
+          state.appTask = false;
+        },
+      }),
       startDataTaskIsLoading: mkAction<void>({
         reducer: (state) => {
           state.dataTask = true;


### PR DESCRIPTION
## Description
The `isLoading` state/slice was made to wait for sagas to complete, marking the app as ready when resources had been loaded. Sadly, no such state existed for the actions dispatched in `startInitialAppTaskQueue` (such as fetching text resources, language, etc). This could lead to the app rendering its content before the text resources it needed had been fetched (easily reproducible by using a proxy such as [Charles](https://www.charlesproxy.com/) to halt the request for a while - causing the app to render without the correct language resources).

I consider this fix to be somewhat *risky*, as it could lead to an app loading forever if any of the actions are supposed to be rejected. It looks fine to me when reading through the actions themselves, but I'm wary of yet again introducing show-stopping problems like we've seen recently.

## Related Issue(s)
- #447 (found in the org/ssb app after this problem had been fixed)

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
