### PR TITLE
Fixing language loading

### DIFF
--- a/src/altinn-app-frontend/src/shared/resources/language/fetch/fetchLanguageSagas.ts
+++ b/src/altinn-app-frontend/src/shared/resources/language/fetch/fetchLanguageSagas.ts
@@ -32,7 +32,9 @@ export function* watchFetchLanguageSaga(): SagaIterator {
 
   const allowAnonymous = yield select(makeGetAllowAnonymousSelector());
   if (!allowAnonymous) {
-    yield waitFor((state) => !!state.profile.profile);
+    // The currently selected language in the profile is preset to 'nb' when this state is initialized, so we
+    // cannot trust it until the profile is properly fetched (having a userId when not anonymous)
+    yield waitFor((state) => state.profile.profile?.userId !== undefined);
   }
 
   yield call(fetchLanguageSaga);

--- a/src/altinn-app-frontend/src/shared/resources/textResources/fetch/fetchTextResourcesSagas.ts
+++ b/src/altinn-app-frontend/src/shared/resources/textResources/fetch/fetchTextResourcesSagas.ts
@@ -50,7 +50,9 @@ export function* watchFetchTextResourcesSaga(): SagaIterator {
 
   const allowAnonymous = yield select(makeGetAllowAnonymousSelector());
   if (!allowAnonymous) {
-    yield waitFor((state) => !!state.profile.profile);
+    // The currently selected language in the profile is preset to 'nb' when this state is initialized, so we
+    // cannot trust it until the profile is properly fetched (having a userId when not anonymous)
+    yield waitFor((state) => state.profile.profile?.userId !== undefined);
   }
 
   yield call(fetchTextResources);


### PR DESCRIPTION
## Description
In PR #480 language loading got subtly changed in a way that caused the user language from the profile to not be loaded. This was caused by a default in the redux store which set the language to 'nb' when no profile had been fetched - but this now caused us to rely on that default when first loading the language.

## Related Issue(s)
- #480

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- ~~[ ] Relevant automated test added (if you find this hard, leave it and we'll help out)~~
  - [x] Creating a separate issue for this (rushing this fix, as it could be quite problematic for some)
  - #495
- [x] All tests run green

## Documentation
- ~~[ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~
