### PR TITLE
Uses tableTitle for table headers if defined

### DIFF
--- a/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupTable.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupTable.tsx
@@ -391,7 +391,7 @@ export function RepeatingGroupTable({
                 {tableComponents.map((component: ILayoutComponent) => (
                   <TableCell
                     align='left'
-                    key={getTableTitle(component)}
+                    key={component.id}
                   >
                     {getTextResource(getTableTitle(component), textResources)}
                   </TableCell>

--- a/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupTable.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupTable.tsx
@@ -248,13 +248,25 @@ export function RepeatingGroupTable({
     components.map((c) => (c as any).baseComponentId || c.id) ||
     [];
   const mobileView = useMediaQuery('(max-width:992px)'); // breakpoint on altinn-modal
-  const componentTitles: string[] = [];
-  renderComponents.forEach((component: ILayoutComponent) => {
-    const childId = (component as any).baseComponentId || component.id;
-    if (tableHeaderComponents.includes(childId)) {
-      componentTitles.push(component.textResourceBindings?.title || '');
-    }
-  });
+
+  const tableRenderComponents: ILayoutComponent[] = renderComponents.filter(
+    (component: ILayoutComponent) => {
+      const childId = (component as any).baseComponentId || component.id;
+      return tableHeaderComponents.includes(childId);
+    },
+  );
+
+  const componentTitles: string[] = tableRenderComponents.map(
+    (component: ILayoutComponent) => {
+      if (component.textResourceBindings?.tableTitle) {
+        return component.textResourceBindings.tableTitle;
+      }
+      if (component.textResourceBindings?.title) {
+        return component.textResourceBindings.title;
+      }
+      return '';
+    },
+  );
   const showTableHeader =
     repeatingGroupIndex > -1 && !(repeatingGroupIndex == 0 && editIndex == 0);
 
@@ -540,21 +552,21 @@ export function RepeatingGroupTable({
                 ].some((component: ILayoutComponent | ILayoutGroup) => {
                   return childElementHasErrors(component, index);
                 });
-                const items: IMobileTableItem[] = [];
-                components.forEach((component) => {
-                  const childId =
-                    (component as any).baseComponentId || component.id;
-                  if (tableHeaderComponents.includes(childId)) {
-                    items.push({
+                const items: IMobileTableItem[] = tableRenderComponents.map(
+                  (component: ILayoutComponent) => {
+                    let label = '';
+                    if (component?.textResourceBindings?.tableTitle) {
+                      label = component.textResourceBindings.tableTitle;
+                    } else if (component?.textResourceBindings?.title) {
+                      label = component.textResourceBindings.title;
+                    }
+                    return {
                       key: component.id,
-                      label: getTextResource(
-                        component?.textResourceBindings?.title,
-                        textResources,
-                      ),
+                      label: getTextResource(label, textResources),
                       value: getFormDataForComponent(component, index),
-                    });
-                  }
-                });
+                    };
+                  },
+                );
                 return (
                   <React.Fragment key={index}>
                     <AltinnMobileTableItem


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`RepeatingGroupTable` now uses the textResourceBinding `tableTitle` for the table header if it is defined.

- Updated docs: https://github.com/Altinn/altinn-studio-docs/pull/691

Before (desktop)             |  After (desktop)
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/47412359/195048617-813e15cf-c51f-4f7b-8e38-8454a9e95ce3.png)  |  ![image](https://user-images.githubusercontent.com/47412359/195048940-fb2b5358-c45b-483c-bff6-6e541c4206ec.png)

Before (mobile)             |  After (mobile)
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/47412359/195048708-587b4694-823c-4214-94cd-2657c9ef82b2.png)  |  ![image](https://user-images.githubusercontent.com/47412359/195048861-84f045d1-753e-4a4a-adf9-cbb4247481d5.png)

## Related Issue(s)
- #68 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
