### PR TITLE
Enabling redux devtools in production

### DIFF
--- a/src/altinn-app-frontend/src/store/index.ts
+++ b/src/altinn-app-frontend/src/store/index.ts
@@ -22,7 +22,7 @@ export const setupStore = (preloadedState?: PreloadedState<RootState>) => {
 
   const innerStore = configureStore({
     reducer: reducers,
-    devTools: isDev,
+    devTools: true,
     middleware: (getDefaultMiddleware) =>
       getDefaultMiddleware({
         serializableCheck: isDev,

--- a/src/altinn-app-frontend/webpack.config.production.js
+++ b/src/altinn-app-frontend/webpack.config.production.js
@@ -5,7 +5,7 @@ const common = require('./webpack.common');
 module.exports = {
   ...common,
   mode: 'production',
-  devtool: 'source-map',
+  devtool: false,
   performance: {
     hints: false,
   },

--- a/src/altinn-app-frontend/webpack.config.production.js
+++ b/src/altinn-app-frontend/webpack.config.production.js
@@ -5,7 +5,7 @@ const common = require('./webpack.common');
 module.exports = {
   ...common,
   mode: 'production',
-  devtool: false,
+  devtool: 'source-map',
   performance: {
     hints: false,
   },


### PR DESCRIPTION
## Description
This change enables redux devtools in the production build, which brings with a few hundred bytes extra code, ~~as well as a 7.1mb `altinn-app-frontend.js.map` and a 556kb `altinn-app-frontend.css.map` to be published on altinncdn.no.~~

Adding these to the production build gives us a few advantages when debugging and reproducing strange bugs:
- We can record the redux state history, saving them to a file, making it possible to save and replay the state history for race condition bugs
- ~~Thrown exceptions in our own code will include references to the actual source files, lines and code that caused the error (instead of line 1, column 489984)~~

## Related Issue(s)
- #392
- #452

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- ~~[ ] Relevant automated test added (if you find this hard, leave it and we'll help out)~~
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
