### PR TITLE
Cleaning up some unit test warnings in console

### DIFF
--- a/src/altinn-app-frontend/src/components/base/DatepickerComponent.test.tsx
+++ b/src/altinn-app-frontend/src/components/base/DatepickerComponent.test.tsx
@@ -93,13 +93,13 @@ describe('DatepickerComponent', () => {
     render({ handleDataChange });
 
     await userEvent.click(getOpenCalendarButton());
-    await userEvent.click(getCalendarDayButton('25'));
+    await userEvent.click(getCalendarDayButton('15'));
 
     expect(handleDataChange).toHaveBeenCalledWith(
       // Ignore TZ part of timestamp to avoid test failing when this changes
       // Calendar opens up on current year/month by default, so we need to cater for this in the expected output
       expect.stringContaining(
-        `${currentYearNumeric}-${currentMonthNumeric}-25T12:00:00.000+`,
+        `${currentYearNumeric}-${currentMonthNumeric}-15T12:00:00.000+`,
       ),
       undefined,
       false,

--- a/src/altinn-app-frontend/src/utils/render.tsx
+++ b/src/altinn-app-frontend/src/utils/render.tsx
@@ -61,13 +61,11 @@ export function renderValidationMessages(
   id: string,
   variant: 'error' | 'warning' | 'info' | 'success',
 ) {
-  const key = JSON.stringify({ messages, id, variant });
-
   if (variant !== 'error') {
     return (
       <SoftValidations
         variant={variant}
-        key={key}
+        key={id}
       >
         <ol id={id}>{messages.map(validationMessagesToList)}</ol>
       </SoftValidations>
@@ -77,7 +75,7 @@ export function renderValidationMessages(
   return (
     <div
       style={{ paddingTop: '0.375rem' }}
-      key={key}
+      key={id}
     >
       <ErrorMessage id={id}>
         <ol>{messages.map(validationMessagesToList)}</ol>

--- a/src/altinn-app-frontend/src/utils/render.tsx
+++ b/src/altinn-app-frontend/src/utils/render.tsx
@@ -61,16 +61,24 @@ export function renderValidationMessages(
   id: string,
   variant: 'error' | 'warning' | 'info' | 'success',
 ) {
+  const key = `error|${JSON.stringify(messages)}`;
+
   if (variant !== 'error') {
     return (
-      <SoftValidations variant={variant}>
+      <SoftValidations
+        variant={variant}
+        key={key}
+      >
         <ol id={id}>{messages.map(validationMessagesToList)}</ol>
       </SoftValidations>
     );
   }
 
   return (
-    <div style={{ paddingTop: '0.375rem' }}>
+    <div
+      style={{ paddingTop: '0.375rem' }}
+      key={key}
+    >
       <ErrorMessage id={id}>
         <ol>{messages.map(validationMessagesToList)}</ol>
       </ErrorMessage>

--- a/src/altinn-app-frontend/src/utils/render.tsx
+++ b/src/altinn-app-frontend/src/utils/render.tsx
@@ -61,7 +61,7 @@ export function renderValidationMessages(
   id: string,
   variant: 'error' | 'warning' | 'info' | 'success',
 ) {
-  const key = `error|${JSON.stringify(messages)}`;
+  const key = JSON.stringify({ messages, id, variant });
 
   if (variant !== 'error') {
     return (

--- a/src/shared/src/components/molecules/AltinnMobileTableItem.test.tsx
+++ b/src/shared/src/components/molecules/AltinnMobileTableItem.test.tsx
@@ -53,7 +53,6 @@ describe('AltinnMobileTableItem', () => {
       deleteIconNode: ' i ',
       onDeleteClick: onDeleteClick,
     });
-    screen.debug();
 
     await user.click(
       screen.queryByRole('button', {


### PR DESCRIPTION
## Description
We had some unit tests that were producing warnings in the console, which makes it difficult to see which tests are failing and why (especially in non-color consoles, like sometimes here on github).

## Fixed
- Removing leftover `screen.debug()`
- Adding missing keys to validation messages (which React complains about). I struggled to find something unique, so serializing all the arguments should be unique enough. 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- ~~[ ] Manual testing done (required)~~
- ~~[ ] Relevant automated test added (if you find this hard, leave it and we'll help out)~~
- [x] All tests run green

## Documentation
- ~~[ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~
