### PR TITLE
feature: include what field/component that triggered save

### DIFF
--- a/src/altinn-app-frontend/src/features/form/data/formDataSlice.ts
+++ b/src/altinn-app-frontend/src/features/form/data/formDataSlice.ts
@@ -24,6 +24,7 @@ import type {
   IFetchFormData,
   IFetchFormDataFulfilled,
   IFormDataRejected,
+  ISaveAction,
   ISubmitDataAction,
   IUpdateFormData,
   IUpdateFormDataFulfilled,
@@ -130,7 +131,7 @@ const formDataSlice = createSagaSlice(
           state.error = error;
         },
       }),
-      save: mkAction<void>({
+      save: mkAction<ISaveAction>({
         takeLatest: saveFormDataSaga,
       }),
       deleteAttachmentReference: mkAction<IDeleteAttachmentReference>({

--- a/src/altinn-app-frontend/src/features/form/data/formDataTypes.ts
+++ b/src/altinn-app-frontend/src/features/form/data/formDataTypes.ts
@@ -19,6 +19,11 @@ export interface ISubmitDataAction {
   componentId: string;
 }
 
+export interface ISaveAction {
+  field?: string;
+  componentId?: string;
+}
+
 export interface IUpdateFormDataProps {
   skipValidation?: boolean;
   skipAutoSave?: boolean;
@@ -33,6 +38,7 @@ export interface IUpdateFormData extends IUpdateFormDataProps {
 
 export interface IUpdateFormDataFulfilled extends IUpdateFormDataProps {
   field: string;
+  componentId: string;
   data: any;
 }
 

--- a/src/altinn-app-frontend/src/features/form/data/submit/submitFormDataSagas.test.ts
+++ b/src/altinn-app-frontend/src/features/form/data/submit/submitFormDataSagas.test.ts
@@ -81,12 +81,27 @@ describe('submitFormDataSagas', () => {
       state.instanceData.instance,
       state.formLayout.layoutsets,
     );
-    return expectSaga(saveFormDataSaga)
+    const field = 'someField';
+    const componentId = 'someComponent';
+    const data = 'someData';
+
+    return expectSaga(saveFormDataSaga, {
+      payload: { componentId, field, data },
+      type: '',
+    })
       .provide([
         [select(), state],
-        [call(put, dataElementUrl(defaultDataElementGuid), model), {}],
+        [
+          call(put, dataElementUrl(defaultDataElementGuid), model, {
+            headers: {
+              field,
+              componentId,
+            },
+          }),
+          {},
+        ],
       ])
-      .call(putFormData, state, model)
+      .call(putFormData, { state, model, field, componentId })
       .put(FormDataActions.submitFulfilled())
       .run();
   });
@@ -130,7 +145,18 @@ describe('submitFormDataSagas', () => {
       layoutSets: state.formLayout.layoutsets,
     });
 
-    return expectSaga(saveFormDataSaga)
+    const field = 'someField';
+    const componentId = 'someComponent';
+    const data = 'someData';
+
+    return expectSaga(saveFormDataSaga, {
+      payload: {
+        field,
+        componentId,
+        data,
+      },
+      type: '',
+    })
       .provide([
         [select(), state],
         [select(makeGetAllowAnonymousSelector()), false],
@@ -141,6 +167,8 @@ describe('submitFormDataSagas', () => {
             {
               headers: {
                 party: `partyid:${stateMock.party.selectedParty.partyId}`,
+                componentId,
+                field,
               },
             },
             model,
@@ -155,7 +183,7 @@ describe('submitFormDataSagas', () => {
           },
         ],
       ])
-      .call(saveStatelessData, state, model)
+      .call(saveStatelessData, { state, model, field, componentId })
       .put(
         FormDataActions.fetchFulfilled({
           formData: {
@@ -208,7 +236,18 @@ describe('submitFormDataSagas', () => {
       layoutSets: state.formLayout.layoutsets,
     });
 
-    return expectSaga(saveFormDataSaga)
+    const field = 'someField';
+    const componentId = 'someComponent';
+    const data = 'someData';
+
+    return expectSaga(saveFormDataSaga, {
+      payload: {
+        field,
+        componentId,
+        data,
+      },
+      type: '',
+    })
       .provide([
         [select(), state],
         [select(makeGetAllowAnonymousSelector()), true],
@@ -216,7 +255,12 @@ describe('submitFormDataSagas', () => {
           call(
             post,
             getStatelessFormDataUrl(currentDataType, true),
-            undefined,
+            {
+              headers: {
+                field: 'someField',
+                componentId: 'someComponent',
+              },
+            },
             model,
           ),
           {
@@ -229,7 +273,7 @@ describe('submitFormDataSagas', () => {
           },
         ],
       ])
-      .call(saveStatelessData, state, model)
+      .call(saveStatelessData, { state, model, field, componentId })
       .put(
         FormDataActions.fetchFulfilled({
           formData: {

--- a/src/altinn-app-frontend/src/features/form/data/submit/submitFormDataSagas.test.ts
+++ b/src/altinn-app-frontend/src/features/form/data/submit/submitFormDataSagas.test.ts
@@ -94,8 +94,8 @@ describe('submitFormDataSagas', () => {
         [
           call(put, dataElementUrl(defaultDataElementGuid), model, {
             headers: {
-              field,
-              componentId,
+              'X-DataField': field,
+              'X-ComponentId': componentId,
             },
           }),
           {},
@@ -167,8 +167,8 @@ describe('submitFormDataSagas', () => {
             {
               headers: {
                 party: `partyid:${stateMock.party.selectedParty.partyId}`,
-                componentId,
-                field,
+                'X-DataField': field,
+                'X-ComponentId': componentId,
               },
             },
             model,
@@ -257,8 +257,8 @@ describe('submitFormDataSagas', () => {
             getStatelessFormDataUrl(currentDataType, true),
             {
               headers: {
-                field: 'someField',
-                componentId: 'someComponent',
+                'X-DataField': field,
+                'X-ComponentId': componentId,
               },
             },
             model,

--- a/src/altinn-app-frontend/src/features/form/data/submit/submitFormDataSagas.ts
+++ b/src/altinn-app-frontend/src/features/form/data/submit/submitFormDataSagas.ts
@@ -132,8 +132,8 @@ export function* putFormData({
   try {
     const options: AxiosRequestConfig = {
       headers: {
-        field,
-        componentId,
+        'X-DataField': field,
+        'X-ComponentId': componentId,
       },
     };
     yield call(put, dataElementUrl(defaultDataElementGuid), model, options);
@@ -224,8 +224,8 @@ export function* saveStatelessData({
   const allowAnonymous = yield select(makeGetAllowAnonymousSelector());
   let options: AxiosRequestConfig = {
     headers: {
-      field,
-      componentId,
+      'X-DataField': field,
+      'X-ComponentId': componentId,
     },
   };
   if (!allowAnonymous) {

--- a/src/altinn-app-frontend/src/features/form/data/submit/submitFormDataSagas.ts
+++ b/src/altinn-app-frontend/src/features/form/data/submit/submitFormDataSagas.ts
@@ -1,5 +1,6 @@
 import { all, call, put as sagaPut, select } from 'redux-saga/effects';
 import type { PayloadAction } from '@reduxjs/toolkit';
+import type { AxiosRequestConfig } from 'axios';
 import type { SagaIterator } from 'redux-saga';
 
 import { FormDataActions } from 'src/features/form/data/formDataSlice';
@@ -71,7 +72,7 @@ export function* submitFormSaga({
       return yield sagaPut(FormDataActions.submitRejected({ error: null }));
     }
 
-    yield call(putFormData, state, model);
+    yield call(putFormData, { state, model });
     if (apiMode === 'Complete') {
       yield call(submitComplete, state, stopWithWarnings);
     }
@@ -116,7 +117,12 @@ function* submitComplete(state: IRuntimeState, stopWithWarnings: boolean) {
   return yield sagaPut(ProcessActions.complete());
 }
 
-export function* putFormData(state: IRuntimeState, model: any) {
+export function* putFormData({
+  state,
+  model,
+  field,
+  componentId,
+}: SaveDataParams) {
   // updates the default data element
   const defaultDataElementGuid = getCurrentTaskDataElementId(
     state.applicationMetadata.applicationMetadata,
@@ -124,7 +130,13 @@ export function* putFormData(state: IRuntimeState, model: any) {
     state.formLayout.layoutsets,
   );
   try {
-    yield call(put, dataElementUrl(defaultDataElementGuid), model);
+    const options: AxiosRequestConfig = {
+      headers: {
+        field,
+        componentId,
+      },
+    };
+    yield call(put, dataElementUrl(defaultDataElementGuid), model, options);
   } catch (error) {
     if (error.response && error.response.status === 303) {
       // 303 means that data has been changed by calculation on server. Try to update from response.
@@ -164,7 +176,9 @@ function* handleCalculationUpdate(changedFields) {
   );
 }
 
-export function* saveFormDataSaga(): SagaIterator {
+export function* saveFormDataSaga({
+  payload: { field, componentId },
+}: PayloadAction<IUpdateFormDataFulfilled>): SagaIterator {
   try {
     const state: IRuntimeState = yield select();
     // updates the default data element
@@ -177,10 +191,10 @@ export function* saveFormDataSaga(): SagaIterator {
     );
 
     if (isStatelessApp(application)) {
-      yield call(saveStatelessData, state, model);
+      yield call(saveStatelessData, { state, model, field, componentId });
     } else {
       // app with instance
-      yield call(putFormData, state, model);
+      yield call(putFormData, { state, model, field, componentId });
     }
 
     if (state.formValidations.currentSingleFieldValidation?.dataModelBinding) {
@@ -194,13 +208,31 @@ export function* saveFormDataSaga(): SagaIterator {
   }
 }
 
-export function* saveStatelessData(state: IRuntimeState, model: any) {
+interface SaveDataParams {
+  state: IRuntimeState;
+  model: any;
+  field?: string;
+  componentId?: string;
+}
+
+export function* saveStatelessData({
+  state,
+  model,
+  field,
+  componentId,
+}: SaveDataParams) {
   const allowAnonymous = yield select(makeGetAllowAnonymousSelector());
-  let options;
+  let options: AxiosRequestConfig = {
+    headers: {
+      field,
+      componentId,
+    },
+  };
   if (!allowAnonymous) {
     const selectedPartyId = state.party.selectedParty.partyId;
     options = {
       headers: {
+        ...options.headers,
         party: `partyid:${selectedPartyId}`,
       },
     };
@@ -223,7 +255,7 @@ export function* saveStatelessData(state: IRuntimeState, model: any) {
 }
 
 export function* autoSaveSaga({
-  payload: { skipAutoSave },
+  payload: { skipAutoSave, field, componentId },
 }: PayloadAction<IUpdateFormDataFulfilled>): SagaIterator {
   if (skipAutoSave) {
     return;
@@ -232,6 +264,6 @@ export function* autoSaveSaga({
   const uiConfig: IUiConfig = yield select(UIConfigSelector);
   if (uiConfig.autoSave !== false) {
     // undefined should default to auto save
-    yield sagaPut(FormDataActions.save());
+    yield sagaPut(FormDataActions.save({ field, componentId }));
   }
 }

--- a/src/altinn-app-frontend/src/features/form/data/update/updateFormDataSagas.test.ts
+++ b/src/altinn-app-frontend/src/features/form/data/update/updateFormDataSagas.test.ts
@@ -61,7 +61,7 @@ describe('updateFormDataSagas', () => {
             formData: expectedUpdatedFormData,
           }),
         )
-        .put(FormDataActions.save())
+        .put(FormDataActions.save({ componentId }))
         .run();
     };
 

--- a/src/altinn-app-frontend/src/features/form/data/update/updateFormDataSagas.ts
+++ b/src/altinn-app-frontend/src/features/form/data/update/updateFormDataSagas.ts
@@ -49,6 +49,7 @@ export function* updateFormDataSaga({
       yield put(
         FormDataActions.updateFulfilled({
           field,
+          componentId,
           data,
           skipValidation,
           skipAutoSave,
@@ -167,7 +168,7 @@ export function* deleteAttachmentReferenceSaga({
     );
 
     yield put(FormDataActions.setFulfilled({ formData: updatedFormData }));
-    yield put(FormDataActions.save());
+    yield put(FormDataActions.save({ componentId }));
   } catch (err) {
     console.error(err);
   }

--- a/src/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.test.ts
+++ b/src/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.test.ts
@@ -153,7 +153,7 @@ describe('updateLayoutSagas', () => {
           }),
         )
         .put(FormDataActions.setFulfilled({ formData: initialFormData }))
-        .put(FormDataActions.save())
+        .put(FormDataActions.save({}))
         .run();
     });
   });

--- a/src/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
+++ b/src/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
@@ -288,7 +288,7 @@ export function* updateRepeatingGroupsSaga({
             attachments: updatedAttachments,
           }),
         );
-        yield put(FormDataActions.save());
+        yield put(FormDataActions.save({}));
       } else {
         yield put(
           FormLayoutActions.updateRepeatingGroupsRemoveCancelled({

--- a/src/altinn-app-frontend/src/shared/resources/options/fetch/fetchOptionsSagas.test.ts
+++ b/src/altinn-app-frontend/src/shared/resources/options/fetch/fetchOptionsSagas.test.ts
@@ -28,6 +28,7 @@ describe('fetchOptionsSagas', () => {
     const action = {
       payload: {
         field: 'some_field',
+        componentId: 'some_component',
         data: '',
       },
       type: '',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Adds two header values `field` and `componentId` when calling put on a data element (which in turns calls processWrite). 
This enables app developers with some c# knowhow to get the header values from the HTTP-context when running data processing. 


## Related Issue(s)
- [Slack discussion (internal link)](https://altinndevops.slack.com/archives/CDU1S3NLW/p1664343663566769)

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
