### PR TITLE
E2E Likert support

### DIFF
--- a/test/cypress/e2e/integration/app-frontend/confirmation.js
+++ b/test/cypress/e2e/integration/app-frontend/confirmation.js
@@ -3,20 +3,19 @@
 
 import AppFrontend from '../../pageobjects/app-frontend';
 import * as texts from '../../fixtures/texts.json';
-import {instanceIdExp} from "../../support/util";
+import { instanceIdExp } from '../../support/util';
 
 const appFrontend = new AppFrontend();
 
 describe('Confirm', () => {
   it('Confirm page displays texts and attachments', () => {
-    cy.completeTask3Form();
-    cy.get(appFrontend.backButton).should('be.visible');
+    cy.completeTask4Form();
     cy.get(appFrontend.sendinButton).should('be.visible').click();
     cy.get(appFrontend.confirm.container).should('be.visible');
     cy.get(appFrontend.confirm.body).should('contain.text', texts.confirmBody);
     cy.get(appFrontend.confirm.receiptPdf)
       .find('a')
-      .should('have.length', 3)
+      .should('have.length', 4)
       .first()
       .should('contain.text', `${Cypress.env('multiData2Stage')}.pdf`);
 

--- a/test/cypress/e2e/integration/app-frontend/group.js
+++ b/test/cypress/e2e/integration/app-frontend/group.js
@@ -70,9 +70,7 @@ describe('Group', () => {
       cy.get(appFrontend.group.mainGroup)
         .find(mui.tableBody)
         .then((table) => {
-          cy.get(table).find(mui.tableElement).find(appFrontend.group.delete)
-            .should('be.visible')
-            .click();
+          cy.get(table).find(mui.tableElement).find(appFrontend.group.delete).should('be.visible').click();
         });
 
       if (openByDefault) {
@@ -105,7 +103,9 @@ describe('Group', () => {
       .should('exist')
       .should('be.visible')
       .should('have.text', texts.zeroIsNotValid);
-    cy.get(appFrontend.group.mainGroup).siblings(appFrontend.group.tableErrors).should('contain.text', texts.errorInGroup);
+    cy.get(appFrontend.group.mainGroup)
+      .siblings(appFrontend.group.tableErrors)
+      .should('contain.text', texts.errorInGroup);
     cy.get(appFrontend.group.newValue).should('be.visible').clear().type('1').blur();
     cy.get(appFrontend.fieldValidationError.replace('field', 'newValue')).should('not.exist');
     cy.get(appFrontend.group.mainGroup).siblings(appFrontend.group.tableErrors).should('not.exist');
@@ -120,7 +120,9 @@ describe('Group', () => {
       .should('exist')
       .should('be.visible')
       .should('have.text', texts.testIsNotValidValue);
-    cy.get(appFrontend.group.subGroup).siblings(appFrontend.group.tableErrors).should('contain.text', texts.errorInGroup);
+    cy.get(appFrontend.group.subGroup)
+      .siblings(appFrontend.group.tableErrors)
+      .should('contain.text', texts.errorInGroup);
     cy.get(appFrontend.group.comments).clear().type('automation').blur();
     cy.get(appFrontend.fieldValidationError.replace('field', 'comments')).should('not.exist');
     cy.get(appFrontend.group.subGroup).siblings(appFrontend.group.tableErrors).should('not.exist');
@@ -207,16 +209,13 @@ describe('Group', () => {
     cy.get(appFrontend.fieldValidationError.replace('field', 'newValue-0'))
       .should('be.visible')
       .should('have.text', texts.requiredFieldToValue);
-    cy.get(appFrontend.group.mainGroup)
-      .siblings(appFrontend.group.tableErrors)
-      .should('have.text', texts.errorInGroup);
+    cy.get(appFrontend.group.mainGroup).siblings(appFrontend.group.tableErrors).should('have.text', texts.errorInGroup);
 
-    cy.get(appFrontend.group.mainGroup).find(mui.tableBody).then((table) => {
-      cy.get(table)
-        .find(appFrontend.group.delete)
-        .should('be.visible')
-        .click();
-    });
+    cy.get(appFrontend.group.mainGroup)
+      .find(mui.tableBody)
+      .then((table) => {
+        cy.get(table).find(appFrontend.group.delete).should('be.visible').click();
+      });
 
     cy.contains(mui.button, texts.next).click();
     cy.get(appFrontend.group.sendersName).should('exist');

--- a/test/cypress/e2e/integration/app-frontend/likert.js
+++ b/test/cypress/e2e/integration/app-frontend/likert.js
@@ -1,0 +1,8 @@
+/// <reference types='cypress' />
+/// <reference types="../../support" />
+
+describe('Likert', () => {
+  it('Fill out required likert', () => {
+    cy.completeTask4Form();
+  });
+});

--- a/test/cypress/e2e/integration/app-frontend/mobile.js
+++ b/test/cypress/e2e/integration/app-frontend/mobile.js
@@ -4,9 +4,11 @@
 import AppFrontend from '../../pageobjects/app-frontend';
 import Common from '../../pageobjects/common';
 import * as texts from '../../fixtures/texts.json';
+import { Likert } from '../../pageobjects/likert';
 
 const appFrontend = new AppFrontend();
 const mui = new Common();
+const likertPage = new Likert();
 
 describe('Mobile', () => {
   beforeEach(() => {
@@ -36,11 +38,16 @@ describe('Mobile', () => {
     cy.contains(mui.button, texts.next).click();
     cy.get(appFrontend.group.sendersName).should('be.visible').type('automation');
     cy.get(appFrontend.navMenu).should('have.attr', 'hidden');
-    cy.get(appFrontend.group.navigationBarButton).should('be.visible').and('have.attr', 'aria-expanded', 'false').click();
+    cy.get(appFrontend.group.navigationBarButton)
+      .should('be.visible')
+      .and('have.attr', 'aria-expanded', 'false')
+      .click();
     cy.get(appFrontend.group.navigationBarButton).should('have.attr', 'aria-expanded', 'true');
     cy.get(appFrontend.navMenu).should('not.have.attr', 'hidden');
     cy.get(appFrontend.navMenu).find('li > button').last().click();
     cy.get(appFrontend.navMenu).should('have.attr', 'hidden');
+    cy.get(appFrontend.sendinButton).click();
+    likertPage.selectRequiredRadiosInMobile();
     cy.sendAndWaitForConfirmation();
     cy.get(appFrontend.confirm.sendIn).should('be.visible').click();
     cy.get(appFrontend.receipt.container).should('be.visible');

--- a/test/cypress/e2e/integration/app-frontend/receipt.js
+++ b/test/cypress/e2e/integration/app-frontend/receipt.js
@@ -10,7 +10,7 @@ const appFrontend = new AppFrontend();
 
 describe('Receipt', () => {
   it('Receipt page displays links and attachments', () => {
-    cy.navigateToTask4();
+    cy.navigateToTask5();
     cy.get(appFrontend.confirm.sendIn).should('be.visible').click();
     cy.get(appFrontend.receipt.container)
       .should('be.visible')
@@ -22,7 +22,7 @@ describe('Receipt', () => {
     cy.get(appFrontend.receipt.linkToArchive).should('be.visible');
     cy.get(appFrontend.receipt.pdf)
       .find('a')
-      .should('have.length', 3)
+      .should('have.length', 4)
       .first()
       .should('contain.text', `${Cypress.env('multiData2Stage')}.pdf`);
 

--- a/test/cypress/e2e/integration/app-frontend/summary.js
+++ b/test/cypress/e2e/integration/app-frontend/summary.js
@@ -94,9 +94,11 @@ describe('Summary', () => {
   it('is possible to view summary of repeating group', () => {
     cy.completeTask3Form();
     cy.get(appFrontend.group.mainGroupSummary)
-      .should('be.visible').and('have.length', 1)
+      .should('be.visible')
+      .and('have.length', 1)
       .first()
-      .children(mui.gridItem).should('have.length', 6)
+      .children(mui.gridItem)
+      .should('have.length', 6)
       .then((item) => {
         cy.get(item).find(mui.buttonIcon).should('have.length', 5);
         cy.get(item)
@@ -117,9 +119,7 @@ describe('Summary', () => {
 
     // Check to show a couple of nested options, then go back to the summary
     cy.get(appFrontend.group.rows[0].editBtn).click();
-    cy.get(appFrontend.group.mainGroup)
-      .siblings(appFrontend.group.editContainer)
-      .find(appFrontend.group.next).click();
+    cy.get(appFrontend.group.mainGroup).siblings(appFrontend.group.editContainer).find(appFrontend.group.next).click();
     cy.get(appFrontend.group.rows[0].nestedGroup.rows[0].nestedDynamics).click();
     cy.get(appFrontend.group.rows[0].nestedGroup.rows[0].nestedOptions[1]).click();
     cy.get(appFrontend.group.rows[0].nestedGroup.rows[0].nestedOptions[2]).click();
@@ -128,9 +128,11 @@ describe('Summary', () => {
     cy.contains(mui.button, texts.backToSummary).click();
 
     cy.get(appFrontend.group.mainGroupSummary)
-      .should('be.visible').and('have.length', 1)
+      .should('be.visible')
+      .and('have.length', 1)
       .first()
-      .children(mui.gridItem).should('have.length', 6)
+      .children(mui.gridItem)
+      .should('have.length', 6)
       .then((item) => {
         cy.get(item).eq(5).should('contain.text', texts.nestedOptionsToggle);
         cy.get(item).eq(5).should('contain.text', texts.nestedOptions);

--- a/test/cypress/e2e/pageobjects/likert.js
+++ b/test/cypress/e2e/pageobjects/likert.js
@@ -1,0 +1,41 @@
+export class Likert {
+  constructor() {
+    this.requiredQuestion1 = /Hører skolen på elevenes forslag/i;
+    this.requiredQuestion2 = /Er dere elever med på å lage regler for hvordan dere skal ha det i klassen/i;
+    this.requiredQuestion3 = /De voksne på skolen synes det er viktig at vi elever er greie med hverandre/i;
+
+    this.option1 = /Alltid/;
+    this.option2 = /nesten alltid/i;
+    this.option3 = /ofte/i;
+  }
+
+  selectRequiredRadios() {
+    cy.findByRole('table', { name: 'Medvirkning' }).within(() => {
+      cy.findByRole('radiogroup', { name: this.requiredQuestion1 }).within(() => {
+        cy.findByRole('radio', { name: this.option1 }).click();
+      });
+      cy.findByRole('radiogroup', {
+        name: this.requiredQuestion2,
+      }).within(() => {
+        cy.findByRole('radio', { name: this.option2 }).click();
+      });
+      cy.findByRole('radiogroup', {
+        name: this.requiredQuestion3,
+      }).within(() => {
+        cy.findByRole('radio', { name: this.option3 }).click();
+      });
+    });
+  }
+
+  selectRequiredRadiosInMobile() {
+    cy.findByRole('radiogroup', { name: this.requiredQuestion1 }).within(() => {
+      cy.findByRole('radio', { name: this.option1 }).click();
+    });
+    cy.findByRole('radiogroup', { name: this.requiredQuestion2 }).within(() => {
+      cy.findByRole('radio', { name: this.option2 }).click();
+    });
+    cy.findByRole('radiogroup', { name: this.requiredQuestion3 }).within(() => {
+      cy.findByRole('radio', { name: this.option3 }).click();
+    });
+  }
+}

--- a/test/cypress/e2e/support/index.d.ts
+++ b/test/cypress/e2e/support/index.d.ts
@@ -44,6 +44,24 @@ declare namespace Cypress {
     completeTask3Form(): Chainable<Element>;
 
     /**
+     * Navigate to the task4 of app ttd/frontend-test
+     * @example cy.navigateToTask3()
+     */
+    navigateToTask4(): Chainable<Element>;
+
+    /**
+     * navigate to task 3 and complete task 3 form
+     * @example cy.completeTask3Form()
+     */
+    completeTask4Form(): Chainable<Element>;
+
+    /**
+     * Navigate to the task4 of app ttd/frontend-test
+     * @example cy.navigateToTask3()
+     */
+    navigateToTask5(): Chainable<Element>;
+
+    /**
      * Puts data and waits for confirmation container to render
      * @example cy.sendAndWaitForConfirmation()
      */
@@ -53,7 +71,7 @@ declare namespace Cypress {
      * Add an item to group component with an item in nested group
      * @example cy.addItemToGroup(1, 2, 'automation')
      */
-    addItemToGroup(oldValue: Number, newValue: Number, comment: string, openByDefault?:boolean): Chainable<Element>;
+    addItemToGroup(oldValue: Number, newValue: Number, comment: string, openByDefault?: boolean): Chainable<Element>;
 
     /**
      * Test for WCAG violations of impact critical, serious, moderate
@@ -82,7 +100,7 @@ declare namespace Cypress {
      * Get the current redux state
      * @example cy.getReduxState((state) => state.formData).should('have.length', 3)
      */
-    getReduxState(selector?:(state:any)=>any):any;
+    getReduxState(selector?: (state: any) => any): any;
 
     /**
      * Allows you to intercept the fetched layout and make changes to it. This makes
@@ -90,6 +108,6 @@ declare namespace Cypress {
      * the app you're testing, such as marking some components as required, etc.
      * Must be called in the beginning of your test.
      */
-    interceptLayout(layoutName:string, mutator:(component:any) => any):Chainable<Element>;
+    interceptLayout(layoutName: string, mutator: (component: any) => any): Chainable<Element>;
   }
 }

--- a/test/cypress/e2e/support/index.js
+++ b/test/cypress/e2e/support/index.js
@@ -6,6 +6,7 @@ import './start-app-instance';
 import './wcag';
 import 'cypress-axe';
 import chaiExtensions from './chai-extensions';
+import '@testing-library/cypress/add-commands';
 
 before(() => {
   chai.use(chaiExtensions);
@@ -24,7 +25,10 @@ afterEach(function () {
     }
 
     const title = this.currentTest.title.replace(/\s+/, '-').replace(/[^a-zA-Z\-0-9_]/, '');
-    const specBaseName = Cypress.spec.relative.split(/[\\\/]/).pop().split('.')[0];
+    const specBaseName = Cypress.spec.relative
+      .split(/[\\\/]/)
+      .pop()
+      .split('.')[0];
     const attempt = `failed${failedCaseTable[testName]}`;
     const fileName = `redux-${specBaseName}-${title}-${attempt}.json`;
 

--- a/test/cypress/package.json
+++ b/test/cypress/package.json
@@ -20,7 +20,7 @@
     "start:frontend": "node ./scripts/startAppFrontend.mjs",
     "before:appfrontend": "concurrently --kill-others --names localtest,app,app-frontend \"yarn start:localtest\" \"yarn start:app\" \"yarn start:frontend\"",
     "test:anonymous-stateless": "yarn run delete:reports && cypress run -b chrome -s 'e2e/integration/app-anonymous-stateless/*.js'",
-    "test:frontend": "yarn run delete:reports && cypress run -b edge -s 'e2e/integration/app-frontend/*.js'",
+    "test:frontend": "yarn run delete:reports && cypress run -b chrome -s 'e2e/integration/app-frontend/*.js'",
     "test:stateless": "yarn run delete:reports && cypress run -b chrome -s 'e2e/integration/app-stateless/*.js'",
     "test:stateless-anonymous": "yarn run delete:reports && cypress run -b chrome -s 'e2e/integration/app-stateless-anonymous/*.js'",
     "test:all": "yarn run delete:reports && cypress run -b chrome -s 'e2e/integration/*/*.js'",

--- a/test/cypress/package.json
+++ b/test/cypress/package.json
@@ -20,13 +20,14 @@
     "start:frontend": "node ./scripts/startAppFrontend.mjs",
     "before:appfrontend": "concurrently --kill-others --names localtest,app,app-frontend \"yarn start:localtest\" \"yarn start:app\" \"yarn start:frontend\"",
     "test:anonymous-stateless": "yarn run delete:reports && cypress run -b chrome -s 'e2e/integration/app-anonymous-stateless/*.js'",
-    "test:frontend": "yarn run delete:reports && cypress run -b chrome -s 'e2e/integration/app-frontend/*.js'",
+    "test:frontend": "yarn run delete:reports && cypress run -b edge -s 'e2e/integration/app-frontend/*.js'",
     "test:stateless": "yarn run delete:reports && cypress run -b chrome -s 'e2e/integration/app-stateless/*.js'",
     "test:stateless-anonymous": "yarn run delete:reports && cypress run -b chrome -s 'e2e/integration/app-stateless-anonymous/*.js'",
     "test:all": "yarn run delete:reports && cypress run -b chrome -s 'e2e/integration/*/*.js'",
     "test:all:headless": "cypress run -s 'e2e/integration/*/*.js'"
   },
   "devDependencies": {
+    "@testing-library/cypress": "^8.0.3",
     "axe-core": "^4.4.3",
     "concurrently": "^7.3.0",
     "cypress": "^10.4.0",

--- a/test/cypress/yarn.lock
+++ b/test/cypress/yarn.lock
@@ -5,6 +5,42 @@ __metadata:
   version: 6
   cacheKey: 8
 
+"@babel/code-frame@npm:^7.10.4":
+  version: 7.18.6
+  resolution: "@babel/code-frame@npm:7.18.6"
+  dependencies:
+    "@babel/highlight": ^7.18.6
+  checksum: 195e2be3172d7684bf95cff69ae3b7a15a9841ea9d27d3c843662d50cdd7d6470fd9c8e64be84d031117e4a4083486effba39f9aef6bbb2c89f7f21bcfba33ba
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-identifier@npm:^7.18.6":
+  version: 7.19.1
+  resolution: "@babel/helper-validator-identifier@npm:7.19.1"
+  checksum: 0eca5e86a729162af569b46c6c41a63e18b43dbe09fda1d2a3c8924f7d617116af39cac5e4cd5d431bb760b4dca3c0970e0c444789b1db42bcf1fa41fbad0a3a
+  languageName: node
+  linkType: hard
+
+"@babel/highlight@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/highlight@npm:7.18.6"
+  dependencies:
+    "@babel/helper-validator-identifier": ^7.18.6
+    chalk: ^2.0.0
+    js-tokens: ^4.0.0
+  checksum: 92d8ee61549de5ff5120e945e774728e5ccd57fd3b2ed6eace020ec744823d4a98e242be1453d21764a30a14769ecd62170fba28539b211799bbaf232bbb2789
+  languageName: node
+  linkType: hard
+
+"@babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.14.6":
+  version: 7.19.0
+  resolution: "@babel/runtime@npm:7.19.0"
+  dependencies:
+    regenerator-runtime: ^0.13.4
+  checksum: fa69c351bb05e1db3ceb9a02fdcf620c234180af68cdda02152d3561015f6d55277265d3109815992f96d910f3db709458cae4f8df1c3def66f32e0867d82294
+  languageName: node
+  linkType: hard
+
 "@cypress/request@npm:^2.88.10":
   version: 2.88.10
   resolution: "@cypress/request@npm:2.88.10"
@@ -149,6 +185,41 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@testing-library/cypress@npm:^8.0.3":
+  version: 8.0.3
+  resolution: "@testing-library/cypress@npm:8.0.3"
+  dependencies:
+    "@babel/runtime": ^7.14.6
+    "@testing-library/dom": ^8.1.0
+  peerDependencies:
+    cypress: ^2.1.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0
+  checksum: 319f6c7297f85e5673882a71009b5d5b576006f986d87a6ca6f2f8c679d96d9779f3ddbc01654b5a943407fa91192814f250835ce01f153e33ef24818cf1bf20
+  languageName: node
+  linkType: hard
+
+"@testing-library/dom@npm:^8.1.0":
+  version: 8.18.1
+  resolution: "@testing-library/dom@npm:8.18.1"
+  dependencies:
+    "@babel/code-frame": ^7.10.4
+    "@babel/runtime": ^7.12.5
+    "@types/aria-query": ^4.2.0
+    aria-query: ^5.0.0
+    chalk: ^4.1.0
+    dom-accessibility-api: ^0.5.9
+    lz-string: ^1.4.4
+    pretty-format: ^27.0.2
+  checksum: 432a7da2bb626b11375b22e22d12c02317b35d69c0f69972c03bd0104895b496f21dc5b9d4447adef6e0c9acb3c0a64337f7d38c9667dbbacf09d5cd523394dd
+  languageName: node
+  linkType: hard
+
+"@types/aria-query@npm:^4.2.0":
+  version: 4.2.2
+  resolution: "@types/aria-query@npm:4.2.2"
+  checksum: 6f2ce11d91e2d665f3873258db19da752d91d85d3679eb5efcdf9c711d14492287e1e4eb52613b28e60375841a9e428594e745b68436c963d8bad4bf72188df3
+  languageName: node
+  linkType: hard
+
 "@types/node@npm:*":
   version: 16.11.9
   resolution: "@types/node@npm:16.11.9"
@@ -275,12 +346,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ansi-styles@npm:^3.2.1":
+  version: 3.2.1
+  resolution: "ansi-styles@npm:3.2.1"
+  dependencies:
+    color-convert: ^1.9.0
+  checksum: d85ade01c10e5dd77b6c89f34ed7531da5830d2cb5882c645f330079975b716438cd7ebb81d0d6e6b4f9c577f19ae41ab55f07f19786b02f9dfd9e0377395665
+  languageName: node
+  linkType: hard
+
 "ansi-styles@npm:^4.0.0, ansi-styles@npm:^4.1.0":
   version: 4.3.0
   resolution: "ansi-styles@npm:4.3.0"
   dependencies:
     color-convert: ^2.0.1
   checksum: 513b44c3b2105dd14cc42a19271e80f386466c4be574bccf60b627432f9198571ebf4ab1e4c3ba17347658f4ee1711c163d574248c0c1cdc2d5917a0ad582ec4
+  languageName: node
+  linkType: hard
+
+"ansi-styles@npm:^5.0.0":
+  version: 5.2.0
+  resolution: "ansi-styles@npm:5.2.0"
+  checksum: d7f4e97ce0623aea6bc0d90dcd28881ee04cba06c570b97fd3391bd7a268eedfd9d5e2dd4fdcbdd82b8105df5faf6f24aaedc08eaf3da898e702db5948f63469
   languageName: node
   linkType: hard
 
@@ -302,6 +389,13 @@ __metadata:
   version: 2.0.1
   resolution: "argparse@npm:2.0.1"
   checksum: 83644b56493e89a254bae05702abf3a1101b4fa4d0ca31df1c9985275a5a5bd47b3c27b7fa0b71098d41114d8ca000e6ed90cad764b306f8a503665e4d517ced
+  languageName: node
+  linkType: hard
+
+"aria-query@npm:^5.0.0":
+  version: 5.0.2
+  resolution: "aria-query@npm:5.0.2"
+  checksum: 2ecb77a64b9bbb030f5267b8672042b9559bdc507348d7c5efc14a6c180b06704c63481b162913f0466391837569b6d84f93ab18d73629e7bfa34c4f927c1fbc
   languageName: node
   linkType: hard
 
@@ -480,6 +574,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chalk@npm:^2.0.0":
+  version: 2.4.2
+  resolution: "chalk@npm:2.4.2"
+  dependencies:
+    ansi-styles: ^3.2.1
+    escape-string-regexp: ^1.0.5
+    supports-color: ^5.3.0
+  checksum: ec3661d38fe77f681200f878edbd9448821924e0f93a9cefc0e26a33b145f1027a2084bf19967160d11e1f03bfe4eaffcabf5493b89098b2782c3fe0b03d80c2
+  languageName: node
+  linkType: hard
+
 "chalk@npm:^4.0.0, chalk@npm:^4.1.0":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
@@ -564,12 +669,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"color-convert@npm:^1.9.0":
+  version: 1.9.3
+  resolution: "color-convert@npm:1.9.3"
+  dependencies:
+    color-name: 1.1.3
+  checksum: fd7a64a17cde98fb923b1dd05c5f2e6f7aefda1b60d67e8d449f9328b4e53b228a428fd38bfeaeb2db2ff6b6503a776a996150b80cdf224062af08a5c8a3a203
+  languageName: node
+  linkType: hard
+
 "color-convert@npm:^2.0.1":
   version: 2.0.1
   resolution: "color-convert@npm:2.0.1"
   dependencies:
     color-name: ~1.1.4
   checksum: 79e6bdb9fd479a205c71d89574fccfb22bd9053bd98c6c4d870d65c132e5e904e6034978e55b43d69fcaa7433af2016ee203ce76eeba9cfa554b373e7f7db336
+  languageName: node
+  linkType: hard
+
+"color-name@npm:1.1.3":
+  version: 1.1.3
+  resolution: "color-name@npm:1.1.3"
+  checksum: 09c5d3e33d2105850153b14466501f2bfb30324a2f76568a408763a3b7433b0e50e5b4ab1947868e65cb101bb7cb75029553f2c333b6d4b8138a73fcc133d69d
   languageName: node
   linkType: hard
 
@@ -686,6 +807,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "cypress-altinn-app-frontend@workspace:."
   dependencies:
+    "@testing-library/cypress": ^8.0.3
     axe-core: ^4.4.3
     concurrently: ^7.3.0
     cypress: ^10.4.0
@@ -858,6 +980,13 @@ __metadata:
   dependencies:
     esutils: ^2.0.2
   checksum: fd7673ca77fe26cd5cba38d816bc72d641f500f1f9b25b83e8ce28827fe2da7ad583a8da26ab6af85f834138cf8dae9f69b0cd6ab925f52ddab1754db44d99ce
+  languageName: node
+  linkType: hard
+
+"dom-accessibility-api@npm:^0.5.9":
+  version: 0.5.14
+  resolution: "dom-accessibility-api@npm:0.5.14"
+  checksum: 782c813f75a09ba6735ef03b5e1624406a3829444ae49d5bdedd272a49d437ae3354f53e02ffc8c9fd9165880250f41546538f27461f839dd4ea1234e77e8d5e
   languageName: node
   linkType: hard
 
@@ -1507,6 +1636,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"has-flag@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "has-flag@npm:3.0.0"
+  checksum: 4a15638b454bf086c8148979aae044dd6e39d63904cd452d970374fa6a87623423da485dfb814e7be882e05c096a7ccf1ebd48e7e7501d0208d8384ff4dea73b
+  languageName: node
+  linkType: hard
+
 "has-flag@npm:^4.0.0":
   version: 4.0.0
   resolution: "has-flag@npm:4.0.0"
@@ -1728,6 +1864,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"js-tokens@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "js-tokens@npm:4.0.0"
+  checksum: 8a95213a5a77deb6cbe94d86340e8d9ace2b93bc367790b260101d2f36a2eaf4e4e22d9fa9cf459b38af3a32fb4190e638024cf82ec95ef708680e405ea7cc78
+  languageName: node
+  linkType: hard
+
 "js-yaml@npm:^4.1.0":
   version: 4.1.0
   resolution: "js-yaml@npm:4.1.0"
@@ -1946,6 +2089,15 @@ __metadata:
   dependencies:
     yallist: ^4.0.0
   checksum: f97f499f898f23e4585742138a22f22526254fdba6d75d41a1c2526b3b6cc5747ef59c5612ba7375f42aca4f8461950e925ba08c991ead0651b4918b7c978297
+  languageName: node
+  linkType: hard
+
+"lz-string@npm:^1.4.4":
+  version: 1.4.4
+  resolution: "lz-string@npm:1.4.4"
+  bin:
+    lz-string: bin/bin.js
+  checksum: 54e31238a61a84d8f664d9860a9fba7310c5b97a52c444f80543069bc084815eff40b8d4474ae1d93992fdf6c252dca37cf27f6adbeb4dbc3df2f3ac773d0e61
   languageName: node
   linkType: hard
 
@@ -2290,6 +2442,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pretty-format@npm:^27.0.2":
+  version: 27.5.1
+  resolution: "pretty-format@npm:27.5.1"
+  dependencies:
+    ansi-regex: ^5.0.1
+    ansi-styles: ^5.0.0
+    react-is: ^17.0.1
+  checksum: cf610cffcb793885d16f184a62162f2dd0df31642d9a18edf4ca298e909a8fe80bdbf556d5c9573992c102ce8bf948691da91bf9739bee0ffb6e79c8a8a6e088
+  languageName: node
+  linkType: hard
+
 "proxy-from-env@npm:1.0.0":
   version: 1.0.0
   resolution: "proxy-from-env@npm:1.0.0"
@@ -2343,6 +2506,20 @@ __metadata:
   version: 1.2.3
   resolution: "queue-microtask@npm:1.2.3"
   checksum: b676f8c040cdc5b12723ad2f91414d267605b26419d5c821ff03befa817ddd10e238d22b25d604920340fd73efd8ba795465a0377c4adf45a4a41e4234e42dc4
+  languageName: node
+  linkType: hard
+
+"react-is@npm:^17.0.1":
+  version: 17.0.2
+  resolution: "react-is@npm:17.0.2"
+  checksum: 9d6d111d8990dc98bc5402c1266a808b0459b5d54830bbea24c12d908b536df7883f268a7868cfaedde3dd9d4e0d574db456f84d2e6df9c4526f99bb4b5344d8
+  languageName: node
+  linkType: hard
+
+"regenerator-runtime@npm:^0.13.4":
+  version: 0.13.9
+  resolution: "regenerator-runtime@npm:0.13.9"
+  checksum: 65ed455fe5afd799e2897baf691ca21c2772e1a969d19bb0c4695757c2d96249eb74ee3553ea34a91062b2a676beedf630b4c1551cc6299afb937be1426ec55e
   languageName: node
   linkType: hard
 
@@ -2678,6 +2855,15 @@ __metadata:
   version: 3.1.1
   resolution: "strip-json-comments@npm:3.1.1"
   checksum: 492f73e27268f9b1c122733f28ecb0e7e8d8a531a6662efbd08e22cccb3f9475e90a1b82cab06a392f6afae6d2de636f977e231296400d0ec5304ba70f166443
+  languageName: node
+  linkType: hard
+
+"supports-color@npm:^5.3.0":
+  version: 5.5.0
+  resolution: "supports-color@npm:5.5.0"
+  dependencies:
+    has-flag: ^3.0.0
+  checksum: 95f6f4ba5afdf92f495b5a912d4abee8dcba766ae719b975c56c084f5004845f6f5a5f7769f52d53f40e21952a6d87411bafe34af4a01e65f9926002e38e1dac
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Added support for e2e testing of the likert component.

NB: The cypress tests will not work before https://dev.altinn.studio/repos/ttd/frontend-test/pulls/8 is deployed to tt02.


## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
