### PR TITLE
Feat/396 Open by default with prefill

### DIFF
--- a/src/altinn-app-frontend/src/features/form/containers/GroupContainer.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/GroupContainer.tsx
@@ -223,7 +223,7 @@ export function GroupContainer({
         layoutElementId: id,
         remove: true,
         index: groupIndex,
-        leaveOpen: container.edit?.openByDefault,
+        leaveOpen: !!container.edit?.openByDefault,
       }),
     );
   };

--- a/src/altinn-app-frontend/src/features/form/layout/index.ts
+++ b/src/altinn-app-frontend/src/features/form/layout/index.ts
@@ -325,7 +325,7 @@ export interface IGroupEditProperties {
   saveButton?: boolean;
   deleteButton?: boolean;
   multiPage?: boolean;
-  openByDefault?: boolean;
+  openByDefault?: boolean | 'first' | 'last';
 }
 
 export interface IGroupFilter {

--- a/src/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
+++ b/src/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
@@ -670,22 +670,24 @@ export function* initRepeatingGroupsSaga(): SagaIterator {
   }
 
   // Open by default
-  const formLayoutState: ILayoutState = yield select(selectFormLayoutState);
   const newGroupKeys = Object.keys(newGroups || {});
+  const groupContainers = Object.values(state.formLayout.layouts)
+    .flatMap((e) => e)
+    .filter((e) => e.type === 'Group');
+
   newGroupKeys.forEach((key) => {
     const group = newGroups[key];
+    const container = groupContainers.find(
+      (element) => element.id === key,
+    ) as ILayoutGroup;
 
-    const groupContainer: ILayoutGroup = Object.values(formLayoutState.layouts)
-      .flatMap((e) => e)
-      .find((element) => element.id === key) as ILayoutGroup;
-
-    if (groupContainer && group.index >= 0) {
+    if (container && group.index >= 0) {
       if (
-        groupContainer.edit.openByDefault === true ||
-        groupContainer.edit.openByDefault === 'first'
+        container.edit.openByDefault === true ||
+        container.edit.openByDefault === 'first'
       ) {
         group.editIndex = 0;
-      } else if (groupContainer.edit.openByDefault === 'last') {
+      } else if (container.edit.openByDefault === 'last') {
         group.editIndex = group.index;
       }
     }

--- a/src/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
+++ b/src/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
@@ -668,6 +668,29 @@ export function* initRepeatingGroupsSaga(): SagaIterator {
     }
     yield put(ValidationActions.updateValidations({ validations }));
   }
+
+  // Open by default
+  const formLayoutState: ILayoutState = yield select(selectFormLayoutState);
+  const newGroupKeys = Object.keys(newGroups || {});
+  newGroupKeys.forEach((key) => {
+    const group = newGroups[key];
+
+    const groupContainer: ILayoutGroup = Object.values(formLayoutState.layouts)
+      .flatMap((e) => e)
+      .find((element) => element.id === key) as ILayoutGroup;
+
+    if (groupContainer && group.index >= 0) {
+      if (
+        groupContainer.edit.openByDefault === true ||
+        groupContainer.edit.openByDefault === 'first'
+      ) {
+        group.editIndex = 0;
+      } else if (groupContainer.edit.openByDefault === 'last') {
+        group.editIndex = group.index;
+      }
+    }
+  });
+
   // preserve current edit index if still valid
   currentGroupKeys
     .filter((key) => !groupsToRemoveValidations.includes(key))

--- a/src/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
+++ b/src/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
@@ -682,10 +682,7 @@ export function* initRepeatingGroupsSaga(): SagaIterator {
     ) as ILayoutGroup;
 
     if (container && group.index >= 0) {
-      if (
-        container.edit.openByDefault === true ||
-        container.edit.openByDefault === 'first'
-      ) {
+      if (container.edit.openByDefault === 'first') {
         group.editIndex = 0;
       } else if (container.edit.openByDefault === 'last') {
         group.editIndex = group.index;

--- a/test/cypress/e2e/integration/app-frontend/group.js
+++ b/test/cypress/e2e/integration/app-frontend/group.js
@@ -25,7 +25,7 @@ describe('Group', () => {
   [true, false].forEach((openByDefault) => {
     it(`Add and delete items on main and nested group (openByDefault = ${openByDefault ? 'true' : 'false'})`, () => {
       cy.interceptLayout('group', (component) => {
-        if (component.edit && component.edit.openByDefault !== undefined) {
+        if (component.edit && typeof component.edit.openByDefault !== 'undefined') {
           component.edit.openByDefault = openByDefault;
         }
         return component;
@@ -33,9 +33,6 @@ describe('Group', () => {
       init();
 
       cy.get(appFrontend.group.showGroupToContinue).find('input').check();
-      if (!openByDefault) {
-        cy.get(appFrontend.group.addNewItem).should('be.visible').focus().click();
-      }
       cy.addItemToGroup(1, 2, 'automation', openByDefault);
       cy.get(appFrontend.group.mainGroup)
         .find(mui.tableBody)
@@ -230,25 +227,21 @@ describe('Group', () => {
     cy.get(appFrontend.group.sendersName).should('exist');
   });
 
-  ['first', 'last', true, false].forEach((openByDefault) => {
-    it(`Open by default on prefilled group (openByDefault = ${openByDefault})`, () => {
+  it('Open by default on prefilled group (openByDefault = [\'first\', \'last\', true, false])', () => {
+    init();
+
+    cy.get(appFrontend.group.showGroupToContinue).find('input').check();
+    cy.addItemToGroup(1, 2, 'item 1');
+    cy.addItemToGroup(20, 30, 'item 2');
+    cy.addItemToGroup(400, 600, 'item 3');
+
+    ['first', 'last', true, false].forEach((openByDefault) => {
       cy.interceptLayout('group', (component) => {
         if (component.edit && component.edit.openByDefault !== undefined) {
           component.edit.openByDefault = openByDefault;
         }
         return component;
       });
-      init();
-
-      cy.get(appFrontend.group.showGroupToContinue).find('input').check();
-      if (!openByDefault) {
-        cy.get(appFrontend.group.addNewItem).should('be.visible').focus().click();
-      }
-      cy.addItemToGroup(1, 2, 'item 1', openByDefault);
-      cy.get(appFrontend.group.addNewItem).should('be.visible').focus().click();
-      cy.addItemToGroup(20, 30, 'item 2', openByDefault);
-      cy.get(appFrontend.group.addNewItem).should('be.visible').focus().click();
-      cy.addItemToGroup(400, 600, 'item 3', openByDefault);
 
       cy.reload();
       cy.wait('@getLayoutGroup');

--- a/test/cypress/e2e/integration/app-frontend/group.js
+++ b/test/cypress/e2e/integration/app-frontend/group.js
@@ -230,7 +230,39 @@ describe('Group', () => {
   it('Open by default on prefilled group (openByDefault = [\'first\', \'last\', true, false])', () => {
     init();
 
+    cy.intercept('PUT', '**/instances/*/*/data/*').as('updateInstance');
     cy.get(appFrontend.group.showGroupToContinue).find('input').check();
+    cy.wait('@updateInstance');
+
+    ['first', 'last', true, false].forEach((openByDefault) => {
+      cy.interceptLayout('group', (component) => {
+        if (component.edit && component.edit.openByDefault !== undefined) {
+          component.edit.openByDefault = openByDefault;
+        }
+        return component;
+      });
+
+      cy.reload();
+      cy.wait('@getLayoutGroup');
+
+      if (openByDefault === 'first') {
+        cy.get(appFrontend.group.mainGroupTableBody).children().should('have.length', 2);
+        cy.get(appFrontend.group.mainGroupTableBody).children().eq(1).find(appFrontend.group.saveMainGroup).should('exist').and('be.visible');
+      } else if (openByDefault === 'last') {
+        cy.get(appFrontend.group.mainGroupTableBody).children().should('have.length', 2);
+        cy.get(appFrontend.group.mainGroupTableBody).children().eq(1).find(appFrontend.group.saveMainGroup).should('exist').and('be.visible');
+      } else if (openByDefault === true) {
+        cy.get(appFrontend.group.mainGroupTableBody).children().should('have.length', 2);
+        cy.get(appFrontend.group.mainGroupTableBody).children().eq(1).find(appFrontend.group.saveMainGroup).should('exist').and('be.visible');
+      } else if (openByDefault === false) {
+        cy.get(appFrontend.group.mainGroupTableBody).find(appFrontend.group.saveMainGroup).should('not.exist');
+      }
+    });
+
+    cy.interceptLayout('group', (component) => component);
+    cy.reload();
+    cy.wait('@getLayoutGroup');
+
     cy.addItemToGroup(1, 2, 'item 1');
     cy.addItemToGroup(20, 30, 'item 2');
     cy.addItemToGroup(400, 600, 'item 3');
@@ -246,12 +278,15 @@ describe('Group', () => {
       cy.reload();
       cy.wait('@getLayoutGroup');
 
-      if (openByDefault === true || openByDefault === 'first') {
+      if (openByDefault === 'first') {
         cy.get(appFrontend.group.mainGroupTableBody).children().should('have.length', 4);
         cy.get(appFrontend.group.mainGroupTableBody).children().eq(1).find(appFrontend.group.saveMainGroup).should('exist').and('be.visible');
       } else if (openByDefault === 'last') {
         cy.get(appFrontend.group.mainGroupTableBody).children().should('have.length', 4);
         cy.get(appFrontend.group.mainGroupTableBody).children().eq(3).find(appFrontend.group.saveMainGroup).should('exist').and('be.visible');
+      } else if (openByDefault === true) {
+        cy.get(appFrontend.group.mainGroupTableBody).children().should('have.length', 3);
+        cy.get(appFrontend.group.mainGroupTableBody).find(appFrontend.group.saveMainGroup).should('not.exist');
       } else if (openByDefault === false) {
         cy.get(appFrontend.group.mainGroupTableBody).children().should('have.length', 3);
         cy.get(appFrontend.group.mainGroupTableBody).find(appFrontend.group.saveMainGroup).should('not.exist');

--- a/test/cypress/e2e/pageobjects/app-frontend.js
+++ b/test/cypress/e2e/pageobjects/app-frontend.js
@@ -174,6 +174,7 @@ export default class AppFrontend {
       next: 'button[aria-label="Neste"]',
       back: 'button[aria-label="Tilbake"]',
       mainGroupSummary: '[id^="mainGroup-"][id$="-summary"]',
+      mainGroupTableBody: '#group-mainGroup-table-body',
       options: '#reduxOptions',
       tableErrors: '[data-testid=group-table-errors]',
       rows: [0, 1].map((idx) => ({

--- a/test/cypress/e2e/support/app-frontend.js
+++ b/test/cypress/e2e/support/app-frontend.js
@@ -140,10 +140,6 @@ Cypress.Commands.add('navigateToTask5', () => {
 });
 
 Cypress.Commands.add('addItemToGroup', (oldValue, newValue, comment, openByDefault) => {
-  if (openByDefault !== true) {
-    cy.get(appFrontend.group.addNewItem).should('be.visible').focus().click();
-  }
-
   cy.get(appFrontend.group.currentValue).should('be.visible').type(oldValue).blur();
   cy.get(appFrontend.group.newValue).should('be.visible').type(newValue).blur();
   cy.get(appFrontend.group.mainGroup)
@@ -152,7 +148,7 @@ Cypress.Commands.add('addItemToGroup', (oldValue, newValue, comment, openByDefau
     .should('be.visible')
     .click();
 
-  if (openByDefault === true || typeof openByDefault === 'undefined') {
+  if (openByDefault || typeof openByDefault === 'undefined') {
     cy.get(appFrontend.group.addNewItemSubGroup).should('not.exist');
   } else {
     cy.get(appFrontend.group.addNewItemSubGroup).click();

--- a/test/cypress/e2e/support/app-frontend.js
+++ b/test/cypress/e2e/support/app-frontend.js
@@ -140,6 +140,10 @@ Cypress.Commands.add('navigateToTask5', () => {
 });
 
 Cypress.Commands.add('addItemToGroup', (oldValue, newValue, comment, openByDefault) => {
+  if (!openByDefault) {
+    cy.get(appFrontend.group.addNewItem).should('be.visible').focus().click();
+  }
+
   cy.get(appFrontend.group.currentValue).should('be.visible').type(oldValue).blur();
   cy.get(appFrontend.group.newValue).should('be.visible').type(newValue).blur();
   cy.get(appFrontend.group.mainGroup)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changes the openByDefault parameter to accept 'first' and 'last' values in addition to boolean. true and 'first' are equivalent. In the initializeRepeatingGroupsSaga it will check the openByDefault variable to see if it should open the first or last item in a repeating group if it has prefilled values. Otherwise, if there are no prefilled items, it works in the same way as before where it adds a new item to the group and opens it.

Updated schema: https://github.com/Altinn/altinn-cdn/pull/111
Updated docs: https://github.com/Altinn/altinn-studio-docs/pull/688

## Related Issue(s)
- #396 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
