### PR TITLE
feat: custom confirm

### DIFF
--- a/src/altinn-app-frontend/src/common/hooks/useProcess.ts
+++ b/src/altinn-app-frontend/src/common/hooks/useProcess.ts
@@ -6,6 +6,7 @@ import { IsLoadingActions } from 'src/shared/resources/isLoading/isLoadingSlice'
 import { ProcessActions } from 'src/shared/resources/process/processSlice';
 import { QueueActions } from 'src/shared/resources/queue/queueSlice';
 import { ProcessTaskType } from 'src/types';
+import { behavesLikeDataTask } from 'src/utils/formLayout';
 
 export function useProcess() {
   const dispatch = useAppDispatch();
@@ -15,6 +16,7 @@ export function useProcess() {
     (state) => state.applicationMetadata.applicationMetadata,
   );
   const process = useAppSelector((state) => state.process);
+  const layoutSets = useAppSelector((state) => state.formLayout.layoutsets);
 
   React.useEffect(() => {
     if (!applicationMetadata || !instanceData) {
@@ -26,11 +28,15 @@ export function useProcess() {
       return;
     }
 
+    if (
+      process.taskType === ProcessTaskType.Data ||
+      behavesLikeDataTask(process.taskId, layoutSets)
+    ) {
+      dispatch(QueueActions.startInitialDataTaskQueue());
+      return;
+    }
+
     switch (process.taskType) {
-      case ProcessTaskType.Data: {
-        dispatch(QueueActions.startInitialDataTaskQueue());
-        break;
-      }
       case ProcessTaskType.Confirm:
       case ProcessTaskType.Feedback:
         dispatch(QueueActions.startInitialInfoTaskQueue());
@@ -42,7 +48,7 @@ export function useProcess() {
       default:
         break;
     }
-  }, [process, applicationMetadata, instanceData, dispatch]);
+  }, [process, applicationMetadata, instanceData, dispatch, layoutSets]);
 
   const appName = useAppSelector(selectAppName);
   const appOwner = useAppSelector(selectAppOwner);

--- a/src/altinn-app-frontend/src/components/base/ButtonComponent.test.tsx
+++ b/src/altinn-app-frontend/src/components/base/ButtonComponent.test.tsx
@@ -49,7 +49,6 @@ const render = ({ isSubmitting }: { isSubmitting: boolean }) => {
       text={submitBtnText}
       handleDataChange={jest.fn()}
       disabled={false}
-      formDataCount={0}
       language={{}}
       {...({} as IButtonProvidedProps)}
     />,

--- a/src/altinn-app-frontend/src/components/base/ButtonComponent.tsx
+++ b/src/altinn-app-frontend/src/components/base/ButtonComponent.tsx
@@ -13,7 +13,6 @@ export interface IButtonProvidedProps
   extends IComponentProps,
     ILayoutCompButton {
   disabled: boolean;
-  formDataCount: number;
 }
 
 const buttonStyle = {
@@ -36,7 +35,7 @@ const rowStyle = {
   marginLeft: '0',
 };
 
-export function ButtonComponent(props: IButtonProvidedProps) {
+export function ButtonComponent({ id, text, language }: IButtonProvidedProps) {
   const dispatch = useAppDispatch();
   const autoSave = useAppSelector(
     (state) => state.formLayout.uiConfig.autoSave,
@@ -57,10 +56,10 @@ export function ButtonComponent(props: IButtonProvidedProps) {
             type='submit'
             className='a-btn a-btn-success'
             onClick={submitForm}
-            id={props.id}
+            id={id}
             style={buttonStyle}
           >
-            {props.text}
+            {text}
           </button>
         )}
       </div>
@@ -94,7 +93,7 @@ export function ButtonComponent(props: IButtonProvidedProps) {
   const renderLoader = () => {
     return (
       <AltinnLoader
-        srContent={getLanguageFromKey('general.loading', props.language)}
+        srContent={getLanguageFromKey('general.loading', language)}
         style={altinnLoaderStyle}
       />
     );

--- a/src/altinn-app-frontend/src/features/form/data/fetch/fetchFormDataSagas.test.ts
+++ b/src/altinn-app-frontend/src/features/form/data/fetch/fetchFormDataSagas.test.ts
@@ -51,7 +51,12 @@ describe('fetchFormDataSagas', () => {
   it('should fetch form data', () => {
     const appMetadata = appMetaDataSelector(mockInitialState);
     const instance = instanceDataSelector(mockInitialState);
-    const taskId = getCurrentTaskDataElementId(appMetadata, instance);
+    const layoutSets: ILayoutSets = { sets: [] };
+    const taskId = getCurrentTaskDataElementId(
+      appMetadata,
+      instance,
+      layoutSets,
+    );
     const url = appUrlHelper.getFetchFormDataUrl(instance.id, taskId);
 
     expectSaga(fetchFormDataSaga)
@@ -106,7 +111,12 @@ describe('fetchFormDataSagas', () => {
   it('should fetch form data initial', () => {
     const appMetadata = appMetaDataSelector(mockInitialState);
     const instance = instanceDataSelector(mockInitialState);
-    const taskId = getCurrentTaskDataElementId(appMetadata, instance);
+    const layoutSets: ILayoutSets = { sets: [] };
+    const taskId = getCurrentTaskDataElementId(
+      appMetadata,
+      instance,
+      layoutSets,
+    );
     const url = appUrlHelper.getFetchFormDataUrl(instance.id, taskId);
 
     expectSaga(fetchFormDataInitialSaga)

--- a/src/altinn-app-frontend/src/features/form/data/fetch/fetchFormDataSagas.ts
+++ b/src/altinn-app-frontend/src/features/form/data/fetch/fetchFormDataSagas.ts
@@ -42,9 +42,11 @@ export function* fetchFormDataSaga(): SagaIterator {
       appMetaDataSelector,
     );
     const instance: IInstance = yield select(instanceDataSelector);
+    const layoutSets: ILayoutSets = yield select(layoutSetsSelector);
     const currentTaskDataElementId = getCurrentTaskDataElementId(
       applicationMetadata,
       instance,
+      layoutSets,
     );
     const fetchedData: any = yield call(
       get,
@@ -70,9 +72,11 @@ export function* fetchFormDataInitialSaga(): SagaIterator {
     } else {
       // app with instance
       const instance: IInstance = yield select(instanceDataSelector);
+      const layoutSets: ILayoutSets = yield select(layoutSetsSelector);
       const currentTaskDataId = getCurrentTaskDataElementId(
         applicationMetadata,
         instance,
+        layoutSets,
       );
       fetchedData = yield call(
         get,

--- a/src/altinn-app-frontend/src/features/form/data/submit/submitFormDataSagas.test.ts
+++ b/src/altinn-app-frontend/src/features/form/data/submit/submitFormDataSagas.test.ts
@@ -79,6 +79,7 @@ describe('submitFormDataSagas', () => {
     const defaultDataElementGuid = getCurrentTaskDataElementId(
       state.applicationMetadata.applicationMetadata,
       state.instanceData.instance,
+      state.formLayout.layoutsets,
     );
     return expectSaga(saveFormDataSaga)
       .provide([

--- a/src/altinn-app-frontend/src/features/form/data/submit/submitFormDataSagas.ts
+++ b/src/altinn-app-frontend/src/features/form/data/submit/submitFormDataSagas.ts
@@ -121,6 +121,7 @@ export function* putFormData(state: IRuntimeState, model: any) {
   const defaultDataElementGuid = getCurrentTaskDataElementId(
     state.applicationMetadata.applicationMetadata,
     state.instanceData.instance,
+    state.formLayout.layoutsets,
   );
   try {
     yield call(put, dataElementUrl(defaultDataElementGuid), model);

--- a/src/altinn-app-frontend/src/features/form/layout/fetch/fetchFormLayoutSagas.ts
+++ b/src/altinn-app-frontend/src/features/form/layout/fetch/fetchFormLayoutSagas.ts
@@ -117,7 +117,6 @@ export function* watchFetchFormLayoutSaga(): SagaIterator {
       take(FormLayoutActions.fetch),
       take(FormDataActions.fetchInitial),
       take(FormDataActions.fetchFulfilled),
-      take(FormLayoutActions.fetchSetsFulfilled),
     ]);
     yield call(fetchLayoutSaga);
   }

--- a/src/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
+++ b/src/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
@@ -22,8 +22,8 @@ import { QueueActions } from 'src/shared/resources/queue/queueSlice';
 import { Triggers } from 'src/types';
 import {
   getCurrentDataTypeForApplication,
+  getCurrentDataTypeId,
   getCurrentTaskDataElementId,
-  getDataTaskDataTypeId,
   isStatelessApp,
 } from 'src/utils/appMetadata';
 import {
@@ -356,6 +356,7 @@ export function* updateCurrentViewSaga({
       const currentTaskDataId = getCurrentTaskDataElementId(
         state.applicationMetadata.applicationMetadata,
         state.instanceData.instance,
+        state.formLayout.layoutsets,
       );
       const serverValidation: any = yield call(
         get,
@@ -444,9 +445,10 @@ export function* calculatePageOrderAndMoveToNextPageSaga({
       layoutSetId = state.applicationMetadata.applicationMetadata.onEntry.show;
     } else {
       const instance = state.instanceData.instance;
-      dataTypeId = getDataTaskDataTypeId(
-        instance.process.currentTask.elementId,
-        state.applicationMetadata.applicationMetadata.dataTypes,
+      dataTypeId = getCurrentDataTypeId(
+        state.applicationMetadata.applicationMetadata,
+        instance,
+        state.formLayout.layoutsets,
       );
       if (layoutSets != null) {
         layoutSetId = getLayoutsetForDataElement(
@@ -567,6 +569,7 @@ export function* updateRepeatingGroupEditIndexSaga({
       const currentTaskDataId = getCurrentTaskDataElementId(
         state.applicationMetadata.applicationMetadata,
         state.instanceData.instance,
+        state.formLayout.layoutsets,
       );
       const serverValidations: IValidationIssue[] = yield call(
         get,

--- a/src/altinn-app-frontend/src/features/form/validation/singleField/singleFieldValidationSagas.ts
+++ b/src/altinn-app-frontend/src/features/form/validation/singleField/singleFieldValidationSagas.ts
@@ -17,6 +17,7 @@ export function* runSingleFieldValidationSaga(): SagaIterator {
   const currentTaskDataId = getCurrentTaskDataElementId(
     state.applicationMetadata.applicationMetadata,
     state.instanceData.instance,
+    state.formLayout.layoutsets,
   );
   const url = getDataValidationUrl(
     state.instanceData.instance.id,

--- a/src/altinn-app-frontend/src/selectors/simpleSelectors.ts
+++ b/src/altinn-app-frontend/src/selectors/simpleSelectors.ts
@@ -1,3 +1,5 @@
+import { createSelector } from 'reselect';
+
 import type { IRuntimeState } from 'src/types';
 
 export const appMetaDataSelector = (state: IRuntimeState) =>
@@ -9,5 +11,11 @@ export const currentSelectedPartyIdSelector = (state: IRuntimeState) =>
   state.party.selectedParty?.partyId;
 export const layoutSetsSelector = (state: IRuntimeState) =>
   state.formLayout.layoutsets;
+export const memoizedLayoutSetsSelector = createSelector(
+  [layoutSetsSelector],
+  (sets) => {
+    return sets;
+  },
+);
 export const profileStateSelector = (state: IRuntimeState) =>
   state.profile.profile;

--- a/src/altinn-app-frontend/src/selectors/simpleSelectors.ts
+++ b/src/altinn-app-frontend/src/selectors/simpleSelectors.ts
@@ -1,5 +1,3 @@
-import { createSelector } from 'reselect';
-
 import type { IRuntimeState } from 'src/types';
 
 export const appMetaDataSelector = (state: IRuntimeState) =>
@@ -11,11 +9,5 @@ export const currentSelectedPartyIdSelector = (state: IRuntimeState) =>
   state.party.selectedParty?.partyId;
 export const layoutSetsSelector = (state: IRuntimeState) =>
   state.formLayout.layoutsets;
-export const memoizedLayoutSetsSelector = createSelector(
-  [layoutSetsSelector],
-  (sets) => {
-    return sets;
-  },
-);
 export const profileStateSelector = (state: IRuntimeState) =>
   state.profile.profile;

--- a/src/altinn-app-frontend/src/shared/containers/ProcessWrapper.tsx
+++ b/src/altinn-app-frontend/src/shared/containers/ProcessWrapper.tsx
@@ -26,9 +26,6 @@ const ProcessWrapper = () => {
     (state) => state.instantiation.instantiating,
   );
   const isLoading = useAppSelector((state) => state.isLoading.dataTask);
-  const taskId = useAppSelector(
-    (state) => state.instanceData.instance?.process.currentTask.elementId,
-  );
   const layoutSets = useAppSelector((state) => state.formLayout.layoutsets);
   const { hasApiErrors } = useApiErrorCheck();
   const { dispatch, process, appOwner, appName } = useProcess();
@@ -65,7 +62,11 @@ const ProcessWrapper = () => {
           {taskType === ProcessTaskType.Data && <Form />}
           {taskType === ProcessTaskType.Archived && <Receipt />}
           {taskType === ProcessTaskType.Confirm &&
-            (behavesLikeDataTask(taskId, layoutSets) ? <Form /> : <Confirm />)}
+            (behavesLikeDataTask(process.taskId, layoutSets) ? (
+              <Form />
+            ) : (
+              <Confirm />
+            ))}
           {taskType === ProcessTaskType.Feedback && <Feedback />}
         </>
       ) : (

--- a/src/altinn-app-frontend/src/shared/containers/ProcessWrapper.tsx
+++ b/src/altinn-app-frontend/src/shared/containers/ProcessWrapper.tsx
@@ -14,6 +14,7 @@ import Receipt from 'src/features/receipt/containers/ReceiptContainer';
 import Presentation from 'src/shared/containers/Presentation';
 import { InstanceDataActions } from 'src/shared/resources/instanceData/instanceDataSlice';
 import { ProcessTaskType } from 'src/types';
+import { behavesLikeDataTask } from 'src/utils/formLayout';
 
 import {
   AltinnContentIconFormData,
@@ -25,6 +26,10 @@ const ProcessWrapper = () => {
     (state) => state.instantiation.instantiating,
   );
   const isLoading = useAppSelector((state) => state.isLoading.dataTask);
+  const taskId = useAppSelector(
+    (state) => state.instanceData.instance?.process.currentTask.elementId,
+  );
+  const layoutSets = useAppSelector((state) => state.formLayout.layoutsets);
   const { hasApiErrors } = useApiErrorCheck();
   const { dispatch, process, appOwner, appName } = useProcess();
 
@@ -59,7 +64,8 @@ const ProcessWrapper = () => {
         <>
           {taskType === ProcessTaskType.Data && <Form />}
           {taskType === ProcessTaskType.Archived && <Receipt />}
-          {taskType === ProcessTaskType.Confirm && <Confirm />}
+          {taskType === ProcessTaskType.Confirm &&
+            (behavesLikeDataTask(taskId, layoutSets) ? <Form /> : <Confirm />)}
           {taskType === ProcessTaskType.Feedback && <Feedback />}
         </>
       ) : (

--- a/src/altinn-app-frontend/src/shared/resources/attachments/map/mapAttachmentsSagas.test.ts
+++ b/src/altinn-app-frontend/src/shared/resources/attachments/map/mapAttachmentsSagas.test.ts
@@ -9,6 +9,7 @@ import {
   SelectApplicationMetaData,
   SelectFormData,
   SelectFormLayouts,
+  SelectFormLayoutSets,
   SelectInstance,
   SelectInstanceData,
 } from 'src/shared/resources/attachments/map/mapAttachmentsSagas';
@@ -145,6 +146,7 @@ describe('mapAttachments', () => {
         [select(SelectInstanceData), SelectInstanceData(state)],
         [select(SelectInstance), SelectInstance(state)],
         [select(SelectApplicationMetaData), SelectApplicationMetaData(state)],
+        [select(SelectFormLayoutSets), SelectFormLayoutSets(state)],
         [select(SelectFormData), SelectFormData(state)],
         [select(SelectFormLayouts), selectFormLayouts(state)],
       ])

--- a/src/altinn-app-frontend/src/shared/resources/attachments/map/mapAttachmentsSagas.ts
+++ b/src/altinn-app-frontend/src/shared/resources/attachments/map/mapAttachmentsSagas.ts
@@ -12,7 +12,7 @@ import type { IFormData } from 'src/features/form/data';
 import type { ILayouts } from 'src/features/form/layout';
 import type { IApplicationMetadata } from 'src/shared/resources/applicationMetadata';
 import type { IAttachments } from 'src/shared/resources/attachments';
-import type { IRuntimeState } from 'src/types';
+import type { ILayoutSets, IRuntimeState } from 'src/types';
 
 import type { IData, IInstance } from 'altinn-shared/types';
 
@@ -39,12 +39,19 @@ export const SelectFormData = (state: IRuntimeState): IFormData =>
   state.formData.formData;
 export const SelectFormLayouts = (state: IRuntimeState): ILayouts =>
   state.formLayout.layouts;
+export const SelectFormLayoutSets = (state: IRuntimeState): ILayoutSets =>
+  state.formLayout.layoutsets;
 
 export function* mapAttachments(): SagaIterator {
   try {
     const instance = yield select(SelectInstance);
     const applicationMetadata = yield select(SelectApplicationMetaData);
-    const defaultElement = getCurrentTaskData(applicationMetadata, instance);
+    const layoutSets: ILayoutSets = yield select(SelectFormLayoutSets);
+    const defaultElement = getCurrentTaskData(
+      applicationMetadata,
+      instance,
+      layoutSets,
+    );
 
     const formData = yield select(SelectFormData);
     const layouts = yield select(SelectFormLayouts);

--- a/src/altinn-app-frontend/src/shared/resources/process/completeProcess/completeProcessSagas.ts
+++ b/src/altinn-app-frontend/src/shared/resources/process/completeProcess/completeProcessSagas.ts
@@ -1,11 +1,13 @@
 import { call, put as sagaPut, select } from 'redux-saga/effects';
 import type { SagaIterator } from 'redux-saga';
 
+import { layoutSetsSelector } from 'src/selectors/simpleSelectors';
 import { InstanceDataActions } from 'src/shared/resources/instanceData/instanceDataSlice';
 import { IsLoadingActions } from 'src/shared/resources/isLoading/isLoadingSlice';
 import { ProcessActions } from 'src/shared/resources/process/processSlice';
 import { ProcessTaskType } from 'src/types';
 import { getCompleteProcessUrl } from 'src/utils/appUrlHelper';
+import { behavesLikeDataTask } from 'src/utils/formLayout';
 import type { IInstanceDataState } from 'src/shared/resources/instanceData';
 import type { IRuntimeState } from 'src/types';
 
@@ -34,9 +36,10 @@ export function* completeProcessSaga(): SagaIterator {
           taskId: result.currentTask.elementId,
         }),
       );
+      const layoutSets = yield select(layoutSetsSelector);
       if (
-        (result.currentTask.altinnTaskType as ProcessTaskType) ===
-        ProcessTaskType.Data
+        result.currentTask.altinnTaskType === ProcessTaskType.Data ||
+        behavesLikeDataTask(result.currentTask.elementId, layoutSets)
       ) {
         yield sagaPut(IsLoadingActions.startDataTaskIsLoading());
         const instanceData: IInstanceDataState = yield select(

--- a/src/altinn-app-frontend/src/shared/resources/queue/infoTask/infoTaskQueueSaga.ts
+++ b/src/altinn-app-frontend/src/shared/resources/queue/infoTask/infoTaskQueueSaga.ts
@@ -2,6 +2,7 @@ import { all, call, put, select, take } from 'redux-saga/effects';
 import type { SagaIterator } from 'redux-saga';
 
 import { FormDataActions } from 'src/features/form/data/formDataSlice';
+import { InstanceDataActions } from 'src/shared/resources/instanceData/instanceDataSlice';
 import { IsLoadingActions } from 'src/shared/resources/isLoading/isLoadingSlice';
 import { QueueActions } from 'src/shared/resources/queue/queueSlice';
 import { TextResourcesActions } from 'src/shared/resources/textResources/textResourcesSlice';
@@ -72,6 +73,7 @@ export function* watchStartInitialInfoTaskQueueSaga(): SagaIterator {
   yield all([
     take(QueueActions.startInitialInfoTaskQueue),
     take(TextResourcesActions.fetchFulfilled),
+    take(InstanceDataActions.getFulfilled),
   ]);
   yield call(startInitialInfoTaskQueueSaga);
 }

--- a/src/altinn-app-frontend/src/shared/resources/queue/queueSlice.ts
+++ b/src/altinn-app-frontend/src/shared/resources/queue/queueSlice.ts
@@ -100,7 +100,6 @@ const queueSlice = createSagaSlice((mkAction: MkActionType<IQueueState>) => ({
       takeEvery: function* (): SagaIterator {
         yield put(FormDataActions.fetchInitial());
         yield put(DataModelActions.fetchJsonSchema());
-        yield put(FormLayoutActions.fetchSets());
         yield put(FormLayoutActions.fetch());
         yield put(FormLayoutActions.fetchSettings());
         yield put(AttachmentActions.mapAttachments());
@@ -131,7 +130,6 @@ const queueSlice = createSagaSlice((mkAction: MkActionType<IQueueState>) => ({
         yield put(IsLoadingActions.startStatelessIsLoading());
         yield put(FormDataActions.fetchInitial());
         yield put(DataModelActions.fetchJsonSchema());
-        yield put(FormLayoutActions.fetchSets());
         yield put(FormLayoutActions.fetch());
         yield put(FormLayoutActions.fetchSettings());
         yield put(QueueActions.startInitialStatelessQueueFulfilled());

--- a/src/altinn-app-frontend/src/utils/formLayout.test.ts
+++ b/src/altinn-app-frontend/src/utils/formLayout.test.ts
@@ -1,4 +1,5 @@
 import {
+  behavesLikeDataTask,
   createRepeatingGroupComponents,
   extractBottomButtons,
   findChildren,
@@ -16,7 +17,12 @@ import type {
   ILayoutGroup,
 } from 'src/features/form/layout';
 import type { IAttachmentState } from 'src/shared/resources/attachments';
-import type { IMapping, IRepeatingGroups, ITextResource } from 'src/types';
+import type {
+  ILayoutSets,
+  IMapping,
+  IRepeatingGroups,
+  ITextResource,
+} from 'src/types';
 
 describe('setMappingForRepeatingGroupComponent', () => {
   it('should replace indexed mapping with the current index', () => {
@@ -944,5 +950,25 @@ describe('extractBottomButtons', () => {
       },
     ]);
     expect(onlyIds(extractedButtons)).toEqual(['bottomButton']);
+  });
+});
+
+describe('behavesLikeDataTask', () => {
+  const layoutSets: ILayoutSets = {
+    sets: [
+      { id: 'set_1', dataType: 'SomeType', tasks: ['Task_1'] },
+      { id: 'set_2', dataType: 'SomeType', tasks: ['Task_2'] },
+    ],
+  };
+  it('should return true if a given task has configured a layout set', () => {
+    const task = 'Task_1';
+    const result = behavesLikeDataTask(task, layoutSets);
+    expect(result).toBe(true);
+  });
+
+  it('should return false if a given task is not configured as a layout set', () => {
+    const task = 'Task_3';
+    const result = behavesLikeDataTask(task, layoutSets);
+    expect(result).toBe(false);
   });
 });

--- a/src/altinn-app-frontend/src/utils/formLayout.ts
+++ b/src/altinn-app-frontend/src/utils/formLayout.ts
@@ -10,6 +10,7 @@ import type { IAttachmentState } from 'src/shared/resources/attachments';
 import type {
   IFileUploadersWithTag,
   ILayoutNavigation,
+  ILayoutSets,
   IMapping,
   IOptionsChosen,
   IRepeatingGroups,
@@ -530,4 +531,16 @@ export function extractBottomButtons(layout: ILayout) {
   }
 
   return [toMainLayout.reverse(), toErrorReport.reverse()];
+}
+
+/**
+ * Some tasks other than data (for instance confirm, or other in the future) can be configured to behave like data steps
+ * @param task the task
+ * @param layoutSets the layout sets
+ */
+export function behavesLikeDataTask(
+  task: string,
+  layoutSets: ILayoutSets,
+): boolean {
+  return layoutSets?.sets.some((set) => set.tasks?.includes(task));
 }

--- a/src/altinn-app-frontend/src/utils/validation/runClientSideValidation.ts
+++ b/src/altinn-app-frontend/src/utils/validation/runClientSideValidation.ts
@@ -1,4 +1,4 @@
-import { getDataTaskDataTypeId } from 'src/utils/appMetadata';
+import { getCurrentDataTypeId } from 'src/utils/appMetadata';
 import { convertDataBindingToModel } from 'src/utils/databindings';
 import {
   getValidator,
@@ -12,9 +12,10 @@ import type { IRuntimeState } from 'src/types';
  * @param state
  */
 export function runClientSideValidation(state: IRuntimeState) {
-  const currentDataTaskDataTypeId = getDataTaskDataTypeId(
-    state.instanceData.instance.process.currentTask.elementId,
-    state.applicationMetadata.applicationMetadata.dataTypes,
+  const currentDataTaskDataTypeId = getCurrentDataTypeId(
+    state.applicationMetadata.applicationMetadata,
+    state.instanceData.instance,
+    state.formLayout.layoutsets,
   );
   const model = convertDataBindingToModel(state.formData.formData);
   const layoutOrder: string[] = state.formLayout.uiConfig.layoutOrder;

--- a/src/altinn-app-frontend/src/utils/validation/validation.ts
+++ b/src/altinn-app-frontend/src/utils/validation/validation.ts
@@ -8,7 +8,7 @@ import type { Options } from 'ajv';
 import type * as AjvCore from 'ajv/dist/core';
 
 import { Severity } from 'src/types';
-import { getDataTaskDataTypeId } from 'src/utils/appMetadata';
+import { getCurrentDataTypeId } from 'src/utils/appMetadata';
 import { AsciiUnitSeparator } from 'src/utils/attachment';
 import {
   convertDataBindingToModel,
@@ -1665,9 +1665,10 @@ export function validateGroup(
       filteredLayout.push(element);
     }
   });
-  const currentDataTaskDataTypeId = getDataTaskDataTypeId(
-    state.instanceData.instance.process.currentTask.elementId,
-    state.applicationMetadata.applicationMetadata.dataTypes,
+  const currentDataTaskDataTypeId = getCurrentDataTypeId(
+    state.applicationMetadata.applicationMetadata,
+    state.instanceData.instance,
+    state.formLayout.layoutsets,
   );
   const validator = getValidator(
     currentDataTaskDataTypeId,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Enables app developers to set up a custom layout for confirmation (or other steps in the future) through the use of our[ layout-set](https://docs.altinn.studio/app/development/ux/pages/layout-sets/) feature.

This feature can be seen implemented in[ this test app](https://altinn.studio/repos/ttd/custom-view-confirm).

Enables app developers to go from this hardcoded view:
![image](https://user-images.githubusercontent.com/10416981/191487950-fcbb3231-8ab4-4a5d-a5da-398e99af5488.png)

To a completely configurable form layout definition with a reference to an earlier data model which they can present data from: 
![customConfirm](https://user-images.githubusercontent.com/10416981/191487901-52fcee5c-dfe3-4908-b0b1-e76665e376af.PNG)


Please note that for this feature to work entirely we rely on some other new features coming in #262. 

## Related Issue(s)
- #482

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable): https://github.com/Altinn/altinn-studio-docs/pull/672
