### PR TITLE
Fixing prerelease script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,6 @@ jobs:
         if: "github.event.release.prerelease"
         run: |
           echo altinn-app-frontend version: ${{ steps.prepare.outputs.APP_FULL }}
-          cd ..
           echo Copy Patch
           test -e toolkits/altinn-app-frontend/${{ steps.prepare.outputs.APP_FULL }} && git rm -r toolkits/altinn-app-frontend/${{ steps.prepare.outputs.APP_FULL }}
           mkdir -p toolkits/altinn-app-frontend/${{ steps.prepare.outputs.APP_FULL }}


### PR DESCRIPTION
## Description
Removing `cd ..` which was removed for regular releases in #433, but not for pre-releases (causing the pre-release script to crash). I'm pretty sure I tested this properly in preparation for #437, but this line must have slipped through.. 

## Related Issue(s)
- #433
- #437

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required) *Yes, I did, but then again obviously I didn't do it right!*
- ~~[ ] Relevant automated test added (if you find this hard, leave it and we'll help out)~~
- [ ] All tests run green

## Documentation
- ~~[ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~
