### PR TITLE
Bug: checkbox group onblur validation

### DIFF
--- a/src/altinn-app-frontend/__mocks__/constants.ts
+++ b/src/altinn-app-frontend/__mocks__/constants.ts
@@ -105,3 +105,5 @@ export const userProfile = {
     doNotPromptForParty: false,
   },
 };
+
+export const defaultHandleDataChangeProps = [undefined, false, false];

--- a/src/altinn-app-frontend/src/components/base/CheckboxesContainerComponent.test.tsx
+++ b/src/altinn-app-frontend/src/components/base/CheckboxesContainerComponent.test.tsx
@@ -8,6 +8,7 @@ import { renderWithProviders } from 'testUtils';
 import type { PreloadedState } from 'redux';
 
 import { CheckboxContainerComponent } from 'src/components/base/CheckboxesContainerComponent';
+import { mockDelayBeforeSaving } from 'src/components/hooks/useDelayedSavedState';
 import { LayoutStyle } from 'src/types';
 import type { IComponentProps } from 'src/components';
 import type { ICheckboxContainerProps } from 'src/components/base/CheckboxesContainerComponent';
@@ -30,8 +31,6 @@ const threeOptions = [
 ];
 
 const twoOptions = threeOptions.slice(1);
-
-const debounceTime = 200;
 
 const render = (
   props: Partial<ICheckboxContainerProps> = {},
@@ -170,9 +169,13 @@ describe('CheckboxContainerComponent', () => {
     expect(getCheckbox({ name: 'Sweden' })).toBeInTheDocument();
     expect(getCheckbox({ name: 'Denmark' })).toBeInTheDocument();
 
+    mockDelayBeforeSaving(25);
     await userEvent.click(getCheckbox({ name: 'Denmark' }));
 
-    await new Promise((r) => setTimeout(r, debounceTime)); // Wait for debounce
+    expect(handleChange).not.toHaveBeenCalled();
+
+    await new Promise((r) => setTimeout(r, 25));
+    mockDelayBeforeSaving(undefined);
 
     expect(handleChange).toHaveBeenCalledWith(
       'norway,denmark',
@@ -197,9 +200,13 @@ describe('CheckboxContainerComponent', () => {
       getCheckbox({ name: 'Denmark', isChecked: true }),
     ).toBeInTheDocument();
 
+    mockDelayBeforeSaving(25);
     await userEvent.click(getCheckbox({ name: 'Denmark', isChecked: true }));
 
-    await new Promise((r) => setTimeout(r, debounceTime)); // Wait for debounce
+    expect(handleChange).not.toHaveBeenCalled();
+
+    await new Promise((r) => setTimeout(r, 25));
+    mockDelayBeforeSaving(undefined);
 
     expect(handleChange).toHaveBeenCalledWith(
       'norway',
@@ -256,9 +263,13 @@ describe('CheckboxContainerComponent', () => {
     expect(getCheckbox({ name: 'Sweden' })).toBeInTheDocument();
     expect(getCheckbox({ name: 'Denmark' })).toBeInTheDocument();
 
+    mockDelayBeforeSaving(25);
     await userEvent.click(getCheckbox({ name: 'Denmark' }));
 
-    await new Promise((r) => setTimeout(r, debounceTime)); // Wait for debounce
+    expect(handleChange).not.toHaveBeenCalled();
+
+    await new Promise((r) => setTimeout(r, 25));
+    mockDelayBeforeSaving(undefined);
 
     expect(handleChange).toHaveBeenCalledWith(
       'denmark',
@@ -367,11 +378,15 @@ describe('CheckboxContainerComponent', () => {
       getCheckbox({ name: 'The value from the group is: Label for second' }),
     ).toBeInTheDocument();
 
+    mockDelayBeforeSaving(25);
     await userEvent.click(
       getCheckbox({ name: 'The value from the group is: Label for second' }),
     );
 
-    await new Promise((r) => setTimeout(r, debounceTime)); // Wait for debounce
+    expect(handleDataChange).not.toHaveBeenCalled();
+
+    await new Promise((r) => setTimeout(r, 25));
+    mockDelayBeforeSaving(undefined);
 
     expect(handleDataChange).toHaveBeenCalledWith(
       'Value for second',

--- a/src/altinn-app-frontend/src/components/base/CheckboxesContainerComponent.test.tsx
+++ b/src/altinn-app-frontend/src/components/base/CheckboxesContainerComponent.test.tsx
@@ -175,12 +175,13 @@ describe('CheckboxContainerComponent', () => {
     expect(handleChange).not.toHaveBeenCalled();
 
     await new Promise((r) => setTimeout(r, 25));
-    mockDelayBeforeSaving(undefined);
 
     expect(handleChange).toHaveBeenCalledWith(
       'norway,denmark',
       ...defaultHandleDataChangeProps,
     );
+
+    mockDelayBeforeSaving(undefined);
   });
 
   it('should call handleDataChange with updated values when deselecting item', async () => {
@@ -206,12 +207,13 @@ describe('CheckboxContainerComponent', () => {
     expect(handleChange).not.toHaveBeenCalled();
 
     await new Promise((r) => setTimeout(r, 25));
-    mockDelayBeforeSaving(undefined);
 
     expect(handleChange).toHaveBeenCalledWith(
       'norway',
       ...defaultHandleDataChangeProps,
     );
+
+    mockDelayBeforeSaving(undefined);
   });
 
   it('should call handleDataChange instantly on blur when the value has changed', async () => {
@@ -228,6 +230,9 @@ describe('CheckboxContainerComponent', () => {
     expect(denmark).toBeInTheDocument();
 
     await userEvent.click(denmark);
+
+    expect(handleChange).not.toHaveBeenCalled();
+
     fireEvent.blur(denmark);
 
     expect(handleChange).toHaveBeenCalledWith(
@@ -269,12 +274,13 @@ describe('CheckboxContainerComponent', () => {
     expect(handleChange).not.toHaveBeenCalled();
 
     await new Promise((r) => setTimeout(r, 25));
-    mockDelayBeforeSaving(undefined);
 
     expect(handleChange).toHaveBeenCalledWith(
       'denmark',
       ...defaultHandleDataChangeProps,
     );
+
+    mockDelayBeforeSaving(undefined);
   });
 
   it('should show spinner while waiting for options', () => {
@@ -386,11 +392,12 @@ describe('CheckboxContainerComponent', () => {
     expect(handleDataChange).not.toHaveBeenCalled();
 
     await new Promise((r) => setTimeout(r, 25));
-    mockDelayBeforeSaving(undefined);
 
     expect(handleDataChange).toHaveBeenCalledWith(
       'Value for second',
       ...defaultHandleDataChangeProps,
     );
+
+    mockDelayBeforeSaving(undefined);
   });
 });

--- a/src/altinn-app-frontend/src/components/base/CheckboxesContainerComponent.test.tsx
+++ b/src/altinn-app-frontend/src/components/base/CheckboxesContainerComponent.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { defaultHandleDataChangeProps } from '__mocks__/constants';
 import { getInitialStateMock } from '__mocks__/initialStateMock';
 import { fireEvent, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -29,6 +30,8 @@ const threeOptions = [
 ];
 
 const twoOptions = threeOptions.slice(1);
+
+const debounceTime = 200;
 
 const render = (
   props: Partial<ICheckboxContainerProps> = {},
@@ -96,7 +99,10 @@ describe('CheckboxContainerComponent', () => {
       },
     });
 
-    expect(handleChange).toHaveBeenCalledWith('sweden');
+    expect(handleChange).toHaveBeenCalledWith(
+      'sweden',
+      ...defaultHandleDataChangeProps,
+    );
   });
 
   it('should not call handleDataChange when simpleBinding is set and preselectedOptionIndex', () => {
@@ -166,7 +172,12 @@ describe('CheckboxContainerComponent', () => {
 
     await userEvent.click(getCheckbox({ name: 'Denmark' }));
 
-    expect(handleChange).toHaveBeenCalledWith('norway,denmark');
+    await new Promise((r) => setTimeout(r, debounceTime)); // Wait for debounce
+
+    expect(handleChange).toHaveBeenCalledWith(
+      'norway,denmark',
+      ...defaultHandleDataChangeProps,
+    );
   });
 
   it('should call handleDataChange with updated values when deselecting item', async () => {
@@ -188,10 +199,15 @@ describe('CheckboxContainerComponent', () => {
 
     await userEvent.click(getCheckbox({ name: 'Denmark', isChecked: true }));
 
-    expect(handleChange).toHaveBeenCalledWith('norway');
+    await new Promise((r) => setTimeout(r, debounceTime)); // Wait for debounce
+
+    expect(handleChange).toHaveBeenCalledWith(
+      'norway',
+      ...defaultHandleDataChangeProps,
+    );
   });
 
-  it('should call handleDataChange on blur with already selected value', () => {
+  it('should call handleDataChange instantly on blur when the value has changed', async () => {
     const handleChange = jest.fn();
     render({
       handleDataChange: handleChange,
@@ -200,15 +216,20 @@ describe('CheckboxContainerComponent', () => {
       },
     });
 
-    expect(getCheckbox({ name: 'Denmark' })).toBeInTheDocument();
+    const denmark = getCheckbox({ name: 'Denmark' });
 
-    fireEvent.focus(getCheckbox({ name: 'Denmark' }));
-    fireEvent.blur(getCheckbox({ name: 'Denmark' }));
+    expect(denmark).toBeInTheDocument();
 
-    expect(handleChange).toHaveBeenCalledWith('norway');
+    await userEvent.click(denmark);
+    fireEvent.blur(denmark);
+
+    expect(handleChange).toHaveBeenCalledWith(
+      'norway,denmark',
+      ...defaultHandleDataChangeProps,
+    );
   });
 
-  it('should call handleDataChange on blur with empty value when no item is selected', () => {
+  it('should not call handleDataChange on blur when the value is unchanged', () => {
     const handleChange = jest.fn();
     render({
       handleDataChange: handleChange,
@@ -219,7 +240,7 @@ describe('CheckboxContainerComponent', () => {
     fireEvent.focus(getCheckbox({ name: 'Denmark' }));
     fireEvent.blur(getCheckbox({ name: 'Denmark' }));
 
-    expect(handleChange).toHaveBeenCalledWith('');
+    expect(handleChange).not.toHaveBeenCalled();
   });
 
   it('should call handleDataChange onBlur with no commas in string when starting with empty string formData', async () => {
@@ -237,7 +258,12 @@ describe('CheckboxContainerComponent', () => {
 
     await userEvent.click(getCheckbox({ name: 'Denmark' }));
 
-    expect(handleChange).toHaveBeenCalledWith('denmark');
+    await new Promise((r) => setTimeout(r, debounceTime)); // Wait for debounce
+
+    expect(handleChange).toHaveBeenCalledWith(
+      'denmark',
+      ...defaultHandleDataChangeProps,
+    );
   });
 
   it('should show spinner while waiting for options', () => {
@@ -345,6 +371,11 @@ describe('CheckboxContainerComponent', () => {
       getCheckbox({ name: 'The value from the group is: Label for second' }),
     );
 
-    expect(handleDataChange).toHaveBeenCalledWith('Value for second');
+    await new Promise((r) => setTimeout(r, debounceTime)); // Wait for debounce
+
+    expect(handleDataChange).toHaveBeenCalledWith(
+      'Value for second',
+      ...defaultHandleDataChangeProps,
+    );
   });
 });

--- a/src/altinn-app-frontend/src/components/base/CheckboxesContainerComponent.tsx
+++ b/src/altinn-app-frontend/src/components/base/CheckboxesContainerComponent.tsx
@@ -111,7 +111,8 @@ export const CheckboxContainerComponent = ({
     formData?.simpleBinding ?? '',
   );
 
-  const selected = value.length > 0 ? value.split(',') : defaultSelectedOptions;
+  const selected =
+    value && value.length > 0 ? value.split(',') : defaultSelectedOptions;
 
   React.useEffect(() => {
     const shouldSelectOptionAutomatically =
@@ -136,7 +137,7 @@ export const CheckboxContainerComponent = ({
     if (optionsHasChanged && formData.simpleBinding) {
       // New options have been loaded, we have to reset form data.
       // We also skip any required validations
-      setValue(undefined, true, true);
+      setValue(undefined, true);
     }
   }, [setValue, optionsHasChanged, formData]);
 
@@ -152,7 +153,7 @@ export const CheckboxContainerComponent = ({
   };
 
   const handleBlur = () => {
-    handleDataChange(formData?.simpleBinding ?? '');
+    setValue(selected.join(','), true);
   };
 
   const isOptionSelected = (option: string) => selected.includes(option);
@@ -182,7 +183,7 @@ export const CheckboxContainerComponent = ({
           <AltinnSpinner />
         ) : (
           <>
-            {calculatedOptions.map((option, index, { length }) => (
+            {calculatedOptions.map((option, index) => (
               <React.Fragment key={option.value}>
                 <FormControlLabel
                   key={option.value}
@@ -191,7 +192,7 @@ export const CheckboxContainerComponent = ({
                     <StyledCheckbox
                       checked={isOptionSelected(option.value)}
                       onChange={handleChange}
-                      onBlur={index === length - 1 ? handleBlur : undefined}
+                      onBlur={handleBlur}
                       value={index}
                       key={option.value}
                       name={option.value}

--- a/src/altinn-app-frontend/src/components/base/CheckboxesContainerComponent.tsx
+++ b/src/altinn-app-frontend/src/components/base/CheckboxesContainerComponent.tsx
@@ -153,7 +153,7 @@ export const CheckboxContainerComponent = ({
   };
 
   const handleBlur = (event: React.FocusEvent<HTMLInputElement>) => {
-    // Only set value instantly if moving focus outside of the radio group
+    // Only set value instantly if moving focus outside of the checkbox group
     if (!event.currentTarget.contains(event.relatedTarget)) {
       saveValue();
     }

--- a/src/altinn-app-frontend/src/components/base/CheckboxesContainerComponent.tsx
+++ b/src/altinn-app-frontend/src/components/base/CheckboxesContainerComponent.tsx
@@ -106,7 +106,7 @@ export const CheckboxContainerComponent = ({
         ?.loading,
   );
 
-  const { value, setValue } = useDelayedSavedState(
+  const { value, setValue, saveValue } = useDelayedSavedState(
     handleDataChange,
     formData?.simpleBinding ?? '',
     200,
@@ -152,8 +152,11 @@ export const CheckboxContainerComponent = ({
     }
   };
 
-  const handleBlur = () => {
-    setValue(selected.join(','), true);
+  const handleBlur = (event: React.FocusEvent<HTMLInputElement>) => {
+    // Only set value instantly if moving focus outside of the radio group
+    if (!event.currentTarget.contains(event.relatedTarget)) {
+      saveValue();
+    }
   };
 
   const isOptionSelected = (option: string) => selected.includes(option);
@@ -178,6 +181,7 @@ export const CheckboxContainerComponent = ({
         })}
         id={id}
         key={`checkboxes_group_${id}`}
+        onBlur={handleBlur}
       >
         {fetchingOptions ? (
           <AltinnSpinner />
@@ -192,7 +196,6 @@ export const CheckboxContainerComponent = ({
                     <StyledCheckbox
                       checked={isOptionSelected(option.value)}
                       onChange={handleChange}
-                      onBlur={handleBlur}
                       value={index}
                       key={option.value}
                       name={option.value}

--- a/src/altinn-app-frontend/src/components/base/CheckboxesContainerComponent.tsx
+++ b/src/altinn-app-frontend/src/components/base/CheckboxesContainerComponent.tsx
@@ -190,6 +190,7 @@ export const CheckboxContainerComponent = ({
             {calculatedOptions.map((option, index) => (
               <React.Fragment key={option.value}>
                 <FormControlLabel
+                  tabIndex={-1}
                   key={option.value}
                   classes={{ root: cn(classes.margin) }}
                   control={

--- a/src/altinn-app-frontend/src/components/base/CheckboxesContainerComponent.tsx
+++ b/src/altinn-app-frontend/src/components/base/CheckboxesContainerComponent.tsx
@@ -109,6 +109,7 @@ export const CheckboxContainerComponent = ({
   const { value, setValue } = useDelayedSavedState(
     handleDataChange,
     formData?.simpleBinding ?? '',
+    200,
   );
 
   const selected =
@@ -136,7 +137,6 @@ export const CheckboxContainerComponent = ({
   React.useEffect(() => {
     if (optionsHasChanged && formData.simpleBinding) {
       // New options have been loaded, we have to reset form data.
-      // We also skip any required validations
       setValue(undefined, true);
     }
   }, [setValue, optionsHasChanged, formData]);

--- a/src/altinn-app-frontend/src/components/base/DropdownComponent.test.tsx
+++ b/src/altinn-app-frontend/src/components/base/DropdownComponent.test.tsx
@@ -128,7 +128,7 @@ describe('DropdownComponent', () => {
     expect(handleDataChange).toHaveBeenCalledTimes(1);
   });
 
-  it('should trigger instantly handleDataChange on blur', async () => {
+  it('should trigger handleDataChange instantly on blur', async () => {
     const handleDataChange = jest.fn();
     render({
       preselectedOptionIndex: 2,

--- a/src/altinn-app-frontend/src/components/base/DropdownComponent.test.tsx
+++ b/src/altinn-app-frontend/src/components/base/DropdownComponent.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { defaultHandleDataChangeProps } from '__mocks__/constants';
 import { getInitialStateMock } from '__mocks__/initialStateMock';
 import { fireEvent, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -7,6 +8,7 @@ import { renderWithProviders } from 'testUtils';
 import type { PreloadedState } from 'redux';
 
 import DropdownComponent from 'src/components/base/DropdownComponent';
+import { mockDelayBeforeSaving } from 'src/components/hooks/useDelayedSavedState';
 import type { IComponentProps } from 'src/components';
 import type { IDropdownProps } from 'src/components/base/DropdownComponent';
 import type { RootState } from 'src/store';
@@ -19,7 +21,6 @@ const render = (
     id: 'component-id',
     optionsId: 'countries',
     formData: {},
-    preselectedOptionIndex: 1,
     handleDataChange: jest.fn(),
     getTextResourceAsString: (value) => value,
     readOnly: false,
@@ -75,11 +76,22 @@ describe('DropdownComponent', () => {
       handleDataChange,
     });
 
+    mockDelayBeforeSaving(25);
+
     await userEvent.selectOptions(screen.getByRole('combobox'), [
       screen.getByText('Sweden'),
     ]);
 
-    expect(handleDataChange).toHaveBeenCalledWith('sweden');
+    expect(handleDataChange).not.toHaveBeenCalled();
+
+    await new Promise((r) => setTimeout(r, 25));
+
+    expect(handleDataChange).toHaveBeenCalledWith(
+      'sweden',
+      ...defaultHandleDataChangeProps,
+    );
+
+    mockDelayBeforeSaving(undefined);
   });
 
   it('should show as disabled when readOnly is true', () => {
@@ -109,24 +121,36 @@ describe('DropdownComponent', () => {
       handleDataChange,
     });
 
-    expect(handleDataChange).toHaveBeenCalledWith('denmark');
+    expect(handleDataChange).toHaveBeenCalledWith(
+      'denmark',
+      ...defaultHandleDataChangeProps,
+    );
     expect(handleDataChange).toHaveBeenCalledTimes(1);
   });
 
-  it('should trigger handleDataChange on blur', async () => {
+  it('should trigger instantly handleDataChange on blur', async () => {
     const handleDataChange = jest.fn();
     render({
       preselectedOptionIndex: 2,
       handleDataChange,
     });
 
-    expect(handleDataChange).toHaveBeenCalledWith('denmark');
+    expect(handleDataChange).toHaveBeenCalledWith(
+      'denmark',
+      ...defaultHandleDataChangeProps,
+    );
     const select = screen.getByRole('combobox');
 
     await userEvent.click(select);
+
+    expect(handleDataChange).toHaveBeenCalledTimes(1);
+
     fireEvent.blur(select);
 
-    expect(handleDataChange).toHaveBeenCalledWith('denmark');
+    expect(handleDataChange).toHaveBeenCalledWith(
+      'denmark',
+      ...defaultHandleDataChangeProps,
+    );
     expect(handleDataChange).toHaveBeenCalledTimes(2);
   });
 
@@ -157,16 +181,35 @@ describe('DropdownComponent', () => {
       },
     });
 
+    mockDelayBeforeSaving(25);
+
     await userEvent.selectOptions(screen.getByRole('combobox'), [
       screen.getByText('The value from the group is: Label for first'),
     ]);
 
-    expect(handleDataChange).toHaveBeenCalledWith('Value for first');
+    expect(handleDataChange).not.toHaveBeenCalled();
+
+    await new Promise((r) => setTimeout(r, 25));
+
+    expect(handleDataChange).toHaveBeenCalledWith(
+      'Value for first',
+      ...defaultHandleDataChangeProps,
+    );
 
     await userEvent.selectOptions(screen.getByRole('combobox'), [
       screen.getByText('The value from the group is: Label for second'),
     ]);
 
-    expect(handleDataChange).toHaveBeenCalledWith('Value for second');
+    expect(handleDataChange).toHaveBeenCalledTimes(1);
+
+    await new Promise((r) => setTimeout(r, 25));
+
+    expect(handleDataChange).toHaveBeenCalledWith(
+      'Value for second',
+      ...defaultHandleDataChangeProps,
+    );
+    expect(handleDataChange).toHaveBeenCalledTimes(2);
+
+    mockDelayBeforeSaving(undefined);
   });
 });

--- a/src/altinn-app-frontend/src/components/base/DropdownComponent.tsx
+++ b/src/altinn-app-frontend/src/components/base/DropdownComponent.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { useAppSelector, useHasChangedIgnoreUndefined } from 'src/common/hooks';
 import { useGetOptions } from 'src/components/hooks';
+import { useDelayedSavedState } from 'src/components/hooks/useDelayedSavedState';
 import { getOptionLookupKey } from 'src/utils/options';
 import type { IComponentProps } from 'src/components';
 import type { ILayoutCompDropdown } from 'src/features/form/layout';
@@ -32,6 +33,12 @@ function DropdownComponent({
   const hasSelectedInitial = React.useRef(false);
   const optionsHasChanged = useHasChangedIgnoreUndefined(options);
 
+  const { value, setValue } = useDelayedSavedState(
+    handleDataChange,
+    formData?.simpleBinding,
+    200,
+  );
+
   React.useEffect(() => {
     const shouldSelectOptionAutomatically =
       !formData?.simpleBinding &&
@@ -41,25 +48,25 @@ function DropdownComponent({
       hasSelectedInitial.current === false;
 
     if (shouldSelectOptionAutomatically) {
-      handleDataChange(options[preselectedOptionIndex].value);
+      setValue(options[preselectedOptionIndex].value, true);
       hasSelectedInitial.current = true;
     }
-  }, [options, formData, preselectedOptionIndex, handleDataChange]);
+  }, [options, formData, preselectedOptionIndex, setValue]);
 
   React.useEffect(() => {
     if (optionsHasChanged && formData.simpleBinding) {
       // New options have been loaded, we have to reset form data.
       // We also skip any required validations
-      handleDataChange(undefined, 'simpleBinding', true);
+      setValue(undefined, true);
     }
-  }, [handleDataChange, optionsHasChanged, formData]);
+  }, [optionsHasChanged, formData, setValue]);
 
   const handleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
-    handleDataChange(event.target.value);
+    setValue(event.target.value);
   };
 
   const handleBlur = (event: React.FocusEvent<HTMLSelectElement>) => {
-    handleDataChange(event.target.value);
+    setValue(event.target.value, true);
   };
 
   return (
@@ -71,7 +78,7 @@ function DropdownComponent({
           id={id}
           onChange={handleChange}
           onBlur={handleBlur}
-          value={formData?.simpleBinding}
+          value={value}
           disabled={readOnly}
           error={!isValid}
           options={

--- a/src/altinn-app-frontend/src/components/base/DropdownComponent.tsx
+++ b/src/altinn-app-frontend/src/components/base/DropdownComponent.tsx
@@ -33,7 +33,7 @@ function DropdownComponent({
   const hasSelectedInitial = React.useRef(false);
   const optionsHasChanged = useHasChangedIgnoreUndefined(options);
 
-  const { value, setValue } = useDelayedSavedState(
+  const { value, setValue, saveValue } = useDelayedSavedState(
     handleDataChange,
     formData?.simpleBinding,
     200,
@@ -65,10 +65,6 @@ function DropdownComponent({
     setValue(event.target.value);
   };
 
-  const handleBlur = (event: React.FocusEvent<HTMLSelectElement>) => {
-    setValue(event.target.value, true);
-  };
-
   return (
     <>
       {fetchingOptions ? (
@@ -77,7 +73,7 @@ function DropdownComponent({
         <Select
           id={id}
           onChange={handleChange}
-          onBlur={handleBlur}
+          onBlur={saveValue}
           value={value}
           disabled={readOnly}
           error={!isValid}

--- a/src/altinn-app-frontend/src/components/base/RadioButtons/ControlledRadioGroup.tsx
+++ b/src/altinn-app-frontend/src/components/base/RadioButtons/ControlledRadioGroup.tsx
@@ -19,7 +19,7 @@ export interface IControlledRadioGroupProps
   extends IRadioButtonsContainerProps {
   fetchingOptions: boolean;
   selected: string;
-  handleBlur: () => void;
+  handleBlur: (event: React.FocusEvent<HTMLInputElement>) => void;
   handleChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
   calculatedOptions: IOption[];
 }

--- a/src/altinn-app-frontend/src/components/base/RadioButtons/ControlledRadioGroup.tsx
+++ b/src/altinn-app-frontend/src/components/base/RadioButtons/ControlledRadioGroup.tsx
@@ -65,6 +65,7 @@ export const ControlledRadioGroup = ({
           {calculatedOptions.map((option: any, index: number) => (
             <React.Fragment key={index}>
               <FormControlLabel
+                tabIndex={-1}
                 control={<StyledRadio />}
                 label={getTextResource(option.label)}
                 value={option.value}

--- a/src/altinn-app-frontend/src/components/base/RadioButtons/RadioButtonsContainerComponent.test.tsx
+++ b/src/altinn-app-frontend/src/components/base/RadioButtons/RadioButtonsContainerComponent.test.tsx
@@ -8,6 +8,7 @@ import { renderWithProviders } from 'testUtils';
 import type { PreloadedState } from 'redux';
 
 import { RadioButtonContainerComponent } from 'src/components/base/RadioButtons/RadioButtonsContainerComponent';
+import { mockDelayBeforeSaving } from 'src/components/hooks/useDelayedSavedState';
 import { LayoutStyle } from 'src/types';
 import type { IComponentProps } from 'src/components';
 import type { IRadioButtonsContainerProps } from 'src/components/base/RadioButtons/RadioButtonsContainerComponent';
@@ -30,8 +31,6 @@ const threeOptions = [
 ];
 
 const twoOptions = threeOptions.slice(1);
-
-const debounceTime = 200;
 
 const render = (
   props: Partial<IRadioButtonsContainerProps> = {},
@@ -144,9 +143,13 @@ describe('RadioButtonsContainerComponent', () => {
     expect(getRadio({ name: 'Sweden' })).toBeInTheDocument();
     expect(getRadio({ name: 'Denmark' })).toBeInTheDocument();
 
+    mockDelayBeforeSaving(25);
     await userEvent.click(getRadio({ name: 'Denmark' }));
 
-    await new Promise((r) => setTimeout(r, debounceTime)); // Wait for debounce
+    expect(handleChange).not.toHaveBeenCalled();
+
+    await new Promise((r) => setTimeout(r, 25));
+    mockDelayBeforeSaving(undefined);
 
     expect(handleChange).toHaveBeenCalledWith(
       'denmark',
@@ -299,11 +302,15 @@ describe('RadioButtonsContainerComponent', () => {
       getRadio({ name: 'The value from the group is: Label for second' }),
     ).toBeInTheDocument();
 
+    mockDelayBeforeSaving(25);
     await userEvent.click(
       getRadio({ name: 'The value from the group is: Label for first' }),
     );
 
-    await new Promise((r) => setTimeout(r, debounceTime)); // Wait for debounce
+    expect(handleDataChange).not.toHaveBeenCalled();
+
+    await new Promise((r) => setTimeout(r, 25));
+    mockDelayBeforeSaving(undefined);
 
     expect(handleDataChange).toHaveBeenCalledWith(
       'Value for first',

--- a/src/altinn-app-frontend/src/components/base/RadioButtons/RadioButtonsContainerComponent.test.tsx
+++ b/src/altinn-app-frontend/src/components/base/RadioButtons/RadioButtonsContainerComponent.test.tsx
@@ -130,7 +130,7 @@ describe('RadioButtonsContainerComponent', () => {
     expect(handleChange).not.toHaveBeenCalled();
   });
 
-  it('should call handleDataChange with updated value after a delay when selection changes', async () => {
+  it('should call handleDataChange with updated value when selection changes', async () => {
     const handleChange = jest.fn();
     render({
       handleDataChange: handleChange,
@@ -149,12 +149,13 @@ describe('RadioButtonsContainerComponent', () => {
     expect(handleChange).not.toHaveBeenCalled();
 
     await new Promise((r) => setTimeout(r, 25));
-    mockDelayBeforeSaving(undefined);
 
     expect(handleChange).toHaveBeenCalledWith(
       'denmark',
       ...defaultHandleDataChangeProps,
     );
+
+    mockDelayBeforeSaving(undefined);
   });
 
   it('should call handleDataChange instantly on blur when the value has changed', async () => {
@@ -171,6 +172,9 @@ describe('RadioButtonsContainerComponent', () => {
     expect(denmark).toBeInTheDocument();
 
     await userEvent.click(denmark);
+
+    expect(handleChange).not.toHaveBeenCalled();
+
     fireEvent.blur(denmark);
 
     expect(handleChange).toHaveBeenCalledWith(
@@ -310,11 +314,12 @@ describe('RadioButtonsContainerComponent', () => {
     expect(handleDataChange).not.toHaveBeenCalled();
 
     await new Promise((r) => setTimeout(r, 25));
-    mockDelayBeforeSaving(undefined);
 
     expect(handleDataChange).toHaveBeenCalledWith(
       'Value for first',
       ...defaultHandleDataChangeProps,
     );
+
+    mockDelayBeforeSaving(undefined);
   });
 });

--- a/src/altinn-app-frontend/src/components/base/RadioButtons/radioButtonsUtils.ts
+++ b/src/altinn-app-frontend/src/components/base/RadioButtons/radioButtonsUtils.ts
@@ -77,6 +77,7 @@ export const useRadioButtons = ({
   const { value: selected, setValue } = useDelayedSavedState(
     handleDataChange,
     formData?.simpleBinding ?? '',
+    200,
   );
 
   React.useEffect(() => {
@@ -99,7 +100,6 @@ export const useRadioButtons = ({
   React.useEffect(() => {
     if (optionsHasChanged && formData.simpleBinding) {
       // New options have been loaded, we have to reset form data.
-      // We also skip any required validations
       setValue(undefined, true);
     }
   }, [setValue, optionsHasChanged, formData]);
@@ -108,8 +108,11 @@ export const useRadioButtons = ({
     setValue(event.target.value);
   };
 
-  const handleBlur = () => {
-    setValue(formData?.simpleBinding ?? '', true);
+  const handleBlur = (event: React.FocusEvent<HTMLInputElement>) => {
+    // Only set value instantly if moving focus outside of the radio group
+    if (!event.currentTarget.contains(event.relatedTarget)) {
+      setValue(selected, true);
+    }
   };
   return {
     handleChange,

--- a/src/altinn-app-frontend/src/components/base/RadioButtons/radioButtonsUtils.ts
+++ b/src/altinn-app-frontend/src/components/base/RadioButtons/radioButtonsUtils.ts
@@ -74,7 +74,11 @@ export const useRadioButtons = ({
       state.optionState.options[getOptionLookupKey({ id: optionsId, mapping })]
         ?.loading,
   );
-  const { value: selected, setValue } = useDelayedSavedState(
+  const {
+    value: selected,
+    setValue,
+    saveValue,
+  } = useDelayedSavedState(
     handleDataChange,
     formData?.simpleBinding ?? '',
     200,
@@ -111,7 +115,7 @@ export const useRadioButtons = ({
   const handleBlur = (event: React.FocusEvent<HTMLInputElement>) => {
     // Only set value instantly if moving focus outside of the radio group
     if (!event.currentTarget.contains(event.relatedTarget)) {
-      setValue(selected, true);
+      saveValue();
     }
   };
   return {

--- a/src/altinn-app-frontend/src/components/base/RadioButtons/radioButtonsUtils.ts
+++ b/src/altinn-app-frontend/src/components/base/RadioButtons/radioButtonsUtils.ts
@@ -4,6 +4,7 @@ import { makeStyles } from '@material-ui/core/styles';
 
 import { useAppSelector, useHasChangedIgnoreUndefined } from 'src/common/hooks';
 import { useGetOptions } from 'src/components/hooks';
+import { useDelayedSavedState } from 'src/components/hooks/useDelayedSavedState';
 import { getOptionLookupKey } from 'src/utils/options';
 import type { IRadioButtonsContainerProps } from 'src/components/base/RadioButtons/RadioButtonsContainerComponent';
 
@@ -62,7 +63,6 @@ export const useRadioButtons = ({
   mapping,
   source,
 }: IRadioButtonsContainerProps) => {
-  const selected = formData?.simpleBinding ?? '';
   const apiOptions = useGetOptions({ optionsId, mapping, source });
   const calculatedOptions = useMemo(
     () => apiOptions || options || [],
@@ -74,6 +74,10 @@ export const useRadioButtons = ({
       state.optionState.options[getOptionLookupKey({ id: optionsId, mapping })]
         ?.loading,
   );
+  const { value: selected, setValue } = useDelayedSavedState(
+    handleDataChange,
+    formData?.simpleBinding ?? '',
+  );
 
   React.useEffect(() => {
     const shouldPreselectItem =
@@ -83,12 +87,12 @@ export const useRadioButtons = ({
       preselectedOptionIndex < calculatedOptions.length;
     if (shouldPreselectItem) {
       const preSelectedValue = calculatedOptions[preselectedOptionIndex].value;
-      handleDataChange(preSelectedValue);
+      setValue(preSelectedValue, true);
     }
   }, [
     formData?.simpleBinding,
     calculatedOptions,
-    handleDataChange,
+    setValue,
     preselectedOptionIndex,
   ]);
 
@@ -96,12 +100,12 @@ export const useRadioButtons = ({
     if (optionsHasChanged && formData.simpleBinding) {
       // New options have been loaded, we have to reset form data.
       // We also skip any required validations
-      handleDataChange(undefined, 'simpleBinding', true);
+      setValue(undefined, true, true);
     }
-  }, [handleDataChange, optionsHasChanged, formData]);
+  }, [setValue, optionsHasChanged, formData]);
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    handleDataChange(event.target.value);
+    setValue(event.target.value);
   };
 
   const handleBlur = () => {

--- a/src/altinn-app-frontend/src/components/base/RadioButtons/radioButtonsUtils.ts
+++ b/src/altinn-app-frontend/src/components/base/RadioButtons/radioButtonsUtils.ts
@@ -100,7 +100,7 @@ export const useRadioButtons = ({
     if (optionsHasChanged && formData.simpleBinding) {
       // New options have been loaded, we have to reset form data.
       // We also skip any required validations
-      setValue(undefined, true, true);
+      setValue(undefined, true);
     }
   }, [setValue, optionsHasChanged, formData]);
 
@@ -109,7 +109,7 @@ export const useRadioButtons = ({
   };
 
   const handleBlur = () => {
-    handleDataChange(formData?.simpleBinding ?? '');
+    setValue(formData?.simpleBinding ?? '', true);
   };
   return {
     handleChange,

--- a/src/altinn-app-frontend/src/components/hooks/useDelayedSavedState.ts
+++ b/src/altinn-app-frontend/src/components/hooks/useDelayedSavedState.ts
@@ -10,7 +10,11 @@ export const mockDelayBeforeSaving = (newDelay: number) => {
 
 export interface DelayedSavedStateRetVal {
   value: string;
-  setValue: (newValue: string, saveImmediately?: boolean) => void;
+  setValue: (
+    newValue: string,
+    saveImmediately?: boolean,
+    skipValidation?: boolean,
+  ) => void;
   saveValue: () => void;
   onPaste: () => void;
 }
@@ -47,11 +51,14 @@ export function useDelayedSavedState(
 
   return {
     value: immediateState,
-    setValue: (newValue, saveImmediately) => {
+    setValue: (newValue, saveImmediately, skipValidation) => {
+      if (skipValidation && !saveImmediately) {
+        throw 'skipValidation is only supported when saving immediatly';
+      }
       setImmediateState(newValue);
       if (newValue !== formValue) {
         if (saveImmediately) {
-          handleDataChange(newValue, undefined, false, false);
+          handleDataChange(newValue, undefined, skipValidation, false);
         } else if (saveNextChangeImmediately) {
           // Save immediately on the next change event after a paste
           handleDataChange(newValue, undefined, false, false);

--- a/src/altinn-app-frontend/src/components/hooks/useDelayedSavedState.ts
+++ b/src/altinn-app-frontend/src/components/hooks/useDelayedSavedState.ts
@@ -10,11 +10,7 @@ export const mockDelayBeforeSaving = (newDelay: number) => {
 
 export interface DelayedSavedStateRetVal {
   value: string;
-  setValue: (
-    newValue: string,
-    saveImmediately?: boolean,
-    skipValidation?: boolean,
-  ) => void;
+  setValue: (newValue: string, saveImmediately?: boolean) => void;
   saveValue: () => void;
   onPaste: () => void;
 }
@@ -51,14 +47,11 @@ export function useDelayedSavedState(
 
   return {
     value: immediateState,
-    setValue: (newValue, saveImmediately, skipValidation) => {
-      if (skipValidation && !saveImmediately) {
-        throw 'skipValidation is only supported when saving immediatly';
-      }
+    setValue: (newValue, saveImmediately) => {
       setImmediateState(newValue);
       if (newValue !== formValue) {
         if (saveImmediately) {
-          handleDataChange(newValue, undefined, skipValidation, false);
+          handleDataChange(newValue, undefined, false, false);
         } else if (saveNextChangeImmediately) {
           // Save immediately on the next change event after a paste
           handleDataChange(newValue, undefined, false, false);

--- a/src/altinn-app-frontend/src/features/form/containers/GroupContainerLikert.test.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/GroupContainerLikert.test.tsx
@@ -1,6 +1,7 @@
 import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+import { mockDelayBeforeSaving } from 'src/components/hooks/useDelayedSavedState';
 import {
   createFormDataUpdateAction,
   createFormError,
@@ -135,29 +136,45 @@ describe('GroupContainer', () => {
       const btn2 = within(rad2).getByRole('radio', {
         name: /Dårlig/i,
       });
+
+      mockDelayBeforeSaving(25);
+
       mockStoreDispatch.mockClear();
       expect(btn1).not.toBeChecked();
       await userEvent.click(btn1);
+      expect(mockStoreDispatch).not.toHaveBeenCalled();
+      await new Promise((r) => setTimeout(r, 25));
       expect(mockStoreDispatch).toHaveBeenCalledWith(
         createFormDataUpdateAction(0, '1'),
       );
+
       mockStoreDispatch.mockClear();
       expect(btn2).not.toBeChecked();
       await userEvent.click(btn2);
-
+      expect(mockStoreDispatch).not.toHaveBeenCalledTimes(2);
+      await new Promise((r) => setTimeout(r, 25));
       expect(mockStoreDispatch).toHaveBeenCalledWith(
         createFormDataUpdateAction(1, '3'),
       );
+
+      mockDelayBeforeSaving(undefined);
     });
 
     it('should render standard view and use keyboard to navigate', async () => {
       const { mockStoreDispatch } = render();
       validateTableLayout(defaultMockQuestions);
+
+      mockDelayBeforeSaving(25);
+
       await userEvent.tab();
       await userEvent.keyboard('[Space]');
+      expect(mockStoreDispatch).not.toHaveBeenCalled();
+      await new Promise((r) => setTimeout(r, 25));
       expect(mockStoreDispatch).toHaveBeenCalledWith(
         createFormDataUpdateAction(0, '1'),
       );
+
+      mockDelayBeforeSaving(undefined);
     });
 
     it('should support nested binding for question text in data model', async () => {
@@ -229,8 +246,12 @@ describe('GroupContainer', () => {
         name: /Bra/i,
       });
 
+      mockDelayBeforeSaving(25);
+
       expect(btn1).not.toBeChecked();
       await userEvent.click(btn1);
+      expect(mockStoreDispatch).not.toHaveBeenCalled();
+      await new Promise((r) => setTimeout(r, 25));
       expect(mockStoreDispatch).toHaveBeenCalledWith(
         createFormDataUpdateAction(0, '1'),
       );
@@ -246,9 +267,13 @@ describe('GroupContainer', () => {
 
       expect(btn2).not.toBeChecked();
       await userEvent.click(btn2);
+      expect(mockStoreDispatch).not.toHaveBeenCalledTimes(2);
+      await new Promise((r) => setTimeout(r, 25));
       expect(mockStoreDispatch).toHaveBeenCalledWith(
         createFormDataUpdateAction(1, '3'),
       );
+
+      mockDelayBeforeSaving(undefined);
     });
 
     it('should render mobile view with selected values', () => {

--- a/src/altinn-app-frontend/src/features/form/containers/GroupContainerLikertTestUtils.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/GroupContainerLikertTestUtils.tsx
@@ -113,7 +113,7 @@ export const createFormDataUpdateAction = (
       data: optionValue,
       field: `Questions[${index}].Answer`,
       skipValidation: false,
-      checkIfRequired: true,
+      checkIfRequired: false,
     },
     type: FormDataActions.update.type,
   };

--- a/test/cypress/e2e/integration/app-frontend/likert.js
+++ b/test/cypress/e2e/integration/app-frontend/likert.js
@@ -24,9 +24,9 @@ describe('Likert', () => {
     likertPage.selectRadio(likertPage.optionalQuestions[0], likertPage.options[2]);
     likertPage.selectRadio(likertPage.optionalQuestions[1], likertPage.options[1]);
     likertPage.selectRadio(likertPage.optionalQuestions[2], likertPage.options[1]);
-    cy.findByTestId('summary-component').within(($summary) => {
-      cy.findByText(likertPage.optionalTableTitle);
+    cy.get('[data-testid=summary-component]').should(($summary) => {
       const text = $summary.text();
+      expect(text).to.contain(likertPage.optionalTableTitle);
       expect(text).to.contain(likertPage.optionalQuestions[0] + ' : ' + likertPage.options[2]);
       expect(text).to.contain(likertPage.optionalQuestions[1] + ' : ' + likertPage.options[1]);
       expect(text).to.contain(likertPage.optionalQuestions[2] + ' : ' + likertPage.options[1]);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The original issue was only concerned with checkbox-groups, but similar issues where also present with dropdown and radio-buttons. The useDelayedSavedState hook is now used for checkbox-groups, radio-buttons, and dropdown. This prevents the premature onBlur validation as it only calls handleDataChange if the data has actually changed. This means that tabbing through the form without editing will no longer trigger validation for these components as is already the case with text-inputs. Additionally, it was previously possible to spam the backend with validation requests by holding an arrow-key in a radiobutton group (switching the input very quickly). The useDelayedSavedState hook mitigates this issue as well.

## Related Issue(s)
- #237 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
