### PR TITLE
Null-checking edit property

### DIFF
--- a/src/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
+++ b/src/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
@@ -682,9 +682,9 @@ export function* initRepeatingGroupsSaga(): SagaIterator {
     ) as ILayoutGroup;
 
     if (container && group.index >= 0) {
-      if (container.edit.openByDefault === 'first') {
+      if (container.edit?.openByDefault === 'first') {
         group.editIndex = 0;
-      } else if (container.edit.openByDefault === 'last') {
+      } else if (container.edit?.openByDefault === 'last') {
         group.editIndex = group.index;
       }
     }


### PR DESCRIPTION
## Description
Adding null-checks for possibly missing `edit` property in repeating group component

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
