### PR TITLE
fix to make sure page doesn't crash

### DIFF
--- a/src/altinn-app-frontend/src/utils/databindings.ts
+++ b/src/altinn-app-frontend/src/utils/databindings.ts
@@ -133,6 +133,11 @@ export function getIndexCombinations(
   }
 
   const repeatingGroupValues = Object.values(repeatingGroups);
+
+  if (!repeatingGroupValues.length) {
+    return combinations;
+  }
+
   const mainGroupMaxIndex = repeatingGroupValues.find(
     (group) => group.dataModelBinding === baseGroupBindings[0],
   ).index;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add a check for empty repeating groups to avoid page crashing if repeating groups are not loaded before options start fetching - this is relevant when app uses dynamic options with mapping to field in repeating group. This also only happens when going TO a data task (using dynamic options w/mapping) FROM a confirmation task. Have not tested going FROM other task types, although it might be a problem then to 🤷‍♀️ 

The root issue still needs to be fixed

## Related Issue(s)
- #511 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
