### PR TITLE
add display options to summary components

### DIFF
--- a/src/altinn-app-frontend/src/components/GenericComponent.tsx
+++ b/src/altinn-app-frontend/src/components/GenericComponent.tsx
@@ -19,6 +19,7 @@ import {
   componentValidationsHandledByGenericComponent,
   getFormDataForComponent,
   getTextResource,
+  gridBreakpoints,
   isComponentValid,
   selectComponentTexts,
 } from 'src/utils/formComponentUtils';
@@ -402,16 +403,6 @@ const RenderLabelScoped = (props: IRenderLabelProps) => {
   );
 };
 
-const gridBreakpoints = (grid?: IGridStyling) => {
-  const { xs, sm, md, lg, xl } = grid || {};
-  return {
-    xs: xs || 12,
-    ...(sm && { sm }),
-    ...(md && { md }),
-    ...(lg && { lg }),
-    ...(xl && { xl }),
-  };
-};
 const gridToHiddenProps = (
   labelGrid: IGridStyling,
   classes: ReturnType<typeof useStyles>,

--- a/src/altinn-app-frontend/src/components/summary/GroupInputSummary.tsx
+++ b/src/altinn-app-frontend/src/components/summary/GroupInputSummary.tsx
@@ -10,7 +10,7 @@ export interface ISingleInputSummary {
 }
 
 const useStyles = makeStyles({
-  label: {
+  data: {
     fontWeight: 500,
     '& p': {
       fontWeight: 500,
@@ -23,10 +23,10 @@ function GroupInputSummary({ formData, label }: ISingleInputSummary) {
   const classes = useStyles();
   return (
     <Typography variant='body1'>
-      <span className={classes.label}>
+      <span>
         {label} {': '}
       </span>
-      <span>{displayData}</span>
+      <span className={classes.data}>{displayData}</span>
     </Typography>
   );
 }

--- a/src/altinn-app-frontend/src/components/summary/SingleInputSummary.tsx
+++ b/src/altinn-app-frontend/src/components/summary/SingleInputSummary.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 
-import { Grid, Typography } from '@material-ui/core';
+import { Grid, makeStyles, Typography } from '@material-ui/core';
 
 import { useDisplayData } from 'src/components/hooks';
 import SummaryBoilerplate from 'src/components/summary/SummaryBoilerplate';
+import type { SummaryDisplayProperties } from 'src/features/form/layout';
 
 export interface ISingleInputSummary {
   formData: any;
@@ -12,19 +13,45 @@ export interface ISingleInputSummary {
   changeText: any;
   onChangeClick: () => void;
   readOnlyComponent?: boolean;
+  display?: SummaryDisplayProperties;
 }
 
-function SingleInputSummary({ formData, ...rest }: ISingleInputSummary) {
+const useStyles = makeStyles({
+  data: {
+    fontWeight: 500,
+    fontSize: '1.8rem',
+    '& p': {
+      fontWeight: 500,
+      fontSize: '1.8rem',
+    },
+  },
+});
+
+function SingleInputSummary({
+  formData,
+  display,
+  ...rest
+}: ISingleInputSummary) {
+  const classes = useStyles();
   const displayData = useDisplayData({ formData });
+
   return (
     <>
-      <SummaryBoilerplate {...rest} />
+      <SummaryBoilerplate
+        display={display}
+        {...rest}
+      />
       <Grid
         item
         xs={12}
         data-testid={'single-input-summary'}
       >
-        <Typography variant='body1'>{displayData}</Typography>
+        <Typography
+          className={classes.data}
+          variant='body1'
+        >
+          {displayData}
+        </Typography>
       </Grid>
     </>
   );

--- a/src/altinn-app-frontend/src/components/summary/SummaryBoilerplate.tsx
+++ b/src/altinn-app-frontend/src/components/summary/SummaryBoilerplate.tsx
@@ -8,7 +8,8 @@ import type { ILayoutCompSummary } from 'src/features/form/layout';
 
 import appTheme from 'altinn-shared/theme/altinnAppTheme';
 
-export interface SummaryBoilerplateProps extends ILayoutCompSummary {
+export interface SummaryBoilerplateProps
+  extends Omit<ILayoutCompSummary, 'type' | 'id'> {
   hasValidationMessages?: boolean;
   onChangeClick: () => void;
   changeText: string;

--- a/src/altinn-app-frontend/src/components/summary/SummaryBoilerplate.tsx
+++ b/src/altinn-app-frontend/src/components/summary/SummaryBoilerplate.tsx
@@ -43,7 +43,7 @@ export default function SummaryBoilerplate({
 }: SummaryBoilerplateProps) {
   const classes = useStyles();
   const shouldShowChangeButton =
-    !readOnlyComponent && !display.hideChangeButton;
+    !readOnlyComponent && !display?.hideChangeButton;
   return (
     <>
       <Grid

--- a/src/altinn-app-frontend/src/components/summary/SummaryBoilerplate.tsx
+++ b/src/altinn-app-frontend/src/components/summary/SummaryBoilerplate.tsx
@@ -4,6 +4,7 @@ import { Grid, makeStyles, Typography } from '@material-ui/core';
 import cn from 'classnames';
 
 import { EditButton } from 'src/components/summary/EditButton';
+import type { SummaryDisplayProperties } from 'src/features/form/layout';
 
 import appTheme from 'altinn-shared/theme/altinnAppTheme';
 
@@ -13,6 +14,7 @@ export interface SummaryBoilerplateProps {
   changeText: string;
   label: any;
   readOnlyComponent?: boolean;
+  display?: SummaryDisplayProperties;
 }
 
 const useStyles = makeStyles({
@@ -37,8 +39,11 @@ export default function SummaryBoilerplate({
   changeText,
   label,
   readOnlyComponent,
+  display,
 }: SummaryBoilerplateProps) {
   const classes = useStyles();
+  const shouldShowChangeButton =
+    !readOnlyComponent && !display.hideChangeButton;
   return (
     <>
       <Grid
@@ -50,10 +55,7 @@ export default function SummaryBoilerplate({
       >
         <Typography
           variant='body1'
-          className={cn(
-            classes.label,
-            hasValidationMessages && classes.labelWithError,
-          )}
+          className={cn(hasValidationMessages && classes.labelWithError)}
           component='span'
         >
           {label}
@@ -63,7 +65,7 @@ export default function SummaryBoilerplate({
         item
         xs={2}
       >
-        {!readOnlyComponent && (
+        {shouldShowChangeButton && (
           <EditButton
             onClick={onChangeClick}
             editText={changeText}

--- a/src/altinn-app-frontend/src/components/summary/SummaryBoilerplate.tsx
+++ b/src/altinn-app-frontend/src/components/summary/SummaryBoilerplate.tsx
@@ -4,17 +4,16 @@ import { Grid, makeStyles, Typography } from '@material-ui/core';
 import cn from 'classnames';
 
 import { EditButton } from 'src/components/summary/EditButton';
-import type { SummaryDisplayProperties } from 'src/features/form/layout';
+import type { ILayoutCompSummary } from 'src/features/form/layout';
 
 import appTheme from 'altinn-shared/theme/altinnAppTheme';
 
-export interface SummaryBoilerplateProps {
+export interface SummaryBoilerplateProps extends ILayoutCompSummary {
   hasValidationMessages?: boolean;
   onChangeClick: () => void;
   changeText: string;
   label: any;
   readOnlyComponent?: boolean;
-  display?: SummaryDisplayProperties;
 }
 
 const useStyles = makeStyles({

--- a/src/altinn-app-frontend/src/components/summary/SummaryComponent.tsx
+++ b/src/altinn-app-frontend/src/components/summary/SummaryComponent.tsx
@@ -185,7 +185,7 @@ export function SummaryComponent({
       <Grid
         container={true}
         className={cn(classes.row, {
-          [classes.border]: !display.hideBottomBorder,
+          [classes.border]: !display?.hideBottomBorder,
         })}
       >
         <SummaryComponentSwitch

--- a/src/altinn-app-frontend/src/components/summary/SummaryComponent.tsx
+++ b/src/altinn-app-frontend/src/components/summary/SummaryComponent.tsx
@@ -16,22 +16,15 @@ import {
 } from 'src/utils/formComponentUtils';
 import { getTextFromAppOrDefault } from 'src/utils/textResource';
 import type {
-  IGrid,
   ILayoutComponent,
-  SummaryDisplayProperties,
+  ILayoutCompSummary,
 } from 'src/features/form/layout';
 import type { IComponentValidations, IRuntimeState } from 'src/types';
 
-export interface ISummaryComponent {
-  id: string;
-  componentRef?: string;
-  pageRef?: string;
-  display?: SummaryDisplayProperties;
+export interface ISummaryComponent extends ILayoutCompSummary {
   parentGroup?: string;
-  largeGroup?: boolean;
   index?: number;
   formData?: any;
-  grid?: IGrid;
 }
 
 const useStyles = makeStyles({

--- a/src/altinn-app-frontend/src/components/summary/SummaryComponent.tsx
+++ b/src/altinn-app-frontend/src/components/summary/SummaryComponent.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { shallowEqual } from 'react-redux';
 
 import { Grid, makeStyles } from '@material-ui/core';
+import cn from 'classnames';
 
 import { useAppDispatch, useAppSelector } from 'src/common/hooks';
 import ErrorPaper from 'src/components/message/ErrorPaper';
@@ -14,13 +15,18 @@ import {
   getDisplayFormDataForComponent,
 } from 'src/utils/formComponentUtils';
 import { getTextFromAppOrDefault } from 'src/utils/textResource';
-import type { IGrid, ILayoutComponent } from 'src/features/form/layout';
+import type {
+  IGrid,
+  ILayoutComponent,
+  SummaryDisplayProperties,
+} from 'src/features/form/layout';
 import type { IComponentValidations, IRuntimeState } from 'src/types';
 
 export interface ISummaryComponent {
   id: string;
   componentRef?: string;
   pageRef?: string;
+  display?: SummaryDisplayProperties;
   parentGroup?: string;
   largeGroup?: boolean;
   index?: number;
@@ -30,9 +36,11 @@ export interface ISummaryComponent {
 
 const useStyles = makeStyles({
   row: {
-    borderBottom: '1px dashed #008FD6',
     marginBottom: 10,
     paddingBottom: 10,
+  },
+  border: {
+    borderBottom: '1px dashed #008FD6',
   },
   link: {
     background: 'none',
@@ -48,7 +56,7 @@ export function SummaryComponent({
   grid,
   ...summaryProps
 }: ISummaryComponent) {
-  const { componentRef, ...groupProps } = summaryProps;
+  const { componentRef, display, ...groupProps } = summaryProps;
   const { pageRef, index } = groupProps;
   const classes = useStyles();
   const dispatch = useAppDispatch();
@@ -161,19 +169,24 @@ export function SummaryComponent({
     onChangeClick,
     changeText,
   };
+
+  const displayGrid =
+    display && display.useComponentGrid ? formComponent.grid : grid;
   return (
     <Grid
       item={true}
-      xs={grid?.xs || 12}
-      sm={grid?.sm || false}
-      md={grid?.md || false}
-      lg={grid?.lg || false}
-      xl={grid?.xl || false}
+      xs={displayGrid?.xs || 12}
+      sm={displayGrid?.sm || false}
+      md={displayGrid?.md || false}
+      lg={displayGrid?.lg || false}
+      xl={displayGrid?.xl || false}
       data-testid='summary-component'
     >
       <Grid
         container={true}
-        className={classes.row}
+        className={cn(classes.row, {
+          [classes.border]: !display.hideBottomBorder,
+        })}
       >
         <SummaryComponentSwitch
           change={change}
@@ -183,6 +196,7 @@ export function SummaryComponent({
           formData={formData}
           componentRef={componentRef}
           groupProps={groupProps}
+          display={display}
         />
         {hasValidationMessages && (
           <Grid
@@ -204,13 +218,15 @@ export function SummaryComponent({
               item={true}
               xs={12}
             >
-              <button
-                className={classes.link}
-                onClick={onChangeClick}
-                type='button'
-              >
-                {goToCorrectPageLinkText}
-              </button>
+              {!display?.hideChangeButton && (
+                <button
+                  className={classes.link}
+                  onClick={onChangeClick}
+                  type='button'
+                >
+                  {goToCorrectPageLinkText}
+                </button>
+              )}
             </Grid>
           </Grid>
         )}

--- a/src/altinn-app-frontend/src/components/summary/SummaryComponent.tsx
+++ b/src/altinn-app-frontend/src/components/summary/SummaryComponent.tsx
@@ -21,7 +21,7 @@ import type {
 } from 'src/features/form/layout';
 import type { IComponentValidations, IRuntimeState } from 'src/types';
 
-export interface ISummaryComponent extends ILayoutCompSummary {
+export interface ISummaryComponent extends Omit<ILayoutCompSummary, 'type'> {
   parentGroup?: string;
   index?: number;
   formData?: any;
@@ -182,6 +182,7 @@ export function SummaryComponent({
         })}
       >
         <SummaryComponentSwitch
+          id={id}
           change={change}
           formComponent={formComponent}
           label={label}

--- a/src/altinn-app-frontend/src/components/summary/SummaryComponentSwitch.test.tsx
+++ b/src/altinn-app-frontend/src/components/summary/SummaryComponentSwitch.test.tsx
@@ -8,6 +8,7 @@ describe('SummaryComponentSwitch', () => {
   test('should not render component', () => {
     const { container } = render(
       <SummaryComponentSwitch
+        id='summary-comp-id'
         change={null}
         formComponent={null}
       />,

--- a/src/altinn-app-frontend/src/components/summary/SummaryComponentSwitch.tsx
+++ b/src/altinn-app-frontend/src/components/summary/SummaryComponentSwitch.tsx
@@ -9,11 +9,12 @@ import SummaryBoilerplate from 'src/components/summary/SummaryBoilerplate';
 import SummaryGroupComponent from 'src/components/summary/SummaryGroupComponent';
 import type {
   ILayoutComponent,
+  ILayoutCompSummary,
   ILayoutGroup,
-  SummaryDisplayProperties,
 } from 'src/features/form/layout';
 
-export interface ISummaryComponentSwitch {
+export interface ISummaryComponentSwitch
+  extends Omit<ILayoutCompSummary, 'type'> {
   change: {
     onChangeClick: () => void;
     changeText: string;
@@ -22,14 +23,12 @@ export interface ISummaryComponentSwitch {
   hasValidationMessages?: boolean;
   label?: any;
   formData?: any;
-  componentRef?: string;
   groupProps?: {
     parentGroup?: string;
     pageRef?: string;
     largeGroup?: boolean;
     index?: number;
   };
-  display?: SummaryDisplayProperties;
 }
 
 export default function SummaryComponentSwitch({

--- a/src/altinn-app-frontend/src/components/summary/SummaryComponentSwitch.tsx
+++ b/src/altinn-app-frontend/src/components/summary/SummaryComponentSwitch.tsx
@@ -7,7 +7,11 @@ import MultipleChoiceSummary from 'src/components/summary/MultipleChoiceSummary'
 import SingleInputSummary from 'src/components/summary/SingleInputSummary';
 import SummaryBoilerplate from 'src/components/summary/SummaryBoilerplate';
 import SummaryGroupComponent from 'src/components/summary/SummaryGroupComponent';
-import type { ILayoutComponent, ILayoutGroup } from 'src/features/form/layout';
+import type {
+  ILayoutComponent,
+  ILayoutGroup,
+  SummaryDisplayProperties,
+} from 'src/features/form/layout';
 
 export interface ISummaryComponentSwitch {
   change: {
@@ -25,6 +29,7 @@ export interface ISummaryComponentSwitch {
     largeGroup?: boolean;
     index?: number;
   };
+  display?: SummaryDisplayProperties;
 }
 
 export default function SummaryComponentSwitch({
@@ -35,6 +40,7 @@ export default function SummaryComponentSwitch({
   hasValidationMessages,
   formData,
   groupProps = {},
+  display,
 }: ISummaryComponentSwitch) {
   if (!formComponent) {
     return null;
@@ -50,6 +56,7 @@ export default function SummaryComponentSwitch({
           {...change}
           label={label}
           hasValidationMessages={hasValidationMessages}
+          display={display}
         />
         <AttachmentSummaryComponent componentRef={componentRef} />
       </>
@@ -63,6 +70,7 @@ export default function SummaryComponentSwitch({
           {...change}
           label={label}
           hasValidationMessages={hasValidationMessages}
+          display={display}
         />
         <AttachmentWithTagSummaryComponent
           componentRef={componentRef}
@@ -78,6 +86,7 @@ export default function SummaryComponentSwitch({
         {...change}
         {...groupProps}
         componentRef={componentRef}
+        display={display}
       />
     );
   }
@@ -101,6 +110,7 @@ export default function SummaryComponentSwitch({
           {...change}
           label={label}
           hasValidationMessages={hasValidationMessages}
+          display={display}
         />
         <MapComponentSummary
           component={formComponent}
@@ -117,6 +127,7 @@ export default function SummaryComponentSwitch({
       hasValidationMessages={hasValidationMessages}
       formData={formData}
       readOnlyComponent={(formComponent as ILayoutComponent).readOnly}
+      display={display}
     />
   );
 }

--- a/src/altinn-app-frontend/src/components/summary/SummaryGroupComponent.tsx
+++ b/src/altinn-app-frontend/src/components/summary/SummaryGroupComponent.tsx
@@ -20,6 +20,7 @@ import type {
   ILayout,
   ILayoutComponent,
   ILayoutGroup,
+  SummaryDisplayProperties,
 } from 'src/features/form/layout';
 import type { IRuntimeState } from 'src/types';
 
@@ -34,6 +35,7 @@ export interface ISummaryGroupComponent {
   onChangeClick: () => void;
   largeGroup?: boolean;
   parentGroup?: string;
+  display?: SummaryDisplayProperties;
 }
 
 export function getComponentForSummaryGroup(
@@ -48,6 +50,12 @@ const gridStyle = {
 };
 
 const useStyles = makeStyles({
+  border: {
+    border: '2px solid #EFEFEF',
+    marginTop: 12,
+    marginBottom: 12,
+    padding: 12,
+  },
   label: {
     fontWeight: 500,
     fontSize: '1.8rem',
@@ -79,6 +87,7 @@ function SummaryGroupComponent({
   largeGroup,
   onChangeClick,
   changeText,
+  display,
 }: ISummaryGroupComponent) {
   const classes = useStyles();
 
@@ -270,7 +279,7 @@ function SummaryGroupComponent({
       componentArray.push(
         <div
           key={i}
-          style={{ paddingBottom: 24 }}
+          className={classes.border}
         >
           {childSummaryComponents}
         </div>,
@@ -333,6 +342,7 @@ function SummaryGroupComponent({
           formData: formDataForComponent,
           index: i,
           parentGroup: isGroupComponent ? groupComponent.id : undefined,
+          display,
         };
 
         childSummaryComponents.push(summaryComponent);
@@ -383,10 +393,12 @@ function SummaryGroupComponent({
           item
           xs={2}
         >
-          <EditButton
-            onClick={onChangeClick}
-            editText={changeText}
-          />
+          {!display?.hideChangeButton && (
+            <EditButton
+              onClick={onChangeClick}
+              editText={changeText}
+            />
+          )}
         </Grid>
         <Grid
           item
@@ -407,19 +419,21 @@ function SummaryGroupComponent({
             item={true}
             xs={12}
           >
-            <button
-              className={classes.link}
-              onClick={onChangeClick}
-              type='button'
-            >
-              {getTextFromAppOrDefault(
-                'form_filler.summary_go_to_correct_page',
-                textResources,
-                language,
-                [],
-                true,
-              )}
-            </button>
+            {!display?.hideChangeButton && (
+              <button
+                className={classes.link}
+                onClick={onChangeClick}
+                type='button'
+              >
+                {getTextFromAppOrDefault(
+                  'form_filler.summary_go_to_correct_page',
+                  textResources,
+                  language,
+                  [],
+                  true,
+                )}
+              </button>
+            )}
           </Grid>
         </Grid>
       )}

--- a/src/altinn-app-frontend/src/components/summary/__snapshots__/MultipleChoiceSummary.test.tsx.snap
+++ b/src/altinn-app-frontend/src/components/summary/__snapshots__/MultipleChoiceSummary.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`MultipleChoiceSummary MultipleChoiceSummary 1`] = `
     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-10"
   >
     <span
-      class="MuiTypography-root makeStyles-label-3 MuiTypography-body1"
+      class="MuiTypography-root MuiTypography-body1"
     >
       TestLabel
     </span>

--- a/src/altinn-app-frontend/src/components/summary/__snapshots__/SummaryGroupComponent.test.tsx.snap
+++ b/src/altinn-app-frontend/src/components/summary/__snapshots__/SummaryGroupComponent.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`SummaryGroupComponent SummaryGroupComponent -- should match snapshot 1`
       class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-10"
     >
       <span
-        class="MuiTypography-root makeStyles-label-1 MuiTypography-body1"
+        class="MuiTypography-root makeStyles-label-2 MuiTypography-body1"
       >
         Mock group
       </span>
@@ -19,7 +19,7 @@ exports[`SummaryGroupComponent SummaryGroupComponent -- should match snapshot 1`
       class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2"
     >
       <button
-        class="MuiButtonBase-root MuiIconButton-root makeStyles-editButton-4"
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-editButton-5"
         tabindex="0"
         type="button"
       >
@@ -27,13 +27,13 @@ exports[`SummaryGroupComponent SummaryGroupComponent -- should match snapshot 1`
           class="MuiIconButton-label"
         >
           <p
-            class="MuiTypography-root makeStyles-change-6 MuiTypography-body1"
+            class="MuiTypography-root makeStyles-change-7 MuiTypography-body1"
           >
             <span>
               Change
             </span>
             <i
-              class="fa fa-editing-file makeStyles-editIcon-5"
+              class="fa fa-editing-file makeStyles-editIcon-6"
             />
           </p>
         </span>
@@ -46,35 +46,35 @@ exports[`SummaryGroupComponent SummaryGroupComponent -- should match snapshot 1`
       class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
     >
       <div
-        style="padding-bottom: 24px;"
+        class="makeStyles-border-1"
       >
         <p
           class="MuiTypography-root MuiTypography-body1"
         >
-          <span
-            class="makeStyles-label-7"
-          >
+          <span>
             <span>
               Mock field 1
             </span>
              : 
           </span>
-          <span>
+          <span
+            class="makeStyles-data-8"
+          >
             1
           </span>
         </p>
         <p
           class="MuiTypography-root MuiTypography-body1"
         >
-          <span
-            class="makeStyles-label-7"
-          >
+          <span>
             <span>
               Mock field 2
             </span>
              : 
           </span>
-          <span>
+          <span
+            class="makeStyles-data-8"
+          >
             2
           </span>
         </p>

--- a/src/altinn-app-frontend/src/features/form/containers/Form.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/Form.tsx
@@ -55,7 +55,7 @@ export function renderLayoutComponent(
 }
 
 function GenericComponent(component: ILayoutComponent, layout: ILayout) {
-  return renderGenericComponent(component, layout);
+  return renderGenericComponent({ component, layout });
 }
 
 function RenderLayoutGroup(

--- a/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupsEditContainer.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupsEditContainer.tsx
@@ -135,7 +135,11 @@ export function RepeatingGroupsEditContainer({
               ) {
                 return null;
               }
-              return renderGenericComponent(component, layout, editIndex);
+              return renderGenericComponent({
+                component,
+                layout,
+                index: editIndex,
+              });
             },
           )}
         </Grid>

--- a/src/altinn-app-frontend/src/features/form/layout/index.ts
+++ b/src/altinn-app-frontend/src/features/form/layout/index.ts
@@ -180,6 +180,8 @@ export interface ILayoutCompImage extends ILayoutCompBase<'Image'> {
 export interface ILayoutCompSummary extends ILayoutCompBase<'Summary'> {
   componentRef?: string;
   pageRef?: string;
+  display?: SummaryDisplayProperties;
+  largeGroup?: boolean;
 }
 
 export type ILayoutCompTextArea = ILayoutCompBase<'TextArea'> &

--- a/src/altinn-app-frontend/src/features/form/layout/index.ts
+++ b/src/altinn-app-frontend/src/features/form/layout/index.ts
@@ -326,3 +326,9 @@ export interface IGroupFilter {
   key: string;
   value: string;
 }
+
+export interface SummaryDisplayProperties {
+  hideChangeButton?: boolean;
+  useComponentGrid?: boolean;
+  hideBottomBorder?: boolean;
+}

--- a/src/altinn-app-frontend/src/utils/formComponentUtils.test.ts
+++ b/src/altinn-app-frontend/src/utils/formComponentUtils.test.ts
@@ -9,6 +9,7 @@ import {
   getFieldName,
   getFileUploadComponentValidations,
   getFormDataForComponentInRepeatingGroup,
+  gridBreakpoints,
   isAttachmentError,
   isComponentValid,
   isNotAttachmentError,
@@ -18,6 +19,7 @@ import {
 } from 'src/utils/formComponentUtils';
 import type { IFormData } from 'src/features/form/data';
 import type {
+  IGridStyling,
   ILayoutComponent,
   ISelectionComponentProps,
 } from 'src/features/form/layout';
@@ -797,6 +799,50 @@ describe('formComponentUtils', () => {
       const validationArray =
         parseFileUploadComponentWithTagValidationObject(mockValidations);
       expect(validationArray).toEqual(expectedResult);
+    });
+  });
+
+  describe('gridBreakpoints', () => {
+    const defaultGrid: IGridStyling = {
+      xs: 12,
+    };
+    it('should return default values when no params are passed', () => {
+      const expected = { ...defaultGrid };
+      const result = gridBreakpoints();
+      expect(result).toEqual(expected);
+    });
+
+    it('should return xs value even if it is not passed', () => {
+      const passValues: IGridStyling = { sm: 4, lg: 8 };
+      const expected: IGridStyling = {
+        ...defaultGrid,
+        ...passValues,
+      };
+      const result = gridBreakpoints(passValues);
+      expect(result).toEqual(expected);
+    });
+
+    it('should return all the sizes that are passed', () => {
+      const passValues: IGridStyling = {
+        xs: 1,
+        sm: 2,
+        md: 3,
+        lg: 4,
+        xl: 5,
+      };
+      const result = gridBreakpoints(passValues);
+      expect(result).toEqual(passValues);
+    });
+
+    it('should not return sizes that not are passed, except xs', () => {
+      const passValues: IGridStyling = {
+        sm: 2,
+        xl: 5,
+      };
+      const result = gridBreakpoints(passValues);
+      expect(result.xs).toBe(12);
+      expect(result.md).toBeUndefined();
+      expect(result.lg).toBeUndefined();
     });
   });
 });

--- a/src/altinn-app-frontend/src/utils/formComponentUtils.ts
+++ b/src/altinn-app-frontend/src/utils/formComponentUtils.ts
@@ -10,6 +10,7 @@ import {
 import { getTextFromAppOrDefault } from 'src/utils/textResource';
 import type { IFormData } from 'src/features/form/data';
 import type {
+  IGridStyling,
   ILayoutComponent,
   ILayoutEntry,
   ILayoutGroup,
@@ -252,7 +253,7 @@ export const getDisplayFormData = (
                   id: selectionComponent.optionsId,
                   mapping: selectionComponent.mapping,
                 })
-              ]?.options.find((option: IOption) => option.value === value)
+              ]?.options?.find((option: IOption) => option.value === value)
                 ?.label,
               textResources,
             ) || '';
@@ -614,3 +615,14 @@ export function smartLowerCaseFirst(text: string): string {
 
   return lowerCaseFirst(text, firstLetterIdx);
 }
+
+export const gridBreakpoints = (grid?: IGridStyling) => {
+  const { xs, sm, md, lg, xl } = grid || {};
+  return {
+    xs: xs || 12,
+    ...(sm && { sm }),
+    ...(md && { md }),
+    ...(lg && { lg }),
+    ...(xl && { xl }),
+  };
+};

--- a/src/altinn-app-frontend/src/utils/layout/index.tsx
+++ b/src/altinn-app-frontend/src/utils/layout/index.tsx
@@ -63,11 +63,17 @@ export function matchLayoutComponent(providedId: string, componentId: string) {
   return providedId.match(`^(${componentId})(-[0-9]+)*$`);
 }
 
-export function renderGenericComponent(
-  component: ILayoutComponentOrGroup,
-  layout: ILayout,
+interface RenderGenericComponentProps {
+  component: ILayoutComponentOrGroup;
+  layout?: ILayout;
+  index?: number;
+}
+
+export function renderGenericComponent({
+  component,
+  layout,
   index = -1,
-) {
+}: RenderGenericComponentProps) {
   if (component.type === 'Group') {
     return renderLayoutGroup(
       component as unknown as ILayoutGroup,
@@ -114,7 +120,7 @@ export function renderLayoutGroup(
     return (
       <>
         {deepCopyComponents.map((component: ILayoutComponent) => {
-          return renderGenericComponent(component, layout);
+          return renderGenericComponent({ component, layout });
         })}
       </>
     );
@@ -136,11 +142,9 @@ export function setupGroupComponents(
   index: number,
 ): (ILayoutGroup | ILayoutComponent)[] {
   return components.map((component: ILayoutComponent | ILayoutGroup) => {
-    if (component.type === 'Group') {
-      if (component.panel?.groupReference) {
-        // Do not treat as a regular group child as this is merely an option to add elements for another group from this group context
-        return component;
-      }
+    if (component.type === 'Group' && component.panel?.groupReference) {
+      // Do not treat as a regular group child as this is merely an option to add elements for another group from this group context
+      return component;
     }
 
     if (!groupDataModelBinding) {


### PR DESCRIPTION
## Description
Updated summary components with some display options to make it more readable with repeating groups:
- `hideBottomBorder` - to hide the blue dotted border between summary components.
- `useComponentGrid` - allows the summary component to use the layout components defined grid setup. Especially useful for summary groups with `largeGroup: true`.
- `hideChangeButton` - Useful when using summary components f.ex. in a custom confirm view, when it is not possible to navigate directly back to the form to change things.

In addition, updated some styling as discussed with @Febakke:
- Added a pale grey border around repeating group items in summary to make it more readable
- Swapped styling of label/data so that data is bold while label is normal.

![Screenshot 2022-09-26 at 13 17 02](https://user-images.githubusercontent.com/1636323/192263268-2c9a990b-a420-421e-b0d8-ae4ecef800f0.png)

Apart from the small styling fixes, existing apps using summary components should not be affected.

## Related Issue(s)
- #461

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
