### PR TITLE
Fix issue with text-wrapping in edit container and width of container when deletebutton not present

### DIFF
--- a/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupTable.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupTable.tsx
@@ -149,6 +149,9 @@ const useStyles = makeStyles({
     '&:hover': {
       background: 'unset !important',
     },
+    '& td': {
+      whiteSpace: 'normal',
+    },
   },
   editingRow: {
     backgroundColor: 'rgba(227, 247, 255, 0.5)',
@@ -503,11 +506,15 @@ export function RepeatingGroupTable({
                       {editIndex === index && (
                         <TableRow
                           key={`edit-container-${index}`}
-                          className={cn([classes.editContainerRow])}
+                          className={classes.editContainerRow}
                         >
                           <TableCell
                             style={{ padding: 0, borderBottom: 0 }}
-                            colSpan={componentTitles.length + 2}
+                            colSpan={
+                              hideDeleteButton
+                                ? componentTitles.length + 1
+                                : componentTitles.length + 2
+                            }
                           >
                             {renderRepeatingGroupsEditContainer()}
                           </TableCell>


### PR DESCRIPTION
Fix issue described in #491 
<img width="986" alt="image" src="https://user-images.githubusercontent.com/32294735/192772189-877884c7-0fb3-41d6-ad41-7adcc31af883.png">

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
