### PR TITLE
Null-checking for currentTask

### DIFF
--- a/src/altinn-app-frontend/src/utils/appMetadata.ts
+++ b/src/altinn-app-frontend/src/utils/appMetadata.ts
@@ -122,7 +122,11 @@ export const getCurrentDataTypeId = (
   instance: IInstance,
   layoutSets: ILayoutSets,
 ) => {
-  const currentTaskId = instance.process.currentTask.elementId;
+  const currentTaskId = instance.process.currentTask?.elementId;
+  if (currentTaskId === null || currentTaskId === undefined) {
+    return undefined;
+  }
+
   return (
     layoutSets?.sets.find((set) => set.tasks?.includes(currentTaskId))
       ?.dataType ||

--- a/src/shared/src/types/index.ts
+++ b/src/shared/src/types/index.ts
@@ -190,7 +190,7 @@ export interface IPerson {
 export interface IProcess {
   started: string;
   startEvent: string;
-  currentTask: ITask;
+  currentTask?: ITask;
   ended: string;
   endEvent: string;
 }


### PR DESCRIPTION
## Description
#483 introduced code that could fail when `currentTask` was `null`/`undefined` which could crash the receipt page for (older?) apps. [See slack thread here](https://app.slack.com/client/TCQRNBDHS/C02FK32FBR6/thread/C02FK32FBR6-1664794330.261989).

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- ~~[ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~
