### PR TITLE
Bug: Fix repeating group UI issues

### DIFF
--- a/src/altinn-app-frontend/src/features/form/containers/GroupContainer.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/GroupContainer.tsx
@@ -47,18 +47,11 @@ const useStyles = makeStyles({
       width: 'calc(100% + 154px)',
     },
     '& &': {
-      width: 'auto',
+      width: '100%',
       marginLeft: '0',
       left: '0',
-
-      '@media (min-width:768px)': {
-        left: '0px',
-        width: 'auto',
-        marginLeft: '0',
-      },
-      '@media (min-width:993px)': {
-        width: 'auto',
-        left: '0',
+      '& div[role=button]': {
+        margin: '0 -24px',
       },
     },
   },

--- a/src/altinn-app-frontend/src/features/form/containers/GroupContainer.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/GroupContainer.tsx
@@ -216,7 +216,6 @@ export function GroupContainer({
         layoutElementId: id,
         remove: true,
         index: groupIndex,
-        leaveOpen: !!container.edit?.openByDefault,
       }),
     );
   };

--- a/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupTable.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupTable.tsx
@@ -402,7 +402,7 @@ export function RepeatingGroupTable({
                   </TableCell>
                 ))}
                 <TableCell
-                  style={{ width: '150px', padding: 0, paddingRight: '10px' }}
+                  style={{ width: '160px', padding: 0, paddingRight: '10px' }}
                 >
                   <span className={classes.visuallyHidden}>
                     {getLanguageFromKey('general.edit', language)}
@@ -477,7 +477,7 @@ export function RepeatingGroupTable({
                         <TableCell
                           align='right'
                           style={{
-                            width: '150px',
+                            width: '160px',
                             padding: 0,
                             paddingRight: '10px',
                           }}

--- a/src/altinn-app-frontend/src/features/form/layout/formLayoutTypes.ts
+++ b/src/altinn-app-frontend/src/features/form/layout/formLayoutTypes.ts
@@ -63,7 +63,6 @@ export interface IUpdateRepeatingGroups {
   layoutElementId: string;
   remove?: boolean;
   index?: number;
-  leaveOpen?: boolean;
 }
 
 export interface IUpdateRepeatingGroupsFulfilled {

--- a/src/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
+++ b/src/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
@@ -105,7 +105,7 @@ export const selectOptions = (state: IRuntimeState): IOptions =>
   state.optionState.options;
 
 export function* updateRepeatingGroupsSaga({
-  payload: { layoutElementId, remove, index, leaveOpen },
+  payload: { layoutElementId, remove, index },
 }: PayloadAction<IUpdateRepeatingGroups>): SagaIterator {
   try {
     const formLayoutState: ILayoutState = yield select(selectFormLayoutState);
@@ -271,11 +271,6 @@ export function* updateRepeatingGroupsSaga({
             (value) => value !== index,
           );
         updatedRepeatingGroups[layoutElementId].editIndex = -1;
-
-        if (leaveOpen && index === 0) {
-          updatedRepeatingGroups[layoutElementId].index = 0;
-          updatedRepeatingGroups[layoutElementId].editIndex = 0;
-        }
 
         yield put(
           FormLayoutActions.updateRepeatingGroupsFulfilled({

--- a/src/shared/src/components/molecules/AltinnMobileTableItem.tsx
+++ b/src/shared/src/components/molecules/AltinnMobileTableItem.tsx
@@ -134,7 +134,7 @@ const useStyles = makeStyles({
     },
   },
   editButtonCell: {
-    width: '140px',
+    width: '150px',
     padding: '0 !important',
     '@media (max-width: 768px)': {
       width: '50px',

--- a/test/cypress/e2e/integration/app-frontend/attachments-in-group.js
+++ b/test/cypress/e2e/integration/app-frontend/attachments-in-group.js
@@ -430,7 +430,6 @@ describe('Repeating group attachments', () => {
 
     // Verify that one of the attachments in the next nested row is visible in the table header. This is also a trick
     // to ensure we wait until the deletion is done before we fetch the redux state.
-    cy.get(appFrontend.group.rows[0].nestedGroup.rows[0].editBtn).click();
     cy.get(appFrontend.group.rows[0].nestedGroup.rows[0].uploadTagMulti.tableRowPreview)
       .should('contain.text', filenames[0].nested[1][2]);
     cy.get(appFrontend.group.rows[0].nestedGroup.rows[0].editBtn).click();

--- a/test/cypress/e2e/integration/app-frontend/group.js
+++ b/test/cypress/e2e/integration/app-frontend/group.js
@@ -234,6 +234,7 @@ describe('Group', () => {
     cy.get(appFrontend.group.showGroupToContinue).find('input').check();
     cy.wait('@updateInstance');
 
+    // Test whether new empty group is opened
     ['first', 'last', true, false].forEach((openByDefault) => {
       cy.interceptLayout('group', (component) => {
         if (component.edit && component.edit.openByDefault !== undefined) {
@@ -267,6 +268,7 @@ describe('Group', () => {
     cy.addItemToGroup(20, 30, 'item 2');
     cy.addItemToGroup(400, 600, 'item 3');
 
+    // Test whether existing item is opened
     ['first', 'last', true, false].forEach((openByDefault) => {
       cy.interceptLayout('group', (component) => {
         if (component.edit && component.edit.openByDefault !== undefined) {
@@ -292,5 +294,19 @@ describe('Group', () => {
         cy.get(appFrontend.group.mainGroupTableBody).find(appFrontend.group.saveMainGroup).should('not.exist');
       }
     });
+
+    cy.interceptLayout('group', (component) => {
+      if (component.edit && component.edit.openByDefault !== undefined) {
+        component.edit.openByDefault = true;
+      }
+      return component;
+    });
+
+    cy.reload();
+    cy.wait('@getLayoutGroup');
+
+    // Test that deleting an item does not cause another group to open if there are more elements in the group
+    cy.get(appFrontend.group.mainGroupTableBody).children().eq(0).find(appFrontend.group.delete).should('be.visible').click();
+    cy.get(appFrontend.group.mainGroupTableBody).find(appFrontend.group.saveMainGroup).should('not.exist');
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Minor css changes to fix the width of the Add button in nested repeating groups. Removed leaveOpen-logic from openByDefault as it seems to do nothing besides causing the bug in #442. Nobody I asked knew what the intended behaviour of leaveOpen was, and openByDefault works as documented without this logic.

## Related Issue(s)
- #398 
- #442 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- ~~User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~
