### PR TITLE
Encoding fields in HTTP headers

### DIFF
--- a/src/altinn-app-frontend/src/features/form/data/submit/submitFormDataSagas.test.ts
+++ b/src/altinn-app-frontend/src/features/form/data/submit/submitFormDataSagas.test.ts
@@ -94,8 +94,8 @@ describe('submitFormDataSagas', () => {
         [
           call(put, dataElementUrl(defaultDataElementGuid), model, {
             headers: {
-              'X-DataField': field,
-              'X-ComponentId': componentId,
+              'X-DataField': encodeURIComponent(field),
+              'X-ComponentId': encodeURIComponent(componentId),
             },
           }),
           {},
@@ -167,8 +167,8 @@ describe('submitFormDataSagas', () => {
             {
               headers: {
                 party: `partyid:${stateMock.party.selectedParty.partyId}`,
-                'X-DataField': field,
-                'X-ComponentId': componentId,
+                'X-DataField': encodeURIComponent(field),
+                'X-ComponentId': encodeURIComponent(componentId),
               },
             },
             model,
@@ -257,8 +257,8 @@ describe('submitFormDataSagas', () => {
             getStatelessFormDataUrl(currentDataType, true),
             {
               headers: {
-                'X-DataField': field,
-                'X-ComponentId': componentId,
+                'X-DataField': encodeURIComponent(field),
+                'X-ComponentId': encodeURIComponent(componentId),
               },
             },
             model,

--- a/src/altinn-app-frontend/src/features/form/data/submit/submitFormDataSagas.ts
+++ b/src/altinn-app-frontend/src/features/form/data/submit/submitFormDataSagas.ts
@@ -132,8 +132,8 @@ export function* putFormData({
   try {
     const options: AxiosRequestConfig = {
       headers: {
-        'X-DataField': field,
-        'X-ComponentId': componentId,
+        'X-DataField': encodeURIComponent(field),
+        'X-ComponentId': encodeURIComponent(componentId),
       },
     };
     yield call(put, dataElementUrl(defaultDataElementGuid), model, options);
@@ -224,8 +224,8 @@ export function* saveStatelessData({
   const allowAnonymous = yield select(makeGetAllowAnonymousSelector());
   let options: AxiosRequestConfig = {
     headers: {
-      'X-DataField': field,
-      'X-ComponentId': componentId,
+      'X-DataField': encodeURIComponent(field),
+      'X-ComponentId': encodeURIComponent(componentId),
     },
   };
   if (!allowAnonymous) {

--- a/test/cypress/e2e/pageobjects/app-frontend.js
+++ b/test/cypress/e2e/pageobjects/app-frontend.js
@@ -75,7 +75,7 @@ export default class AppFrontend {
       newMiddleName: '#newMiddleName',
       newMiddleNameDescription: '#description-newMiddleName',
       oldFullName: '#changeNameFrom',
-      newFullName: '#changeNameTo',
+      newFullName: '#changeNameTo_æøå',
       confirmChangeName: '#confirmChangeName',
       reasons: '#reason',
       reference: '#reference',


### PR DESCRIPTION
## Description
This should fix a bug where UTF8 characters are sent in the HTTP header when changing a field.

**PS:** This changes the `frontend-test` app, and a new version has been deployed. Most cypress tests will fail until this is merged.

## Related Issue(s)
- #{issue number}

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
