### PR TITLE
Remove grid-item when title is undefined

### DIFF
--- a/src/altinn-app-frontend/src/features/form/containers/DisplayGroupContainer.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/DisplayGroupContainer.tsx
@@ -68,19 +68,19 @@ export function DisplayGroupContainer(props: IDisplayGroupContainer) {
       alignItems='flex-start'
       data-testid='display-group-container'
     >
-      <Grid
-        item={true}
-        xs={12}
-      >
-        {title && (
+      {title && (
+        <Grid
+          item={true}
+          xs={12}
+        >
           <Typography
             className={classes.groupTitle}
             variant='body1'
           >
             {title}
           </Typography>
-        )}
-      </Grid>
+        </Grid>
+      )}
       {props.components.map((component) => {
         return props.renderLayoutComponent(component, layout);
       })}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change simply also removes the surrounding `<Grid>` when the group title is undefined, which removes the empty whitespace mentioned in the related issue.

## Related Issue(s)
- Fixes #501 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] ~~Relevant automated test added (if you find this hard, leave it and we'll help out)~~
- [ ] All tests run green

## Documentation
- [ ] ~~User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~
