### PR TITLE
Expressions: Type-changes

### DIFF
--- a/src/altinn-app-frontend/src/components/advanced/AddressComponent.test.tsx
+++ b/src/altinn-app-frontend/src/components/advanced/AddressComponent.test.tsx
@@ -7,7 +7,6 @@ import mockAxios from 'jest-mock-axios';
 import configureStore from 'redux-mock-store';
 
 import { AddressComponent } from 'src/components/advanced/AddressComponent';
-import type { IComponentProps } from 'src/components';
 import type { IAddressComponentProps } from 'src/components/advanced/AddressComponent';
 
 const render = (props: Partial<IAddressComponentProps> = {}) => {
@@ -47,7 +46,7 @@ const render = (props: Partial<IAddressComponentProps> = {}) => {
     readOnly: false,
     required: false,
     textResourceBindings: {},
-    ...({} as IComponentProps),
+    ...({} as IAddressComponentProps),
     ...props,
   };
 

--- a/src/altinn-app-frontend/src/components/advanced/AddressComponent.tsx
+++ b/src/altinn-app-frontend/src/components/advanced/AddressComponent.tsx
@@ -6,16 +6,15 @@ import axios from 'axios';
 import { AddressLabel } from 'src/components/advanced/AddressLabel';
 import { useDelayedSavedState } from 'src/components/hooks/useDelayedSavedState';
 import { renderValidationMessagesForComponent } from 'src/utils/render';
-import type { IComponentProps } from 'src/components';
-import type { ILayoutCompAddress } from 'src/features/form/layout';
+import type { PropsFromGenericComponent } from 'src/components';
 import type { IComponentValidations } from 'src/types';
 
 import { get, getLanguageFromKey } from 'altinn-shared/utils';
 
 import 'src/components/advanced/AddressComponent.css';
 
-export type IAddressComponentProps = IComponentProps &
-  Omit<ILayoutCompAddress, 'type'>;
+export type IAddressComponentProps =
+  PropsFromGenericComponent<'AddressComponent'>;
 
 interface IAddressValidationErrors {
   address?: string;

--- a/src/altinn-app-frontend/src/components/base/AttachmentListComponent.tsx
+++ b/src/altinn-app-frontend/src/components/base/AttachmentListComponent.tsx
@@ -3,14 +3,12 @@ import * as React from 'react';
 import { Grid, Typography } from '@material-ui/core';
 
 import { useAppSelector } from 'src/common/hooks';
-import type { IComponentProps } from 'src/components';
-import type { ILayoutCompAttachmentList } from 'src/features/form/layout';
+import type { PropsFromGenericComponent } from 'src/components';
 
 import { AltinnAttachment } from 'altinn-shared/components';
 import { mapInstanceAttachments } from 'altinn-shared/utils';
 
-export type IAttachmentListProps = IComponentProps &
-  Omit<ILayoutCompAttachmentList, 'type'>;
+export type IAttachmentListProps = PropsFromGenericComponent<'AttachmentList'>;
 
 export function AttachmentListComponent(props: IAttachmentListProps) {
   const currentTaskId = useAppSelector(

--- a/src/altinn-app-frontend/src/components/base/ButtonComponent/InstantiationButtonComponent.tsx
+++ b/src/altinn-app-frontend/src/components/base/ButtonComponent/InstantiationButtonComponent.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react';
 
 import { InstantiationButton } from 'src/components/base/ButtonComponent/InstantiationButton';
-import type { IComponentProps } from 'src/components';
-import type { ILayoutCompInstantiationButton } from 'src/features/form/layout';
+import type { PropsFromGenericComponent } from 'src/components';
 
-export type IInstantiationButtonComponentProps = IComponentProps &
-  Omit<ILayoutCompInstantiationButton, 'type'>;
+export type IInstantiationButtonComponentProps =
+  PropsFromGenericComponent<'InstantiationButton'>;
 
 const btnGroupStyle = {
   marginTop: '3.6rem',

--- a/src/altinn-app-frontend/src/components/base/CheckboxesContainerComponent.test.tsx
+++ b/src/altinn-app-frontend/src/components/base/CheckboxesContainerComponent.test.tsx
@@ -9,7 +9,6 @@ import type { PreloadedState } from 'redux';
 import { CheckboxContainerComponent } from 'src/components/base/CheckboxesContainerComponent';
 import { mockDelayBeforeSaving } from 'src/components/hooks/useDelayedSavedState';
 import { LayoutStyle } from 'src/types';
-import type { IComponentProps } from 'src/components';
 import type { ICheckboxContainerProps } from 'src/components/base/CheckboxesContainerComponent';
 import type { IOptionsState } from 'src/shared/resources/options';
 import type { RootState } from 'src/store';
@@ -36,7 +35,6 @@ const render = (
   customState: PreloadedState<RootState> = {},
 ) => {
   const allProps: ICheckboxContainerProps = {
-    type: 'Checkboxes',
     options: [],
     optionsId: 'countries',
     preselectedOptionIndex: undefined,
@@ -45,7 +43,7 @@ const render = (
     handleDataChange: jest.fn(),
     getTextResource: (value) => value,
     getTextResourceAsString: (value) => value,
-    ...({} as IComponentProps),
+    ...({} as ICheckboxContainerProps),
     ...props,
   };
 

--- a/src/altinn-app-frontend/src/components/base/CheckboxesContainerComponent.tsx
+++ b/src/altinn-app-frontend/src/components/base/CheckboxesContainerComponent.tsx
@@ -13,15 +13,13 @@ import { useDelayedSavedState } from 'src/components/hooks/useDelayedSavedState'
 import { shouldUseRowLayout } from 'src/utils/layout';
 import { getOptionLookupKey } from 'src/utils/options';
 import { renderValidationMessagesForComponent } from 'src/utils/render';
-import type { IComponentProps } from 'src/components';
-import type { ILayoutCompCheckboxes } from 'src/features/form/layout';
+import type { PropsFromGenericComponent } from 'src/components';
 import type { IComponentValidations, IOption } from 'src/types';
 
 import { AltinnSpinner } from 'altinn-shared/components';
 
 export interface ICheckboxContainerProps
-  extends IComponentProps,
-    ILayoutCompCheckboxes {
+  extends PropsFromGenericComponent<'Checkboxes'> {
   validationMessages: IComponentValidations;
 }
 

--- a/src/altinn-app-frontend/src/components/base/DatepickerComponent.test.tsx
+++ b/src/altinn-app-frontend/src/components/base/DatepickerComponent.test.tsx
@@ -6,7 +6,6 @@ import { mockMediaQuery, renderWithProviders } from 'testUtils';
 import type { PreloadedState } from 'redux';
 
 import DatepickerComponent from 'src/components/base/DatepickerComponent';
-import type { IComponentProps } from 'src/components';
 import type { IDatePickerProps } from 'src/components/base/DatepickerComponent';
 import type { RootState } from 'src/store';
 
@@ -19,7 +18,7 @@ const render = (
     minDate: '1900-01-01T12:00:00.000Z',
     maxDate: '2100-01-01T12:00:00.000Z',
     handleDataChange: jest.fn(),
-    ...({} as IComponentProps),
+    ...({} as IDatePickerProps),
     ...props,
   };
 

--- a/src/altinn-app-frontend/src/components/base/DatepickerComponent.tsx
+++ b/src/altinn-app-frontend/src/components/base/DatepickerComponent.tsx
@@ -23,8 +23,7 @@ import {
   DatePickerSaveFormatNoTimestamp,
   validateDatepickerFormData,
 } from 'src/utils/validation';
-import type { IComponentProps } from 'src/components';
-import type { ILayoutCompDatePicker } from 'src/features/form/layout';
+import type { PropsFromGenericComponent } from 'src/components';
 import type { DateFlags, IComponentBindingValidation } from 'src/types';
 
 import { getLanguageFromKey } from 'altinn-shared/utils';
@@ -32,8 +31,7 @@ import { getLanguageFromKey } from 'altinn-shared/utils';
 import 'src/components/base/DatepickerComponent.css';
 import 'src/styles/shared.css';
 
-export type IDatePickerProps = IComponentProps &
-  Omit<ILayoutCompDatePicker, 'type'>;
+export type IDatePickerProps = PropsFromGenericComponent<'DatePicker'>;
 
 const iconSize = '30px';
 

--- a/src/altinn-app-frontend/src/components/base/DropdownComponent.test.tsx
+++ b/src/altinn-app-frontend/src/components/base/DropdownComponent.test.tsx
@@ -8,7 +8,6 @@ import type { PreloadedState } from 'redux';
 
 import DropdownComponent from 'src/components/base/DropdownComponent';
 import { mockDelayBeforeSaving } from 'src/components/hooks/useDelayedSavedState';
-import type { IComponentProps } from 'src/components';
 import type { IDropdownProps } from 'src/components/base/DropdownComponent';
 import type { RootState } from 'src/store';
 
@@ -24,7 +23,7 @@ const render = (
     getTextResourceAsString: (value) => value,
     readOnly: false,
     isValid: true,
-    ...({} as IComponentProps),
+    ...({} as IDropdownProps),
     ...props,
   };
 

--- a/src/altinn-app-frontend/src/components/base/DropdownComponent.tsx
+++ b/src/altinn-app-frontend/src/components/base/DropdownComponent.tsx
@@ -4,13 +4,11 @@ import { useAppSelector, useHasChangedIgnoreUndefined } from 'src/common/hooks';
 import { useGetOptions } from 'src/components/hooks';
 import { useDelayedSavedState } from 'src/components/hooks/useDelayedSavedState';
 import { getOptionLookupKey } from 'src/utils/options';
-import type { IComponentProps } from 'src/components';
-import type { ILayoutCompDropdown } from 'src/features/form/layout';
+import type { PropsFromGenericComponent } from 'src/components';
 
 import { AltinnSpinner, Select } from 'altinn-shared/components';
 
-export type IDropdownProps = IComponentProps &
-  Omit<ILayoutCompDropdown, 'type'>;
+export type IDropdownProps = PropsFromGenericComponent<'Dropdown'>;
 
 function DropdownComponent({
   optionsId,

--- a/src/altinn-app-frontend/src/components/base/FileUpload/FileUploadComponent.test.tsx
+++ b/src/altinn-app-frontend/src/components/base/FileUpload/FileUploadComponent.test.tsx
@@ -6,7 +6,6 @@ import { screen } from '@testing-library/react';
 import { renderWithProviders } from 'testUtils';
 
 import { FileUploadComponent } from 'src/components/base/FileUpload/FileUploadComponent';
-import type { IComponentProps } from 'src/components';
 import type { IFileUploadProps } from 'src/components/base/FileUpload/FileUploadComponent';
 import type { IAttachment } from 'src/shared/resources/attachments';
 
@@ -155,7 +154,7 @@ const render = ({
     minNumberOfAttachments: 1,
     isValid: true,
     readOnly: false,
-    ...({} as IComponentProps),
+    ...({} as IFileUploadProps),
     ...props,
   };
 

--- a/src/altinn-app-frontend/src/components/base/FileUpload/FileUploadComponent.tsx
+++ b/src/altinn-app-frontend/src/components/base/FileUpload/FileUploadComponent.tsx
@@ -16,8 +16,7 @@ import {
 } from 'src/components/base/FileUpload/shared/render';
 import { AttachmentActions } from 'src/shared/resources/attachments/attachmentSlice';
 import { renderValidationMessagesForComponent } from 'src/utils/render';
-import type { IComponentProps } from 'src/components';
-import type { ILayoutCompFileUpload } from 'src/features/form/layout';
+import type { PropsFromGenericComponent } from 'src/components';
 import type { IAttachment } from 'src/shared/resources/attachments';
 import type { IComponentValidations } from 'src/types';
 
@@ -27,8 +26,7 @@ import { getLanguageFromKey } from 'altinn-shared/utils';
 
 import 'src/components/base/FileUpload/FileUploadComponent.css';
 
-export type IFileUploadProps = IComponentProps &
-  Omit<ILayoutCompFileUpload, 'type'>;
+export type IFileUploadProps = PropsFromGenericComponent<'FileUpload'>;
 
 export const bytesInOneMB = 1048576;
 export const emptyArray = [];

--- a/src/altinn-app-frontend/src/components/base/FileUpload/FileUploadWithTag/EditWindowComponent.tsx
+++ b/src/altinn-app-frontend/src/components/base/FileUpload/FileUploadWithTag/EditWindowComponent.tsx
@@ -7,7 +7,7 @@ import { useAppDispatch } from 'src/common/hooks';
 import { FileName } from 'src/components/base/FileUpload/shared/render';
 import { AttachmentActions } from 'src/shared/resources/attachments/attachmentSlice';
 import { renderValidationMessages } from 'src/utils/render';
-import type { IComponentProps } from 'src/components';
+import type { PropsFromGenericComponent } from 'src/components';
 import type { IAttachment } from 'src/shared/resources/attachments';
 import type { IOption } from 'src/types';
 
@@ -46,7 +46,8 @@ const useStyles = makeStyles({
   },
 });
 
-export interface EditWindowProps extends IComponentProps {
+export interface EditWindowProps
+  extends PropsFromGenericComponent<'FileUploadWithTag'> {
   attachment: IAttachment;
   mobileView: boolean;
   options: IOption[];

--- a/src/altinn-app-frontend/src/components/base/FileUpload/FileUploadWithTag/FileListComponent.tsx
+++ b/src/altinn-app-frontend/src/components/base/FileUpload/FileUploadWithTag/FileListComponent.tsx
@@ -15,7 +15,7 @@ import {
 import { EditWindowComponent } from 'src/components/base/FileUpload/FileUploadWithTag/EditWindowComponent';
 import { FileName } from 'src/components/base/FileUpload/shared/render';
 import { atleastOneTagExists } from 'src/utils/formComponentUtils';
-import type { IComponentProps } from 'src/components';
+import type { PropsFromGenericComponent } from 'src/components';
 import type { IAttachment } from 'src/shared/resources/attachments';
 import type { IDataModelBindings, IOption } from 'src/types';
 
@@ -126,7 +126,8 @@ const useStyles = makeStyles({
   },
 });
 
-export interface FileListProps extends IComponentProps {
+export interface FileListProps
+  extends PropsFromGenericComponent<'FileUploadWithTag'> {
   attachments: IAttachment[];
   editIndex: number;
   mobileView: boolean;
@@ -356,7 +357,7 @@ export function FileList(props: FileListProps): JSX.Element {
                       onDropdownDataChange={props.onDropdownDataChange}
                       setEditIndex={props.setEditIndex}
                       textResourceBindings={props.textResourceBindings}
-                      {...({} as IComponentProps)}
+                      {...({} as PropsFromGenericComponent<'FileUploadWithTag'>)}
                     />
                   </TableCell>
                 </TableRow>

--- a/src/altinn-app-frontend/src/components/base/FileUpload/FileUploadWithTag/FileUploadWithTagComponent.test.tsx
+++ b/src/altinn-app-frontend/src/components/base/FileUpload/FileUploadWithTag/FileUploadWithTagComponent.test.tsx
@@ -9,7 +9,6 @@ import { renderWithProviders } from 'testUtils';
 
 import { FileUploadWithTagComponent } from 'src/components/base/FileUpload/FileUploadWithTag/FileUploadWithTagComponent';
 import { AsciiUnitSeparator } from 'src/utils/attachment';
-import type { IComponentProps } from 'src/components';
 import type { IFileUploadWithTagProps } from 'src/components/base/FileUpload/FileUploadWithTag/FileUploadWithTagComponent';
 import type { IAttachment } from 'src/shared/resources/attachments';
 
@@ -275,7 +274,7 @@ const render = ({
     getTextResource: jest.fn(),
     getTextResourceAsString: jest.fn(),
     textResourceBindings: textResourceBindings,
-    ...({} as IComponentProps),
+    ...({} as IFileUploadWithTagProps),
     ...props,
   };
 

--- a/src/altinn-app-frontend/src/components/base/FileUpload/FileUploadWithTag/FileUploadWithTagComponent.tsx
+++ b/src/altinn-app-frontend/src/components/base/FileUpload/FileUploadWithTag/FileUploadWithTagComponent.tsx
@@ -22,15 +22,14 @@ import {
 } from 'src/utils/formComponentUtils';
 import { getOptionLookupKey } from 'src/utils/options';
 import { renderValidationMessagesForComponent } from 'src/utils/render';
-import type { IComponentProps } from 'src/components';
-import type { ILayoutCompFileUploadWithTag } from 'src/features/form/layout';
+import type { PropsFromGenericComponent } from 'src/components';
 import type { IAttachment } from 'src/shared/resources/attachments';
 import type { IRuntimeState } from 'src/types';
 
 import { getLanguageFromKey } from 'altinn-shared/utils';
 
-export type IFileUploadWithTagProps = IComponentProps &
-  Omit<ILayoutCompFileUploadWithTag, 'type'>;
+export type IFileUploadWithTagProps =
+  PropsFromGenericComponent<'FileUploadWithTag'>;
 
 export function FileUploadWithTagComponent({
   id,
@@ -291,7 +290,7 @@ export function FileUploadWithTagComponent({
         setEditIndex={setEditIndex}
         textResourceBindings={textResourceBindings}
         dataModelBindings={dataModelBindings}
-        {...({} as IComponentProps)}
+        {...({} as PropsFromGenericComponent<'FileUploadWithTag'>)}
       />
 
       {!shouldShowFileUpload() &&

--- a/src/altinn-app-frontend/src/components/base/HeaderComponent.tsx
+++ b/src/altinn-app-frontend/src/components/base/HeaderComponent.tsx
@@ -3,10 +3,9 @@ import * as React from 'react';
 import { Grid } from '@material-ui/core';
 
 import { HelpTextContainer } from 'src/features/form/components/HelpTextContainer';
-import type { IComponentProps } from 'src/components';
-import type { ILayoutCompHeader } from 'src/features/form/layout';
+import type { PropsFromGenericComponent } from 'src/components';
 
-export type IHeaderProps = IComponentProps & Omit<ILayoutCompHeader, 'type'>;
+export type IHeaderProps = PropsFromGenericComponent<'Header'>;
 
 const marginStyling = {
   marginTop: '0',

--- a/src/altinn-app-frontend/src/components/base/ImageComponent.tsx
+++ b/src/altinn-app-frontend/src/components/base/ImageComponent.tsx
@@ -4,11 +4,10 @@ import { Grid, makeStyles } from '@material-ui/core';
 
 import { useAppSelector } from 'src/common/hooks';
 import { HelpTextContainer } from 'src/features/form/components/HelpTextContainer';
-import type { IComponentProps } from 'src/components';
-import type { ILayoutCompImage } from 'src/features/form/layout';
+import type { PropsFromGenericComponent } from 'src/components';
 import type { IAltinnWindow } from 'src/types';
 
-export type IImageProps = IComponentProps & Omit<ILayoutCompImage, 'type'>;
+export type IImageProps = PropsFromGenericComponent<'Image'>;
 
 const useStyles = makeStyles({
   spacing: {

--- a/src/altinn-app-frontend/src/components/base/InputComponent.tsx
+++ b/src/altinn-app-frontend/src/components/base/InputComponent.tsx
@@ -3,10 +3,9 @@ import React from 'react';
 import { TextField } from '@altinn/altinn-design-system';
 import type { ReadOnlyVariant } from '@altinn/altinn-design-system';
 
-import type { IComponentProps } from '..';
-
 import { useDelayedSavedState } from 'src/components/hooks/useDelayedSavedState';
-import type { ILayoutCompInput } from 'src/features/form/layout';
+import type { PropsFromGenericComponent } from 'src/components/index';
+import type { IInputFormatting } from 'src/features/form/layout';
 
 export interface IInputBaseProps {
   id: string;
@@ -16,7 +15,7 @@ export interface IInputBaseProps {
   inputRef?: ((el: HTMLInputElement) => void) | React.Ref<any>;
 }
 
-export type IInputProps = IComponentProps & Omit<ILayoutCompInput, 'type'>;
+export type IInputProps = PropsFromGenericComponent<'Input'>;
 
 export function InputComponent({
   id,
@@ -50,7 +49,7 @@ export function InputComponent({
       aria-describedby={
         textResourceBindings?.description ? `description-${id}` : undefined
       }
-      formatting={formatting}
+      formatting={formatting as IInputFormatting}
     />
   );
 }

--- a/src/altinn-app-frontend/src/components/base/MapComponent.test.tsx
+++ b/src/altinn-app-frontend/src/components/base/MapComponent.test.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { render as rtlRender, screen } from '@testing-library/react';
 
 import { MapComponent } from 'src/components/base/MapComponent';
-import type { IComponentProps } from 'src/components';
 import type { IMapComponentProps } from 'src/components/base/MapComponent';
 
 const render = (props: Partial<IMapComponentProps> = {}) => {
@@ -28,7 +27,7 @@ const render = (props: Partial<IMapComponentProps> = {}) => {
     readOnly: false,
     required: false,
     textResourceBindings: {},
-    ...({} as IComponentProps),
+    ...({} as IMapComponentProps),
     ...props,
   };
 

--- a/src/altinn-app-frontend/src/components/base/MapComponent.tsx
+++ b/src/altinn-app-frontend/src/components/base/MapComponent.tsx
@@ -2,20 +2,16 @@ import React from 'react';
 
 import { Map } from '@altinn/altinn-design-system';
 import { makeStyles, Typography } from '@material-ui/core';
-import type { Location, MapLayer } from '@altinn/altinn-design-system';
+import type { Location } from '@altinn/altinn-design-system';
 
-import type { IComponentProps } from '..';
+import type { PropsFromGenericComponent } from 'src/components';
 
 import {
   getLanguageFromKey,
   getParsedLanguageFromKey,
 } from 'altinn-shared/utils';
 
-export interface IMapComponentProps extends IComponentProps {
-  layers?: MapLayer[];
-  centerLocation?: Location;
-  zoom?: number;
-}
+export type IMapComponentProps = PropsFromGenericComponent<'Map'>;
 
 export const useStyles = makeStyles(() => ({
   footer: {

--- a/src/altinn-app-frontend/src/components/base/MultipleSelect.tsx
+++ b/src/altinn-app-frontend/src/components/base/MultipleSelect.tsx
@@ -2,11 +2,10 @@ import React from 'react';
 import Select from 'react-select';
 import type { MultiValue } from 'react-select';
 
-import type { IComponentProps } from '..';
+import type { PropsFromGenericComponent } from '..';
 
 import { useAppSelector } from 'src/common/hooks';
 import { useGetOptions } from 'src/components/hooks';
-import type { ILayoutCompMultipleSelect } from 'src/features/form/layout';
 import type { IOption } from 'src/types';
 
 import { getLanguageFromKey } from 'altinn-shared/utils';
@@ -16,8 +15,7 @@ import 'src/components/base/MultipleSelect.css';
 const multipleSelectCssPrefix = 'multipleSelect';
 const invalidBorderColor = '#D5203B !important';
 
-export type IMultipleSelectProps = IComponentProps &
-  Omit<ILayoutCompMultipleSelect, 'type'>;
+export type IMultipleSelectProps = PropsFromGenericComponent<'MultipleSelect'>;
 
 export function MultipleSelect({
   options,

--- a/src/altinn-app-frontend/src/components/base/NavigationBar.tsx
+++ b/src/altinn-app-frontend/src/components/base/NavigationBar.tsx
@@ -8,8 +8,7 @@ import { FormLayoutActions } from 'src/features/form/layout/formLayoutSlice';
 import { Triggers } from 'src/types';
 import { getTextResource } from 'src/utils/formComponentUtils';
 import { getTextFromAppOrDefault } from 'src/utils/textResource';
-import type { IComponentProps } from 'src/components';
-import type { ILayoutCompNavBar } from 'src/features/form/layout';
+import type { PropsFromGenericComponent } from 'src/components';
 
 const useStyles = makeStyles((theme) => ({
   menu: {
@@ -64,7 +63,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-export type INavigationBar = IComponentProps & Omit<ILayoutCompNavBar, 'type'>;
+export type INavigationBar = PropsFromGenericComponent<'NavigationBar'>;
 
 interface INavigationButton {
   onClick: () => void;

--- a/src/altinn-app-frontend/src/components/base/PanelComponent.tsx
+++ b/src/altinn-app-frontend/src/components/base/PanelComponent.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
 
 import { Panel } from 'src/features/form/components/Panel';
-import type { IComponentProps } from 'src/components';
-import type { ILayoutCompPanel } from 'src/features/form/layout';
+import type { PropsFromGenericComponent } from 'src/components';
 
-type IPanelProps = IComponentProps & Omit<ILayoutCompPanel, 'type'>;
+type IPanelProps = PropsFromGenericComponent<'Panel'>;
 
 export const PanelComponent = ({
   getTextResource,

--- a/src/altinn-app-frontend/src/components/base/ParagraphComponent.test.tsx
+++ b/src/altinn-app-frontend/src/components/base/ParagraphComponent.test.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { render as rtlRender, screen } from '@testing-library/react';
 
 import { ParagraphComponent } from 'src/components/base/ParagraphComponent';
-import type { IComponentProps } from 'src/components';
 import type { IParagraphProps } from 'src/components/base/ParagraphComponent';
 
 describe('ParagraphComponent', () => {
@@ -60,7 +59,7 @@ describe('ParagraphComponent', () => {
   });
 });
 
-const render = (props: Partial<IComponentProps> = {}) => {
+const render = (props: Partial<IParagraphProps> = {}) => {
   const allProps = {
     id: 'abc123',
     type: 'Paragraph',

--- a/src/altinn-app-frontend/src/components/base/ParagraphComponent.tsx
+++ b/src/altinn-app-frontend/src/components/base/ParagraphComponent.tsx
@@ -3,11 +3,9 @@ import React from 'react';
 import { Grid, makeStyles, Typography } from '@material-ui/core';
 
 import { HelpTextContainer } from 'src/features/form/components/HelpTextContainer';
-import type { IComponentProps } from 'src/components';
-import type { ILayoutCompParagraph } from 'src/features/form/layout';
+import type { PropsFromGenericComponent } from 'src/components';
 
-export type IParagraphProps = IComponentProps &
-  Omit<ILayoutCompParagraph, 'type'>;
+export type IParagraphProps = PropsFromGenericComponent<'Paragraph'>;
 
 const useStyles = makeStyles({
   spacing: {

--- a/src/altinn-app-frontend/src/components/base/RadioButtons/RadioButtonsContainerComponent.test.tsx
+++ b/src/altinn-app-frontend/src/components/base/RadioButtons/RadioButtonsContainerComponent.test.tsx
@@ -9,7 +9,6 @@ import type { PreloadedState } from 'redux';
 import { RadioButtonContainerComponent } from 'src/components/base/RadioButtons/RadioButtonsContainerComponent';
 import { mockDelayBeforeSaving } from 'src/components/hooks/useDelayedSavedState';
 import { LayoutStyle } from 'src/types';
-import type { IComponentProps } from 'src/components';
 import type { IRadioButtonsContainerProps } from 'src/components/base/RadioButtons/RadioButtonsContainerComponent';
 import type { IOptionsState } from 'src/shared/resources/options';
 import type { RootState } from 'src/store';
@@ -36,14 +35,13 @@ const render = (
   customState: PreloadedState<RootState> = {},
 ) => {
   const allProps: IRadioButtonsContainerProps = {
-    type: 'RadioButtons',
     options: [],
     optionsId: 'countries',
     preselectedOptionIndex: undefined,
     legend: 'legend',
     handleDataChange: jest.fn(),
     getTextResource: (value) => value,
-    ...({} as IComponentProps),
+    ...({} as IRadioButtonsContainerProps),
     ...props,
   };
 

--- a/src/altinn-app-frontend/src/components/base/RadioButtons/RadioButtonsContainerComponent.tsx
+++ b/src/altinn-app-frontend/src/components/base/RadioButtons/RadioButtonsContainerComponent.tsx
@@ -2,12 +2,10 @@ import React from 'react';
 
 import { ControlledRadioGroup } from 'src/components/base/RadioButtons/ControlledRadioGroup';
 import { useRadioButtons } from 'src/components/base/RadioButtons/radioButtonsUtils';
-import type { IComponentProps } from 'src/components';
-import type { ILayoutCompRadioButtons } from 'src/features/form/layout';
+import type { PropsFromGenericComponent } from 'src/components';
 
 export interface IRadioButtonsContainerProps
-  extends IComponentProps,
-    ILayoutCompRadioButtons {
+  extends PropsFromGenericComponent<'RadioButtons'> {
   validationMessages?: any;
 }
 

--- a/src/altinn-app-frontend/src/components/base/TextAreaComponent.test.tsx
+++ b/src/altinn-app-frontend/src/components/base/TextAreaComponent.test.tsx
@@ -4,7 +4,6 @@ import { render as rtlRender, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { TextAreaComponent } from 'src/components/base/TextAreaComponent';
-import type { IComponentProps } from 'src/components';
 import type { ITextAreaProps } from 'src/components/base/TextAreaComponent';
 
 describe('TextAreaComponent.tsx', () => {
@@ -78,7 +77,7 @@ describe('TextAreaComponent.tsx', () => {
   });
 });
 
-const render = (props: Partial<IComponentProps> = {}) => {
+const render = (props: Partial<ITextAreaProps> = {}) => {
   const allProps = {
     id: 'id',
     type: 'TextArea',

--- a/src/altinn-app-frontend/src/components/base/TextAreaComponent.tsx
+++ b/src/altinn-app-frontend/src/components/base/TextAreaComponent.tsx
@@ -1,13 +1,11 @@
 import * as React from 'react';
 
 import { useDelayedSavedState } from 'src/components/hooks/useDelayedSavedState';
-import type { IComponentProps } from 'src/components';
-import type { ILayoutCompTextArea } from 'src/features/form/layout';
+import type { PropsFromGenericComponent } from 'src/components';
 
 import 'src/styles/shared.css';
 
-export type ITextAreaProps = IComponentProps &
-  Omit<ILayoutCompTextArea, 'type'>;
+export type ITextAreaProps = PropsFromGenericComponent<'TextArea'>;
 
 export function TextAreaComponent({
   id,

--- a/src/altinn-app-frontend/src/components/custom/CustomWebComponent.tsx
+++ b/src/altinn-app-frontend/src/components/custom/CustomWebComponent.tsx
@@ -1,16 +1,14 @@
 import React from 'react';
 
 import { useAppSelector } from 'src/common/hooks';
-import type { IComponentProps } from 'src/components';
-import type { ILayoutCompCustom } from 'src/features/form/layout';
+import type { PropsFromGenericComponent } from 'src/components';
 import type { ITextResource, ITextResourceBindings } from 'src/types';
 
 import { getTextResourceByKey } from 'altinn-shared/utils';
 
-export type ICustomComponentProps = IComponentProps &
-  Omit<ILayoutCompCustom, 'type'> & {
-    [key: string]: string | number | boolean | object;
-  };
+export type ICustomComponentProps = PropsFromGenericComponent<'Custom'> & {
+  [key: string]: string | number | boolean | object;
+};
 
 function CustomWebComponent({
   tagName,

--- a/src/altinn-app-frontend/src/components/index.ts
+++ b/src/altinn-app-frontend/src/components/index.ts
@@ -27,8 +27,10 @@ import CustomComponent from 'src/components/custom/CustomWebComponent';
 import { NavigationButtons as NavigationButtonsComponent } from 'src/components/presentation/NavigationButtons';
 import type { IGenericComponentProps } from 'src/components/GenericComponent';
 import type {
+  ComponentExceptGroup,
   ComponentExceptGroupAndSummary,
   IGrid,
+  ILayoutComponent,
 } from 'src/features/form/layout';
 import type { IComponentFormData } from 'src/utils/formComponentUtils';
 
@@ -81,13 +83,18 @@ export interface IComponentProps extends IGenericComponentProps {
   isValid?: boolean;
 }
 
+export type PropsFromGenericComponent<T extends ComponentExceptGroup> =
+  IComponentProps & Omit<ILayoutComponent<T>, 'type'>;
+
 export interface IFormComponentContext {
   grid?: IGrid;
+  id?: string;
   baseComponentId?: string;
 }
 
 export const FormComponentContext = createContext<IFormComponentContext>({
   grid: undefined,
+  id: undefined,
   baseComponentId: undefined,
 });
 

--- a/src/altinn-app-frontend/src/components/presentation/NavigationButtons.test.tsx
+++ b/src/altinn-app-frontend/src/components/presentation/NavigationButtons.test.tsx
@@ -6,7 +6,7 @@ import { render, screen } from '@testing-library/react';
 import configureStore from 'redux-mock-store';
 
 import { NavigationButtons } from 'src/components/presentation/NavigationButtons';
-import type { IComponentProps } from 'src/components';
+import type { INavigationButtons } from 'src/components/presentation/NavigationButtons';
 
 describe('NavigationButton', () => {
   let mockStore;
@@ -92,7 +92,7 @@ describe('NavigationButton', () => {
           id='nav-button-1'
           showBackButton={false}
           textResourceBindings={null}
-          {...({} as IComponentProps)}
+          {...({} as INavigationButtons)}
         />
       </Provider>,
     );
@@ -108,7 +108,7 @@ describe('NavigationButton', () => {
           id='nav-button-1'
           showBackButton={true}
           textResourceBindings={null}
-          {...({} as IComponentProps)}
+          {...({} as INavigationButtons)}
         />
       </Provider>,
     );
@@ -138,7 +138,7 @@ describe('NavigationButton', () => {
           id='nav-button-2'
           showBackButton={true}
           textResourceBindings={null}
-          {...({} as IComponentProps)}
+          {...({} as INavigationButtons)}
         />
       </Provider>,
     );

--- a/src/altinn-app-frontend/src/components/presentation/NavigationButtons.tsx
+++ b/src/altinn-app-frontend/src/components/presentation/NavigationButtons.tsx
@@ -2,20 +2,18 @@ import * as React from 'react';
 
 import { Grid } from '@material-ui/core';
 
-import type { IComponentProps } from '..';
+import type { PropsFromGenericComponent } from '..';
 
 import { useAppDispatch, useAppSelector } from 'src/common/hooks';
 import { FormLayoutActions } from 'src/features/form/layout/formLayoutSlice';
 import { Triggers } from 'src/types';
 import { getTextFromAppOrDefault } from 'src/utils/textResource';
-import type { ILayoutCompNavButtons } from 'src/features/form/layout';
 import type { IKeepComponentScrollPos } from 'src/features/form/layout/formLayoutTypes';
 import type { ILayoutNavigation, INavigationConfig } from 'src/types';
 
 import { AltinnButton } from 'altinn-shared/components';
 
-export type INavigationButtons = IComponentProps &
-  Omit<ILayoutCompNavButtons, 'type'>;
+export type INavigationButtons = PropsFromGenericComponent<'NavigationButtons'>;
 
 export function NavigationButtons(props: INavigationButtons) {
   const dispatch = useAppDispatch();

--- a/src/altinn-app-frontend/src/components/summary/SummaryComponentSwitch.tsx
+++ b/src/altinn-app-frontend/src/components/summary/SummaryComponentSwitch.tsx
@@ -97,7 +97,7 @@ export default function SummaryComponentSwitch({
         label={label}
         hasValidationMessages={hasValidationMessages}
         formData={formData}
-        readOnlyComponent={(formComponent as ILayoutComponent).readOnly}
+        readOnlyComponent={formComponent.readOnly}
       />
     );
   }
@@ -125,7 +125,7 @@ export default function SummaryComponentSwitch({
       label={label}
       hasValidationMessages={hasValidationMessages}
       formData={formData}
-      readOnlyComponent={(formComponent as ILayoutComponent).readOnly}
+      readOnlyComponent={formComponent.readOnly}
       display={display}
     />
   );

--- a/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupsLikertContainer.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupsLikertContainer.tsx
@@ -35,7 +35,7 @@ export const RepeatingGroupsLikertContainer = ({
   container,
 }: RepeatingGroupsLikertContainerProps) => {
   const { optionsId, mapping, source, options } =
-    repeatingGroupDeepCopyComponents[0] as IRadioButtonsContainerProps;
+    repeatingGroupDeepCopyComponents[0] as unknown as IRadioButtonsContainerProps;
   const mobileView = useMediaQuery('(max-width:992px)'); // breakpoint on altinn-modal
   const apiOptions = useGetOptions({ optionsId, mapping, source });
   const calculatedOptions = apiOptions || options || [];
@@ -100,7 +100,7 @@ export const RepeatingGroupsLikertContainer = ({
             return (
               <GenericComponent
                 key={comp.id}
-                {...comp}
+                {...(comp as ILayoutComponent)}
               />
             );
           })}


### PR DESCRIPTION
## Description
Splitting up the massive #540 into smaller parts. This part is the simplest one; mostly type-changes. Until now the props sent from `GenericComponent` and passed to the respective components have been defined for each component, but now I've introduced `PropsFromGenericComponent` to handle this for all of them. This prepares for expressions, where the expressions inside the props will be resolved by `GenericComponent` (thus altering what is sent from `GenericComponent` to all other components.

Removing the `hidden` prop passed into `GenericComponent`, as this is just a result of the read from redux state (which `GenericComponent` does anyway).

## Related Issue(s)
- #540

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- ~~[ ] Relevant automated test added (if you find this hard, leave it and we'll help out)~~
- [x] All tests run green

## Documentation
- ~~[ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~
