### PR TITLE
Docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ React SPA used by applications developed in [altinn-studio](https://github.com/A
 
 ## Prerequisites
 
+### Docker
+If you can't/won't install node on your computer, you can also run frontend in docker using the command.
+
+```bash
+docker compose up
+```
+This is really slow to start and rebuild, but sometimes better than getting someone to install node if you just want to test if a new branch fixes an issue.
+
 ### Node and Corepack
 
 - Latest [Node LTS release](https://nodejs.org/en/)
@@ -24,11 +32,20 @@ git clone https://github.com/Altinn/app-frontend-react
 cd app-frontend-react
 ```
 
+The development server can be started by following these steps:
+
+- Navigate to `./src/altinn-app-frontend`
+- `yarn --immutable` (only needed when `package.json` has changed)
+- `yarn start` (to start the development server)
+
 ### Developing app-frontend
 
-You need an Altinn app to effectively make changes to the app-frontend codebase. To serve the development version of app-frontend code, you need to make some changes to `views/Home/Index.cshtml` in the app repo you are using:
+You need an Altinn app to effectively make changes to the app-frontend codebase.
 
-Change
+Localtest now includes a way to avoid editing your app to use different frontends [see docs](https://docs.altinn.studio/app/testing/local/debug/#using-other-frontend-versions)
+
+
+If you want to test in `tt02` or other places, you need to make some changes to `views/Home/Index.cshtml` in the app repo you are using:
 
 ```html
 <link
@@ -52,11 +69,7 @@ to
 <script src="http://localhost:8080/altinn-app-frontend.js"></script>
 ```
 
-This will make the browser request the files from the local development server. The development server can be started by following these steps:
-
-- Navigate to `./src/altinn-app-frontend`
-- `yarn --immutable` (only needed when `package.json` has changed)
-- `yarn start` (to start the development server)
+This will make the browser request the files from the local development server.
 
 In addition, you need to serve the app from somewhere. There are two ways of doing this, either deploy the application via Altinn Studio, or run the app locally on your machine.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.6'
+
+services:
+  webpack:
+    container_name: name
+    image: node:16
+    volumes:
+      - ./:/usr/src/app
+    working_dir: /usr/src/app/src/altinn-app-frontend
+    command: bash -c "yarn --immutable && yarn docker"
+    ports:
+      - "8080:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.6'
 
 services:
   webpack:
-    container_name: name
+    container_name: altinn-app-frontend
     image: node:16
     volumes:
       - ./:/usr/src/app

--- a/src/altinn-app-frontend/package.json
+++ b/src/altinn-app-frontend/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "cross-env NODE_ENV=development webpack-dev-server --config webpack.config.development.js --mode development --progress",
     "build": "cross-env NODE_ENV=production webpack --config webpack.config.production.js --progress",
+    "docker": "cross-env NODE_ENV=development webpack-dev-server --config webpack.config.docker.js --mode development --progress",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:watchall": "jest --watchAll",

--- a/src/altinn-app-frontend/webpack.config.docker.js
+++ b/src/altinn-app-frontend/webpack.config.docker.js
@@ -1,0 +1,13 @@
+const common = require('./webpack.config.development');
+
+module.exports = {
+  ...common,
+  devServer: {
+    ...common.devServer,
+    host: '0.0.0.0', // docker needs to bind to public interface in container
+  },
+  watchOptions: {
+    ignored: ['**/node_modules', '**/.git', '**/dist'],
+    poll: 60000,
+  },
+};


### PR DESCRIPTION
## Description
Re-merging #492 onto `main` (it was merged into `feat/layout-expressions` by mistake). I experimented with building an image containing (and caching) `node_modules`, but it got a bit too messy. Keeping the feature as-is, just fixing the container name.

## Related Issue(s)
- #492

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
