### PR TITLE
Fixing index.json regex

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
         run: |
           echo altinn-app-frontend version: ${{ steps.prepare.outputs.APP_FULL }}
           cd toolkits/altinn-app-frontend
-          ls -1 | grep --perl-regexp '^[\d\.]+(-[a-z]+)?$' | sort --version-sort | jq --raw-input --slurp 'split("\n") | map(select(. != ""))' > index.json
+          ls -1 | grep --perl-regexp '^[\d\.]+(-[a-z0-9.]+)?$' | sort --version-sort | jq --raw-input --slurp 'split("\n") | map(select(. != ""))' > index.json
           cd ../..
           git config --global user.email "${{ steps.prepare.outputs.AUTHOR_EMAIL }}"
           git config --global user.name "${{ steps.prepare.outputs.AUTHOR_NAME }}"


### PR DESCRIPTION
## Description
This makes the regex match the `3.50.5-alpha2` version already on CDN

## Related Issue(s)
- #179
- #256
- #433 
- #437 
- #467
- @olemartinorg (*I have issues* with the release script! :face_with_head_bandage:)

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required) (I've tested properly this time! :partying_face:)
- ~~[ ] Relevant automated test added (if you find this hard, leave it and we'll help out)~~
- ~~[ ] All tests run green~~

## Documentation
- ~~[ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~
