### PR TITLE
Bug: Tests failing when removing altinn3local.no from hosts

### DIFF
--- a/src/altinn-app-frontend/__mocks__/instanceDataStateMock.ts
+++ b/src/altinn-app-frontend/__mocks__/instanceDataStateMock.ts
@@ -39,9 +39,9 @@ export function getInstanceDataStateMock(
           blobStoragePath:
             'mockOrg/mockApp/b174e1f8-135c-4419-bd1c-fd171a0af1fe/data/917e7e06-2665-4307-8c05-b0accd8964c6',
           selfLinks: {
-            apps: 'https://altinn3local.no/mockOrg/mockApp/instances/501337/b174e1f8-135c-4419-bd1c-fd171a0af1fe/data/917e7e06-2665-4307-8c05-b0accd8964c6',
+            apps: 'https://local.altinn.cloud/mockOrg/mockApp/instances/501337/b174e1f8-135c-4419-bd1c-fd171a0af1fe/data/917e7e06-2665-4307-8c05-b0accd8964c6',
             platform:
-              'https://platform.altinn3local.no/storage/api/v1/instances/501337/b174e1f8-135c-4419-bd1c-fd171a0af1fe/data/917e7e06-2665-4307-8c05-b0accd8964c6',
+              'https://platform.local.altinn.cloud/storage/api/v1/instances/501337/b174e1f8-135c-4419-bd1c-fd171a0af1fe/data/917e7e06-2665-4307-8c05-b0accd8964c6',
           },
           size: 3537,
           locked: false,

--- a/src/altinn-app-frontend/package.json
+++ b/src/altinn-app-frontend/package.json
@@ -128,7 +128,7 @@
       "src/**/*.{ts,tsx}"
     ],
     "testEnvironmentOptions": {
-      "url": "https://altinn3local.no/ttd/test"
+      "url": "https://local.altinn.cloud/ttd/test"
     },
     "testEnvironment": "jsdom",
     "transformIgnorePatterns": [

--- a/src/altinn-app-frontend/src/features/instantiate/containers/InstanceSelection.test.tsx
+++ b/src/altinn-app-frontend/src/features/instantiate/containers/InstanceSelection.test.tsx
@@ -113,7 +113,7 @@ describe('InstanceSelection', () => {
     const row = screen.getByRole('row', {
       name: /10\/05\/2021 navn navnesen fortsett her/i,
     });
-    expect(window.location.href).toBe('https://altinn3local.no/ttd/test');
+    expect(window.location.href).toBe('https://local.altinn.cloud/ttd/test');
 
     const button = within(row).getByRole('button', {
       name: /fortsett her/i,
@@ -121,7 +121,7 @@ describe('InstanceSelection', () => {
 
     await user.click(button);
     expect(window.location.href).toBe(
-      'https://altinn3local.no/ttd/test#/instance/some-id',
+      'https://local.altinn.cloud/ttd/test#/instance/some-id',
     );
   });
 
@@ -137,7 +137,7 @@ describe('InstanceSelection', () => {
       name: /sist endret 05\/13\/2021/i,
     });
     expect(window.location.href).toBe(
-      'https://altinn3local.no/ttd/test#/instance/some-id',
+      'https://local.altinn.cloud/ttd/test#/instance/some-id',
     );
 
     const button = within(row).getByRole('button', {
@@ -146,7 +146,7 @@ describe('InstanceSelection', () => {
 
     await user.click(button);
     expect(window.location.href).toBe(
-      'https://altinn3local.no/ttd/test#/instance/some-other-id',
+      'https://local.altinn.cloud/ttd/test#/instance/some-other-id',
     );
   });
 });

--- a/src/altinn-app-frontend/src/features/receipt/containers/ReceiptContainer.test.tsx
+++ b/src/altinn-app-frontend/src/features/receipt/containers/ReceiptContainer.test.tsx
@@ -59,8 +59,8 @@ function getMockState({ autoDeleteOnProcessEnd = false, hasPdf = true }) {
           contentType: 'application/pdf',
           blobStoragePath: `ttd/ui-components/${exampleGuid}/data/${exampleDataGuid}`,
           selfLinks: {
-            apps: `https://altinn3local.no/ttd/ui-components/instances/${exampleInstanceId}/data/${exampleDataGuid}`,
-            platform: `https://platform.altinn3local.no/storage/api/v1/instances/${exampleInstanceId}/data/${exampleDataGuid}`,
+            apps: `https://local.altinn.cloud/ttd/ui-components/instances/${exampleInstanceId}/data/${exampleDataGuid}`,
+            platform: `https://platform.local.altinn.cloud/storage/api/v1/instances/${exampleInstanceId}/data/${exampleDataGuid}`,
           },
           size: 15366,
           locked: false,
@@ -121,8 +121,8 @@ function getMockState({ autoDeleteOnProcessEnd = false, hasPdf = true }) {
             contentType: 'application/xml',
             blobStoragePath: `ttd/ui-components/${exampleGuid}/data/${exampleDataGuid2}`,
             selfLinks: {
-              apps: `https://altinn3local.no/ttd/ui-components/instances/${exampleInstanceId}/data/${exampleDataGuid2}`,
-              platform: `https://platform.altinn3local.no/storage/api/v1/instances/${exampleInstanceId}/data/${exampleDataGuid2}`,
+              apps: `https://local.altinn.cloud/ttd/ui-components/instances/${exampleInstanceId}/data/${exampleDataGuid2}`,
+              platform: `https://platform.local.altinn.cloud/storage/api/v1/instances/${exampleInstanceId}/data/${exampleDataGuid2}`,
             },
             size: 1254,
             locked: true,

--- a/src/altinn-app-frontend/src/shared/containers/Presentation.test.tsx
+++ b/src/altinn-app-frontend/src/shared/containers/Presentation.test.tsx
@@ -72,7 +72,7 @@ describe('Presentation', () => {
   });
 
   it('should change window.location.href to default messagebox url if query parameter returnUrl is not valid', async () => {
-    const origin = 'https://altinn3local.no';
+    const origin = 'https://local.altinn.cloud';
     const returnUrl = 'https://altinn.cloud.no';
     (axios.get as jest.Mock).mockRejectedValue({
       data: 'Error',
@@ -106,7 +106,7 @@ describe('Presentation', () => {
   });
 
   it('should change window.location.href to default messagebox url if query parameter returnUrl is not found', async () => {
-    const origin = 'https://altinn3local.no';
+    const origin = 'https://local.altinn.cloud';
     Object.defineProperty(window, 'location', {
       value: {
         ...window,

--- a/src/altinn-app-frontend/src/utils/appUrlHelper.test.ts
+++ b/src/altinn-app-frontend/src/utils/appUrlHelper.test.ts
@@ -29,70 +29,70 @@ describe('Frontend urlHelper.ts', () => {
   describe('constants', () => {
     it('should return the expected url for validPartiesUrl', () => {
       expect(validPartiesUrl).toBe(
-        'https://altinn3local.no/ttd/test/api/v1/parties?allowedtoinstantiatefilter=true',
+        'https://local.altinn.cloud/ttd/test/api/v1/parties?allowedtoinstantiatefilter=true',
       );
     });
     it('should return the expected url for updateCookieUrl', () => {
       expect(updateCookieUrl('12345')).toBe(
-        'https://altinn3local.no/ttd/test/api/v1/parties/12345',
+        'https://local.altinn.cloud/ttd/test/api/v1/parties/12345',
       );
     });
     it('should return the expected url for textResourcesUrl', () => {
       expect(textResourcesUrl('nb')).toBe(
-        'https://altinn3local.no/ttd/test/api/v1/texts/nb',
+        'https://local.altinn.cloud/ttd/test/api/v1/texts/nb',
       );
     });
     it('should return the expected url for fileUploadUrl', () => {
       expect(fileUploadUrl('dataGuid')).toBe(
-        'https://altinn3local.no/ttd/test/instances/12345/instanceId-1234/data?dataType=dataGuid',
+        'https://local.altinn.cloud/ttd/test/instances/12345/instanceId-1234/data?dataType=dataGuid',
       );
     });
     it('should return the expected url for fileTagUrl', () => {
       expect(fileTagUrl('dataGuid')).toBe(
-        'https://altinn3local.no/ttd/test/instances/12345/instanceId-1234/data/dataGuid/tags',
+        'https://local.altinn.cloud/ttd/test/instances/12345/instanceId-1234/data/dataGuid/tags',
       );
     });
     it('should return the expected url for dataElementUrl', () => {
       expect(dataElementUrl('dataGuid')).toBe(
-        'https://altinn3local.no/ttd/test/instances/12345/instanceId-1234/data/dataGuid',
+        'https://local.altinn.cloud/ttd/test/instances/12345/instanceId-1234/data/dataGuid',
       );
     });
     it('should return the expected url for getProcessStateUrl', () => {
       expect(getProcessStateUrl()).toBe(
-        'https://altinn3local.no/ttd/test/instances/12345/instanceId-1234/process',
+        'https://local.altinn.cloud/ttd/test/instances/12345/instanceId-1234/process',
       );
     });
     it('should return the expected url for getCreateInstancesUrl', () => {
       expect(getCreateInstancesUrl('12345')).toBe(
-        'https://altinn3local.no/ttd/test/instances?instanceOwnerPartyId=12345',
+        'https://local.altinn.cloud/ttd/test/instances?instanceOwnerPartyId=12345',
       );
     });
     it('should return the expected url for getValidationUrl', () => {
       expect(getValidationUrl('12345/instanceId-1234')).toBe(
-        'https://altinn3local.no/ttd/test/instances/12345/instanceId-1234/validate',
+        'https://local.altinn.cloud/ttd/test/instances/12345/instanceId-1234/validate',
       );
     });
     it('should return the expected url for getDataValidationUrl', () => {
       expect(getDataValidationUrl('12345/instanceId-1234', 'dataGuid')).toBe(
-        'https://altinn3local.no/ttd/test/instances/12345/instanceId-1234/data/dataGuid/validate',
+        'https://local.altinn.cloud/ttd/test/instances/12345/instanceId-1234/data/dataGuid/validate',
       );
     });
     it('should return the expected url for getProcessNextUrl', () => {
       expect(getProcessNextUrl('taskId')).toBe(
-        'https://altinn3local.no/ttd/test/instances/12345/instanceId-1234/process/next?elementId=taskId',
+        'https://local.altinn.cloud/ttd/test/instances/12345/instanceId-1234/process/next?elementId=taskId',
       );
       expect(getProcessNextUrl()).toBe(
-        'https://altinn3local.no/ttd/test/instances/12345/instanceId-1234/process/next',
+        'https://local.altinn.cloud/ttd/test/instances/12345/instanceId-1234/process/next',
       );
     });
     it('should return the expected url for getRedirectUrl', () => {
       expect(getRedirectUrl('http://www.nrk.no')).toBe(
-        'https://altinn3local.no/ttd/test/api/v1/redirect?url=http%3A%2F%2Fwww.nrk.no',
+        'https://local.altinn.cloud/ttd/test/api/v1/redirect?url=http%3A%2F%2Fwww.nrk.no',
       );
     });
     it('should return the expected url for getUpgradeAuthLevelUrl', () => {
       expect(getUpgradeAuthLevelUrl('overlord')).toBe(
-        'https://altinn3local.no/ui/authentication/upgrade?goTo=https%3A%2F%2Fplatform.altinn3local.no%2Fauthentication%2Fapi%2Fv1%2Fauthentication%3Fgoto%3Dhttps%3A%2F%2Faltinn3local.no%2Fttd%2Ftest&reqAuthLevel=overlord',
+        'https://local.altinn.cloud/ui/authentication/upgrade?goTo=https%3A%2F%2Fplatform.local.altinn.cloud%2Fauthentication%2Fapi%2Fv1%2Fauthentication%3Fgoto%3Dhttps%3A%2F%2Flocal.altinn.cloud%2Fttd%2Ftest&reqAuthLevel=overlord',
       );
     });
   });
@@ -117,7 +117,7 @@ describe('Frontend urlHelper.ts', () => {
       it('should return the expected url for getUpgradeAuthLevelUrl', () => {
         resetWindow();
         expect(getUpgradeAuthLevelUrl('overlord')).toBe(
-          'https://altinn.no/ui/authentication/upgrade?goTo=https%3A%2F%2Fplatform.altinn.no%2Fauthentication%2Fapi%2Fv1%2Fauthentication%3Fgoto%3Dhttps%3A%2F%2Faltinn3local.no%2Fttd%2Ftest&reqAuthLevel=overlord',
+          'https://altinn.no/ui/authentication/upgrade?goTo=https%3A%2F%2Fplatform.altinn.no%2Fauthentication%2Fapi%2Fv1%2Fauthentication%3Fgoto%3Dhttps%3A%2F%2Flocal.altinn.cloud%2Fttd%2Ftest&reqAuthLevel=overlord',
         );
       });
       it('changes the window location', () => {
@@ -127,7 +127,7 @@ describe('Frontend urlHelper.ts', () => {
         );
         redirectToUpgrade('overlord');
         expect(window.location.href).toBe(
-          'https://altinn.no/ui/authentication/upgrade?goTo=https%3A%2F%2Fplatform.altinn.no%2Fauthentication%2Fapi%2Fv1%2Fauthentication%3Fgoto%3Dhttps%3A%2F%2Faltinn3local.no%2Fttd%2Ftest&reqAuthLevel=overlord',
+          'https://altinn.no/ui/authentication/upgrade?goTo=https%3A%2F%2Fplatform.altinn.no%2Fauthentication%2Fapi%2Fv1%2Fauthentication%3Fgoto%3Dhttps%3A%2F%2Flocal.altinn.cloud%2Fttd%2Ftest&reqAuthLevel=overlord',
         );
       });
     });
@@ -200,9 +200,9 @@ describe('Frontend urlHelper.ts', () => {
 
       it('should return correct hostname when host has 2 domain parts, and the first part is "altinn3local"', () => {
         resetWindow({
-          host: 'altinn3local.no',
+          host: 'local.altinn.cloud',
         });
-        expect(getHostname()).toEqual('altinn3local.no');
+        expect(getHostname()).toEqual('local.altinn.cloud');
       });
 
       it('should return correct hostname for new local test url', () => {
@@ -235,7 +235,7 @@ describe('Frontend urlHelper.ts', () => {
       });
 
       expect(result).toEqual(
-        'https://altinn3local.no/ttd/test/api/options/county',
+        'https://local.altinn.cloud/ttd/test/api/options/county',
       );
     });
 
@@ -246,7 +246,7 @@ describe('Frontend urlHelper.ts', () => {
       });
 
       expect(result).toEqual(
-        'https://altinn3local.no/ttd/test/api/options/county?language=en',
+        'https://local.altinn.cloud/ttd/test/api/options/county?language=en',
       );
     });
 
@@ -262,7 +262,7 @@ describe('Frontend urlHelper.ts', () => {
       });
 
       expect(result).toEqual(
-        'https://altinn3local.no/ttd/test/api/options/country?selectedCountry=Norway',
+        'https://local.altinn.cloud/ttd/test/api/options/country?selectedCountry=Norway',
       );
     });
 
@@ -281,7 +281,7 @@ describe('Frontend urlHelper.ts', () => {
       });
 
       expect(result).toEqual(
-        'https://altinn3local.no/ttd/test/api/options/country?language=en&selectedCountry=Norway&selectedPostCode=0123',
+        'https://local.altinn.cloud/ttd/test/api/options/country?language=en&selectedCountry=Norway&selectedPostCode=0123',
       );
     });
 
@@ -302,7 +302,7 @@ describe('Frontend urlHelper.ts', () => {
       });
 
       expect(result).toEqual(
-        'https://altinn3local.no/ttd/test/instances/someInstanceId/options/country?language=en&selectedCountry=Norway&selectedPostCode=0123',
+        'https://local.altinn.cloud/ttd/test/instances/someInstanceId/options/country?language=en&selectedCountry=Norway&selectedPostCode=0123',
       );
     });
 
@@ -314,7 +314,7 @@ describe('Frontend urlHelper.ts', () => {
       });
 
       expect(result).toEqual(
-        'https://altinn3local.no/ttd/test/instances/someInstanceId/options/country',
+        'https://local.altinn.cloud/ttd/test/instances/someInstanceId/options/country',
       );
     });
   });
@@ -324,7 +324,7 @@ describe('Frontend urlHelper.ts', () => {
       const result = getRulehandlerUrl(null);
 
       expect(result).toBe(
-        'https://altinn3local.no/ttd/test/api/resource/RuleHandler.js',
+        'https://local.altinn.cloud/ttd/test/api/resource/RuleHandler.js',
       );
     });
 
@@ -332,7 +332,7 @@ describe('Frontend urlHelper.ts', () => {
       const result = getRulehandlerUrl('custom-handler.js');
 
       expect(result).toBe(
-        'https://altinn3local.no/ttd/test/api/rulehandler/custom-handler.js',
+        'https://local.altinn.cloud/ttd/test/api/rulehandler/custom-handler.js',
       );
     });
   });
@@ -342,14 +342,14 @@ describe('Frontend urlHelper.ts', () => {
       const result = getCalculatePageOrderUrl(false);
 
       expect(result).toBe(
-        'https://altinn3local.no/ttd/test/instances/12345/instanceId-1234/pages/order',
+        'https://local.altinn.cloud/ttd/test/instances/12345/instanceId-1234/pages/order',
       );
     });
 
     it('should return stateless url if stateless is true', () => {
       const result = getCalculatePageOrderUrl(true);
 
-      expect(result).toBe('https://altinn3local.no/ttd/test/v1/pages/order');
+      expect(result).toBe('https://local.altinn.cloud/ttd/test/v1/pages/order');
     });
   });
 
@@ -358,7 +358,7 @@ describe('Frontend urlHelper.ts', () => {
       const result = getLayoutsUrl(null);
 
       expect(result).toBe(
-        'https://altinn3local.no/ttd/test/api/resource/FormLayout.json',
+        'https://local.altinn.cloud/ttd/test/api/resource/FormLayout.json',
       );
     });
 
@@ -366,7 +366,7 @@ describe('Frontend urlHelper.ts', () => {
       const result = getLayoutsUrl('custom-layout.json');
 
       expect(result).toBe(
-        'https://altinn3local.no/ttd/test/api/layouts/custom-layout.json',
+        'https://local.altinn.cloud/ttd/test/api/layouts/custom-layout.json',
       );
     });
   });
@@ -376,7 +376,7 @@ describe('Frontend urlHelper.ts', () => {
       const result = getLayoutSettingsUrl(null);
 
       expect(result).toBe(
-        'https://altinn3local.no/ttd/test/api/layoutsettings',
+        'https://local.altinn.cloud/ttd/test/api/layoutsettings',
       );
     });
 
@@ -384,7 +384,7 @@ describe('Frontend urlHelper.ts', () => {
       const result = getLayoutSettingsUrl('custom-layout.json');
 
       expect(result).toBe(
-        'https://altinn3local.no/ttd/test/api/layoutsettings/custom-layout.json',
+        'https://local.altinn.cloud/ttd/test/api/layoutsettings/custom-layout.json',
       );
     });
   });
@@ -395,7 +395,7 @@ describe('Frontend urlHelper.ts', () => {
       const undefinedResult = getFetchFormDynamicsUrl();
 
       const expected =
-        'https://altinn3local.no/ttd/test/api/resource/RuleConfiguration.json';
+        'https://local.altinn.cloud/ttd/test/api/resource/RuleConfiguration.json';
 
       expect(nullResult).toBe(expected);
       expect(undefinedResult).toBe(expected);
@@ -405,7 +405,7 @@ describe('Frontend urlHelper.ts', () => {
       const result = getFetchFormDynamicsUrl('custom-rule.json');
 
       expect(result).toBe(
-        'https://altinn3local.no/ttd/test/api/ruleconfiguration/custom-rule.json',
+        'https://local.altinn.cloud/ttd/test/api/ruleconfiguration/custom-rule.json',
       );
     });
   });
@@ -416,7 +416,7 @@ describe('Frontend urlHelper.ts', () => {
       const nullResult = getStatelessFormDataUrl(dataType, null);
       const undefinedResult = getStatelessFormDataUrl(dataType);
 
-      const expected = `https://altinn3local.no/ttd/test/v1/data?dataType=${dataType}`;
+      const expected = `https://local.altinn.cloud/ttd/test/v1/data?dataType=${dataType}`;
 
       expect(nullResult).toBe(expected);
       expect(undefinedResult).toBe(expected);
@@ -424,13 +424,13 @@ describe('Frontend urlHelper.ts', () => {
 
     it('should return anonymous url when anonymous is passed as true', () => {
       const trueResult = getStatelessFormDataUrl(dataType, true);
-      const expected = `https://altinn3local.no/ttd/test/v1/data/anonymous?dataType=${dataType}`;
+      const expected = `https://local.altinn.cloud/ttd/test/v1/data/anonymous?dataType=${dataType}`;
       expect(trueResult).toBe(expected);
     });
 
     it('should return default url when anonymous is passed as false', () => {
       const trueResult = getStatelessFormDataUrl(dataType, false);
-      const expected = `https://altinn3local.no/ttd/test/v1/data?dataType=${dataType}`;
+      const expected = `https://local.altinn.cloud/ttd/test/v1/data?dataType=${dataType}`;
       expect(trueResult).toBe(expected);
     });
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When removing `altinn3local.no` from hosts file two tests started failing locally: one in `InstantiationButton.test.tsx`, and one in `ConfirmPage.test.tsx`:
![image](https://user-images.githubusercontent.com/47412359/193775465-23cbb6eb-e571-4ae0-b77b-ee63d031f6e3.png)

There are still many references to `altinn3local.no` in several unit tests, in `instanceDataStateMock.ts` and in `package.json`. I did a simple search and replace to update these to use the new `local.altinn.cloud`, and now all of the unit tests run fine locally without the entry in the hosts file.

I am not sure whether there are any other notable consequences to these changes so please look through them thoroughly.


## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
