### PR TITLE
Expressions: Tracks

### DIFF
--- a/src/altinn-app-frontend/__mocks__/uiConfigStateMock.ts
+++ b/src/altinn-app-frontend/__mocks__/uiConfigStateMock.ts
@@ -6,6 +6,11 @@ export const getUiConfigStateMock = (
   return {
     autoSave: true,
     focus: null,
+    tracks: {
+      hidden: [],
+      hiddenExpr: {},
+      order: ['FormLayout'],
+    },
     hiddenFields: [],
     repeatingGroups: {
       group: {
@@ -24,7 +29,6 @@ export const getUiConfigStateMock = (
     fileUploadersWithTag: null,
     currentView: 'FormLayout',
     navigationConfig: {},
-    layoutOrder: ['FormLayout'],
     ...customStates,
   };
 };

--- a/src/altinn-app-frontend/src/components/base/NavigationBar.test.tsx
+++ b/src/altinn-app-frontend/src/components/base/NavigationBar.test.tsx
@@ -22,7 +22,11 @@ const render = ({ props = {}, dispatch = jest.fn() } = {}) => {
       error: null,
       layoutsets: null,
       uiConfig: {
-        layoutOrder: ['page1', 'page2', 'page3'],
+        tracks: {
+          order: ['page1', 'page2', 'page3'],
+          hiddenExpr: {},
+          hidden: [],
+        },
         currentView: 'page1',
         autoSave: false,
         focus: 'focus',

--- a/src/altinn-app-frontend/src/components/base/NavigationBar.tsx
+++ b/src/altinn-app-frontend/src/components/base/NavigationBar.tsx
@@ -5,6 +5,7 @@ import cn from 'classnames';
 
 import { useAppDispatch, useAppSelector } from 'src/common/hooks';
 import { FormLayoutActions } from 'src/features/form/layout/formLayoutSlice';
+import { selectLayoutOrder } from 'src/selectors/getLayoutOrder';
 import { Triggers } from 'src/types';
 import { getTextResource } from 'src/utils/formComponentUtils';
 import { getTextFromAppOrDefault } from 'src/utils/textResource';
@@ -103,9 +104,7 @@ NavigationButton.displayName = 'NavigationButton';
 export const NavigationBar = ({ triggers }: INavigationBar) => {
   const classes = useStyles();
   const dispatch = useAppDispatch();
-  const pageIds = useAppSelector(
-    (state) => state.formLayout.uiConfig.layoutOrder,
-  );
+  const pageIds = useAppSelector(selectLayoutOrder);
   const returnToView = useAppSelector(
     (state) => state.formLayout.uiConfig.returnToView,
   );

--- a/src/altinn-app-frontend/src/components/presentation/Header.test.tsx
+++ b/src/altinn-app-frontend/src/components/presentation/Header.test.tsx
@@ -48,7 +48,10 @@ describe('Header', () => {
             ...mockFormLayout.uiConfig,
             showProgress: true,
             currentView: '3',
-            layoutOrder: ['1', '2', '3', '4', '5', '6'],
+            tracks: {
+              ...mockFormLayout.uiConfig.tracks,
+              order: ['1', '2', '3', '4', '5', '6'],
+            },
           },
         },
       }),
@@ -65,7 +68,10 @@ describe('Header', () => {
             ...mockFormLayout.uiConfig,
             showProgress: true,
             currentView: '3',
-            layoutOrder: ['1', '2', '3', '4', '5', '6'],
+            tracks: {
+              ...mockFormLayout.uiConfig.tracks,
+              order: ['1', '2', '3', '4', '5', '6'],
+            },
           },
         },
       }),

--- a/src/altinn-app-frontend/src/components/presentation/NavigationButtons.test.tsx
+++ b/src/altinn-app-frontend/src/components/presentation/NavigationButtons.test.tsx
@@ -64,7 +64,11 @@ describe('NavigationButton', () => {
         focus: null,
         hiddenFields: [],
         repeatingGroups: null,
-        layoutOrder: ['layout1', 'layout2'],
+        tracks: {
+          order: ['layout1', 'layout2'],
+          hidden: [],
+          hiddenExpr: {},
+        },
         navigationConfig: {
           layout1: {
             next: 'layout2',

--- a/src/altinn-app-frontend/src/components/presentation/NavigationButtons.tsx
+++ b/src/altinn-app-frontend/src/components/presentation/NavigationButtons.tsx
@@ -6,6 +6,7 @@ import type { IComponentProps } from '..';
 
 import { useAppDispatch, useAppSelector } from 'src/common/hooks';
 import { FormLayoutActions } from 'src/features/form/layout/formLayoutSlice';
+import { selectLayoutOrder } from 'src/selectors/getLayoutOrder';
 import { Triggers } from 'src/types';
 import { getTextFromAppOrDefault } from 'src/utils/textResource';
 import type { ILayoutCompNavButtons } from 'src/features/form/layout';
@@ -32,9 +33,7 @@ export function NavigationButtons(props: INavigationButtons) {
   const currentView = useAppSelector(
     (state) => state.formLayout.uiConfig.currentView,
   );
-  const orderedLayoutKeys = useAppSelector(
-    (state) => state.formLayout.uiConfig.layoutOrder,
-  );
+  const orderedLayoutKeys = useAppSelector(selectLayoutOrder);
   const returnToView = useAppSelector(
     (state) => state.formLayout.uiConfig.returnToView,
   );

--- a/src/altinn-app-frontend/src/components/presentation/Progress.tsx
+++ b/src/altinn-app-frontend/src/components/presentation/Progress.tsx
@@ -3,15 +3,14 @@ import React from 'react';
 import { CircularProgress } from '@altinn/altinn-design-system';
 
 import { useAppSelector } from 'src/common/hooks';
+import { selectLayoutOrder } from 'src/selectors/getLayoutOrder';
 import { getTextFromAppOrDefault } from 'src/utils/textResource';
 
 export const Progress = () => {
   const currentPageId = useAppSelector(
     (state) => state.formLayout.uiConfig.currentView,
   );
-  const pageIds = useAppSelector(
-    (state) => state.formLayout.uiConfig.layoutOrder,
-  );
+  const pageIds = useAppSelector(selectLayoutOrder);
   const language = useAppSelector((state) => state.language.language);
   const textResources = useAppSelector(
     (state) => state.textResources.resources,

--- a/src/altinn-app-frontend/src/components/summary/SummaryGroupComponent.test.tsx
+++ b/src/altinn-app-frontend/src/components/summary/SummaryGroupComponent.test.tsx
@@ -77,7 +77,11 @@ describe('SummaryGroupComponent', () => {
         },
         currentView: 'FormLayout',
         navigationConfig: {},
-        layoutOrder: [],
+        tracks: {
+          order: [],
+          hidden: [],
+          hiddenExpr: {},
+        },
       },
     });
 

--- a/src/altinn-app-frontend/src/features/form/containers/GroupContainerLikertTestUtils.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/GroupContainerLikertTestUtils.tsx
@@ -142,7 +142,11 @@ const createLayout = (
       autoSave: null,
       fileUploadersWithTag: {},
       navigationConfig: {},
-      layoutOrder: null,
+      tracks: {
+        order: null,
+        hidden: [],
+        hiddenExpr: {},
+      },
       pageTriggers: [],
     },
   };

--- a/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupsTable.test.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupsTable.test.tsx
@@ -104,7 +104,11 @@ describe('RepeatingGroupTable', () => {
       autoSave: false,
       currentView: 'FormLayout',
       focus: undefined,
-      layoutOrder: ['FormLayout'],
+      tracks: {
+        order: ['FormLayout'],
+        hidden: [],
+        hiddenExpr: {},
+      },
     },
     error: null,
     layoutsets: null,

--- a/src/altinn-app-frontend/src/features/form/layout/formLayoutSlice.test.ts
+++ b/src/altinn-app-frontend/src/features/form/layout/formLayoutSlice.test.ts
@@ -19,7 +19,7 @@ describe('layoutSlice', () => {
       );
 
       expect(nextState.layouts).toEqual(layouts);
-      expect(nextState.uiConfig.layoutOrder).toEqual(Object.keys(layouts));
+      expect(nextState.uiConfig.tracks.order).toEqual(Object.keys(layouts));
       expect(nextState.uiConfig.navigationConfig).toEqual(navigationConfig);
     });
 

--- a/src/altinn-app-frontend/src/features/form/layout/formLayoutSlice.ts
+++ b/src/altinn-app-frontend/src/features/form/layout/formLayoutSlice.ts
@@ -42,7 +42,11 @@ export const initialState: ILayoutState = {
     fileUploadersWithTag: {},
     currentView: 'FormLayout',
     navigationConfig: {},
-    layoutOrder: null,
+    tracks: {
+      hidden: [],
+      hiddenExpr: {},
+      order: null,
+    },
     pageTriggers: [],
     keepScrollPos: undefined,
   },
@@ -66,7 +70,7 @@ const formLayoutSlice = createSagaSlice(
           const { layouts, navigationConfig } = action.payload;
           state.layouts = layouts;
           state.uiConfig.navigationConfig = navigationConfig;
-          state.uiConfig.layoutOrder = Object.keys(layouts);
+          state.uiConfig.tracks.order = Object.keys(layouts);
           state.error = null;
           state.uiConfig.repeatingGroups = {};
         },
@@ -114,7 +118,7 @@ const formLayoutSlice = createSagaSlice(
               updateCommonPageSettings(state, settings.pages);
               const order = settings.pages.order;
               if (order) {
-                state.uiConfig.layoutOrder = order;
+                state.uiConfig.tracks.order = order;
                 if (state.uiConfig.currentViewCacheKey) {
                   let currentView: string;
                   const lastVisitedPage = localStorage.getItem(
@@ -305,7 +309,7 @@ const formLayoutSlice = createSagaSlice(
         mkAction<LayoutTypes.ICalculatePageOrderAndMoveToNextPageFulfilled>({
           reducer: (state, action) => {
             const { order } = action.payload;
-            state.uiConfig.layoutOrder = order;
+            state.uiConfig.tracks.order = order;
           },
         }),
       calculatePageOrderAndMoveToNextPageRejected:
@@ -315,6 +319,11 @@ const formLayoutSlice = createSagaSlice(
             state.error = error;
           },
         }),
+      updateHiddenLayouts: mkAction<LayoutTypes.IHiddenLayoutsUpdate>({
+        reducer: (state, action) => {
+          state.uiConfig.tracks.hidden = action.payload.hiddenLayouts;
+        },
+      }),
       initRepeatingGroups: mkAction<void>({
         saga: () => watchInitRepeatingGroupsSaga,
       }),

--- a/src/altinn-app-frontend/src/features/form/layout/formLayoutTypes.ts
+++ b/src/altinn-app-frontend/src/features/form/layout/formLayoutTypes.ts
@@ -136,3 +136,7 @@ export interface ICalculatePageOrderAndMoveToNextPage {
 export interface ICalculatePageOrderAndMoveToNextPageFulfilled {
   order: string[];
 }
+
+export interface IHiddenLayoutsUpdate {
+  hiddenLayouts: string[];
+}

--- a/src/altinn-app-frontend/src/selectors/getLayoutOrder.test.ts
+++ b/src/altinn-app-frontend/src/selectors/getLayoutOrder.test.ts
@@ -1,0 +1,23 @@
+import { getLayoutOrderFromTracks } from 'src/selectors/getLayoutOrder';
+
+describe('getLayoutOrderFromTracks', () => {
+  it('should hide a layout after expressions have been evaluated', () => {
+    expect(
+      getLayoutOrderFromTracks({
+        order: ['first', 'second', 'third'],
+        hidden: ['second'],
+        hiddenExpr: {},
+      }),
+    ).toEqual(['first', 'third']);
+  });
+
+  it('should not affect the order sent from the server', () => {
+    expect(
+      getLayoutOrderFromTracks({
+        order: ['4', '3', '2', '1'],
+        hidden: ['2', '3'],
+        hiddenExpr: {},
+      }),
+    ).toEqual(['4', '1']);
+  });
+});

--- a/src/altinn-app-frontend/src/selectors/getLayoutOrder.ts
+++ b/src/altinn-app-frontend/src/selectors/getLayoutOrder.ts
@@ -1,0 +1,22 @@
+import { createSelector } from 'reselect';
+
+import type { RootState } from 'src/store';
+import type { ITracks } from 'src/types';
+
+/**
+ * Given the ITracks state, this returns the final order for layouts
+ */
+export function getLayoutOrderFromTracks(tracks: ITracks): string[] | null {
+  if (tracks.order === null) {
+    return null;
+  }
+
+  const hiddenSet = new Set(tracks.hidden);
+  return [...tracks.order].filter((layout) => !hiddenSet.has(layout));
+}
+
+const selectTracks = (state: RootState) => state.formLayout.uiConfig.tracks;
+
+export const selectLayoutOrder = createSelector(selectTracks, (tracks) =>
+  getLayoutOrderFromTracks(tracks),
+);

--- a/src/altinn-app-frontend/src/shared/containers/Presentation.tsx
+++ b/src/altinn-app-frontend/src/shared/containers/Presentation.tsx
@@ -4,6 +4,7 @@ import { useAppDispatch, useAppSelector } from 'src/common/hooks';
 import Header from 'src/components/presentation/Header';
 import NavBar from 'src/components/presentation/NavBar';
 import { FormLayoutActions } from 'src/features/form/layout/formLayoutSlice';
+import { getLayoutOrderFromTracks } from 'src/selectors/getLayoutOrder';
 import { PresentationType, ProcessTaskType } from 'src/types';
 import { getRedirectUrl } from 'src/utils/appUrlHelper';
 import { getNextView } from 'src/utils/formLayout';
@@ -46,7 +47,7 @@ const PresentationComponent = (props: IPresentationProvidedProps) => {
       state.formLayout.uiConfig.navigationConfig[
         state.formLayout.uiConfig.currentView
       ],
-      state.formLayout.uiConfig.layoutOrder,
+      getLayoutOrderFromTracks(state.formLayout.uiConfig.tracks),
       state.formLayout.uiConfig.currentView,
       true,
     ),

--- a/src/altinn-app-frontend/src/types/index.ts
+++ b/src/altinn-app-frontend/src/types/index.ts
@@ -150,6 +150,10 @@ export interface IValidationIssue {
   targetId: string;
 }
 
+export interface IHiddenLayoutsExpressions {
+  [layoutKey: string]: never; // Will be set in a later PR
+}
+
 export interface IUiConfig {
   autoSave: boolean;
   currentView: string;
@@ -160,12 +164,39 @@ export interface IUiConfig {
   repeatingGroups?: IRepeatingGroups;
   fileUploadersWithTag?: IFileUploadersWithTag;
   navigationConfig?: INavigationConfig;
-  layoutOrder: string[];
+  tracks: ITracks;
   pageTriggers?: Triggers[];
   hideCloseButton?: boolean;
   showLanguageSelector?: boolean;
   showProgress?: boolean;
   keepScrollPos?: IKeepComponentScrollPos;
+}
+
+/**
+ * This state includes everything needed to calculate which layouts should be shown, and their order.
+ * @see https://docs.altinn.studio/app/development/ux/pages/tracks/
+ */
+export interface ITracks {
+  /**
+   * The main 'order' is the list of layouts available, or which layouts the server tells us to display. If a layout
+   * is not in this list, it should be considered hidden. It will be null until layouts have been fetched.
+   *
+   * Do NOT use this directly, as it will not respect layouts hidden using expressions!
+   * @see getLayoutOrderFromTracks
+   * @see selectLayoutOrder
+   */
+  order: string[] | null;
+
+  /**
+   * This state contains the results from calculating `hiddenExpr` (expressions to decide if a certain layout should
+   * be hidden or not). If a layout is in this list, is should also not be displayed.
+   */
+  hidden: string[];
+
+  /**
+   * List of expressions containing logic used to show/hide certain layouts.
+   */
+  hiddenExpr: IHiddenLayoutsExpressions;
 }
 
 export interface IValidationResult {

--- a/src/altinn-app-frontend/src/utils/validation/runClientSideValidation.ts
+++ b/src/altinn-app-frontend/src/utils/validation/runClientSideValidation.ts
@@ -1,3 +1,4 @@
+import { getLayoutOrderFromTracks } from 'src/selectors/getLayoutOrder';
 import { getCurrentDataTypeId } from 'src/utils/appMetadata';
 import { convertDataBindingToModel } from 'src/utils/databindings';
 import {
@@ -8,7 +9,8 @@ import {
 } from 'src/utils/validation/validation';
 import type { IRuntimeState } from 'src/types';
 
-/** Runs client side validations on state.
+/**
+ * Runs client side validations on state.
  * @param state
  */
 export function runClientSideValidation(state: IRuntimeState) {
@@ -18,11 +20,15 @@ export function runClientSideValidation(state: IRuntimeState) {
     state.formLayout.layoutsets,
   );
   const model = convertDataBindingToModel(state.formData.formData);
-  const layoutOrder: string[] = state.formLayout.uiConfig.layoutOrder;
   const validator = getValidator(
     currentDataTaskDataTypeId,
     state.formDataModel.schemas,
   );
+
+  const layoutOrder = getLayoutOrderFromTracks(
+    state.formLayout.uiConfig.tracks,
+  );
+
   const validationResult = validateFormData(
     model,
     state.formLayout.layouts,


### PR DESCRIPTION
## Description
Splitting up the massive #540 into smaller parts. This part includes a new redux structure for 'tracks', (i.e. showing/hiding entire layouts/pages). This structure is needed to group together state that revolves around which pages should be visible, and the order of these pages.

The new rules for page visibility and order is:
1. The order is decided by the backend
2. Hidden pages are removed from the ordered list by the backend
3. The frontend may also hide some pages via expressions in the layout definition (but this should not affect the order)

This PR includes the structures needed to store the expressions in the frontend, the result of these expressions (calculated when there are changes to the form data, etc), and the code to calculate the final ordered list of layouts. 

## Related Issue(s)
- #540

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- ~~[ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~
