### PR TITLE
Removing the checkIfRequired option in handleDataChange

### DIFF
--- a/src/altinn-app-frontend/__mocks__/constants.ts
+++ b/src/altinn-app-frontend/__mocks__/constants.ts
@@ -105,5 +105,3 @@ export const userProfile = {
     doNotPromptForParty: false,
   },
 };
-
-export const defaultHandleDataChangeProps = [undefined, false, false];

--- a/src/altinn-app-frontend/src/components/GenericComponent.tsx
+++ b/src/altinn-app-frontend/src/components/GenericComponent.tsx
@@ -175,10 +175,10 @@ export function GenericComponent<Type extends ComponentExceptGroup>(
 
   const handleDataChange: IComponentProps['handleDataChange'] = (
     value,
-    key = 'simpleBinding',
-    skipValidation = false,
-    checkIfRequired = true,
+    options = {},
   ) => {
+    const { key = 'simpleBinding', validate = true } = options;
+
     if (!props.dataModelBindings || !props.dataModelBindings[key]) {
       return;
     }
@@ -208,8 +208,7 @@ export function GenericComponent<Type extends ComponentExceptGroup>(
         field: dataModelBinding,
         data: value,
         componentId: props.id,
-        skipValidation,
-        checkIfRequired,
+        skipValidation: !validate,
       }),
     );
   };

--- a/src/altinn-app-frontend/src/components/advanced/AddressComponent.test.tsx
+++ b/src/altinn-app-frontend/src/components/advanced/AddressComponent.test.tsx
@@ -186,12 +186,9 @@ describe('AddressComponent', () => {
     await userEvent.type(address, 'Slottsplassen 1');
     fireEvent.blur(address);
 
-    expect(handleDataChange).toHaveBeenCalledWith(
-      'Slottsplassen 1',
-      'address',
-      false,
-      false,
-    );
+    expect(handleDataChange).toHaveBeenCalledWith('Slottsplassen 1', {
+      key: 'address',
+    });
   });
 
   it('should not fire change event when readonly', async () => {
@@ -250,12 +247,7 @@ describe('AddressComponent', () => {
 
     await screen.findByDisplayValue('OSLO');
 
-    expect(handleDataChange).toHaveBeenCalledWith(
-      'OSLO',
-      'postPlace',
-      false,
-      false,
-    );
+    expect(handleDataChange).toHaveBeenCalledWith('OSLO', { key: 'postPlace' });
   });
 
   it('should call change event when zipcode is valid', async () => {
@@ -277,12 +269,7 @@ describe('AddressComponent', () => {
     await userEvent.type(field, '0001');
     fireEvent.blur(field);
 
-    expect(handleDataChange).toHaveBeenCalledWith(
-      '0001',
-      'zipCode',
-      false,
-      false,
-    );
+    expect(handleDataChange).toHaveBeenCalledWith('0001', { key: 'zipCode' });
   });
 
   it('should call handleDataChange for post place when zip code is cleared', async () => {
@@ -303,13 +290,8 @@ describe('AddressComponent', () => {
     await userEvent.clear(field);
     fireEvent.blur(field);
 
-    expect(handleDataChange).toHaveBeenCalledWith('', 'zipCode', false, false);
-    expect(handleDataChange).toHaveBeenCalledWith(
-      '',
-      'postPlace',
-      false,
-      false,
-    );
+    expect(handleDataChange).toHaveBeenCalledWith('', { key: 'zipCode' });
+    expect(handleDataChange).toHaveBeenCalledWith('', { key: 'postPlace' });
   });
 
   it('should display error message coming from props', () => {

--- a/src/altinn-app-frontend/src/components/advanced/AddressComponent.tsx
+++ b/src/altinn-app-frontend/src/components/advanced/AddressComponent.tsx
@@ -129,7 +129,7 @@ export function AddressComponent({
       const validationErrors: IAddressValidationErrors = validate();
       setValidations(validationErrors);
       if (!validationErrors[key]) {
-        handleDataChange(value, key, false, false);
+        handleDataChange(value, { key });
         if (key === AddressKeys.zipCode && !value) {
           // if we are removing a zip code, also remove post place from form data
           setPostPlace('', true);

--- a/src/altinn-app-frontend/src/components/base/CheckboxesContainerComponent.test.tsx
+++ b/src/altinn-app-frontend/src/components/base/CheckboxesContainerComponent.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import { defaultHandleDataChangeProps } from '__mocks__/constants';
 import { getInitialStateMock } from '__mocks__/initialStateMock';
 import { fireEvent, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -98,10 +97,7 @@ describe('CheckboxContainerComponent', () => {
       },
     });
 
-    expect(handleChange).toHaveBeenCalledWith(
-      'sweden',
-      ...defaultHandleDataChangeProps,
-    );
+    expect(handleChange).toHaveBeenCalledWith('sweden');
   });
 
   it('should not call handleDataChange when simpleBinding is set and preselectedOptionIndex', () => {
@@ -176,10 +172,7 @@ describe('CheckboxContainerComponent', () => {
 
     await new Promise((r) => setTimeout(r, 25));
 
-    expect(handleChange).toHaveBeenCalledWith(
-      'norway,denmark',
-      ...defaultHandleDataChangeProps,
-    );
+    expect(handleChange).toHaveBeenCalledWith('norway,denmark');
 
     mockDelayBeforeSaving(undefined);
   });
@@ -208,10 +201,7 @@ describe('CheckboxContainerComponent', () => {
 
     await new Promise((r) => setTimeout(r, 25));
 
-    expect(handleChange).toHaveBeenCalledWith(
-      'norway',
-      ...defaultHandleDataChangeProps,
-    );
+    expect(handleChange).toHaveBeenCalledWith('norway');
 
     mockDelayBeforeSaving(undefined);
   });
@@ -235,10 +225,7 @@ describe('CheckboxContainerComponent', () => {
 
     fireEvent.blur(denmark);
 
-    expect(handleChange).toHaveBeenCalledWith(
-      'norway,denmark',
-      ...defaultHandleDataChangeProps,
-    );
+    expect(handleChange).toHaveBeenCalledWith('norway,denmark');
   });
 
   it('should not call handleDataChange on blur when the value is unchanged', () => {
@@ -275,10 +262,7 @@ describe('CheckboxContainerComponent', () => {
 
     await new Promise((r) => setTimeout(r, 25));
 
-    expect(handleChange).toHaveBeenCalledWith(
-      'denmark',
-      ...defaultHandleDataChangeProps,
-    );
+    expect(handleChange).toHaveBeenCalledWith('denmark');
 
     mockDelayBeforeSaving(undefined);
   });
@@ -393,10 +377,7 @@ describe('CheckboxContainerComponent', () => {
 
     await new Promise((r) => setTimeout(r, 25));
 
-    expect(handleDataChange).toHaveBeenCalledWith(
-      'Value for second',
-      ...defaultHandleDataChangeProps,
-    );
+    expect(handleDataChange).toHaveBeenCalledWith('Value for second');
 
     mockDelayBeforeSaving(undefined);
   });

--- a/src/altinn-app-frontend/src/components/base/DatepickerComponent.test.tsx
+++ b/src/altinn-app-frontend/src/components/base/DatepickerComponent.test.tsx
@@ -101,9 +101,6 @@ describe('DatepickerComponent', () => {
       expect.stringContaining(
         `${currentYearNumeric}-${currentMonthNumeric}-15T12:00:00.000+`,
       ),
-      undefined,
-      false,
-      false,
     );
   });
 
@@ -118,9 +115,6 @@ describe('DatepickerComponent', () => {
     expect(handleDataChange).toHaveBeenCalledWith(
       // Ignore TZ part of timestamp to avoid test failing when this changes
       expect.stringContaining('2022-12-26T12:00:00.000+'),
-      undefined,
-      false,
-      false,
     );
   });
 
@@ -135,9 +129,6 @@ describe('DatepickerComponent', () => {
     expect(handleDataChange).toHaveBeenCalledWith(
       // Ignore TZ part of timestamp to avoid test failing when this changes
       expect.stringContaining('2022-12-26T12:00:00.000+'),
-      undefined,
-      false,
-      false,
     );
   });
 
@@ -149,12 +140,7 @@ describe('DatepickerComponent', () => {
 
     await userEvent.type(inputField, '12.26.2022');
 
-    expect(handleDataChange).toHaveBeenCalledWith(
-      '2022-12-26',
-      undefined,
-      false,
-      false,
-    );
+    expect(handleDataChange).toHaveBeenCalledWith('2022-12-26');
   });
 
   it('should not call handleDataChange when field is changed with a invalid date', async () => {
@@ -260,7 +246,7 @@ describe('DatepickerComponent', () => {
       screen.getByText('date_picker.invalid_date_message'),
     ).toBeInTheDocument();
 
-    expect(handleDataChange).toHaveBeenCalledWith('', undefined, false, false);
+    expect(handleDataChange).toHaveBeenCalledWith('');
   });
 
   it('should have aria-describedby if textResourceBindings.description is present', () => {

--- a/src/altinn-app-frontend/src/components/base/DatepickerComponent.tsx
+++ b/src/altinn-app-frontend/src/components/base/DatepickerComponent.tsx
@@ -203,11 +203,11 @@ function DatepickerComponent({
           timeStamp === true
             ? dateValue?.toISOString(true)
             : dateValue.format(DatePickerSaveFormatNoTimestamp);
-        handleDataChange(dateString, undefined, false, false);
+        handleDataChange(dateString);
       }
     } else if (!dateValue) {
       setDate(null);
-      handleDataChange('', undefined, false, false);
+      handleDataChange('');
     } else if (
       dateValue.parsingFlags().charsLeftOver == 0 &&
       !dateValue.isValid()
@@ -242,10 +242,10 @@ function DatepickerComponent({
           ? date?.format(DatePickerSaveFormatNoTimestamp)
           : date?.toISOString(true);
       const saveDate = isDateEmpty() ? '' : dateString;
-      handleDataChange(saveDate, undefined, false, false);
+      handleDataChange(saveDate);
     } else {
       if (formData?.simpleBinding) {
-        handleDataChange('', undefined, false, false);
+        handleDataChange('');
       }
     }
   };

--- a/src/altinn-app-frontend/src/components/base/DropdownComponent.test.tsx
+++ b/src/altinn-app-frontend/src/components/base/DropdownComponent.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import { defaultHandleDataChangeProps } from '__mocks__/constants';
 import { getInitialStateMock } from '__mocks__/initialStateMock';
 import { fireEvent, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -86,10 +85,7 @@ describe('DropdownComponent', () => {
 
     await new Promise((r) => setTimeout(r, 25));
 
-    expect(handleDataChange).toHaveBeenCalledWith(
-      'sweden',
-      ...defaultHandleDataChangeProps,
-    );
+    expect(handleDataChange).toHaveBeenCalledWith('sweden');
 
     mockDelayBeforeSaving(undefined);
   });
@@ -121,10 +117,7 @@ describe('DropdownComponent', () => {
       handleDataChange,
     });
 
-    expect(handleDataChange).toHaveBeenCalledWith(
-      'denmark',
-      ...defaultHandleDataChangeProps,
-    );
+    expect(handleDataChange).toHaveBeenCalledWith('denmark');
     expect(handleDataChange).toHaveBeenCalledTimes(1);
   });
 
@@ -135,10 +128,7 @@ describe('DropdownComponent', () => {
       handleDataChange,
     });
 
-    expect(handleDataChange).toHaveBeenCalledWith(
-      'denmark',
-      ...defaultHandleDataChangeProps,
-    );
+    expect(handleDataChange).toHaveBeenCalledWith('denmark');
     const select = screen.getByRole('combobox');
 
     await userEvent.click(select);
@@ -147,10 +137,7 @@ describe('DropdownComponent', () => {
 
     fireEvent.blur(select);
 
-    expect(handleDataChange).toHaveBeenCalledWith(
-      'denmark',
-      ...defaultHandleDataChangeProps,
-    );
+    expect(handleDataChange).toHaveBeenCalledWith('denmark');
     expect(handleDataChange).toHaveBeenCalledTimes(2);
   });
 
@@ -191,10 +178,7 @@ describe('DropdownComponent', () => {
 
     await new Promise((r) => setTimeout(r, 25));
 
-    expect(handleDataChange).toHaveBeenCalledWith(
-      'Value for first',
-      ...defaultHandleDataChangeProps,
-    );
+    expect(handleDataChange).toHaveBeenCalledWith('Value for first');
 
     await userEvent.selectOptions(screen.getByRole('combobox'), [
       screen.getByText('The value from the group is: Label for second'),
@@ -204,10 +188,7 @@ describe('DropdownComponent', () => {
 
     await new Promise((r) => setTimeout(r, 25));
 
-    expect(handleDataChange).toHaveBeenCalledWith(
-      'Value for second',
-      ...defaultHandleDataChangeProps,
-    );
+    expect(handleDataChange).toHaveBeenCalledWith('Value for second');
     expect(handleDataChange).toHaveBeenCalledTimes(2);
 
     mockDelayBeforeSaving(undefined);

--- a/src/altinn-app-frontend/src/components/base/InputComponent.test.tsx
+++ b/src/altinn-app-frontend/src/components/base/InputComponent.test.tsx
@@ -65,12 +65,7 @@ describe('InputComponent', () => {
     await user.type(inputComponent, typedValue);
     await user.tab();
     expect(inputComponent).toHaveValue(typedValue);
-    expect(handleDataChange).toHaveBeenCalledWith(
-      typedValue,
-      undefined,
-      false,
-      false,
-    );
+    expect(handleDataChange).toHaveBeenCalledWith(typedValue);
   });
 
   it('should render input with formatted number when this is specified', async () => {
@@ -100,12 +95,7 @@ describe('InputComponent', () => {
 
     expect(inputComponent).toHaveValue(finalValueFormatted);
     expect(handleDataChange).toHaveBeenCalledTimes(1);
-    expect(handleDataChange).toHaveBeenCalledWith(
-      finalValuePlainText,
-      undefined,
-      false,
-      false,
-    );
+    expect(handleDataChange).toHaveBeenCalledWith(finalValuePlainText);
   });
 
   it('should show aria-describedby if textResourceBindings.description is present', () => {

--- a/src/altinn-app-frontend/src/components/base/RadioButtons/RadioButtonsContainerComponent.test.tsx
+++ b/src/altinn-app-frontend/src/components/base/RadioButtons/RadioButtonsContainerComponent.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import { defaultHandleDataChangeProps } from '__mocks__/constants';
 import { getInitialStateMock } from '__mocks__/initialStateMock';
 import { fireEvent, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -96,10 +95,7 @@ describe('RadioButtonsContainerComponent', () => {
       },
     });
 
-    expect(handleChange).toHaveBeenCalledWith(
-      'sweden',
-      ...defaultHandleDataChangeProps,
-    );
+    expect(handleChange).toHaveBeenCalledWith('sweden');
   });
 
   it('should not call handleDataChange when simpleBinding is set and preselectedOptionIndex', () => {
@@ -150,10 +146,7 @@ describe('RadioButtonsContainerComponent', () => {
 
     await new Promise((r) => setTimeout(r, 25));
 
-    expect(handleChange).toHaveBeenCalledWith(
-      'denmark',
-      ...defaultHandleDataChangeProps,
-    );
+    expect(handleChange).toHaveBeenCalledWith('denmark');
 
     mockDelayBeforeSaving(undefined);
   });
@@ -177,10 +170,7 @@ describe('RadioButtonsContainerComponent', () => {
 
     fireEvent.blur(denmark);
 
-    expect(handleChange).toHaveBeenCalledWith(
-      'denmark',
-      ...defaultHandleDataChangeProps,
-    );
+    expect(handleChange).toHaveBeenCalledWith('denmark');
   });
 
   it('should not call handleDataChange on blur when the value is unchanged', () => {
@@ -315,10 +305,7 @@ describe('RadioButtonsContainerComponent', () => {
 
     await new Promise((r) => setTimeout(r, 25));
 
-    expect(handleDataChange).toHaveBeenCalledWith(
-      'Value for first',
-      ...defaultHandleDataChangeProps,
-    );
+    expect(handleDataChange).toHaveBeenCalledWith('Value for first');
 
     mockDelayBeforeSaving(undefined);
   });

--- a/src/altinn-app-frontend/src/components/base/TextAreaComponent.test.tsx
+++ b/src/altinn-app-frontend/src/components/base/TextAreaComponent.test.tsx
@@ -38,12 +38,7 @@ describe('TextAreaComponent.tsx', () => {
     await user.type(textarea, addedText);
     await user.keyboard('{Tab}');
 
-    expect(handleDataChange).toHaveBeenCalledWith(
-      `${initialText}${addedText}`,
-      undefined,
-      false,
-      false,
-    );
+    expect(handleDataChange).toHaveBeenCalledWith(`${initialText}${addedText}`);
   });
 
   it('should not fire handleDataChange when readOnly is true', async () => {

--- a/src/altinn-app-frontend/src/components/custom/CustomWebComponent.tsx
+++ b/src/altinn-app-frontend/src/components/custom/CustomWebComponent.tsx
@@ -33,7 +33,7 @@ function CustomWebComponent({
     if (current) {
       const handleChange = (customEvent: CustomEvent) => {
         const { value, field } = customEvent.detail;
-        handleDataChange(value, field);
+        handleDataChange(value, { key: field });
       };
 
       current.addEventListener('dataChanged', handleChange);

--- a/src/altinn-app-frontend/src/components/hooks/useDelayedSavedState.ts
+++ b/src/altinn-app-frontend/src/components/hooks/useDelayedSavedState.ts
@@ -38,7 +38,7 @@ export function useDelayedSavedState(
       ((typeof saveAfter === 'number' ? saveAfter : 400) as number);
     const timeoutId = setTimeout(() => {
       if (immediateState !== formValue) {
-        handleDataChange(immediateState, undefined, false, false);
+        handleDataChange(immediateState);
       }
     }, timeout);
 
@@ -51,17 +51,17 @@ export function useDelayedSavedState(
       setImmediateState(newValue);
       if (newValue !== formValue) {
         if (saveImmediately) {
-          handleDataChange(newValue, undefined, false, false);
+          handleDataChange(newValue);
         } else if (saveNextChangeImmediately) {
           // Save immediately on the next change event after a paste
-          handleDataChange(newValue, undefined, false, false);
+          handleDataChange(newValue);
           setSaveNextChangeImmediately(false);
         }
       }
     },
     saveValue: () => {
       if (immediateState !== formValue) {
-        handleDataChange(immediateState, undefined, false, false);
+        handleDataChange(immediateState);
       }
     },
     onPaste: () => {

--- a/src/altinn-app-frontend/src/components/index.ts
+++ b/src/altinn-app-frontend/src/components/index.ts
@@ -65,9 +65,10 @@ const components: {
 export interface IComponentProps extends IGenericComponentProps {
   handleDataChange: (
     value: string,
-    key?: string,
-    skipValidation?: boolean,
-    checkIfRequired?: boolean,
+    options?: {
+      key?: string; // Defaults to simpleBinding
+      validate?: boolean; // Defaults to true
+    },
   ) => void;
   getTextResource: (key: string) => React.ReactNode;
   getTextResourceAsString: (key: string) => string;

--- a/src/altinn-app-frontend/src/features/form/containers/GroupContainerLikert.test.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/GroupContainerLikert.test.tsx
@@ -13,7 +13,7 @@ import {
   validateTableLayout,
 } from 'src/features/form/containers/GroupContainerLikertTestUtils';
 
-describe('GroupContainer', () => {
+describe('GroupContainerLikert', () => {
   describe('Desktop', () => {
     it('should render table using options and not optionsId', () => {
       render({

--- a/src/altinn-app-frontend/src/features/form/containers/GroupContainerLikertTestUtils.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/GroupContainerLikertTestUtils.tsx
@@ -113,7 +113,6 @@ export const createFormDataUpdateAction = (
       data: optionValue,
       field: `Questions[${index}].Answer`,
       skipValidation: false,
-      checkIfRequired: false,
     },
     type: FormDataActions.update.type,
   };

--- a/src/altinn-app-frontend/src/features/form/data/formDataTypes.ts
+++ b/src/altinn-app-frontend/src/features/form/data/formDataTypes.ts
@@ -27,7 +27,6 @@ export interface ISaveAction {
 export interface IUpdateFormDataProps {
   skipValidation?: boolean;
   skipAutoSave?: boolean;
-  checkIfRequired?: boolean;
 }
 
 export interface IUpdateFormData extends IUpdateFormDataProps {

--- a/src/altinn-app-frontend/src/features/form/data/update/updateFormDataSagas.ts
+++ b/src/altinn-app-frontend/src/features/form/data/update/updateFormDataSagas.ts
@@ -22,27 +22,13 @@ import type { IAttachments } from 'src/shared/resources/attachments';
 import type { IRuntimeState, IValidationResult } from 'src/types';
 
 export function* updateFormDataSaga({
-  payload: {
-    field,
-    data,
-    componentId,
-    skipValidation,
-    skipAutoSave,
-    checkIfRequired,
-  },
+  payload: { field, data, componentId, skipValidation, skipAutoSave },
 }: PayloadAction<IUpdateFormData>): SagaIterator {
   try {
     const state: IRuntimeState = yield select();
 
     if (!skipValidation) {
-      yield call(
-        runValidations,
-        field,
-        data,
-        componentId,
-        state,
-        checkIfRequired,
-      );
+      yield call(runValidations, field, data, componentId, state);
     }
 
     if (shouldUpdateFormData(state.formData.formData[field], data)) {
@@ -53,7 +39,6 @@ export function* updateFormDataSaga({
           data,
           skipValidation,
           skipAutoSave,
-          checkIfRequired,
         }),
       );
     }
@@ -72,7 +57,6 @@ function* runValidations(
   data: any,
   componentId: string,
   state: IRuntimeState,
-  checkIfRequired: boolean,
 ) {
   if (!componentId) {
     yield put(
@@ -110,7 +94,6 @@ function* runValidations(
     validator,
     state.formValidations.validations[componentId],
     componentId !== component.id ? componentId : null,
-    checkIfRequired,
   );
 
   const componentValidations =

--- a/src/altinn-app-frontend/src/features/form/rules/check/checkRulesSagas.ts
+++ b/src/altinn-app-frontend/src/features/form/rules/check/checkRulesSagas.ts
@@ -25,7 +25,7 @@ export interface IResponse {
 }
 
 export function* checkIfRuleShouldRunSaga({
-  payload: { field, checkIfRequired, skipAutoSave, skipValidation },
+  payload: { field, skipAutoSave, skipValidation },
 }: PayloadAction<IUpdateFormDataFulfilled>): SagaIterator {
   try {
     const ruleConnectionState: IRuleConnections = yield select(
@@ -60,7 +60,6 @@ export function* checkIfRuleShouldRunSaga({
               data: rule.result,
               field: rule.dataBindingName,
               skipValidation,
-              checkIfRequired,
               skipAutoSave,
             }),
           );

--- a/src/altinn-app-frontend/src/utils/formLayout.ts
+++ b/src/altinn-app-frontend/src/utils/formLayout.ts
@@ -431,7 +431,6 @@ export function getVariableTextKeysForRepeatingGroupComponent(
 }
 
 export function hasRequiredFields(layout: ILayout) {
-  // TODO: Make sure expressions have been resolved
   return layout.find((c: ILayoutComponent) => c.required);
 }
 

--- a/src/altinn-app-frontend/src/utils/formLayout.ts
+++ b/src/altinn-app-frontend/src/utils/formLayout.ts
@@ -431,6 +431,7 @@ export function getVariableTextKeysForRepeatingGroupComponent(
 }
 
 export function hasRequiredFields(layout: ILayout) {
+  // TODO: Make sure expressions have been resolved
   return layout.find((c: ILayoutComponent) => c.required);
 }
 

--- a/src/altinn-app-frontend/src/utils/validation/validation.ts
+++ b/src/altinn-app-frontend/src/utils/validation/validation.ts
@@ -674,7 +674,6 @@ export function validateComponentFormData(
   schemaValidator: ISchemaValidator,
   existingValidationErrors: IComponentValidations | undefined,
   componentIdWithIndex: string | null,
-  checkIfRequired: boolean,
 ): IValidationResult {
   const { validator, rootElementPath, schema } = schemaValidator;
   const fieldKey = Object.keys(component.dataModelBindings).find(
@@ -748,24 +747,6 @@ export function validateComponentFormData(
           { ...component, id: componentIdWithIndex || component.id },
         );
       });
-  }
-  if (checkIfRequired && component.required && (!formData || formData === '')) {
-    const fieldName = getFieldName(
-      component.textResourceBindings,
-      textResources,
-      language,
-      fieldKey !== 'simpleBinding' ? fieldKey : undefined,
-    );
-    validationResult.validations[layoutId][
-      componentIdWithIndex || component.id
-    ][fieldKey].errors.push(
-      getParsedLanguageFromKey(
-        'form_filler.error_required',
-        language,
-        [fieldName],
-        true,
-      ),
-    );
   }
 
   if (


### PR DESCRIPTION
## Description
Components used to be able to turn off the 'required' validation when saving changes, but this should be the default (and no component should be able to force that check). Cleaning up this code.

## Related Issue(s)
- #99 
- #100 
- #237

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- ~~[ ] Relevant automated test added (if you find this hard, leave it and we'll help out)~~
- [ ] All tests run green

## Documentation
- ~~[ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~
