### PR TITLE
bug: fix getHostname for new local test url

### DIFF
--- a/src/altinn-app-frontend/src/utils/appUrlHelper.test.ts
+++ b/src/altinn-app-frontend/src/utils/appUrlHelper.test.ts
@@ -205,6 +205,13 @@ describe('Frontend urlHelper.ts', () => {
         expect(getHostname()).toEqual('altinn3local.no');
       });
 
+      it('should return correct hostname for new local test url', () => {
+        resetWindow({
+          host: 'local.altinn.cloud',
+        });
+        expect(getHostname()).toEqual('local.altinn.cloud');
+      });
+
       it('should throw error when hostname has 3 parts', () => {
         resetWindow({
           host: 'apps.altinn.no',

--- a/src/altinn-app-frontend/src/utils/appUrlHelper.ts
+++ b/src/altinn-app-frontend/src/utils/appUrlHelper.ts
@@ -101,8 +101,8 @@ export const getHostname = () => {
   if (domainSplitted.length === 4) {
     return `${domainSplitted[2]}.${domainSplitted[3]}`;
   }
-  if (domainSplitted.length === 2 && domainSplitted[0] === 'altinn3local') {
-    // Local test
+  if (domainSplitted[0] === 'altinn3local' || domainSplitted[0] === 'local') {
+    // Local test, needs to be backward compat with users who uses old local test
     return window.location.host;
   }
   throw new Error('Unknown domain');


### PR DESCRIPTION
## Description

Quick and dirty fix for `getHostname` function that failed using newest local test url (local.altinn.cloud) and latest app frontend prod build.

Some of these methods could probably be cleaned up, but I did not take the time to evaluate if the throwing of errors are used for anything. 

Fix and forget. 
