### PR TITLE
Expressions: Engine

### DIFF
--- a/src/altinn-app-frontend/package.json
+++ b/src/altinn-app-frontend/package.json
@@ -90,6 +90,7 @@
     "terser-webpack-plugin": "5.3.6",
     "ts-jest": "29.0.3",
     "ts-loader": "9.4.1",
+    "utility-types": "^3.10.0",
     "webpack": "5.74.0",
     "webpack-cli": "4.10.0",
     "webpack-dev-server": "4.11.1"

--- a/src/altinn-app-frontend/src/features/expressions/ExprContext.ts
+++ b/src/altinn-app-frontend/src/features/expressions/ExprContext.ts
@@ -1,0 +1,171 @@
+import dot from 'dot-object';
+
+import {
+  ExprRuntimeError,
+  NodeNotFound,
+  NodeNotFoundWithoutContext,
+} from 'src/features/expressions/errors';
+import {
+  prettyErrors,
+  prettyErrorsToConsole,
+} from 'src/features/expressions/prettyErrors';
+import type { Expression } from 'src/features/expressions/types';
+import type { IFormData } from 'src/features/form/data';
+import type { LayoutNode, LayoutRootNode } from 'src/utils/layout/hierarchy';
+
+import type {
+  IApplicationSettings,
+  IInstanceContext,
+} from 'altinn-shared/types';
+
+export interface ContextDataSources {
+  instanceContext: IInstanceContext;
+  applicationSettings: IApplicationSettings;
+  formData: IFormData;
+}
+
+export interface PrettyErrorsOptions {
+  defaultValue?: any;
+  introText?: string;
+}
+
+/**
+ * The expression context object is passed around when executing/evaluating a expression, and is
+ * a toolbox for expressions to resolve lookups in data sources, getting the current node, etc.
+ */
+export class ExprContext {
+  public path: string[] = [];
+
+  private constructor(
+    public expr: Expression,
+    public node:
+      | LayoutNode<any>
+      | LayoutRootNode<any>
+      | NodeNotFoundWithoutContext,
+    public dataSources: ContextDataSources,
+  ) {}
+
+  /**
+   * Start a new context with a blank path (i.e. with a pointer at the top-level of an expression)
+   */
+  public static withBlankPath(
+    expr: Expression,
+    node: LayoutNode<any> | LayoutRootNode<any> | NodeNotFoundWithoutContext,
+    dataSources: ContextDataSources,
+  ): ExprContext {
+    return new ExprContext(expr, node, dataSources);
+  }
+
+  /**
+   * Reference a previous instance, but move our path pointer to a new path (meaning the context is working on an
+   * inner part of the expression)
+   */
+  public static withPath(prevInstance: ExprContext, newPath: string[]) {
+    const newInstance = new ExprContext(
+      prevInstance.expr,
+      prevInstance.node,
+      prevInstance.dataSources,
+    );
+    newInstance.path = newPath;
+
+    return newInstance;
+  }
+
+  /**
+   * Utility function used to get the LayoutNode for this context, or fail if the node was not found
+   */
+  public failWithoutNode(): LayoutNode<any> | LayoutRootNode<any> {
+    if (this.node instanceof NodeNotFoundWithoutContext) {
+      throw new NodeNotFound(this, this.node);
+    }
+    return this.node;
+  }
+
+  /**
+   * Get the expression for the current path
+   */
+  public getExpr(): Expression {
+    if (this.path.length === 0) {
+      return this.expr;
+    }
+
+    // For some reason dot.pick wants to use the format '0[1][2]' for arrays instead of '[0][1][2]', so we'll rewrite
+    const [firstKey, ...restKeys] = this.path;
+    const stringPath =
+      firstKey.replace('[', '').replace(']', '') + restKeys.join('');
+
+    return dot.pick(stringPath, this.expr, false);
+  }
+
+  /**
+   * Create a string representation of the full expression, using the path pointer to point out where the expression
+   * failed (with a message).
+   */
+  public trace(err: Error, options?: PrettyErrorsOptions) {
+    if (!(err instanceof ExprRuntimeError)) {
+      console.error(err);
+      return;
+    }
+
+    // eslint-disable-next-line no-console
+    console.log(...this.prettyErrorConsole(err, options));
+  }
+
+  public prettyError(err: Error, options?: PrettyErrorsOptions): string {
+    if (err instanceof ExprRuntimeError) {
+      const prettyPrinted = prettyErrors({
+        input: this.expr,
+        errors: { [this.path.join('')]: [err.message] },
+        indentation: 1,
+      });
+
+      const introText =
+        options && 'introText' in options
+          ? options.introText
+          : 'Evaluated expression';
+
+      const extra =
+        options && 'defaultValue' in options
+          ? ['Using default value instead:', `  ${options.defaultValue}`]
+          : [];
+
+      return [`${introText}:`, prettyPrinted, ...extra].join('\n');
+    }
+
+    return err.message;
+  }
+
+  public prettyErrorConsole(
+    err: Error,
+    options?: PrettyErrorsOptions,
+  ): string[] {
+    if (err instanceof ExprRuntimeError) {
+      const prettyPrinted = prettyErrorsToConsole({
+        input: this.expr,
+        errors: { [this.path.join('')]: [err.message] },
+        indentation: 1,
+        defaultStyle: '',
+      });
+
+      const introText =
+        options && 'introText' in options
+          ? options.introText
+          : 'Evaluated expression:';
+
+      const extra =
+        options && 'defaultValue' in options
+          ? `\n%cUsing default value instead:\n  %c${options.defaultValue}%c`
+          : '';
+      const extraCss =
+        options && 'defaultValue' in options ? ['', 'color: red;', ''] : [];
+
+      return [
+        `${introText}:\n${prettyPrinted.lines}${extra}`,
+        ...prettyPrinted.css,
+        ...extraCss,
+      ];
+    }
+
+    return [err.message];
+  }
+}

--- a/src/altinn-app-frontend/src/features/expressions/errors.ts
+++ b/src/altinn-app-frontend/src/features/expressions/errors.ts
@@ -1,0 +1,52 @@
+import type { ExprContext } from 'src/features/expressions/ExprContext';
+
+export class ExprRuntimeError extends Error {
+  public constructor(public context: ExprContext, message: string) {
+    super(message);
+  }
+}
+
+export class LookupNotFound extends ExprRuntimeError {
+  public constructor(context: ExprContext, message: string) {
+    super(context, message);
+  }
+}
+
+export class UnknownTargetType extends ExprRuntimeError {
+  public constructor(context: ExprContext, type: string) {
+    super(context, `Cannot cast to unknown type '${type}'`);
+  }
+}
+
+export class UnknownSourceType extends ExprRuntimeError {
+  public constructor(context: ExprContext, type: string, supported: string) {
+    super(
+      context,
+      `Received unsupported type '${type}, only ${supported} are supported'`,
+    );
+  }
+}
+
+export class UnexpectedType extends ExprRuntimeError {
+  public constructor(context: ExprContext, expected: string, actual: any) {
+    super(context, `Expected ${expected}, got value ${JSON.stringify(actual)}`);
+  }
+}
+
+export class NodeNotFound extends ExprRuntimeError {
+  public constructor(
+    context: ExprContext,
+    original: NodeNotFoundWithoutContext,
+  ) {
+    super(
+      context,
+      `Unable to evaluate expressions in context of the ${JSON.stringify(
+        original.nodeId,
+      )} component (it could not be found)`,
+    );
+  }
+}
+
+export class NodeNotFoundWithoutContext {
+  public constructor(public nodeId: string) {}
+}

--- a/src/altinn-app-frontend/src/features/expressions/index.test.ts
+++ b/src/altinn-app-frontend/src/features/expressions/index.test.ts
@@ -1,0 +1,20 @@
+import { NodeNotFoundWithoutContext } from 'src/features/expressions/errors';
+import { evalExpr } from 'src/features/expressions/index';
+import type { ContextDataSources } from 'src/features/expressions/ExprContext';
+
+describe('Expressions', () => {
+  it('should return default value if expression evaluates to null', () => {
+    expect(
+      evalExpr(
+        ['frontendSettings', 'whatever'],
+        new NodeNotFoundWithoutContext('test'),
+        {
+          applicationSettings: {},
+        } as ContextDataSources,
+        {
+          defaultValue: 'hello world',
+        },
+      ),
+    ).toEqual('hello world');
+  });
+});

--- a/src/altinn-app-frontend/src/features/expressions/index.ts
+++ b/src/altinn-app-frontend/src/features/expressions/index.ts
@@ -1,0 +1,554 @@
+import dot from 'dot-object';
+import type { Mutable } from 'utility-types';
+
+import {
+  ExprRuntimeError,
+  LookupNotFound,
+  NodeNotFoundWithoutContext,
+  UnexpectedType,
+  UnknownSourceType,
+  UnknownTargetType,
+} from 'src/features/expressions/errors';
+import { ExprContext } from 'src/features/expressions/ExprContext';
+import {
+  addError,
+  asExpression,
+  canBeExpression,
+} from 'src/features/expressions/validation';
+import { LayoutNode } from 'src/utils/layout/hierarchy';
+import type { ContextDataSources } from 'src/features/expressions/ExprContext';
+import type {
+  BaseToActual,
+  BaseValue,
+  ExprDefaultValues,
+  Expression,
+  ExprFunction,
+  ExprResolved,
+  FuncDef,
+} from 'src/features/expressions/types';
+import type { ILayoutComponent, ILayoutGroup } from 'src/features/form/layout';
+import type { LayoutRootNode } from 'src/utils/layout/hierarchy';
+
+import type { IInstanceContext } from 'altinn-shared/types';
+
+export interface EvalExprOptions {
+  defaultValue?: any;
+  errorIntroText?: string;
+}
+
+export interface EvalExprInObjArgs<T> {
+  input: T;
+  node: LayoutNode<any> | NodeNotFoundWithoutContext;
+  dataSources: ContextDataSources;
+  defaults?: ExprDefaultValues<T>;
+}
+
+/**
+ * This function is the brains behind the useExpressions() hook, as it will find any expressions inside a deep
+ * object and resolve them.
+ * @see useExpressions
+ */
+export function evalExprInObj<T>(args: EvalExprInObjArgs<T>): ExprResolved<T> {
+  if (!args.input) {
+    return args.input as ExprResolved<T>;
+  }
+
+  return evalExprInObjectRecursive(
+    args.input,
+    args as Omit<EvalExprInObjArgs<T>, 'input'>,
+    [],
+  );
+}
+
+/**
+ * Recurse through an input object/array/any, finds expressions and evaluates them
+ */
+function evalExprInObjectRecursive<T>(
+  input: any,
+  args: Omit<EvalExprInObjArgs<T>, 'input'>,
+  path: string[],
+) {
+  if (typeof input !== 'object') {
+    return input;
+  }
+
+  if (Array.isArray(input)) {
+    let evaluateAsExpression = false;
+    if (args.defaults) {
+      const pathString = path.join('.');
+      const defaultValue = dot.pick(pathString, args.defaults);
+      evaluateAsExpression = typeof defaultValue !== 'undefined';
+    } else if (canBeExpression(input)) {
+      evaluateAsExpression = true;
+    }
+
+    if (evaluateAsExpression) {
+      const expression = asExpression(input);
+      if (expression) {
+        return evalExprInObjectCaller(expression, args, path);
+      }
+    }
+
+    const newPath = [...path];
+    const lastLeg = newPath.pop() || '';
+    return input.map((item, idx) =>
+      evalExprInObjectRecursive(item, args, [...newPath, `${lastLeg}[${idx}]`]),
+    );
+  }
+
+  const out = {};
+  for (const key of Object.keys(input)) {
+    out[key] = evalExprInObjectRecursive(input[key], args, [...path, key]);
+  }
+
+  return out;
+}
+
+/**
+ * Extracted function for evaluating expressions in the context of a larger object
+ */
+function evalExprInObjectCaller<T>(
+  expr: Expression,
+  args: Omit<EvalExprInObjArgs<T>, 'input'>,
+  path: string[],
+) {
+  const pathString = path.join('.');
+  const nodeId =
+    args.node instanceof NodeNotFoundWithoutContext
+      ? args.node.nodeId
+      : args.node.item.id;
+
+  const exprOptions: EvalExprOptions = {
+    errorIntroText: `Evaluated expression for '${pathString}' in component '${nodeId}'`,
+  };
+
+  if (args.defaults) {
+    const defaultValue = dot.pick(pathString, args.defaults);
+    if (typeof defaultValue !== 'undefined') {
+      exprOptions.defaultValue = defaultValue;
+    }
+  }
+
+  return evalExpr(expr, args.node, args.dataSources, exprOptions);
+}
+
+/**
+ * Run/evaluate an expression. You have to provide your own context containing functions for looking up external
+ * values. If you need a more concrete implementation:
+ * @see evalExprInObj
+ * @see useExpressions
+ */
+export function evalExpr(
+  expr: Expression,
+  node: LayoutNode<any> | LayoutRootNode<any> | NodeNotFoundWithoutContext,
+  dataSources: ContextDataSources,
+  options?: EvalExprOptions,
+) {
+  let ctx = ExprContext.withBlankPath(expr, node, dataSources);
+  try {
+    const result = innerEvalExpr(ctx);
+    if (
+      (result === null || result === undefined) &&
+      options &&
+      'defaultValue' in options
+    ) {
+      return options.defaultValue;
+    }
+
+    return result;
+  } catch (err) {
+    if (err instanceof ExprRuntimeError) {
+      ctx = err.context;
+    } else {
+      throw err;
+    }
+    if (options && 'defaultValue' in options) {
+      // When we know of a default value, we can safely print it as an error to the console and safely recover
+      ctx.trace(err, {
+        defaultValue: options.defaultValue,
+        ...(options.errorIntroText
+          ? { introText: options.errorIntroText }
+          : {}),
+      });
+      return options.defaultValue;
+    } else {
+      // We cannot possibly know the expected default value here, so there are no safe ways to fail here except
+      // throwing the exception to let everyone know we failed.
+      throw new Error(ctx.prettyError(err));
+    }
+  }
+}
+
+export function argTypeAt(
+  func: ExprFunction,
+  argIndex: number,
+): BaseValue | undefined {
+  const funcDef = ExprFunctions[func];
+  const possibleArgs = funcDef.args;
+  const maybeReturn = possibleArgs[argIndex];
+  if (maybeReturn) {
+    return maybeReturn;
+  }
+
+  if (funcDef.lastArgSpreads) {
+    return possibleArgs[possibleArgs.length - 1];
+  }
+
+  return undefined;
+}
+
+function innerEvalExpr(context: ExprContext) {
+  const [func, ...args] = context.getExpr();
+
+  const returnType = ExprFunctions[func].returns;
+  const neverCastIndexes = new Set(
+    ExprFunctions[func].neverCastArguments || [],
+  );
+
+  const computedArgs = args.map((arg, idx) => {
+    const realIdx = idx + 1;
+    const argContext = ExprContext.withPath(context, [
+      ...context.path,
+      `[${realIdx}]`,
+    ]);
+
+    const argValue = Array.isArray(arg) ? innerEvalExpr(argContext) : arg;
+    if (neverCastIndexes.has(idx)) {
+      return argValue;
+    }
+
+    const argType = argTypeAt(func, idx);
+    return castValue(argValue, argType, argContext);
+  });
+
+  const actualFunc: (...args: any) => any = ExprFunctions[func].impl;
+  const returnValue = actualFunc.apply(context, computedArgs);
+
+  if (ExprFunctions[func].castReturnValue === false) {
+    return returnValue;
+  }
+
+  return castValue(returnValue, returnType, context);
+}
+
+function valueToBaseValueType(value: any): BaseValue | string {
+  if (typeof value === 'number' || typeof value === 'bigint') {
+    return 'number';
+  }
+  return typeof value;
+}
+
+function isLikeNull(arg: any) {
+  return arg === 'null' || arg === null || typeof arg === 'undefined';
+}
+
+/**
+ * This function is used to cast any value to a target type before/after it is passed
+ * through a function call.
+ */
+function castValue<T extends BaseValue>(
+  value: any,
+  toType: T,
+  context: ExprContext,
+): BaseToActual<T> {
+  if (!(toType in ExprTypes)) {
+    throw new UnknownTargetType(this, toType);
+  }
+
+  const typeObj = ExprTypes[toType];
+
+  if (typeObj.nullable && isLikeNull(value)) {
+    return null;
+  }
+
+  const valueBaseType = valueToBaseValueType(value) as BaseValue;
+  if (!typeObj.accepts.includes(valueBaseType)) {
+    const supported = [
+      ...typeObj.accepts,
+      ...(typeObj.nullable ? ['null'] : []),
+    ].join(', ');
+    throw new UnknownSourceType(this, typeof value, supported);
+  }
+
+  return typeObj.impl.apply(context, [value]);
+}
+
+function defineFunc<Args extends readonly BaseValue[], Ret extends BaseValue>(
+  def: FuncDef<Args, Ret>,
+): FuncDef<Mutable<Args>, Ret> {
+  return def;
+}
+
+const instanceContextKeys: { [key in keyof IInstanceContext]: true } = {
+  instanceId: true,
+  appId: true,
+  instanceOwnerPartyId: true,
+};
+
+/**
+ * All the functions available to execute inside expressions
+ */
+export const ExprFunctions = {
+  equals: defineFunc({
+    impl: (arg1, arg2) => arg1 === arg2,
+    args: ['string', 'string'] as const,
+    returns: 'boolean',
+  }),
+  notEquals: defineFunc({
+    impl: (arg1, arg2) => arg1 !== arg2,
+    args: ['string', 'string'] as const,
+    returns: 'boolean',
+  }),
+  greaterThan: defineFunc({
+    impl: (arg1, arg2) => {
+      if (arg1 === null || arg2 === null) {
+        return false;
+      }
+
+      return arg1 > arg2;
+    },
+    args: ['number', 'number'] as const,
+    returns: 'boolean',
+  }),
+  greaterThanEq: defineFunc({
+    impl: (arg1, arg2) => {
+      if (arg1 === null || arg2 === null) {
+        return false;
+      }
+
+      return arg1 >= arg2;
+    },
+    args: ['number', 'number'] as const,
+    returns: 'boolean',
+  }),
+  lessThan: defineFunc({
+    impl: (arg1, arg2) => {
+      if (arg1 === null || arg2 === null) {
+        return false;
+      }
+
+      return arg1 < arg2;
+    },
+    args: ['number', 'number'] as const,
+    returns: 'boolean',
+  }),
+  lessThanEq: defineFunc({
+    impl: (arg1, arg2) => {
+      if (arg1 === null || arg2 === null) {
+        return false;
+      }
+
+      return arg1 <= arg2;
+    },
+    args: ['number', 'number'] as const,
+    returns: 'boolean',
+  }),
+  concat: defineFunc({
+    impl: (...args) => args.join(''),
+    args: ['string'],
+    minArguments: 0,
+    returns: 'string',
+    lastArgSpreads: true,
+  }),
+  and: defineFunc({
+    impl: (...args) => args.reduce((prev, cur) => !!prev && !!cur, true),
+    args: ['boolean'],
+    returns: 'boolean',
+    lastArgSpreads: true,
+  }),
+  or: defineFunc({
+    impl: (...args) => args.reduce((prev, cur) => !!prev || !!cur, false),
+    args: ['boolean'],
+    returns: 'boolean',
+    lastArgSpreads: true,
+  }),
+  if: defineFunc({
+    impl: function (...args) {
+      const [condition, result] = args;
+      if (condition === 'true') {
+        return result;
+      }
+
+      return args.length === 4 ? args[3] : null;
+    },
+    validator: ({ rawArgs, ctx, path }) => {
+      if (rawArgs.length === 2) {
+        return;
+      }
+      if (rawArgs.length > 2 && rawArgs[2] !== 'else') {
+        addError(ctx, [...path, '[2]'], 'Expected third argument to be "else"');
+      }
+      if (rawArgs.length === 4) {
+        return;
+      }
+      addError(
+        ctx,
+        path,
+        'Expected either 2 arguments (if) or 4 (if + else), got %s',
+        `${rawArgs.length}`,
+      );
+    },
+    args: ['string', 'string'],
+    returns: 'string',
+    lastArgSpreads: true,
+    neverCastArguments: [1, 3],
+    castReturnValue: false,
+  }),
+  instanceContext: defineFunc({
+    impl: function (key) {
+      if (instanceContextKeys[key] !== true) {
+        throw new LookupNotFound(
+          this,
+          `Unknown Instance context property ${key}`,
+        );
+      }
+
+      return this.dataSources.instanceContext[key];
+    },
+    args: ['string'] as const,
+    returns: 'string',
+  }),
+  frontendSettings: defineFunc({
+    impl: function (key) {
+      return this.dataSources.applicationSettings[key];
+    },
+    args: ['string'] as const,
+    returns: 'string',
+  }),
+  component: defineFunc({
+    impl: function (id): string {
+      const component = this.failWithoutNode().closest(
+        (c) => c.id === id || c.baseComponentId === id,
+      );
+      if (
+        component &&
+        component.item.dataModelBindings &&
+        component.item.dataModelBindings.simpleBinding
+      ) {
+        return this.dataSources.formData[
+          component.item.dataModelBindings.simpleBinding
+        ];
+      }
+
+      throw new LookupNotFound(
+        this,
+        `Unable to find component with identifier ${id} or it does not have a simpleBinding`,
+      );
+    },
+    args: ['string'] as const,
+    returns: 'string',
+  }),
+  dataModel: defineFunc({
+    impl: function (path): string {
+      const maybeNode = this.failWithoutNode();
+      if (maybeNode instanceof LayoutNode) {
+        const newPath = maybeNode.transposeDataModel(path);
+        return this.dataSources.formData[newPath] || null;
+      }
+
+      // No need to transpose the data model according to the location inside a repeating group when the context is
+      // a LayoutRootNode (i.e., when we're resolving an expression directly on the layout definition).
+      return this.dataSources.formData[path] || null;
+    },
+    args: ['string'] as const,
+    returns: 'string',
+  }),
+};
+
+function asNumber(arg: string) {
+  if (arg.match(/^-?\d+$/)) {
+    return parseInt(arg, 10);
+  }
+  if (arg.match(/^-?\d+\.\d+$/)) {
+    return parseFloat(arg);
+  }
+
+  return undefined;
+}
+
+/**
+ * All the types available in expressions, along with functions to cast possible values to them
+ * @see castValue
+ */
+export const ExprTypes: {
+  [Type in BaseValue]: {
+    nullable: boolean;
+    accepts: BaseValue[];
+    impl: (this: ExprContext, arg: any) => BaseToActual<Type>;
+  };
+} = {
+  boolean: {
+    nullable: true,
+    accepts: ['boolean', 'string', 'number'],
+    impl: function (arg) {
+      if (typeof arg === 'boolean') {
+        return arg;
+      }
+      if (arg === 'true') return true;
+      if (arg === 'false') return false;
+
+      if (
+        typeof arg === 'string' ||
+        typeof arg === 'number' ||
+        typeof arg === 'bigint'
+      ) {
+        const num = typeof arg === 'string' ? asNumber(arg) : arg;
+        if (num !== undefined) {
+          if (num === 1) return true;
+          if (num === 0) return false;
+        }
+      }
+
+      throw new UnexpectedType(this, 'boolean', arg);
+    },
+  },
+  string: {
+    nullable: true,
+    accepts: ['boolean', 'string', 'number'],
+    impl: function (arg) {
+      if (['number', 'bigint', 'boolean'].includes(typeof arg)) {
+        return JSON.stringify(arg);
+      }
+
+      // Always lowercase these values, to make comparisons case-insensitive
+      if (arg.toLowerCase() === 'null') return null;
+      if (arg.toLowerCase() === 'false') return 'false';
+      if (arg.toLowerCase() === 'true') return 'true';
+
+      return `${arg}`;
+    },
+  },
+  number: {
+    nullable: true,
+    accepts: ['boolean', 'string', 'number'],
+    impl: function (arg) {
+      if (typeof arg === 'number' || typeof arg === 'bigint') {
+        return arg as number;
+      }
+      if (typeof arg === 'string') {
+        const num = asNumber(arg);
+        if (num !== undefined) {
+          return num;
+        }
+      }
+
+      throw new UnexpectedType(this, 'number', arg);
+    },
+  },
+};
+
+export const ExprDefaultsForComponent: ExprDefaultValues<ILayoutComponent> = {
+  readOnly: false,
+  required: false,
+  hidden: false,
+};
+
+export const ExprDefaultsForGroup: ExprDefaultValues<ILayoutGroup> = {
+  ...ExprDefaultsForComponent,
+  edit: {
+    addButton: true,
+    deleteButton: true,
+    saveButton: true,
+    saveAndNextButton: false,
+  },
+};

--- a/src/altinn-app-frontend/src/features/expressions/prettyErrors.test.ts
+++ b/src/altinn-app-frontend/src/features/expressions/prettyErrors.test.ts
@@ -1,0 +1,204 @@
+import { prettyErrors } from 'src/features/expressions/prettyErrors';
+
+describe('prettyErrors', () => {
+  it('should pretty-print errors for simple values', () => {
+    expect(
+      prettyErrors({
+        input: 'hello world',
+        errors: { '': ['Some error message'] },
+      }),
+    ).toEqual(
+      ['"hello world"', '~~~~~~~~~~~~~', '→ Some error message'].join('\n'),
+    );
+  });
+  it('should pretty-print multiple errors', () => {
+    expect(
+      prettyErrors({
+        input: 'hello world',
+        errors: {
+          '': ['Some error message', 'some other message'],
+        },
+      }),
+    ).toEqual(
+      [
+        '"hello world"',
+        '~~~~~~~~~~~~~',
+        '→ Some error message',
+        '→ some other message',
+      ].join('\n'),
+    );
+  });
+  it('should pretty-print errors inside a simple array', () => {
+    expect(
+      prettyErrors({
+        input: ['hello', 'world'],
+        errors: {
+          '[0]': ['Hello is not valid', 'some other message'],
+          '[1]': ['World is not valid'],
+        },
+      }),
+    ).toEqual(
+      [
+        '[',
+        '  "hello",',
+        '  ~~~~~~~',
+        '  → Hello is not valid',
+        '  → some other message',
+        '  "world"',
+        '  ~~~~~~~',
+        '  → World is not valid',
+        ']',
+      ].join('\n'),
+    );
+  });
+  it('should pretty-print errors inside a complex object', () => {
+    expect(
+      prettyErrors({
+        input: {
+          key1: ['hello', 'world'],
+          key2: ['hello', 'world'],
+          key3: {
+            arr1: ['hello', 'world'],
+            arr2: ['hello', 'world'],
+            string1: 'foo',
+            number1: 5,
+            null1: null,
+            bool1: true,
+          },
+        },
+        errors: {
+          key1: ['this array is fine'],
+          'key2[1]': ['world found here'],
+          'key3.arr2[1]': ['world found here as well', 'some other line'],
+          'key3.arr2': ['this whole array is wrong'],
+          'key3.string1': ['foo found here'],
+          key3: ['this whole object is wrong'],
+        },
+      }),
+    ).toEqual(
+      [
+        '{',
+        '  key1: ["hello", "world"],',
+        '  ~~~~~~~~~~~~~~~~~~~~~~~~',
+        '  → this array is fine',
+        '  key2: [',
+        '    "hello",',
+        '    "world"',
+        '    ~~~~~~~',
+        '    → world found here',
+        '  ],',
+        '  key3: {',
+        '    arr1: ["hello", "world"],',
+        '    arr2: [',
+        '      "hello",',
+        '      "world"',
+        '      ~~~~~~~',
+        '      → world found here as well',
+        '      → some other line',
+        '    ],',
+        '    ~',
+        '    → this whole array is wrong',
+        '    string1: "foo",',
+        '    ~~~~~~~~~~~~~~',
+        '    → foo found here',
+        '    number1: 5,',
+        '    null1: null,',
+        '    bool1: true',
+        '  }',
+        '  ~',
+        '  → this whole object is wrong',
+        '}',
+      ].join('\n'),
+    );
+  });
+  it('should pretty-print a complex object without errors', () => {
+    expect(
+      prettyErrors({
+        input: {
+          arr1: ['hello', 'world'],
+          arr2: ['hello', 'world'],
+          obj3: { key: 'value' },
+          obj4: {
+            arr1: ['hello', 'world'],
+            arr2: ['hello', 'world'],
+            arr3: ['hello', 'world', 'and', 'many', 'other', 'items'],
+            string1: 'foo',
+            number1: 5,
+            null1: null,
+            bool1: true,
+          },
+        },
+      }),
+    ).toEqual(
+      [
+        '{',
+        '  arr1: ["hello", "world"],',
+        '  arr2: ["hello", "world"],',
+        '  obj3: {key: "value"},',
+        '  obj4: {',
+        '    arr1: ["hello", "world"],',
+        '    arr2: ["hello", "world"],',
+        '    arr3: [',
+        '      "hello",',
+        '      "world",',
+        '      "and",',
+        '      "many",',
+        '      "other",',
+        '      "items"',
+        '    ],',
+        '    string1: "foo",',
+        '    number1: 5,',
+        '    null1: null,',
+        '    bool1: true',
+        '  }',
+        '}',
+      ].join('\n'),
+    );
+  });
+  it('should render an expression error message', () => {
+    expect(
+      prettyErrors({
+        input: {
+          function: 'greaterThanEq',
+          args: [{ function: 'component', args: ['alder'] }, 18],
+        },
+        errors: { 'args[0]': ['some error message about this expression'] },
+      }),
+    ).toEqual(
+      [
+        '{',
+        '  function: "greaterThanEq",',
+        '  args: [',
+        '    {function: "component", args: ["alder"]},',
+        '    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~',
+        '    → some error message about this expression',
+        '    18',
+        '  ]',
+        '}',
+      ].join('\n'),
+    );
+  });
+  it('should render another expression error message', () => {
+    expect(
+      prettyErrors({
+        input: {
+          function: 'greaterThanEq',
+          args: [{ function: 'component', args: ['alder'] }, 18],
+        },
+        errors: { 'args[1]': ['some error message about 18'] },
+      }),
+    ).toEqual(
+      [
+        '{',
+        '  function: "greaterThanEq",',
+        '  args: [',
+        '    {function: "component", args: ["alder"]},',
+        '    18',
+        '    ~~',
+        '    → some error message about 18',
+        '  ]',
+        '}',
+      ].join('\n'),
+    );
+  });
+});

--- a/src/altinn-app-frontend/src/features/expressions/prettyErrors.ts
+++ b/src/altinn-app-frontend/src/features/expressions/prettyErrors.ts
@@ -1,0 +1,304 @@
+import { v4 as uuidv4 } from 'uuid';
+
+export type ErrorList = { [path: string]: string[] };
+
+export interface PrettyErrorsOptions {
+  input: any;
+  errors?: ErrorList;
+  indentation?: number;
+}
+
+export interface PrettyErrorsOptionsStyling {
+  defaultStyle?: string;
+}
+
+interface In {
+  obj: any;
+  errors: ErrorList;
+  path: string[];
+  css: { [unique: string]: { original: string; style: string } } | undefined;
+}
+
+type RecursiveLines = (string | RecursiveLines)[];
+
+interface Out {
+  lines: RecursiveLines;
+  start: string;
+  end: string;
+  inline: boolean;
+  errors: string[];
+}
+
+function trimTrailingComma(str: string): string {
+  return str.replace(/,$/, '');
+}
+
+function trimLastTrailingComma(lines: RecursiveLines) {
+  const lastIdx = lines.length - 1;
+  if (typeof lines[lastIdx] === 'string') {
+    lines[lastIdx] = trimTrailingComma(lines[lastIdx] as string);
+  }
+}
+
+const cssRegex = /(\{css:[a-f0-9]+})/g;
+
+function style(text: string, style: string, input: In): string {
+  if (input.css !== undefined) {
+    const uuid = `{css:${uuidv4().replaceAll('-', '')}}`;
+    input.css[uuid] = {
+      original: text,
+      style,
+    };
+    return uuid;
+  }
+
+  return text;
+}
+
+function errorLines(input: In): string[] {
+  const stringPath = input.path.join('.');
+  if (input.errors[stringPath] && input.errors[stringPath].length) {
+    return input.errors[stringPath].map((err) =>
+      [
+        style('→', 'color: red; font-weight: bold;', input),
+        style(err, 'color: red; font-style: italic;', input),
+      ].join(' '),
+    );
+  }
+
+  return [];
+}
+
+function prettyJsonSerializable(input: In): Out {
+  const { obj } = input;
+  const value = JSON.stringify(obj);
+  const errors = errorLines(input);
+
+  return {
+    lines: [`${value},`],
+    start: '',
+    end: '',
+    inline: true,
+    errors,
+  };
+}
+
+function inline(out: Out): RecursiveLines {
+  const newLines: RecursiveLines = [];
+  if (out.start) {
+    if (out.lines.length === 1) {
+      newLines.push(`${out.start}${out.lines[0]}${out.end}`);
+    } else {
+      newLines.push(
+        `${out.start}${out.lines.map(trimTrailingComma).join(', ')}${out.end}`,
+      );
+    }
+  } else {
+    newLines.push(...out.lines);
+  }
+
+  return newLines;
+}
+
+function appendErrors(
+  input: In,
+  out: Out,
+  lineLength?: number,
+): RecursiveLines {
+  const lines: RecursiveLines = [];
+  if (out.errors.length) {
+    let lastLineLength = lineLength || 1;
+    const lastLineIdx = out.lines.length - 1;
+    if (
+      lineLength === undefined &&
+      !out.end &&
+      typeof out.lines[lastLineIdx] === 'string'
+    ) {
+      lastLineLength =
+        trimTrailingComma(out.lines[lastLineIdx] as string).length +
+        (out.inline ? out.start.length : 0);
+    }
+
+    lines.push(
+      style('~'.repeat(lastLineLength), 'color: red;', input),
+      ...out.errors,
+    );
+  }
+
+  return lines;
+}
+
+function postProcessObjectLike(
+  input: In,
+  results: Out[],
+  out: Omit<Out, 'lines' | 'errors'>,
+): Out {
+  const newLines: RecursiveLines = [];
+  for (const idx in results) {
+    const result = results[idx];
+    let fixedErrorLength: number;
+    if (result.inline) {
+      const lines = inline(result);
+      fixedErrorLength = trimTrailingComma(lines[0] as string).length;
+      newLines.push(...lines);
+    } else {
+      result.start && newLines.push(result.start);
+      newLines.push(result.lines);
+      result.end && newLines.push(result.end);
+    }
+    if (parseInt(idx) === results.length - 1) {
+      trimLastTrailingComma(newLines);
+    }
+    newLines.push(...appendErrors(input, result, fixedErrorLength));
+  }
+
+  const errors = errorLines(input);
+  return { ...out, lines: newLines, errors };
+}
+
+function prettyArray(input: In): Out {
+  const { obj, path } = input;
+  const parentPath = [...path];
+  const ourKey = parentPath.pop() || '';
+
+  const results: Out[] = [];
+  let oneLiner = obj.length <= 5;
+  for (const idx in obj) {
+    const currentPath = [...parentPath, `${ourKey}[${idx}]`];
+    const result = prettyErrorsRecursive({
+      ...input,
+      obj: obj[idx],
+      path: currentPath,
+    });
+    oneLiner = oneLiner && result.inline && result.errors.length === 0;
+    results.push(result);
+  }
+
+  return postProcessObjectLike(input, results, {
+    start: '[',
+    end: '],',
+    inline: oneLiner,
+  });
+}
+
+function prettyObject(input: In): Out {
+  const { obj, path } = input;
+
+  const results: Out[] = [];
+  let oneLiner = Object.keys(obj).length <= 3;
+  for (const key of Object.keys(obj)) {
+    const currentPath = [...path, key];
+    const result = prettyErrorsRecursive({
+      ...input,
+      obj: obj[key],
+      path: currentPath,
+    });
+    oneLiner = oneLiner && result.inline && result.errors.length === 0;
+    result.start = `${key}: ${result.start}`;
+    results.push(result);
+  }
+
+  return postProcessObjectLike(input, results, {
+    start: '{',
+    end: '},',
+    inline: oneLiner,
+  });
+}
+
+function prettyErrorsRecursive(input: In): Out {
+  if (typeof input.obj === 'object') {
+    if (input.obj === null) {
+      return prettyJsonSerializable(input);
+    }
+
+    if (Array.isArray(input.obj)) {
+      return prettyArray(input);
+    }
+
+    return prettyObject(input);
+  }
+
+  return prettyJsonSerializable(input);
+}
+
+function indent(lines: RecursiveLines, level: number): string[] {
+  const indentation = '  '.repeat(level);
+  const returnVal: string[] = [];
+
+  for (const lineOrLines of lines) {
+    if (typeof lineOrLines === 'string') {
+      returnVal.push(`${indentation}${lineOrLines}`);
+    } else {
+      returnVal.push(...indent(lineOrLines, level + 1));
+    }
+  }
+
+  return returnVal;
+}
+
+function postProcessOuterObject(input: In, out: Out, level: number): string[] {
+  trimLastTrailingComma(out.lines);
+
+  const lines = out.inline
+    ? [...inline(out), ...appendErrors(input, out)]
+    : out.start
+    ? [
+        out.start,
+        out.lines,
+        trimTrailingComma(out.end),
+        ...appendErrors(input, out),
+      ]
+    : [...out.lines, ...appendErrors(input, out)];
+
+  return indent(lines, level);
+}
+
+/**
+ * Pretty-prints errors tied to some keys/values in any object
+ */
+export function prettyErrors({
+  input,
+  errors,
+  indentation,
+}: PrettyErrorsOptions): string {
+  const i: In = {
+    obj: input,
+    errors: errors || {},
+    path: [],
+    css: undefined,
+  };
+  const out = prettyErrorsRecursive(i);
+  return postProcessOuterObject(i, out, indentation || 0).join('\n');
+}
+
+/**
+ * The same as above, but prepares a colored output which can be passed to console.log() with color support
+ */
+export function prettyErrorsToConsole({
+  input,
+  errors,
+  indentation,
+  defaultStyle,
+}: PrettyErrorsOptions & PrettyErrorsOptionsStyling): {
+  lines: string;
+  css: string[];
+} {
+  const css: In['css'] = {};
+  const i: In = {
+    obj: input,
+    errors: errors || {},
+    path: [],
+    css,
+  };
+  const cssList = [defaultStyle || ''];
+  const out = prettyErrorsRecursive(i);
+  const lines = postProcessOuterObject(i, out, indentation || 0)
+    .join('\n')
+    .replaceAll(cssRegex, (match) => {
+      cssList.push(css[match].style);
+      cssList.push(defaultStyle || '');
+      return `%c${css[match].original}%c`;
+    });
+
+  return { lines: `%c${lines}`, css: cssList };
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/README.md
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/README.md
@@ -1,0 +1,14 @@
+## Shared tests for layout expressions
+
+These tests are defined in platform-independent JSON files. The goal of these tests
+is to provide a cross-platform test suite which runs the same tests on both the
+frontend and backend implementations of layout expressions.
+
+For this reason, it is very important to sync any changes in these tests with the
+corresponding test collection on the backend (and port any changes from there
+over here).
+
+These tests are duplicated in:
+
+- [app-lib-dotnet](https://github.com/Altinn/app-lib-dotnet)
+- [app-frontend-react](https://github.com/Altinn/app-frontend-react)

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/context-lists/groups/noData.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/context-lists/groups/noData.json
@@ -1,0 +1,89 @@
+{
+  "name": "Group Layout with no data",
+  "layouts": {
+    "Page1": {
+      "data": {
+        "layout": [
+          {
+            "id": "comp1",
+            "type": "Heading"
+          },
+          {
+            "id": "group1",
+            "type": "Group",
+            "children": ["comp3", "comp4"],
+            "dataModelBindings": {
+              "group": "dddd"
+            },
+            "maxCount": 99
+          },
+          {
+            "id": "comp3",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "dddd.comp3"
+            }
+          },
+          {
+            "id": "comp4",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "dddd.comp4"
+            }
+          }
+        ]
+      }
+    },
+    "Page2": {
+      "data": {
+        "layout": [
+          {
+            "id": "comp5",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "asdf"
+            }
+          },
+          {
+            "id": "comp6",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "asdf"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "expectedContexts": [
+    {
+      "component": "Page1",
+      "currentLayout": "Page1",
+      "children": [
+        {
+          "component": "comp1",
+          "currentLayout": "Page1"
+        },
+        {
+          "component": "group1",
+          "currentLayout": "Page1"
+        }
+      ]
+    },
+    {
+      "component": "Page2",
+      "currentLayout": "Page2",
+      "children": [
+        {
+          "component": "comp5",
+          "currentLayout": "Page2"
+        },
+        {
+          "component": "comp6",
+          "currentLayout": "Page2"
+        }
+      ]
+    }
+  ],
+  "dataModel": {}
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/context-lists/groups/oneRow.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/context-lists/groups/oneRow.json
@@ -1,0 +1,103 @@
+{
+  "name": "Group Layout with one row",
+  "layouts": {
+    "Page1": {
+      "data": {
+        "layout": [
+          {
+            "id": "comp1",
+            "type": "Heading"
+          },
+          {
+            "id": "group1",
+            "type": "Group",
+            "dataModelBindings": {
+              "group": "gruppe1"
+            },
+            "maxCount": 99,
+            "children": ["comp3", "comp4"]
+          },
+          {
+            "id": "comp3",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "gruppe1.comp3binding"
+            }
+          },
+          {
+            "id": "comp4",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "gruppe1.comp4binding"
+            }
+          }
+        ]
+      }
+    },
+    "Page2": {
+      "data": {
+        "layout": [
+          {
+            "id": "comp5",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "asdf"
+            }
+          },
+          {
+            "id": "comp6",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "asdf"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "expectedContexts": [
+    {
+      "component": "Page1",
+      "currentLayout": "Page1",
+      "children": [
+        {
+          "component": "comp1",
+          "currentLayout": "Page1"
+        },
+        {
+          "component": "group1",
+          "currentLayout": "Page1",
+          "children": [
+            {
+              "component": "comp3",
+              "rowIndices": [0],
+              "currentLayout": "Page1"
+            },
+            {
+              "component": "comp4",
+              "rowIndices": [0],
+              "currentLayout": "Page1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "component": "Page2",
+      "currentLayout": "Page2",
+      "children": [
+        {
+          "component": "comp5",
+          "currentLayout": "Page2"
+        },
+        {
+          "component": "comp6",
+          "currentLayout": "Page2"
+        }
+      ]
+    }
+  ],
+  "dataModel": {
+    "gruppe1": [{ "comp3binding": "123", "comp4binding": "dadda" }]
+  }
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/context-lists/groups/twoRows.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/context-lists/groups/twoRows.json
@@ -1,0 +1,116 @@
+{
+  "name": "Group Layout with two rows",
+  "layouts": {
+    "Page1": {
+      "data": {
+        "layout": [
+          {
+            "id": "comp1",
+            "type": "Heading"
+          },
+          {
+            "id": "group1",
+            "type": "Group",
+            "dataModelBindings": {
+              "group": "gruppe1"
+            },
+            "maxCount": 99,
+            "children": ["comp3", "comp4"]
+          },
+          {
+            "id": "comp3",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "gruppe1.comp3binding"
+            }
+          },
+          {
+            "id": "comp4",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "gruppe1.comp4binding"
+            }
+          }
+        ]
+      }
+    },
+    "Page2": {
+      "data": {
+        "layout": [
+          {
+            "id": "comp5",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "asdf"
+            }
+          },
+          {
+            "id": "comp6",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "asdf"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "expectedContexts": [
+    {
+      "component": "Page1",
+      "currentLayout": "Page1",
+      "children": [
+        {
+          "component": "comp1",
+          "currentLayout": "Page1"
+        },
+        {
+          "component": "group1",
+          "currentLayout": "Page1",
+          "children": [
+            {
+              "component": "comp3",
+              "rowIndices": [0],
+              "currentLayout": "Page1"
+            },
+            {
+              "component": "comp4",
+              "rowIndices": [0],
+              "currentLayout": "Page1"
+            },
+            {
+              "component": "comp3",
+              "rowIndices": [1],
+              "currentLayout": "Page1"
+            },
+            {
+              "component": "comp4",
+              "rowIndices": [1],
+              "currentLayout": "Page1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "component": "Page2",
+      "currentLayout": "Page2",
+      "children": [
+        {
+          "component": "comp5",
+          "currentLayout": "Page2"
+        },
+        {
+          "component": "comp6",
+          "currentLayout": "Page2"
+        }
+      ]
+    }
+  ],
+  "dataModel": {
+    "gruppe1": [
+      { "comp3binding": "123", "comp4binding": "dadda" },
+      { "comp3binding": "456", "comp4binding": "dodo" }
+    ]
+  }
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/context-lists/nonRepeatingGroups/maxCount0.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/context-lists/nonRepeatingGroups/maxCount0.json
@@ -1,0 +1,96 @@
+{
+  "name": "Non-repeating group with maxCount = 0",
+  "layouts": {
+    "Page1": {
+      "data": {
+        "layout": [
+          {
+            "id": "comp1",
+            "type": "Heading"
+          },
+          {
+            "id": "group1",
+            "type": "Group",
+            "children": ["comp3", "comp4"],
+            "maxCount": 0
+          },
+          {
+            "id": "comp3",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "asdf"
+            }
+          },
+          {
+            "id": "comp4",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "asdf"
+            }
+          }
+        ]
+      }
+    },
+    "Page2": {
+      "data": {
+        "layout": [
+          {
+            "id": "comp5",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "asdf"
+            }
+          },
+          {
+            "id": "comp6",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "asdf"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "expectedContexts": [
+    {
+      "component": "Page1",
+      "currentLayout": "Page1",
+      "children": [
+        {
+          "component": "comp1",
+          "currentLayout": "Page1"
+        },
+        {
+          "component": "group1",
+          "currentLayout": "Page1",
+          "children": [
+            {
+              "component": "comp3",
+              "currentLayout": "Page1"
+            },
+            {
+              "component": "comp4",
+              "currentLayout": "Page1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "component": "Page2",
+      "currentLayout": "Page2",
+      "children": [
+        {
+          "component": "comp5",
+          "currentLayout": "Page2"
+        },
+        {
+          "component": "comp6",
+          "currentLayout": "Page2"
+        }
+      ]
+    }
+  ],
+  "dataModel": {}
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/context-lists/nonRepeatingGroups/maxCount1.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/context-lists/nonRepeatingGroups/maxCount1.json
@@ -1,0 +1,96 @@
+{
+  "name": "Non-repeating group with maxCount = 1",
+  "layouts": {
+    "Page1": {
+      "data": {
+        "layout": [
+          {
+            "id": "comp1",
+            "type": "Heading"
+          },
+          {
+            "id": "group1",
+            "type": "Group",
+            "children": ["comp3", "comp4"],
+            "maxCount": 1
+          },
+          {
+            "id": "comp3",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "asdf"
+            }
+          },
+          {
+            "id": "comp4",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "asdf"
+            }
+          }
+        ]
+      }
+    },
+    "Page2": {
+      "data": {
+        "layout": [
+          {
+            "id": "comp5",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "asdf"
+            }
+          },
+          {
+            "id": "comp6",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "asdf"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "expectedContexts": [
+    {
+      "component": "Page1",
+      "currentLayout": "Page1",
+      "children": [
+        {
+          "component": "comp1",
+          "currentLayout": "Page1"
+        },
+        {
+          "component": "group1",
+          "currentLayout": "Page1",
+          "children": [
+            {
+              "component": "comp3",
+              "currentLayout": "Page1"
+            },
+            {
+              "component": "comp4",
+              "currentLayout": "Page1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "component": "Page2",
+      "currentLayout": "Page2",
+      "children": [
+        {
+          "component": "comp5",
+          "currentLayout": "Page2"
+        },
+        {
+          "component": "comp6",
+          "currentLayout": "Page2"
+        }
+      ]
+    }
+  ],
+  "dataModel": {}
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/context-lists/nonRepeatingGroups/simple.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/context-lists/nonRepeatingGroups/simple.json
@@ -1,0 +1,95 @@
+{
+  "name": "Non-repeating group with no maxCount",
+  "layouts": {
+    "Page1": {
+      "data": {
+        "layout": [
+          {
+            "id": "comp1",
+            "type": "Heading"
+          },
+          {
+            "id": "group1",
+            "type": "Group",
+            "children": ["comp3", "comp4"]
+          },
+          {
+            "id": "comp3",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "asdf"
+            }
+          },
+          {
+            "id": "comp4",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "asdf"
+            }
+          }
+        ]
+      }
+    },
+    "Page2": {
+      "data": {
+        "layout": [
+          {
+            "id": "comp5",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "asdf"
+            }
+          },
+          {
+            "id": "comp6",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "asdf"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "expectedContexts": [
+    {
+      "component": "Page1",
+      "currentLayout": "Page1",
+      "children": [
+        {
+          "component": "comp1",
+          "currentLayout": "Page1"
+        },
+        {
+          "component": "group1",
+          "currentLayout": "Page1",
+          "children": [
+            {
+              "component": "comp3",
+              "currentLayout": "Page1"
+            },
+            {
+              "component": "comp4",
+              "currentLayout": "Page1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "component": "Page2",
+      "currentLayout": "Page2",
+      "children": [
+        {
+          "component": "comp5",
+          "currentLayout": "Page2"
+        },
+        {
+          "component": "comp6",
+          "currentLayout": "Page2"
+        }
+      ]
+    }
+  ],
+  "dataModel": {}
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/context-lists/recursiveGroups/recursiveNoData.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/context-lists/recursiveGroups/recursiveNoData.json
@@ -1,0 +1,98 @@
+{
+  "name": "Recursive group Layout with no data",
+  "layouts": {
+    "Page1": {
+      "data": {
+        "layout": [
+          {
+            "id": "comp1",
+            "type": "Heading"
+          },
+          {
+            "id": "group0",
+            "type": "Group",
+            "children": ["group1"],
+            "maxCount": 99,
+            "dataModelBindings": {
+              "group": "group"
+            }
+          },
+          {
+            "id": "group1",
+            "type": "Group",
+            "children": ["comp3", "comp4"],
+            "maxCount": 99,
+            "dataModelBindings": {
+              "group": "group.subgroup"
+            }
+          },
+          {
+            "id": "comp3",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "group.subgroup.asdf"
+            }
+          },
+          {
+            "id": "comp4",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "group.subgroup.asdf"
+            }
+          }
+        ]
+      }
+    },
+    "Page2": {
+      "data": {
+        "layout": [
+          {
+            "id": "comp5",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "asdf"
+            }
+          },
+          {
+            "id": "comp6",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "asdf"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "expectedContexts": [
+    {
+      "component": "Page1",
+      "currentLayout": "Page1",
+      "children": [
+        {
+          "component": "comp1",
+          "currentLayout": "Page1"
+        },
+        {
+          "component": "group0",
+          "currentLayout": "Page1"
+        }
+      ]
+    },
+    {
+      "component": "Page2",
+      "currentLayout": "Page2",
+      "children": [
+        {
+          "component": "comp5",
+          "currentLayout": "Page2"
+        },
+        {
+          "component": "comp6",
+          "currentLayout": "Page2"
+        }
+      ]
+    }
+  ],
+  "dataModel": {}
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/context-lists/recursiveGroups/recursiveOneRow.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/context-lists/recursiveGroups/recursiveOneRow.json
@@ -1,0 +1,127 @@
+{
+  "name": "Recursive group Layout with one row",
+  "layouts": {
+    "Page1": {
+      "data": {
+        "layout": [
+          {
+            "id": "comp1",
+            "type": "Heading"
+          },
+          {
+            "id": "group0",
+            "type": "Group",
+            "children": ["group1"],
+            "maxCount": 99,
+            "dataModelBindings": {
+              "group": "group"
+            }
+          },
+          {
+            "id": "group1",
+            "type": "Group",
+            "children": ["comp3", "comp4"],
+            "maxCount": 99,
+            "dataModelBindings": {
+              "group": "group.subgroup"
+            }
+          },
+          {
+            "id": "comp3",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "group.subgroup.asdf"
+            }
+          },
+          {
+            "id": "comp4",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "group.subgroup.asdf"
+            }
+          }
+        ]
+      }
+    },
+    "Page2": {
+      "data": {
+        "layout": [
+          {
+            "id": "comp5",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "asdf"
+            }
+          },
+          {
+            "id": "comp6",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "asdf"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "expectedContexts": [
+    {
+      "component": "Page1",
+      "currentLayout": "Page1",
+      "children": [
+        {
+          "component": "comp1",
+          "currentLayout": "Page1"
+        },
+        {
+          "component": "group0",
+          "currentLayout": "Page1",
+          "children": [
+            {
+              "component": "group1",
+              "currentLayout": "Page1",
+              "rowIndices": [0],
+              "children": [
+                {
+                  "component": "comp3",
+                  "currentLayout": "Page1",
+                  "rowIndices": [0, 0]
+                },
+                {
+                  "component": "comp4",
+                  "currentLayout": "Page1",
+                  "rowIndices": [0, 0]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "component": "Page2",
+      "currentLayout": "Page2",
+      "children": [
+        {
+          "component": "comp5",
+          "currentLayout": "Page2"
+        },
+        {
+          "component": "comp6",
+          "currentLayout": "Page2"
+        }
+      ]
+    }
+  ],
+  "dataModel": {
+    "group": [
+      {
+        "subgroup": [
+          {
+            "asdf": "123"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/context-lists/recursiveGroups/recursiveTwoRowsInner.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/context-lists/recursiveGroups/recursiveTwoRowsInner.json
@@ -1,0 +1,140 @@
+{
+  "name": "Recursive group Layout with two rows on inner group",
+  "layouts": {
+    "Page1": {
+      "data": {
+        "layout": [
+          {
+            "id": "comp1",
+            "type": "Heading"
+          },
+          {
+            "id": "group0",
+            "type": "Group",
+            "children": ["group1"],
+            "maxCount": 99,
+            "dataModelBindings": {
+              "group": "group"
+            }
+          },
+          {
+            "id": "group1",
+            "type": "Group",
+            "children": ["comp3", "comp4"],
+            "maxCount": 99,
+            "dataModelBindings": {
+              "group": "group.subgroup"
+            }
+          },
+          {
+            "id": "comp3",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "group.subgroup.asdf"
+            }
+          },
+          {
+            "id": "comp4",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "group.subgroup.asdf"
+            }
+          }
+        ]
+      }
+    },
+    "Page2": {
+      "data": {
+        "layout": [
+          {
+            "id": "comp5",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "asdf"
+            }
+          },
+          {
+            "id": "comp6",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "asdf"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "expectedContexts": [
+    {
+      "component": "Page1",
+      "currentLayout": "Page1",
+      "children": [
+        {
+          "component": "comp1",
+          "currentLayout": "Page1"
+        },
+        {
+          "component": "group0",
+          "currentLayout": "Page1",
+          "children": [
+            {
+              "component": "group1",
+              "currentLayout": "Page1",
+              "rowIndices": [0],
+              "children": [
+                {
+                  "component": "comp3",
+                  "currentLayout": "Page1",
+                  "rowIndices": [0, 0]
+                },
+                {
+                  "component": "comp4",
+                  "currentLayout": "Page1",
+                  "rowIndices": [0, 0]
+                },
+                {
+                  "component": "comp3",
+                  "currentLayout": "Page1",
+                  "rowIndices": [0, 1]
+                },
+                {
+                  "component": "comp4",
+                  "currentLayout": "Page1",
+                  "rowIndices": [0, 1]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "component": "Page2",
+      "currentLayout": "Page2",
+      "children": [
+        {
+          "component": "comp5",
+          "currentLayout": "Page2"
+        },
+        {
+          "component": "comp6",
+          "currentLayout": "Page2"
+        }
+      ]
+    }
+  ],
+  "dataModel": {
+    "group": [
+      {
+        "subgroup": [
+          {
+            "asdf": "123"
+          },
+          {
+            "asdf": "456"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/context-lists/recursiveGroups/recursiveTwoRowsOuter.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/context-lists/recursiveGroups/recursiveTwoRowsOuter.json
@@ -1,0 +1,151 @@
+{
+  "name": "Recursive group Layout with two rows on outer group",
+  "layouts": {
+    "Page1": {
+      "data": {
+        "layout": [
+          {
+            "id": "comp1",
+            "type": "Heading"
+          },
+          {
+            "id": "group0",
+            "type": "Group",
+            "children": ["group1"],
+            "maxCount": 99,
+            "dataModelBindings": {
+              "group": "group"
+            }
+          },
+          {
+            "id": "group1",
+            "type": "Group",
+            "children": ["comp3", "comp4"],
+            "maxCount": 99,
+            "dataModelBindings": {
+              "group": "group.subgroup"
+            }
+          },
+          {
+            "id": "comp3",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "group.subgroup.asdf"
+            }
+          },
+          {
+            "id": "comp4",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "group.subgroup.asdf"
+            }
+          }
+        ]
+      }
+    },
+    "Page2": {
+      "data": {
+        "layout": [
+          {
+            "id": "comp5",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "asdf"
+            }
+          },
+          {
+            "id": "comp6",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "asdf"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "expectedContexts": [
+    {
+      "component": "Page1",
+      "currentLayout": "Page1",
+      "children": [
+        {
+          "component": "comp1",
+          "currentLayout": "Page1"
+        },
+        {
+          "component": "group0",
+          "currentLayout": "Page1",
+          "children": [
+            {
+              "component": "group1",
+              "currentLayout": "Page1",
+              "rowIndices": [0],
+              "children": [
+                {
+                  "component": "comp3",
+                  "currentLayout": "Page1",
+                  "rowIndices": [0, 0]
+                },
+                {
+                  "component": "comp4",
+                  "currentLayout": "Page1",
+                  "rowIndices": [0, 0]
+                }
+              ]
+            },
+            {
+              "component": "group1",
+              "currentLayout": "Page1",
+              "rowIndices": [1],
+              "children": [
+                {
+                  "component": "comp3",
+                  "currentLayout": "Page1",
+                  "rowIndices": [1, 0]
+                },
+                {
+                  "component": "comp4",
+                  "currentLayout": "Page1",
+                  "rowIndices": [1, 0]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "component": "Page2",
+      "currentLayout": "Page2",
+      "children": [
+        {
+          "component": "comp5",
+          "currentLayout": "Page2"
+        },
+        {
+          "component": "comp6",
+          "currentLayout": "Page2"
+        }
+      ]
+    }
+  ],
+  "dataModel": {
+    "group": [
+      {
+        "subgroup": [
+          {
+            "asdf": "123"
+          }
+        ]
+      },
+      {
+        "subgroup": [
+          {
+            "asdf": "456"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/context-lists/simple/simple.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/context-lists/simple/simple.json
@@ -1,0 +1,31 @@
+{
+  "name": "Simple layout with single component",
+  "layouts": {
+    "Page1": {
+      "data": {
+        "layout": [
+          {
+            "id": "comp1",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "asdf"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "expectedContexts": [
+    {
+      "component": "Page1",
+      "currentLayout": "Page1",
+      "children": [
+        {
+          "component": "comp1",
+          "currentLayout": "Page1"
+        }
+      ]
+    }
+  ],
+  "dataModel": {}
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/context-lists/simple/twoPages.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/context-lists/simple/twoPages.json
@@ -1,0 +1,73 @@
+{
+  "name": "Simple layout with two pages",
+  "layouts": {
+    "Page1": {
+      "data": {
+        "layout": [
+          {
+            "id": "comp1",
+            "type": "Heading"
+          },
+          {
+            "id": "comp2",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "asdf"
+            }
+          }
+        ]
+      }
+    },
+    "Page2": {
+      "data": {
+        "layout": [
+          {
+            "id": "comp3",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "asdf"
+            }
+          },
+          {
+            "id": "comp4",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "asdf"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "expectedContexts": [
+    {
+      "component": "Page1",
+      "currentLayout": "Page1",
+      "children": [
+        {
+          "component": "comp1",
+          "currentLayout": "Page1"
+        },
+        {
+          "component": "comp2",
+          "currentLayout": "Page1"
+        }
+      ]
+    },
+    {
+      "component": "Page2",
+      "currentLayout": "Page2",
+      "children": [
+        {
+          "component": "comp3",
+          "currentLayout": "Page2"
+        },
+        {
+          "component": "comp4",
+          "currentLayout": "Page2"
+        }
+      ]
+    }
+  ],
+  "dataModel": {}
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/and/all-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/and/all-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "All true inputs",
+  "expression": ["and", true, true, true],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/and/allows-0.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/and/allows-0.json
@@ -1,0 +1,5 @@
+{
+  "name": "Allows 0 as false",
+  "expression": ["and", true, 0, 0, 0],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/and/allows-1.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/and/allows-1.json
@@ -1,0 +1,5 @@
+{
+  "name": "Allows 1 as true",
+  "expression": ["and", 1, 1],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/and/allows-stringy-0.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/and/allows-stringy-0.json
@@ -1,0 +1,5 @@
+{
+  "name": "Allows stringy 0 as false",
+  "expression": ["and", "0", "0.0", "0.0000"],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/and/allows-stringy-1.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/and/allows-stringy-1.json
@@ -1,0 +1,5 @@
+{
+  "name": "Allows stringy 1 as true",
+  "expression": ["and", "1", "1.0", "1.0000"],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/and/allows-stringy-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/and/allows-stringy-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Allows 'false' as false",
+  "expression": ["and", "false"],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/and/allows-stringy-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/and/allows-stringy-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Allows 'true' as true",
+  "expression": ["and", true, "true"],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/and/casts-to-boolean.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/and/casts-to-boolean.json
@@ -1,0 +1,5 @@
+{
+  "name": "Casts 1 to a boolean",
+  "expression": ["and", 1],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/and/casts-to-boolean2.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/and/casts-to-boolean2.json
@@ -1,0 +1,5 @@
+{
+  "name": "Casts 1.000 to a boolean",
+  "expression": ["and", 1],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/and/disallows-2.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/and/disallows-2.json
@@ -1,0 +1,5 @@
+{
+  "name": "Disallows 2 as true",
+  "expression": ["and", 2, true],
+  "expectsFailure": "Expected boolean, got value 2"
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/and/disallows-empty-strings.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/and/disallows-empty-strings.json
@@ -1,0 +1,5 @@
+{
+  "name": "Disallows empty strings",
+  "expression": ["and", true, ""],
+  "expectsFailure": "Expected boolean, got value \"\""
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/and/disallows-other-strings.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/and/disallows-other-strings.json
@@ -1,0 +1,5 @@
+{
+  "name": "Disallows other strings",
+  "expression": ["and", true, "yes"],
+  "expectsFailure": "Expected boolean, got value \"yes\""
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/and/empty-and.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/and/empty-and.json
@@ -1,0 +1,5 @@
+{
+  "name": "Empty input produces an error",
+  "expression": ["and"],
+  "expectsFailure": "Expected 1+ argument(s), got 0"
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/and/last-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/and/last-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Last input false",
+  "expression": ["and", true, true, false],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/and/null-is-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/and/null-is-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Null is false",
+  "expression": ["and", true, null],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/and/single-input-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/and/single-input-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Single input returns the same (false)",
+  "expression": ["and", false],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/and/single-input-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/and/single-input-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Single input returns the same (true)",
+  "expression": ["and", true],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/component/in-group.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/component/in-group.json
@@ -1,0 +1,67 @@
+{
+  "name": "Lookup inside repeating group",
+  "expression": ["greaterThanEq", ["component", "alder"], 18],
+  "context": {
+    "component": "myndig",
+    "rowIndices": [1],
+    "currentLayout": "Page2"
+  },
+  "expects": false,
+  "layouts": {
+    "Page1": {
+      "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+      "data": {
+        "layout": []
+      }
+    },
+    "Page2": {
+      "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+      "data": {
+        "layout": [
+          {
+            "id": "myGroup",
+            "type": "Group",
+            "maxCount": 99,
+            "dataModelBindings": {
+              "group": "Mennesker"
+            },
+            "children": ["navn", "alder", "myndig"]
+          },
+          {
+            "id": "navn",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "Mennesker.Navn"
+            }
+          },
+          {
+            "id": "alder",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "Mennesker.Alder"
+            }
+          },
+          {
+            "id": "myndig",
+            "type": "Paragraph",
+            "textResourceBindings": {
+              "title": "Hurra, du er myndig!"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "dataModel": {
+    "Mennesker": [
+      {
+        "Navn": "Kåre",
+        "Alder": 24
+      },
+      {
+        "Navn": "Arild",
+        "Alder": 14
+      }
+    ]
+  }
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/component/in-nested-group.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/component/in-nested-group.json
@@ -1,0 +1,101 @@
+{
+  "name": "Lookup inside nested repeating group",
+  "expression": ["greaterThanEq", ["component", "alder"], 18],
+  "context": {
+    "component": "myndig",
+    "rowIndices": [1, 1],
+    "currentLayout": "Page2"
+  },
+  "expects": false,
+  "layouts": {
+    "Page1": {
+      "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+      "data": {
+        "layout": []
+      }
+    },
+    "Page2": {
+      "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+      "data": {
+        "layout": [
+          {
+            "id": "bedrifter",
+            "type": "Group",
+            "maxCount": 99,
+            "dataModelBindings": {
+              "group": "Bedrifter"
+            },
+            "children": ["bedriftsNavn", "ansatte"]
+          },
+          {
+            "id": "bedriftsNavn",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "Bedrifter.Navn"
+            }
+          },
+          {
+            "id": "ansatte",
+            "type": "Group",
+            "maxCount": 99,
+            "dataModelBindings": {
+              "group": "Bedrifter.Ansatte"
+            },
+            "children": ["navn", "alder", "myndig"]
+          },
+          {
+            "id": "navn",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "Bedrifter.Ansatte.Navn"
+            }
+          },
+          {
+            "id": "alder",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "Bedrifter.Ansatte.Alder"
+            }
+          },
+          {
+            "id": "myndig",
+            "type": "Paragraph",
+            "textResourceBindings": {
+              "title": "Hurra, den ansatte er myndig!"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "dataModel": {
+    "Bedrifter": [
+      {
+        "Navn": "Hell og lykke AS",
+        "Ansatte": [
+          {
+            "Navn": "Kaare",
+            "Alder": 24
+          },
+          {
+            "Navn": "Per",
+            "Alder": 24
+          }
+        ]
+      },
+      {
+        "Navn": "Nedtur og motgang AS",
+        "Ansatte": [
+          {
+            "Navn": "Arne",
+            "Alder": 24
+          },
+          {
+            "Navn": "Vidar",
+            "Alder": 14
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/component/simple-lookup-equals.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/component/simple-lookup-equals.json
@@ -1,0 +1,44 @@
+{
+  "name": "Simple lookup equals other lookup",
+  "expression": [
+    "equals",
+    ["component", "my-component"],
+    ["component", "my-other-component"]
+  ],
+  "expects": true,
+  "layouts": {
+    "Page1": {
+      "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+      "data": {
+        "layout": [
+          {
+            "id": "my-component",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "ComponentContent"
+            }
+          },
+          {
+            "id": "my-other-component",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "OtherComponentContent"
+            }
+          },
+          {
+            "id": "current-component",
+            "type": "Paragraph"
+          }
+        ]
+      }
+    }
+  },
+  "dataModel": {
+    "ComponentContent": "hello world",
+    "OtherComponentContent": "hello world"
+  },
+  "context": {
+    "component": "current-component",
+    "currentLayout": "Page1"
+  }
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/component/simple-lookup.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/component/simple-lookup.json
@@ -1,0 +1,32 @@
+{
+  "name": "Simple lookup",
+  "expression": ["component", "my-component"],
+  "expects": "hello world",
+  "layouts": {
+    "Page1": {
+      "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+      "data": {
+        "layout": [
+          {
+            "id": "my-component",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "ComponentContent"
+            }
+          },
+          {
+            "id": "current-component",
+            "type": "Paragraph"
+          }
+        ]
+      }
+    }
+  },
+  "dataModel": {
+    "ComponentContent": "hello world"
+  },
+  "context": {
+    "component": "current-component",
+    "currentLayout": "Page1"
+  }
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/concat/boolean-are-empty-strings.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/concat/boolean-are-empty-strings.json
@@ -1,0 +1,5 @@
+{
+  "name": "Booleans encode as literal strings",
+  "expression": ["concat", "foo", false, "bar", true],
+  "expects": "foofalsebartrue"
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/concat/casts-numbers.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/concat/casts-numbers.json
@@ -1,0 +1,5 @@
+{
+  "name": "Casts numbers to strings",
+  "expression": ["concat", 1, " + ", 2.5, " = ", 3],
+  "expects": "1 + 2.5 = 3"
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/concat/empty-string.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/concat/empty-string.json
@@ -1,0 +1,5 @@
+{
+  "name": "No arguments results in empty string",
+  "expression": ["concat"],
+  "expects": ""
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/concat/inside-lookup.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/concat/inside-lookup.json
@@ -1,0 +1,46 @@
+{
+  "name": "Inside a lookup argument",
+  "expression": [
+    "dataModel",
+    [
+      "concat",
+      "FirstPart",
+      ".",
+      ["dataModel", "Middle"],
+      ".Last",
+      ["frontendSettings", "suffix"]
+    ]
+  ],
+  "expects": "foo bar",
+  "dataModel": {
+    "Middle": "MiddlePart",
+    "FirstPart": {
+      "MiddlePart": {
+        "LastPart": "foo bar"
+      }
+    },
+    "b": {
+      "value": "C"
+    }
+  },
+  "frontendSettings": {
+    "suffix": "Part"
+  },
+  "layouts": {
+    "Page1": {
+      "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+      "data": {
+        "layout": [
+          {
+            "id": "current-component",
+            "type": "Paragraph"
+          }
+        ]
+      }
+    }
+  },
+  "context": {
+    "component": "current-component",
+    "currentLayout": "Page1"
+  }
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/concat/nulls-are-empty-strings.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/concat/nulls-are-empty-strings.json
@@ -1,0 +1,5 @@
+{
+  "name": "Nulls are represented as empty strings",
+  "expression": ["concat", "foo", null, "bar"],
+  "expects": "foobar"
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/concat/one-string.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/concat/one-string.json
@@ -1,0 +1,5 @@
+{
+  "name": "One arguments returns the same",
+  "expression": ["concat", "test"],
+  "expects": "test"
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/concat/simple-lookup.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/concat/simple-lookup.json
@@ -1,0 +1,30 @@
+{
+  "name": "Simple lookup",
+  "expression": ["concat", ["dataModel", "a.value"], ["dataModel", "b.value"]],
+  "expects": "ABC",
+  "dataModel": {
+    "a": {
+      "value": "AB"
+    },
+    "b": {
+      "value": "C"
+    }
+  },
+  "layouts": {
+    "Page1": {
+      "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+      "data": {
+        "layout": [
+          {
+            "id": "current-component",
+            "type": "Paragraph"
+          }
+        ]
+      }
+    }
+  },
+  "context": {
+    "component": "current-component",
+    "currentLayout": "Page1"
+  }
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/dataModel/direct-reference-in-group.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/dataModel/direct-reference-in-group.json
@@ -1,0 +1,67 @@
+{
+  "name": "Direct lookup inside repeating group (not respecting the group)",
+  "expression": ["greaterThanEq", ["dataModel", "Mennesker[0].Alder"], 18],
+  "context": {
+    "component": "myndig",
+    "rowIndices": [1],
+    "currentLayout": "Page2"
+  },
+  "expects": true,
+  "layouts": {
+    "Page1": {
+      "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+      "data": {
+        "layout": []
+      }
+    },
+    "Page2": {
+      "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+      "data": {
+        "layout": [
+          {
+            "id": "myGroup",
+            "type": "Group",
+            "maxCount": 99,
+            "dataModelBindings": {
+              "group": "Mennesker"
+            },
+            "children": ["navn", "alder", "myndig"]
+          },
+          {
+            "id": "navn",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "Mennesker.Navn"
+            }
+          },
+          {
+            "id": "alder",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "Mennesker.Alder"
+            }
+          },
+          {
+            "id": "myndig",
+            "type": "Paragraph",
+            "textResourceBindings": {
+              "title": "Hurra, du er myndig!"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "dataModel": {
+    "Mennesker": [
+      {
+        "Navn": "Kåre",
+        "Alder": 24
+      },
+      {
+        "Navn": "Arild",
+        "Alder": 14
+      }
+    ]
+  }
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/dataModel/direct-reference-in-nested-group.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/dataModel/direct-reference-in-nested-group.json
@@ -1,0 +1,101 @@
+{
+  "name": "Direct lookup inside repeating group (not respecting any groups)",
+  "expression": ["equals", ["dataModel", "Bedrifter[0].Ansatte[0].Alder"], 55],
+  "context": {
+    "component": "myndig",
+    "rowIndices": [1, 1],
+    "currentLayout": "Page2"
+  },
+  "expects": true,
+  "layouts": {
+    "Page1": {
+      "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+      "data": {
+        "layout": []
+      }
+    },
+    "Page2": {
+      "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+      "data": {
+        "layout": [
+          {
+            "id": "bedrifter",
+            "type": "Group",
+            "maxCount": 99,
+            "dataModelBindings": {
+              "group": "Bedrifter"
+            },
+            "children": ["bedriftsNavn", "ansatte"]
+          },
+          {
+            "id": "bedriftsNavn",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "Bedrifter.Navn"
+            }
+          },
+          {
+            "id": "ansatte",
+            "type": "Group",
+            "maxCount": 99,
+            "dataModelBindings": {
+              "group": "Bedrifter.Ansatte"
+            },
+            "children": ["navn", "alder", "myndig"]
+          },
+          {
+            "id": "navn",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "Bedrifter.Ansatte.Navn"
+            }
+          },
+          {
+            "id": "alder",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "Bedrifter.Ansatte.Alder"
+            }
+          },
+          {
+            "id": "myndig",
+            "type": "Paragraph",
+            "textResourceBindings": {
+              "title": "Hurra, den ansatte er myndig!"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "dataModel": {
+    "Bedrifter": [
+      {
+        "Navn": "Hell og lykke AS",
+        "Ansatte": [
+          {
+            "Navn": "Kaare",
+            "Alder": 55
+          },
+          {
+            "Navn": "Per",
+            "Alder": 24
+          }
+        ]
+      },
+      {
+        "Navn": "Nedtur og motgang AS",
+        "Ansatte": [
+          {
+            "Navn": "Arne",
+            "Alder": 24
+          },
+          {
+            "Navn": "Vidar",
+            "Alder": 14
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/dataModel/direct-reference-in-nested-group2.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/dataModel/direct-reference-in-nested-group2.json
@@ -1,0 +1,101 @@
+{
+  "name": "Direct lookup inside repeating group (not respecting the first group)",
+  "expression": ["equals", ["dataModel", "Bedrifter.Ansatte[0].Alder"], 26],
+  "context": {
+    "component": "myndig",
+    "rowIndices": [1, 1],
+    "currentLayout": "Page2"
+  },
+  "expects": true,
+  "layouts": {
+    "Page1": {
+      "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+      "data": {
+        "layout": []
+      }
+    },
+    "Page2": {
+      "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+      "data": {
+        "layout": [
+          {
+            "id": "bedrifter",
+            "type": "Group",
+            "maxCount": 99,
+            "dataModelBindings": {
+              "group": "Bedrifter"
+            },
+            "children": ["bedriftsNavn", "ansatte"]
+          },
+          {
+            "id": "bedriftsNavn",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "Bedrifter.Navn"
+            }
+          },
+          {
+            "id": "ansatte",
+            "type": "Group",
+            "maxCount": 99,
+            "dataModelBindings": {
+              "group": "Bedrifter.Ansatte"
+            },
+            "children": ["navn", "alder", "myndig"]
+          },
+          {
+            "id": "navn",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "Bedrifter.Ansatte.Navn"
+            }
+          },
+          {
+            "id": "alder",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "Bedrifter.Ansatte.Alder"
+            }
+          },
+          {
+            "id": "myndig",
+            "type": "Paragraph",
+            "textResourceBindings": {
+              "title": "Hurra, den ansatte er myndig!"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "dataModel": {
+    "Bedrifter": [
+      {
+        "Navn": "Hell og lykke AS",
+        "Ansatte": [
+          {
+            "Navn": "Kaare",
+            "Alder": 24
+          },
+          {
+            "Navn": "Per",
+            "Alder": 25
+          }
+        ]
+      },
+      {
+        "Navn": "Nedtur og motgang AS",
+        "Ansatte": [
+          {
+            "Navn": "Arne",
+            "Alder": 26
+          },
+          {
+            "Navn": "Vidar",
+            "Alder": 14
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/dataModel/direct-reference-in-nested-group3.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/dataModel/direct-reference-in-nested-group3.json
@@ -1,0 +1,101 @@
+{
+  "name": "Direct lookup inside repeating group (not respecting the second group)",
+  "expression": ["dataModel", "Bedrifter[0].Ansatte.Alder"],
+  "context": {
+    "component": "myndig",
+    "rowIndices": [1, 1],
+    "currentLayout": "Page2"
+  },
+  "expects": null,
+  "layouts": {
+    "Page1": {
+      "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+      "data": {
+        "layout": []
+      }
+    },
+    "Page2": {
+      "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+      "data": {
+        "layout": [
+          {
+            "id": "bedrifter",
+            "type": "Group",
+            "maxCount": 99,
+            "dataModelBindings": {
+              "group": "Bedrifter"
+            },
+            "children": ["bedriftsNavn", "ansatte"]
+          },
+          {
+            "id": "bedriftsNavn",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "Bedrifter.Navn"
+            }
+          },
+          {
+            "id": "ansatte",
+            "type": "Group",
+            "maxCount": 99,
+            "dataModelBindings": {
+              "group": "Bedrifter.Ansatte"
+            },
+            "children": ["navn", "alder", "myndig"]
+          },
+          {
+            "id": "navn",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "Bedrifter.Ansatte.Navn"
+            }
+          },
+          {
+            "id": "alder",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "Bedrifter.Ansatte.Alder"
+            }
+          },
+          {
+            "id": "myndig",
+            "type": "Paragraph",
+            "textResourceBindings": {
+              "title": "Hurra, den ansatte er myndig!"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "dataModel": {
+    "Bedrifter": [
+      {
+        "Navn": "Hell og lykke AS",
+        "Ansatte": [
+          {
+            "Navn": "Kaare",
+            "Alder": 24
+          },
+          {
+            "Navn": "Per",
+            "Alder": 25
+          }
+        ]
+      },
+      {
+        "Navn": "Nedtur og motgang AS",
+        "Ansatte": [
+          {
+            "Navn": "Arne",
+            "Alder": 26
+          },
+          {
+            "Navn": "Vidar",
+            "Alder": 14
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/dataModel/direct-reference-in-nested-group4.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/dataModel/direct-reference-in-nested-group4.json
@@ -1,0 +1,101 @@
+{
+  "name": "Direct lookup inside repeating group (not respecting the second group, even if first matches)",
+  "expression": ["dataModel", "Bedrifter[1].Ansatte.Alder"],
+  "context": {
+    "component": "myndig",
+    "rowIndices": [1, 1],
+    "currentLayout": "Page2"
+  },
+  "expects": null,
+  "layouts": {
+    "Page1": {
+      "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+      "data": {
+        "layout": []
+      }
+    },
+    "Page2": {
+      "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+      "data": {
+        "layout": [
+          {
+            "id": "bedrifter",
+            "type": "Group",
+            "maxCount": 99,
+            "dataModelBindings": {
+              "group": "Bedrifter"
+            },
+            "children": ["bedriftsNavn", "ansatte"]
+          },
+          {
+            "id": "bedriftsNavn",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "Bedrifter.Navn"
+            }
+          },
+          {
+            "id": "ansatte",
+            "type": "Group",
+            "maxCount": 99,
+            "dataModelBindings": {
+              "group": "Bedrifter.Ansatte"
+            },
+            "children": ["navn", "alder", "myndig"]
+          },
+          {
+            "id": "navn",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "Bedrifter.Ansatte.Navn"
+            }
+          },
+          {
+            "id": "alder",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "Bedrifter.Ansatte.Alder"
+            }
+          },
+          {
+            "id": "myndig",
+            "type": "Paragraph",
+            "textResourceBindings": {
+              "title": "Hurra, den ansatte er myndig!"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "dataModel": {
+    "Bedrifter": [
+      {
+        "Navn": "Hell og lykke AS",
+        "Ansatte": [
+          {
+            "Navn": "Kaare",
+            "Alder": 24
+          },
+          {
+            "Navn": "Per",
+            "Alder": 25
+          }
+        ]
+      },
+      {
+        "Navn": "Nedtur og motgang AS",
+        "Ansatte": [
+          {
+            "Navn": "Arne",
+            "Alder": 26
+          },
+          {
+            "Navn": "Vidar",
+            "Alder": 14
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/dataModel/in-group.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/dataModel/in-group.json
@@ -1,0 +1,67 @@
+{
+  "name": "Lookup inside repeating group",
+  "expression": ["greaterThanEq", ["dataModel", "Mennesker.alder"], 18],
+  "context": {
+    "component": "myndig",
+    "rowIndices": [1],
+    "currentLayout": "Page2"
+  },
+  "expects": false,
+  "layouts": {
+    "Page1": {
+      "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+      "data": {
+        "layout": []
+      }
+    },
+    "Page2": {
+      "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+      "data": {
+        "layout": [
+          {
+            "id": "myGroup",
+            "type": "Group",
+            "maxCount": 99,
+            "dataModelBindings": {
+              "group": "Mennesker"
+            },
+            "children": ["navn", "alder", "myndig"]
+          },
+          {
+            "id": "navn",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "Mennesker.Navn"
+            }
+          },
+          {
+            "id": "alder",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "Mennesker.Alder"
+            }
+          },
+          {
+            "id": "myndig",
+            "type": "Paragraph",
+            "textResourceBindings": {
+              "title": "Hurra, du er myndig!"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "dataModel": {
+    "Mennesker": [
+      {
+        "Navn": "Kåre",
+        "Alder": 24
+      },
+      {
+        "Navn": "Arild",
+        "Alder": 14
+      }
+    ]
+  }
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/dataModel/in-nested-group.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/dataModel/in-nested-group.json
@@ -1,0 +1,101 @@
+{
+  "name": "Lookup inside nested repeating group",
+  "expression": ["greaterThanEq", ["dataModel", "Bedrifter.Ansatte.Alder"], 18],
+  "context": {
+    "component": "myndig",
+    "rowIndices": [1, 1],
+    "currentLayout": "Page2"
+  },
+  "expects": false,
+  "layouts": {
+    "Page1": {
+      "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+      "data": {
+        "layout": []
+      }
+    },
+    "Page2": {
+      "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+      "data": {
+        "layout": [
+          {
+            "id": "bedrifter",
+            "type": "Group",
+            "maxCount": 99,
+            "dataModelBindings": {
+              "group": "Bedrifter"
+            },
+            "children": ["bedriftsNavn", "ansatte"]
+          },
+          {
+            "id": "bedriftsNavn",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "Bedrifter.Navn"
+            }
+          },
+          {
+            "id": "ansatte",
+            "type": "Group",
+            "maxCount": 99,
+            "dataModelBindings": {
+              "group": "Bedrifter.Ansatte"
+            },
+            "children": ["navn", "alder", "myndig"]
+          },
+          {
+            "id": "navn",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "Bedrifter.Ansatte.Navn"
+            }
+          },
+          {
+            "id": "alder",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "Bedrifter.Ansatte.Alder"
+            }
+          },
+          {
+            "id": "myndig",
+            "type": "Paragraph",
+            "textResourceBindings": {
+              "title": "Hurra, den ansatte er myndig!"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "dataModel": {
+    "Bedrifter": [
+      {
+        "Navn": "Hell og lykke AS",
+        "Ansatte": [
+          {
+            "Navn": "Kaare",
+            "Alder": 24
+          },
+          {
+            "Navn": "Per",
+            "Alder": 24
+          }
+        ]
+      },
+      {
+        "Navn": "Nedtur og motgang AS",
+        "Ansatte": [
+          {
+            "Navn": "Arne",
+            "Alder": 24
+          },
+          {
+            "Navn": "Vidar",
+            "Alder": 14
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/dataModel/object-is-null.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/dataModel/object-is-null.json
@@ -1,0 +1,27 @@
+{
+  "name": "Looking up an object returns null",
+  "expression": ["dataModel", "a"],
+  "expects": null,
+  "dataModel": {
+    "a": {
+      "value": "ABC"
+    }
+  },
+  "layouts": {
+    "Page1": {
+      "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+      "data": {
+        "layout": [
+          {
+            "id": "current-component",
+            "type": "Paragraph"
+          }
+        ]
+      }
+    }
+  },
+  "context": {
+    "component": "current-component",
+    "currentLayout": "Page1"
+  }
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/dataModel/simple-lookup-equals.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/dataModel/simple-lookup-equals.json
@@ -1,0 +1,30 @@
+{
+  "name": "Simple lookup equals other lookup",
+  "expression": ["equals", ["dataModel", "a.value"], ["dataModel", "b.value"]],
+  "expects": true,
+  "dataModel": {
+    "a": {
+      "value": "hello world"
+    },
+    "b": {
+      "value": "hello world"
+    }
+  },
+  "layouts": {
+    "Page1": {
+      "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+      "data": {
+        "layout": [
+          {
+            "id": "current-component",
+            "type": "Paragraph"
+          }
+        ]
+      }
+    }
+  },
+  "context": {
+    "component": "current-component",
+    "currentLayout": "Page1"
+  }
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/dataModel/simple-lookup-is-null.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/dataModel/simple-lookup-is-null.json
@@ -1,0 +1,27 @@
+{
+  "name": "Simple lookup for non-existing key equals null (1)",
+  "expression": ["dataModel", "a.value.length"],
+  "expects": null,
+  "dataModel": {
+    "a": {
+      "value": "ABC"
+    }
+  },
+  "layouts": {
+    "Page1": {
+      "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+      "data": {
+        "layout": [
+          {
+            "id": "current-component",
+            "type": "Paragraph"
+          }
+        ]
+      }
+    }
+  },
+  "context": {
+    "component": "current-component",
+    "currentLayout": "Page1"
+  }
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/dataModel/simple-lookup-is-null2.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/dataModel/simple-lookup-is-null2.json
@@ -1,0 +1,27 @@
+{
+  "name": "Simple lookup for non-existing key equals null (2)",
+  "expression": ["dataModel", "a.otherValue.Count"],
+  "expects": null,
+  "dataModel": {
+    "a": {
+      "value": "ABC"
+    }
+  },
+  "layouts": {
+    "Page1": {
+      "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+      "data": {
+        "layout": [
+          {
+            "id": "current-component",
+            "type": "Paragraph"
+          }
+        ]
+      }
+    }
+  },
+  "context": {
+    "component": "current-component",
+    "currentLayout": "Page1"
+  }
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/dataModel/simple-lookup.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/dataModel/simple-lookup.json
@@ -1,0 +1,27 @@
+{
+  "name": "Simple lookup",
+  "expression": ["dataModel", "a.value"],
+  "expects": "ABC",
+  "dataModel": {
+    "a": {
+      "value": "ABC"
+    }
+  },
+  "layouts": {
+    "Page1": {
+      "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+      "data": {
+        "layout": [
+          {
+            "id": "current-component",
+            "type": "Paragraph"
+          }
+        ]
+      }
+    }
+  },
+  "context": {
+    "component": "current-component",
+    "currentLayout": "Page1"
+  }
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/diff-types-bool-float-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/diff-types-bool-float-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [boolean, float] (false)",
+  "expression": ["equals", false, 0],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/diff-types-bool-int-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/diff-types-bool-int-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [boolean, integer] (false)",
+  "expression": ["equals", true, 1],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/diff-types-bool-null-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/diff-types-bool-null-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [boolean, null] (false)",
+  "expression": ["equals", false, null],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/diff-types-float-int-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/diff-types-float-int-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [float, integer] (false)",
+  "expression": ["equals", 123.0001, 123],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/diff-types-float-int-false2.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/diff-types-float-int-false2.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [-float, integer] (false)",
+  "expression": ["equals", -123, 123],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/diff-types-float-int-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/diff-types-float-int-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [float, integer] (true)",
+  "expression": ["equals", 123, 123],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/diff-types-float-null-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/diff-types-float-null-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [float, null] (false)",
+  "expression": ["equals", 0, null],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/diff-types-int-null-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/diff-types-int-null-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [integer, null] (false)",
+  "expression": ["equals", 0, null],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/diff-types-string-bool-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/diff-types-string-bool-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [string, boolean] (false)",
+  "expression": ["equals", "hello world", false],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/diff-types-string-bool-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/diff-types-string-bool-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [string, boolean] (true)",
+  "expression": ["equals", "false", false],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/diff-types-string-float-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/diff-types-string-float-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [string, float] (false)",
+  "expression": ["equals", "1234", 1234.55],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/diff-types-string-float-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/diff-types-string-float-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [string, float] (true)",
+  "expression": ["equals", "1234.5678", 1234.5678],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/diff-types-string-int-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/diff-types-string-int-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [string, integer] (false)",
+  "expression": ["equals", "hello world", 55],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/diff-types-string-int-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/diff-types-string-int-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [string, integer] (true)",
+  "expression": ["equals", "1234", 1234],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/diff-types-string-null-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/diff-types-string-null-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [string, null] (false)",
+  "expression": ["equals", "nil", null],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/diff-types-string-null-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/diff-types-string-null-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [string, null] (true)",
+  "expression": ["equals", "null", null],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/false-case-insensitive.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/false-case-insensitive.json
@@ -1,0 +1,5 @@
+{
+  "name": "Booleans are compared case-insensitively",
+  "expression": ["equals", "FalSE", false],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/false-case-insensitive2.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/false-case-insensitive2.json
@@ -1,0 +1,5 @@
+{
+  "name": "Booleans are compared case-insensitively (2)",
+  "expression": ["equals", "TRUE", true],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/null-case-insensitive.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/null-case-insensitive.json
@@ -1,0 +1,5 @@
+{
+  "name": "Null is compared case-insensitively",
+  "expression": ["equals", "nULL", null],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/same-types-bool-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/same-types-bool-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with booleans (false)",
+  "expression": ["equals", true, false],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/same-types-bool-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/same-types-bool-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with booleans (true)",
+  "expression": ["equals", false, false],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/same-types-float-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/same-types-float-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with floats (false)",
+  "expression": ["equals", 1.5, 2.5],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/same-types-float-false2.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/same-types-float-false2.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with -floats (false)",
+  "expression": ["equals", -2.5, 2.5],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/same-types-float-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/same-types-float-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with floats (true)",
+  "expression": ["equals", 2.5, 2.5],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/same-types-int-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/same-types-int-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with integers (false)",
+  "expression": ["equals", 1, 2],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/same-types-int-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/same-types-int-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with integers (true)",
+  "expression": ["equals", 2, 2],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/same-types-null.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/same-types-null.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with null",
+  "expression": ["equals", null, null],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/same-types-string-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/same-types-string-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with strings (false)",
+  "expression": ["equals", "foo", "bar"],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/same-types-string-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/same-types-string-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with strings (true)",
+  "expression": ["equals", "bar", "bar"],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/same-types-string-true2.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/same-types-string-true2.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with strings (true)",
+  "expression": ["equals", "true", "true"],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/strings-case-sensitive.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/strings-case-sensitive.json
@@ -1,0 +1,5 @@
+{
+  "name": "Regular strings are compared case-sensitively",
+  "expression": ["equals", "Hello World", "hello World"],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/too-few-args.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/too-few-args.json
@@ -1,0 +1,5 @@
+{
+  "name": "Too few arguments give an error",
+  "expression": ["equals", true, ["equals"]],
+  "expectsFailure": "Expected 2 argument(s), got 0"
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/too-many-args.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/equals/too-many-args.json
@@ -1,0 +1,5 @@
+{
+  "name": "Too many arguments give an error",
+  "expression": ["equals", true, ["equals", true, false, true]],
+  "expectsFailure": "Expected 2 argument(s), got 3"
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/frontendSettings/simple-lookup-equals.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/frontendSettings/simple-lookup-equals.json
@@ -1,0 +1,13 @@
+{
+  "name": "Simple lookup equals other lookup",
+  "expression": [
+    "equals",
+    ["frontendSettings", "mySetting1"],
+    ["frontendSettings", "mySetting2"]
+  ],
+  "expects": true,
+  "frontendSettings": {
+    "mySetting1": "foo",
+    "mySetting2": "foo"
+  }
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/frontendSettings/simple-lookup-is-null.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/frontendSettings/simple-lookup-is-null.json
@@ -1,0 +1,9 @@
+{
+  "name": "Simple lookup for non-existing key equals null",
+  "expression": ["equals", ["frontendSettings", "doesNotExist"], null],
+  "expects": true,
+  "frontendSettings": {
+    "mySetting1": "foo",
+    "mySetting2": "bar"
+  }
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/frontendSettings/simple-lookup.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/frontendSettings/simple-lookup.json
@@ -1,0 +1,9 @@
+{
+  "name": "Simple lookup",
+  "expression": ["frontendSettings", "mySetting1"],
+  "expects": "foo",
+  "frontendSettings": {
+    "mySetting1": "foo",
+    "mySetting2": "bar"
+  }
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/diff-types-bool-float.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/diff-types-bool-float.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should fail with [boolean, float]",
+  "expression": ["greaterThan", true, 123.456],
+  "expectsFailure": "Expected number, got value true"
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/diff-types-bool-int.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/diff-types-bool-int.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should fail with [boolean, integer]",
+  "expression": ["greaterThan", true, 123],
+  "expectsFailure": "Expected number, got value true"
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/diff-types-bool-null.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/diff-types-bool-null.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should fail with [boolean, null]",
+  "expression": ["greaterThan", true, null],
+  "expectsFailure": "Expected number, got value true"
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/diff-types-float-int-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/diff-types-float-int-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [float, integer] (false)",
+  "expression": ["greaterThan", 123.456, 124],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/diff-types-float-int-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/diff-types-float-int-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [float, integer] (true)",
+  "expression": ["greaterThan", 123.456, 123],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/diff-types-float-null-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/diff-types-float-null-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [float, null] (false)",
+  "expression": ["greaterThan", 123.456, null],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/diff-types-float-null-false2.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/diff-types-float-null-false2.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [-float, null] (false)",
+  "expression": ["greaterThan", -123.456, null],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/diff-types-int-null-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/diff-types-int-null-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [integer, null] (false)",
+  "expression": ["greaterThan", 1, null],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/diff-types-int-null-false2.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/diff-types-int-null-false2.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [-integer, null] (false)",
+  "expression": ["greaterThan", -1, null],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/diff-types-int-null-false3.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/diff-types-int-null-false3.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [0, null] (false)",
+  "expression": ["greaterThan", 0, null],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/diff-types-string-bool.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/diff-types-string-bool.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should fail with [string, boolean]",
+  "expression": ["greaterThan", "1", true],
+  "expectsFailure": "Expected number, got value true"
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/diff-types-string-float-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/diff-types-string-float-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [string, float] (false)",
+  "expression": ["greaterThan", "122", 123.456],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/diff-types-string-float-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/diff-types-string-float-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [string, float] (true)",
+  "expression": ["greaterThan", "124", 123.456],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/diff-types-string-int-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/diff-types-string-int-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [string, integer] (false)",
+  "expression": ["greaterThan", "1", 123],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/diff-types-string-int-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/diff-types-string-int-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [string, integer] (true)",
+  "expression": ["greaterThan", "3", 2],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/diff-types-string-null.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/diff-types-string-null.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [string, null] (false)",
+  "expression": ["greaterThan", "12", null],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/diff-types-string-null2.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/diff-types-string-null2.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should fail with [string, null]",
+  "expression": ["greaterThan", "hello world", null],
+  "expectsFailure": "Expected number, got value \"hello world\""
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/doble-dots-fail-negative.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/doble-dots-fail-negative.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should fail with [-string with two periods, integer]",
+  "expression": ["greaterThan", "-55.88.66", -57],
+  "expectsFailure": "Expected number, got value \"-55.88.66\""
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/doble-dots-fail.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/doble-dots-fail.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should fail with [string with two periods, integer]",
+  "expression": ["greaterThan", "55.88.66", -57],
+  "expectsFailure": "Expected number, got value \"55.88.66\""
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/negative-string-float.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/negative-string-float.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [-string, float] (1)",
+  "expression": ["greaterThan", "-55.5", -55.3],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/negative-string-float2.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/negative-string-float2.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [-string, float] (2)",
+  "expression": ["greaterThan", "-55.5", -55.7],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/negative-string.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/negative-string.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [-string, integer] (1)",
+  "expression": ["greaterThan", "-55", -57],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/negative-string2.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/negative-string2.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [-string, integer] (2)",
+  "expression": ["greaterThan", "-55", -54],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/no-decimals-fail-negative.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/no-decimals-fail-negative.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should fail with [-string with no decimals, integer]",
+  "expression": ["greaterThan", "-55.", -57],
+  "expectsFailure": "Expected number, got value \"-55.\""
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/no-decimals-fail.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/no-decimals-fail.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should fail with [string with no decimals, integer]",
+  "expression": ["greaterThan", "55.", -57],
+  "expectsFailure": "Expected number, got value \"55.\""
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/same-types-bool.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/same-types-bool.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should fail with booleans",
+  "expression": ["greaterThan", true, true],
+  "expectsFailure": "Expected number, got value true"
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/same-types-float-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/same-types-float-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with floats (false)",
+  "expression": ["greaterThan", 123.456, 123.456],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/same-types-float-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/same-types-float-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with floats (true)",
+  "expression": ["greaterThan", 123.456, 123.455],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/same-types-int-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/same-types-int-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with integers (false)",
+  "expression": ["greaterThan", 123, 123],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/same-types-int-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/same-types-int-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with integers (true)",
+  "expression": ["greaterThan", 123, 122],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/same-types-null.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/same-types-null.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with nulls",
+  "expression": ["greaterThan", null, null],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/same-types-string-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/same-types-string-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with strings (false)",
+  "expression": ["greaterThan", "1", "1.5"],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/same-types-string-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThan/same-types-string-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with strings (true)",
+  "expression": ["greaterThan", "1.1", "1.001"],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThanEq/diff-types-bool-float.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThanEq/diff-types-bool-float.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should fail with [boolean, float]",
+  "expression": ["greaterThanEq", true, 123.456],
+  "expectsFailure": "Expected number, got value true"
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThanEq/diff-types-bool-int.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThanEq/diff-types-bool-int.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should fail with [boolean, integer]",
+  "expression": ["greaterThanEq", true, 123],
+  "expectsFailure": "Expected number, got value true"
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThanEq/diff-types-bool-null.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThanEq/diff-types-bool-null.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should fail with [boolean, null]",
+  "expression": ["greaterThanEq", true, null],
+  "expectsFailure": "Expected number, got value true"
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThanEq/diff-types-float-int-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThanEq/diff-types-float-int-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [float, integer] (false)",
+  "expression": ["greaterThanEq", 123.9999, 124],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThanEq/diff-types-float-int-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThanEq/diff-types-float-int-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [float, integer] (true)",
+  "expression": ["greaterThanEq", 123, 123],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThanEq/diff-types-float-null-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThanEq/diff-types-float-null-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [float, null] (false)",
+  "expression": ["greaterThanEq", 123.456, null],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThanEq/diff-types-float-null-false2.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThanEq/diff-types-float-null-false2.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [-float, null] (false)",
+  "expression": ["greaterThanEq", -123.456, null],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThanEq/diff-types-int-null-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThanEq/diff-types-int-null-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [integer, null] (false)",
+  "expression": ["greaterThanEq", 1, null],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThanEq/diff-types-int-null-false2.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThanEq/diff-types-int-null-false2.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [-integer, null] (false)",
+  "expression": ["greaterThanEq", -1, null],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThanEq/diff-types-int-null-false3.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThanEq/diff-types-int-null-false3.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [0, null] (false)",
+  "expression": ["greaterThanEq", 0, null],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThanEq/diff-types-string-bool.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThanEq/diff-types-string-bool.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should fail with [string, boolean]",
+  "expression": ["greaterThanEq", "1", true],
+  "expectsFailure": "Expected number, got value true"
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThanEq/diff-types-string-float-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThanEq/diff-types-string-float-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [string, float] (false)",
+  "expression": ["greaterThanEq", "122", 123.456],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThanEq/diff-types-string-float-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThanEq/diff-types-string-float-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [string, float] (true)",
+  "expression": ["greaterThanEq", "123.456", 123.456],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThanEq/diff-types-string-int-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThanEq/diff-types-string-int-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [string, integer] (false)",
+  "expression": ["greaterThanEq", "1", 123],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThanEq/diff-types-string-int-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThanEq/diff-types-string-int-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [string, integer] (true)",
+  "expression": ["greaterThanEq", "2", 2],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThanEq/diff-types-string-null.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThanEq/diff-types-string-null.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [string, null] (false)",
+  "expression": ["greaterThanEq", "12", null],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThanEq/diff-types-string-null2.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThanEq/diff-types-string-null2.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should fail with [string, null]",
+  "expression": ["greaterThanEq", "hello world", null],
+  "expectsFailure": "Expected number, got value \"hello world\""
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThanEq/same-types-bool.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThanEq/same-types-bool.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should fail with booleans",
+  "expression": ["greaterThanEq", true, true],
+  "expectsFailure": "Expected number, got value true"
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThanEq/same-types-float-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThanEq/same-types-float-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with floats (false)",
+  "expression": ["greaterThanEq", 123.455, 123.456],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThanEq/same-types-float-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThanEq/same-types-float-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with floats (true)",
+  "expression": ["greaterThanEq", 123.455, 123.455],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThanEq/same-types-int-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThanEq/same-types-int-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with integers (false)",
+  "expression": ["greaterThanEq", 122, 123],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThanEq/same-types-int-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThanEq/same-types-int-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with integers (true)",
+  "expression": ["greaterThanEq", 122, 122],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThanEq/same-types-null.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThanEq/same-types-null.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with nulls",
+  "expression": ["greaterThanEq", null, null],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThanEq/same-types-string-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThanEq/same-types-string-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with strings (false)",
+  "expression": ["greaterThanEq", "1", "1.5"],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThanEq/same-types-string-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/greaterThanEq/same-types-string-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with strings (true)",
+  "expression": ["greaterThanEq", "1.1", "1.1"],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/if/else-otherwise.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/if/else-otherwise.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should return else result on failure",
+  "expression": ["if", false, 123.456, "else", 456.123],
+  "expects": 456.123
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/if/else-otherwise2.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/if/else-otherwise2.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should return else result on failure (2)",
+  "expression": ["if", false, 123.456, "else", false],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/if/fail-without-else.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/if/fail-without-else.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should fail without \"else\" constant",
+  "expression": ["if", true, 123.456, false],
+  "expectsFailure": "Expected third argument to be \"else\""
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/if/fail-without-else2.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/if/fail-without-else2.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should fail without \"else\" constant",
+  "expression": ["if", true, 123.456, false, false],
+  "expectsFailure": "Expected third argument to be \"else\""
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/if/never-3-arguments.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/if/never-3-arguments.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should fail when given 3 arguments",
+  "expression": ["if", false, 123.456, "else"],
+  "expectsFailure": "Expected either 2 arguments (if) or 4 (if + else), got 3"
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/if/never-5-arguments.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/if/never-5-arguments.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should fail when given 5 arguments",
+  "expression": ["if", false, 123.456, "else", "test", "something"],
+  "expectsFailure": "Expected either 2 arguments (if) or 4 (if + else), got 5"
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/if/null-otherwise.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/if/null-otherwise.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should return null on failure",
+  "expression": ["if", false, 123.456],
+  "expects": null
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/if/simple.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/if/simple.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should return result on success",
+  "expression": ["if", true, 123.456],
+  "expects": 123.456
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/instanceContext/only-dict.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/instanceContext/only-dict.json
@@ -1,0 +1,10 @@
+{
+  "name": "Only works on one level (as a dictionary)",
+  "expression": ["equals", ["instanceContext", "deep.key"], null],
+  "expectsFailure": "Unknown Instance context property deep.key",
+  "instanceContext": {
+    "deep": {
+      "key": "should not be found"
+    }
+  }
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/instanceContext/simple-lookup-equals.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/instanceContext/simple-lookup-equals.json
@@ -1,0 +1,14 @@
+{
+  "name": "Simple lookup equals other lookup",
+  "expression": [
+    "equals",
+    ["instanceContext", "instanceOwnerPartyId"],
+    ["instanceContext", "appId"]
+  ],
+  "expects": false,
+  "instanceContext": {
+    "instanceId": "d00ce51c-800b-416a-a906-ccab55f597e9",
+    "appId": "org/app-name",
+    "instanceOwnerPartyId": "12345"
+  }
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/instanceContext/simple-lookup-is-null.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/instanceContext/simple-lookup-is-null.json
@@ -1,0 +1,10 @@
+{
+  "name": "Simple lookup for non-existing key equals null",
+  "expression": ["equals", ["instanceContext", "doesNotExist"], null],
+  "expectsFailure": "Unknown Instance context property doesNotExist",
+  "instanceContext": {
+    "instanceId": "d00ce51c-800b-416a-a906-ccab55f597e9",
+    "appId": "org/app-name",
+    "instanceOwnerPartyId": "12345"
+  }
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/instanceContext/simple-lookup.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/instanceContext/simple-lookup.json
@@ -1,0 +1,10 @@
+{
+  "name": "Simple lookup",
+  "expression": ["instanceContext", "appId"],
+  "expects": "org/app-name",
+  "instanceContext": {
+    "instanceId": "d00ce51c-800b-416a-a906-ccab55f597e9",
+    "appId": "org/app-name",
+    "instanceOwnerPartyId": "12345"
+  }
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThan/diff-types-bool-float.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThan/diff-types-bool-float.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should fail with [boolean, float]",
+  "expression": ["lessThan", true, 123.456],
+  "expectsFailure": "Expected number, got value true"
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThan/diff-types-bool-int.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThan/diff-types-bool-int.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should fail with [boolean, integer]",
+  "expression": ["lessThan", true, 123],
+  "expectsFailure": "Expected number, got value true"
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThan/diff-types-bool-null.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThan/diff-types-bool-null.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should fail with [boolean, null]",
+  "expression": ["lessThan", true, null],
+  "expectsFailure": "Expected number, got value true"
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThan/diff-types-float-int-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThan/diff-types-float-int-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [float, integer] (false)",
+  "expression": ["lessThan", 123.456, 123],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThan/diff-types-float-int-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThan/diff-types-float-int-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [float, integer] (true)",
+  "expression": ["lessThan", 123.456, 124],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThan/diff-types-float-null-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThan/diff-types-float-null-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [float, null] (false)",
+  "expression": ["lessThan", 123.456, null],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThan/diff-types-float-null-false2.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThan/diff-types-float-null-false2.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [-float, null] (false)",
+  "expression": ["lessThan", -123.456, null],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThan/diff-types-int-null-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThan/diff-types-int-null-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [integer, null] (false)",
+  "expression": ["lessThan", 1, null],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThan/diff-types-int-null-false2.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThan/diff-types-int-null-false2.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [-integer, null] (false)",
+  "expression": ["lessThan", -1, null],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThan/diff-types-int-null-false3.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThan/diff-types-int-null-false3.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [0, null] (false)",
+  "expression": ["lessThan", 0, null],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThan/diff-types-string-bool.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThan/diff-types-string-bool.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should fail with [string, boolean]",
+  "expression": ["lessThan", "1", true],
+  "expectsFailure": "Expected number, got value true"
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThan/diff-types-string-float-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThan/diff-types-string-float-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [string, float] (false)",
+  "expression": ["lessThan", "124", 123.456],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThan/diff-types-string-float-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThan/diff-types-string-float-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [string, float] (true)",
+  "expression": ["lessThan", "122", 123.456],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThan/diff-types-string-int-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThan/diff-types-string-int-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [string, integer] (false)",
+  "expression": ["lessThan", "123", 1],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThan/diff-types-string-int-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThan/diff-types-string-int-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [string, integer] (true)",
+  "expression": ["lessThan", "2", 3],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThan/diff-types-string-null.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThan/diff-types-string-null.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [string, null] (false)",
+  "expression": ["lessThan", "12", null],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThan/diff-types-string-null2.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThan/diff-types-string-null2.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should fail with [string, null]",
+  "expression": ["lessThan", "hello world", null],
+  "expectsFailure": "Expected number, got value \"hello world\""
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThan/same-types-bool.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThan/same-types-bool.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should fail with booleans",
+  "expression": ["lessThan", true, true],
+  "expectsFailure": "Expected number, got value true"
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThan/same-types-float-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThan/same-types-float-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with floats (false)",
+  "expression": ["lessThan", 123.456, 123.456],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThan/same-types-float-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThan/same-types-float-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with floats (true)",
+  "expression": ["lessThan", 123.455, 123.456],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThan/same-types-int-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThan/same-types-int-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with integers (false)",
+  "expression": ["lessThan", 123, 123],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThan/same-types-int-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThan/same-types-int-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with integers (true)",
+  "expression": ["lessThan", 122, 123],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThan/same-types-null.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThan/same-types-null.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with nulls",
+  "expression": ["lessThan", null, null],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThan/same-types-string-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThan/same-types-string-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with strings (false)",
+  "expression": ["lessThan", "1.5", "1"],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThan/same-types-string-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThan/same-types-string-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with strings (true)",
+  "expression": ["lessThan", "1.001", "1.1"],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThanEq/diff-types-bool-float.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThanEq/diff-types-bool-float.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should fail with [boolean, float]",
+  "expression": ["lessThanEq", true, 123.456],
+  "expectsFailure": "Expected number, got value true"
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThanEq/diff-types-bool-int.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThanEq/diff-types-bool-int.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should fail with [boolean, integer]",
+  "expression": ["lessThanEq", true, 123],
+  "expectsFailure": "Expected number, got value true"
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThanEq/diff-types-bool-null.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThanEq/diff-types-bool-null.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should fail with [boolean, null]",
+  "expression": ["lessThanEq", true, null],
+  "expectsFailure": "Expected number, got value true"
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThanEq/diff-types-float-int-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThanEq/diff-types-float-int-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [float, integer] (false)",
+  "expression": ["lessThanEq", 123.456, 123],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThanEq/diff-types-float-int-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThanEq/diff-types-float-int-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [float, integer] (true)",
+  "expression": ["lessThanEq", 124, 124],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThanEq/diff-types-float-null-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThanEq/diff-types-float-null-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [float, null] (false)",
+  "expression": ["lessThanEq", 123.456, null],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThanEq/diff-types-float-null-false2.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThanEq/diff-types-float-null-false2.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [-float, null] (false)",
+  "expression": ["lessThanEq", -123.456, null],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThanEq/diff-types-int-null-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThanEq/diff-types-int-null-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [integer, null] (false)",
+  "expression": ["lessThanEq", 1, null],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThanEq/diff-types-int-null-false2.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThanEq/diff-types-int-null-false2.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [-integer, null] (false)",
+  "expression": ["lessThanEq", -1, null],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThanEq/diff-types-int-null-false3.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThanEq/diff-types-int-null-false3.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [0, null] (false)",
+  "expression": ["lessThanEq", 0, null],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThanEq/diff-types-string-bool.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThanEq/diff-types-string-bool.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should fail with [string, boolean]",
+  "expression": ["lessThanEq", "1", true],
+  "expectsFailure": "Expected number, got value true"
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThanEq/diff-types-string-float-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThanEq/diff-types-string-float-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [string, float] (false)",
+  "expression": ["lessThanEq", "124", 123.456],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThanEq/diff-types-string-float-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThanEq/diff-types-string-float-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [string, float] (true)",
+  "expression": ["lessThanEq", "123.456", 123.456],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThanEq/diff-types-string-int-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThanEq/diff-types-string-int-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [string, integer] (false)",
+  "expression": ["lessThanEq", "123", 1],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThanEq/diff-types-string-int-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThanEq/diff-types-string-int-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [string, integer] (true)",
+  "expression": ["lessThanEq", "2", 2],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThanEq/diff-types-string-null.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThanEq/diff-types-string-null.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [string, null] (false)",
+  "expression": ["lessThanEq", "12", null],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThanEq/diff-types-string-null2.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThanEq/diff-types-string-null2.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should fail with [string, null]",
+  "expression": ["lessThanEq", "hello world", null],
+  "expectsFailure": "Expected number, got value \"hello world\""
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThanEq/same-types-bool.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThanEq/same-types-bool.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should fail with booleans",
+  "expression": ["lessThanEq", true, true],
+  "expectsFailure": "Expected number, got value true"
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThanEq/same-types-float-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThanEq/same-types-float-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with floats (false)",
+  "expression": ["lessThanEq", 123.457, 123.456],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThanEq/same-types-float-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThanEq/same-types-float-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with floats (true)",
+  "expression": ["lessThanEq", 123.456, 123.456],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThanEq/same-types-int-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThanEq/same-types-int-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with integers (false)",
+  "expression": ["lessThanEq", 123, 122],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThanEq/same-types-int-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThanEq/same-types-int-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with integers (true)",
+  "expression": ["lessThanEq", 122, 122],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThanEq/same-types-null.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThanEq/same-types-null.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with nulls",
+  "expression": ["lessThanEq", null, null],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThanEq/same-types-string-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThanEq/same-types-string-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with strings (false)",
+  "expression": ["lessThanEq", "1.5", "1"],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThanEq/same-types-string-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/lessThanEq/same-types-string-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with strings (true)",
+  "expression": ["lessThanEq", "1.001", "1.001"],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/notEquals/diff-types-bool-float-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/notEquals/diff-types-bool-float-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [boolean, float] (true)",
+  "expression": ["notEquals", false, 0.0005],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/notEquals/diff-types-bool-int-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/notEquals/diff-types-bool-int-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [boolean, integer] (true)",
+  "expression": ["notEquals", true, 1],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/notEquals/diff-types-bool-null-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/notEquals/diff-types-bool-null-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [boolean, null] (true)",
+  "expression": ["notEquals", true, null],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/notEquals/diff-types-float-int-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/notEquals/diff-types-float-int-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [float, integer] (false)",
+  "expression": ["notEquals", 123, 123],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/notEquals/diff-types-float-int-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/notEquals/diff-types-float-int-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [float, integer] (true)",
+  "expression": ["notEquals", 123.005, 123],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/notEquals/diff-types-float-null-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/notEquals/diff-types-float-null-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [float, null] (true)",
+  "expression": ["notEquals", 0, null],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/notEquals/diff-types-int-null-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/notEquals/diff-types-int-null-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [integer, null] (true)",
+  "expression": ["notEquals", 0, null],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/notEquals/diff-types-string-bool-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/notEquals/diff-types-string-bool-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [string, boolean] (false)",
+  "expression": ["notEquals", "false", false],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/notEquals/diff-types-string-bool-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/notEquals/diff-types-string-bool-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [string, boolean] (true)",
+  "expression": ["notEquals", "0", false],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/notEquals/diff-types-string-float-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/notEquals/diff-types-string-float-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [string, float] (false)",
+  "expression": ["notEquals", "1234.55", 1234.55],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/notEquals/diff-types-string-float-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/notEquals/diff-types-string-float-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [string, float] (true)",
+  "expression": ["notEquals", "1234.56789", 1234.5678],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/notEquals/diff-types-string-int-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/notEquals/diff-types-string-int-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [string, integer] (false)",
+  "expression": ["notEquals", "55", 55],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/notEquals/diff-types-string-int-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/notEquals/diff-types-string-int-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [string, integer] (true)",
+  "expression": ["notEquals", "12345", 1234],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/notEquals/diff-types-string-null-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/notEquals/diff-types-string-null-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [string, null] (false)",
+  "expression": ["notEquals", "null", null],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/notEquals/diff-types-string-null-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/notEquals/diff-types-string-null-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with [string, null] (true)",
+  "expression": ["notEquals", "false", null],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/notEquals/same-types-bool-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/notEquals/same-types-bool-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with booleans (false)",
+  "expression": ["notEquals", false, false],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/notEquals/same-types-bool-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/notEquals/same-types-bool-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with booleans (true)",
+  "expression": ["notEquals", false, true],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/notEquals/same-types-float-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/notEquals/same-types-float-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with floats (false)",
+  "expression": ["notEquals", 12.56, 12.56],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/notEquals/same-types-float-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/notEquals/same-types-float-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with floats (true)",
+  "expression": ["notEquals", 2.51, 2.5],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/notEquals/same-types-int-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/notEquals/same-types-int-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with integers (false)",
+  "expression": ["notEquals", 2, 2],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/notEquals/same-types-int-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/notEquals/same-types-int-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with integers (true)",
+  "expression": ["notEquals", 2, 25],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/notEquals/same-types-null.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/notEquals/same-types-null.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with null",
+  "expression": ["notEquals", null, null],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/notEquals/same-types-string-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/notEquals/same-types-string-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with strings (false)",
+  "expression": ["notEquals", "bar", "bar"],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/notEquals/same-types-string-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/notEquals/same-types-string-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should work with strings (true)",
+  "expression": ["notEquals", "foo", "bar"],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/or/all-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/or/all-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "All true inputs",
+  "expression": ["or", true, true, true],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/or/allows-0.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/or/allows-0.json
@@ -1,0 +1,5 @@
+{
+  "name": "Allows 0 as false",
+  "expression": ["or", 0, 0, 0],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/or/allows-1.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/or/allows-1.json
@@ -1,0 +1,5 @@
+{
+  "name": "Allows 1 as true",
+  "expression": ["or", 1, 1, false],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/or/allows-stringy-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/or/allows-stringy-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Allows 'false' as false",
+  "expression": ["or", "false"],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/or/allows-stringy-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/or/allows-stringy-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Allows 'true' as true",
+  "expression": ["or", "true"],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/or/disallows-2.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/or/disallows-2.json
@@ -1,0 +1,5 @@
+{
+  "name": "Disallows 2 as true",
+  "expression": ["or", 2, true],
+  "expectsFailure": "Expected boolean, got value 2"
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/or/disallows-empty-strings.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/or/disallows-empty-strings.json
@@ -1,0 +1,5 @@
+{
+  "name": "Disallows empty strings",
+  "expression": ["or", true, ""],
+  "expectsFailure": "Expected boolean, got value \"\""
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/or/disallows-other-strings.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/or/disallows-other-strings.json
@@ -1,0 +1,5 @@
+{
+  "name": "Disallows other strings",
+  "expression": ["or", true, "yes"],
+  "expectsFailure": "Expected boolean, got value \"yes\""
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/or/empty-or.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/or/empty-or.json
@@ -1,0 +1,5 @@
+{
+  "name": "Empty input produces an error",
+  "expression": ["or"],
+  "expectsFailure": "Expected 1+ argument(s), got 0"
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/or/last-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/or/last-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Last input false",
+  "expression": ["or", true, true, false],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/or/null-is-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/or/null-is-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Null is false",
+  "expression": ["or", null],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/or/single-input-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/or/single-input-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Single input returns the same (false)",
+  "expression": ["or", false],
+  "expects": false
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/or/single-input-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/or/single-input-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Single input returns the same (true)",
+  "expression": ["or", true],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/unknown/appSettings.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/unknown/appSettings.json
@@ -1,0 +1,5 @@
+{
+  "name": "Invalid function gives an error",
+  "expression": ["equals", true, ["applicationSettings"]],
+  "expectsFailure": "Function \"applicationSettings\" not implemented"
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/unknown/function-wrong-case.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/unknown/function-wrong-case.json
@@ -1,0 +1,5 @@
+{
+  "name": "Function with wrong case gives an error",
+  "expression": ["datamodel", "test"],
+  "expectsFailure": "Function \"datamodel\" not implemented"
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/unknown/invalid-function.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/unknown/invalid-function.json
@@ -1,0 +1,5 @@
+{
+  "name": "Invalid function gives an error",
+  "expression": ["equals", true, ["functionThatDoesNotExist"]],
+  "expectsFailure": "Function \"functionThatDoesNotExist\" not implemented"
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/invalid/empty-array-inside.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/invalid/empty-array-inside.json
@@ -1,0 +1,5 @@
+{
+  "name": "Empty array inside expression gives error",
+  "expression": ["equals", [], true],
+  "expectsFailure": "Missing function name in expression"
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/invalid/empty-array.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/invalid/empty-array.json
@@ -1,0 +1,5 @@
+{
+  "name": "Empty array gives error",
+  "expression": [],
+  "expectsFailure": "Missing function name in expression"
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/invalid/empty-object.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/invalid/empty-object.json
@@ -1,0 +1,5 @@
+{
+  "name": "Empty object inside expression parsed as other expression",
+  "expression": ["equals", true, {}],
+  "expectsFailure": "Invalid type \"object\""
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/invalid/extra-argument.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/invalid/extra-argument.json
@@ -1,0 +1,5 @@
+{
+  "name": "Extra argument in expression gives error",
+  "expression": ["equals", true, false, 55],
+  "expectsFailure": "Expected 2 argument(s), got 3"
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/invalid/func-not-implemented.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/invalid/func-not-implemented.json
@@ -1,0 +1,5 @@
+{
+  "name": "Non-implemented function gives error",
+  "expression": ["non-existing-function", 1, 2],
+  "expectsFailure": "Function \"non-existing-function\" not implemented"
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/invalid/missing-args.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/invalid/missing-args.json
@@ -1,0 +1,5 @@
+{
+  "name": "Missing arguments produces an error",
+  "expression": ["equals"],
+  "expectsFailure": "Expected 2 argument(s), got 0"
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/invalid/numeric-array.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/invalid/numeric-array.json
@@ -1,0 +1,5 @@
+{
+  "name": "Numeric array gives error",
+  "expression": ["equals", [true, [1, 2, 3]]],
+  "expectsFailure": "Function name in expression should be string"
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/layout-preprocessor/failures.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/layout-preprocessor/failures.json
@@ -1,0 +1,166 @@
+{
+  "name": "Layout expressions failing to parse are replaced with default values",
+  "layouts": {
+    "Page1": {
+      "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+      "data": {
+        "layout": [
+          {
+            "id": "bekreftelse",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "Bekreftelse"
+            },
+            "hidden": ["bedriftsNavn", "ansatte"],
+            "required": true
+          }
+        ]
+      }
+    },
+    "Page2": {
+      "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+      "data": {
+        "layout": [
+          {
+            "id": "bedrifter",
+            "type": "Group",
+            "maxCount": 99,
+            "dataModelBindings": {
+              "group": "Bedrifter"
+            },
+            "children": ["bedriftsNavn", "ansatte"]
+          },
+          {
+            "id": "bedriftsNavn",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "Bedrifter.Navn"
+            },
+            "hidden": ["equals", true, false],
+            "required": ["dataModel", "Bedrifter.isRequired"]
+          },
+          {
+            "id": "ansatte",
+            "type": "Group",
+            "maxCount": 99,
+            "dataModelBindings": {
+              "group": "Bedrifter.Ansatte"
+            },
+            "children": ["navn", "alder", "myndig"]
+          },
+          {
+            "id": "navn",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "Bedrifter.Ansatte.Navn"
+            },
+            "hidden": [
+              "and",
+              ["greaterThan", ["non-existing-function", "alder"], 99],
+              ["notEquals", ["component", "alder", "test", 123, true], 101, 102]
+            ],
+            "required": ["dataModel", "Bedrifter.isRequired", "other.model"]
+          },
+          {
+            "id": "alder",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "Bedrifter.Ansatte.Alder"
+            }
+          },
+          {
+            "id": "myndig",
+            "type": "Paragraph",
+            "textResourceBindings": {
+              "title": "Hurra, den ansatte er myndig!"
+            },
+            "hidden": true
+          }
+        ]
+      }
+    }
+  },
+  "expects": {
+    "Page1": {
+      "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+      "data": {
+        "layout": [
+          {
+            "id": "bekreftelse",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "Bekreftelse"
+            },
+            "hidden": false,
+            "required": true
+          }
+        ]
+      }
+    },
+    "Page2": {
+      "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+      "data": {
+        "layout": [
+          {
+            "id": "bedrifter",
+            "type": "Group",
+            "maxCount": 99,
+            "dataModelBindings": {
+              "group": "Bedrifter"
+            },
+            "children": ["bedriftsNavn", "ansatte"]
+          },
+          {
+            "id": "bedriftsNavn",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "Bedrifter.Navn"
+            },
+            "hidden": ["equals", true, false],
+            "required": ["dataModel", "Bedrifter.isRequired"]
+          },
+          {
+            "id": "ansatte",
+            "type": "Group",
+            "maxCount": 99,
+            "dataModelBindings": {
+              "group": "Bedrifter.Ansatte"
+            },
+            "children": ["navn", "alder", "myndig"]
+          },
+          {
+            "id": "navn",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "Bedrifter.Ansatte.Navn"
+            },
+            "hidden": false,
+            "required": false
+          },
+          {
+            "id": "alder",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "Bedrifter.Ansatte.Alder"
+            }
+          },
+          {
+            "id": "myndig",
+            "type": "Paragraph",
+            "textResourceBindings": {
+              "title": "Hurra, den ansatte er myndig!"
+            },
+            "hidden": true
+          }
+        ]
+      }
+    }
+  },
+  "expectsWarnings": [
+    "Function \"bedriftsNavn\" not implemented",
+    "Function \"non-existing-function\" not implemented",
+    "Expected 1 argument(s), got 2",
+    "Expected 1 argument(s), got 4",
+    "Expected 2 argument(s), got 3"
+  ]
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/layout-preprocessor/successful.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/layout-preprocessor/successful.json
@@ -1,0 +1,165 @@
+{
+  "name": "Successfully parsed and validated layout expressions",
+  "layouts": {
+    "Page1": {
+      "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+      "data": {
+        "layout": [
+          {
+            "id": "bekreftelse",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "Bekreftelse"
+            },
+            "hidden": ["equals", true, false],
+            "required": true
+          }
+        ]
+      }
+    },
+    "Page2": {
+      "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+      "data": {
+        "layout": [
+          {
+            "id": "bedrifter",
+            "type": "Group",
+            "maxCount": 99,
+            "dataModelBindings": {
+              "group": "Bedrifter"
+            },
+            "children": ["bedriftsNavn", "ansatte"]
+          },
+          {
+            "id": "bedriftsNavn",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "Bedrifter.Navn"
+            },
+            "hidden": ["equals", true, false],
+            "required": ["dataModel", "Bedrifter.isRequired"]
+          },
+          {
+            "id": "ansatte",
+            "type": "Group",
+            "maxCount": 99,
+            "dataModelBindings": {
+              "group": "Bedrifter.Ansatte"
+            },
+            "children": ["navn", "alder", "myndig"],
+            "triggers": ["validation"]
+          },
+          {
+            "id": "navn",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "Bedrifter.Ansatte.Navn"
+            },
+            "hidden": [
+              "and",
+              ["greaterThan", ["component", "alder"], 99],
+              ["notEquals", ["component", "alder"], 101]
+            ],
+            "required": ["dataModel", "Bedrifter.isRequired"]
+          },
+          {
+            "id": "alder",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "Bedrifter.Ansatte.Alder"
+            }
+          },
+          {
+            "id": "myndig",
+            "type": "Paragraph",
+            "textResourceBindings": {
+              "title": "Hurra, den ansatte er myndig!"
+            },
+            "hidden": true
+          }
+        ]
+      }
+    }
+  },
+  "expects": {
+    "Page1": {
+      "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+      "data": {
+        "layout": [
+          {
+            "id": "bekreftelse",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "Bekreftelse"
+            },
+            "hidden": ["equals", true, false],
+            "required": true
+          }
+        ]
+      }
+    },
+    "Page2": {
+      "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+      "data": {
+        "layout": [
+          {
+            "id": "bedrifter",
+            "type": "Group",
+            "maxCount": 99,
+            "dataModelBindings": {
+              "group": "Bedrifter"
+            },
+            "children": ["bedriftsNavn", "ansatte"]
+          },
+          {
+            "id": "bedriftsNavn",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "Bedrifter.Navn"
+            },
+            "hidden": ["equals", true, false],
+            "required": ["dataModel", "Bedrifter.isRequired"]
+          },
+          {
+            "id": "ansatte",
+            "type": "Group",
+            "maxCount": 99,
+            "dataModelBindings": {
+              "group": "Bedrifter.Ansatte"
+            },
+            "children": ["navn", "alder", "myndig"],
+            "triggers": ["validation"]
+          },
+          {
+            "id": "navn",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "Bedrifter.Ansatte.Navn"
+            },
+            "hidden": [
+              "and",
+              ["greaterThan", ["component", "alder"], 99],
+              ["notEquals", ["component", "alder"], 101]
+            ],
+            "required": ["dataModel", "Bedrifter.isRequired"]
+          },
+          {
+            "id": "alder",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "Bedrifter.Ansatte.Alder"
+            }
+          },
+          {
+            "id": "myndig",
+            "type": "Paragraph",
+            "textResourceBindings": {
+              "title": "Hurra, den ansatte er myndig!"
+            },
+            "hidden": true
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared.test.ts
+++ b/src/altinn-app-frontend/src/features/expressions/shared.test.ts
@@ -1,0 +1,160 @@
+import dot from 'dot-object';
+
+import { evalExpr } from 'src/features/expressions';
+import { NodeNotFoundWithoutContext } from 'src/features/expressions/errors';
+import { getSharedTests } from 'src/features/expressions/shared';
+import { asExpression } from 'src/features/expressions/validation';
+import { getRepeatingGroups, splitDashedKey } from 'src/utils/formLayout';
+import {
+  LayoutRootNodeCollection,
+  nodesInLayout,
+} from 'src/utils/layout/hierarchy';
+import type { ContextDataSources } from 'src/features/expressions/ExprContext';
+import type {
+  FunctionTest,
+  SharedTestContext,
+  SharedTestContextList,
+} from 'src/features/expressions/shared';
+import type { LayoutNode } from 'src/utils/layout/hierarchy';
+
+import type {
+  IApplicationSettings,
+  IInstanceContext,
+} from 'altinn-shared/types';
+
+function toComponentId({ component, rowIndices }: FunctionTest['context']) {
+  return (
+    (component || 'no-component') +
+    (rowIndices ? `-${rowIndices.join('-')}` : '')
+  );
+}
+
+describe('Expressions shared function tests', () => {
+  const sharedTests = getSharedTests('functions');
+
+  describe.each(sharedTests.content)('Function: $folderName', (folder) => {
+    it.each(folder.content)(
+      '$name',
+      ({
+        expression,
+        expects,
+        expectsFailure,
+        context,
+        layouts,
+        dataModel,
+        instanceContext,
+        frontendSettings,
+      }) => {
+        const dataSources: ContextDataSources = {
+          formData: dataModel ? dot.dot(dataModel) : {},
+          instanceContext: instanceContext || ({} as IInstanceContext),
+          applicationSettings: frontendSettings || ({} as IApplicationSettings),
+        };
+
+        const asNodes = {};
+        for (const key of Object.keys(layouts || {})) {
+          const repeatingGroups = getRepeatingGroups(
+            layouts[key].data.layout,
+            dataSources.formData,
+          );
+          asNodes[key] = nodesInLayout(
+            layouts[key].data.layout,
+            repeatingGroups,
+          );
+        }
+
+        const currentLayout = (context && context.currentLayout) || '';
+        const rootCollection = new LayoutRootNodeCollection(
+          currentLayout as keyof typeof asNodes,
+          asNodes,
+        );
+        const componentId = context ? toComponentId(context) : 'no-component';
+        const component =
+          rootCollection.findComponentById(componentId) ||
+          new NodeNotFoundWithoutContext(componentId);
+
+        if (expectsFailure) {
+          expect(() => {
+            const expr = asExpression(expression);
+            return evalExpr(expr, component, dataSources);
+          }).toThrow(expectsFailure);
+        } else {
+          expect(evalExpr(expression, component, dataSources)).toEqual(expects);
+        }
+      },
+    );
+  });
+});
+
+describe('Expressions shared context tests', () => {
+  const sharedTests = getSharedTests('context-lists');
+
+  function contextSorter(
+    a: SharedTestContext,
+    b: SharedTestContext,
+  ): -1 | 0 | 1 {
+    if (a.component === b.component) {
+      return 0;
+    }
+
+    return a.component > b.component ? 1 : -1;
+  }
+
+  function recurse(node: LayoutNode<any>, key: string): SharedTestContextList {
+    const splitKey = splitDashedKey(node.item.id);
+    const context: SharedTestContextList = {
+      component: splitKey.baseComponentId,
+      currentLayout: key,
+    };
+    const children = node.children().map((child) => recurse(child, key));
+    if (children.length) {
+      context.children = children;
+    }
+    if (splitKey.depth.length) {
+      context.rowIndices = splitKey.depth;
+    }
+
+    return context;
+  }
+
+  describe.each(sharedTests.content)('$folderName', (folder) => {
+    it.each(folder.content)(
+      '$name',
+      ({
+        layouts,
+        dataModel,
+        instanceContext,
+        frontendSettings,
+        expectedContexts,
+      }) => {
+        const dataSources: ContextDataSources = {
+          formData: dataModel ? dot.dot(dataModel) : {},
+          instanceContext: instanceContext || ({} as IInstanceContext),
+          applicationSettings: frontendSettings || ({} as IApplicationSettings),
+        };
+
+        const foundContexts: SharedTestContextList[] = [];
+        for (const key of Object.keys(layouts || {})) {
+          const repeatingGroups = getRepeatingGroups(
+            layouts[key].data.layout,
+            dataSources.formData,
+          );
+          const nodes = nodesInLayout(
+            layouts[key].data.layout,
+            repeatingGroups,
+          );
+
+          foundContexts.push({
+            component: key,
+            currentLayout: key,
+            children: nodes.children().map((child) => recurse(child, key)),
+          });
+        }
+
+        expect(foundContexts.sort(contextSorter)).toEqual(
+          expectedContexts.sort(contextSorter),
+        );
+      },
+    );
+  });
+});

--- a/src/altinn-app-frontend/src/features/expressions/shared.ts
+++ b/src/altinn-app-frontend/src/features/expressions/shared.ts
@@ -1,0 +1,103 @@
+import fs from 'node:fs';
+
+import type { Expression } from 'src/features/expressions/types';
+import type { ILayout } from 'src/features/form/layout';
+
+import type {
+  IApplicationSettings,
+  IInstanceContext,
+} from 'altinn-shared/types';
+
+export interface Layouts {
+  [key: string]: {
+    $schema: string;
+    data: {
+      layout: ILayout;
+    };
+  };
+}
+
+export interface SharedTest {
+  name: string;
+  layouts?: Layouts;
+  dataModel?: any;
+  instanceContext?: IInstanceContext;
+  frontendSettings?: IApplicationSettings;
+}
+
+export interface SharedTestContext {
+  component?: string;
+  currentLayout?: string;
+}
+
+export interface SharedTestFunctionContext extends SharedTestContext {
+  rowIndices?: number[];
+}
+
+export interface SharedTestContextList extends SharedTestFunctionContext {
+  children?: SharedTestContext[];
+}
+
+export interface ContextTest extends SharedTest {
+  expectedContexts: SharedTestContextList[];
+}
+
+export interface FunctionTest extends SharedTest {
+  expression: Expression;
+  expects?: any;
+  expectsFailure?: string;
+  context?: SharedTestFunctionContext;
+}
+
+export interface LispLikeTest {
+  name: string;
+  expression: any;
+  expects?: Expression;
+  expectsFailure?: string;
+}
+
+export interface LayoutPreprocessorTest {
+  name: string;
+  layouts: Layouts;
+  expects: Layouts;
+  expectsWarnings?: string[];
+}
+
+interface TestFolder<T> {
+  folderName: string;
+  content: T[];
+}
+
+interface TestFolders {
+  'context-lists': TestFolder<TestFolder<ContextTest>>;
+  functions: TestFolder<TestFolder<FunctionTest>>;
+  invalid: TestFolder<FunctionTest>;
+  'layout-preprocessor': TestFolder<LayoutPreprocessorTest>;
+}
+
+export function getSharedTests<Folder extends keyof TestFolders>(
+  subPath: Folder,
+  parentPath = '',
+): TestFolders[Folder] {
+  const out: TestFolder<any> = {
+    folderName: subPath,
+    content: [],
+  };
+  const fullPath = `${__dirname}/shared-tests/${parentPath}/${subPath}`;
+
+  fs.readdirSync(fullPath).forEach((name) => {
+    const isDir = fs.statSync(`${fullPath}/${name}`).isDirectory();
+    if (isDir) {
+      out.content.push(
+        getSharedTests(name as keyof TestFolders, `${parentPath}/${subPath}`),
+      );
+    } else if (name.endsWith('.json')) {
+      const testJson = fs.readFileSync(`${fullPath}/${name}`);
+      const test = JSON.parse(testJson.toString());
+      test.name += ` (${name})`;
+      out.content.push(test);
+    }
+  });
+
+  return out;
+}

--- a/src/altinn-app-frontend/src/features/expressions/types.ts
+++ b/src/altinn-app-frontend/src/features/expressions/types.ts
@@ -1,0 +1,209 @@
+import type { PickByValue } from 'utility-types';
+
+import type { ExprFunctions } from 'src/features/expressions';
+import type { ExprContext } from 'src/features/expressions/ExprContext';
+import type { ValidationContext } from 'src/features/expressions/validation';
+
+type Functions = typeof ExprFunctions;
+
+/**
+ * This union type includes all possible functions usable in expressions
+ */
+export type ExprFunction = keyof Functions;
+
+export type BaseValue = 'string' | 'number' | 'boolean';
+export type BaseToActual<T extends BaseValue> = T extends 'string'
+  ? string
+  : T extends 'number'
+  ? number
+  : T extends 'boolean'
+  ? boolean
+  : never;
+
+/**
+ * A version of the type above that avoids spreading union types. Meaning, it only accepts concrete types from inside
+ * BaseValue, not the union type BaseValue itself:
+ *    type Test1 = BaseToActual<BaseValue>; // string | number | boolean
+ *    type Test2 = BaseToActualStrict<BaseValue>; // never
+ *
+ * @see https://www.typescriptlang.org/docs/handbook/2/conditional-types.html#distributive-conditional-types
+ */
+export type BaseToActualStrict<T extends BaseValue> = [T] extends ['string']
+  ? string
+  : [T] extends ['number']
+  ? number
+  : [T] extends ['boolean']
+  ? boolean
+  : never;
+
+type ArgsToActual<T extends readonly BaseValue[]> = {
+  [Index in keyof T]: BaseToActual<T[Index]>;
+};
+
+export interface FuncDef<
+  Args extends readonly BaseValue[],
+  Ret extends BaseValue,
+> {
+  impl: (this: ExprContext, ...params: ArgsToActual<Args>) => BaseToActual<Ret>;
+  args: Args;
+  minArguments?: number;
+  returns: Ret;
+
+  // Optional: Set this to true if the last argument type is considered a '...spread' argument, meaning
+  // all the rest of the arguments should be cast to the last type (and that the function allows any
+  // amount  of parameters).
+  lastArgSpreads?: true;
+
+  // Optional: Validator function which runs when the function is validated. This allows a function to add its own
+  // validation requirements. Use the addError() function if any errors are found.
+  validator?: (options: {
+    rawArgs: any[];
+    argTypes: (BaseValue | undefined)[];
+    ctx: ValidationContext;
+    path: string[];
+  }) => void;
+
+  // Optional: Allows a function to specify that certain arguments (at the given indexes) should never be cast on the
+  // way in.
+  neverCastArguments?: number[];
+
+  // Optional: Cast return value to the one specified in the 'returns' property. Setting to false allows for functions
+  // passing through their arguments without knowing (or caring) about their specific types. Defaults to true.
+  castReturnValue?: boolean;
+}
+
+type BaseValueArgsFor<F extends ExprFunction> = F extends ExprFunction
+  ? Functions[F]['args']
+  : never;
+
+type FunctionsReturning<T extends BaseValue> = keyof PickByValue<
+  Functions,
+  { returns: T }
+>;
+
+export type ExprReturning<T extends BaseValue> = Expression<
+  FunctionsReturning<T>
+>;
+
+/**
+ * An expression definition is basically [functionName, ...arguments], but when we map arguments (using their
+ * index from zero) in MaybeRecursive (to support recursive expressions) we'll need to place the function name first.
+ * Because of a TypeScript limitation we can't do this the easy way, so this hack makes sure to place our argument
+ * base value types from index 1 and onwards.
+ *
+ * @see https://github.com/microsoft/TypeScript/issues/29919
+ */
+type IndexHack<F extends ExprFunction> = [
+  'Here goes the function name',
+  ...BaseValueArgsFor<F>,
+];
+
+type MaybeRecursive<
+  F extends ExprFunction,
+  Iterations extends Prev[number],
+  Args extends ('Here goes the function name' | BaseValue)[] = IndexHack<F>,
+> = [Iterations] extends [never]
+  ? never
+  : {
+      [Index in keyof Args]: Args[Index] extends BaseValue
+        ?
+            | BaseToActual<Args[Index]>
+            | MaybeRecursive<FunctionsReturning<Args[Index]>, Prev[Iterations]>
+        : F;
+    };
+
+/**
+ * The base type that represents any valid expression function call. When used as a type
+ * inside a layout definition, you probably want something like ExpressionOr<'boolean'>
+ *
+ * @see ExpressionOr
+ */
+export type Expression<F extends ExprFunction = ExprFunction> = MaybeRecursive<
+  F,
+  2
+>;
+
+/**
+ * This type represents an expression for a function that returns the T type, or just the T type itself.
+ */
+export type ExpressionOr<T extends BaseValue> =
+  | ExprReturning<T>
+  | BaseToActual<T>;
+
+/**
+ * Type that lets you convert an expression function name to its return value type
+ */
+export type ReturnValueFor<Func extends ExprFunction> =
+  Func extends keyof Functions
+    ? BaseToActual<Functions[Func]['returns']>
+    : never;
+
+/**
+ * This is the heavy lifter for ExprResolved that will recursively work through objects and remove
+ * expressions (replacing them with the type the expression is expected to return).
+ *
+ * @see https://www.typescriptlang.org/docs/handbook/2/conditional-types.html#distributive-conditional-types
+ */
+type ResolveDistributive<T> = [T] extends [any]
+  ? [T] extends [Expression<infer Func>]
+    ? ReturnValueFor<Func>
+    : T extends Expression
+    ? // When using ExpressionOr<...>, it creates a union type. Removing the Expression from this union
+      never
+    : T extends object
+    ? Exclude<ExprResolved<T>, Expression>
+    : T
+  : never;
+
+/**
+ * This type removes all expressions from the input type (replacing them with the type
+ * the expression is expected to return)
+ *
+ * @see https://stackoverflow.com/a/54487392
+ */
+export type ExprResolved<T> = {
+  [P in keyof T]: ResolveDistributive<T[P]>;
+};
+
+/**
+ * This type can be self-references in order to limit recursion depth for advanced types
+ * @see https://stackoverflow.com/a/70552078
+ */
+type Prev = [never, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+/**
+ * Removes all properties from an object where its keys point to never types. This turns { defunctProp: never } into {}
+ */
+type OmitNeverKeys<T> = {
+  [P in keyof T as T[P] extends never ? never : P]: T[P];
+};
+
+type OmitEmptyObjects<T> = T extends Record<string, never> ? never : T;
+
+type OmitNeverArrays<T> = T extends never[] ? never : T;
+
+/**
+ * This is the heavy lifter used by ExprDefaultValues to recursively iterate types
+ */
+type ReplaceDistributive<T, Iterations extends Prev[number]> = [T] extends [
+  ExpressionOr<infer BT>,
+]
+  ? BaseToActualStrict<BT>
+  : [T] extends [object]
+  ? OmitEmptyObjects<ExprDefaultValues<T, Prev[Iterations]>>
+  : never;
+
+/**
+ * This type looks through an object recursively, finds any expressions, and requires you to provide a default
+ * value for them (i.e. a fallback value should the expression evaluation fail).
+ */
+export type ExprDefaultValues<
+  T,
+  Iterations extends Prev[number] = 1, // <-- Recursion depth limited to 2 levels by default
+> = [Iterations] extends [never]
+  ? never
+  : Required<
+      OmitNeverKeys<{
+        [P in keyof T]: OmitNeverArrays<ReplaceDistributive<T[P], Iterations>>;
+      }>
+    >;

--- a/src/altinn-app-frontend/src/features/expressions/useExpressions.test.tsx
+++ b/src/altinn-app-frontend/src/features/expressions/useExpressions.test.tsx
@@ -1,0 +1,385 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+
+import { getInitialStateMock } from '__mocks__/initialStateMock';
+import { act, renderHook } from '@testing-library/react';
+import type { MockInstance } from 'jest-mock';
+
+import { useExpressions } from 'src/features/expressions/useExpressions';
+import { FormDataActions } from 'src/features/form/data/formDataSlice';
+import { setupStore } from 'src/store';
+import type { ExpressionOr } from 'src/features/expressions/types';
+import type { UseExpressionsOptions } from 'src/features/expressions/useExpressions';
+import type { IFormData } from 'src/features/form/data';
+import type {
+  ILayout,
+  ILayoutComponent,
+  ILayoutGroup,
+} from 'src/features/form/layout';
+import type { IRuntimeState } from 'src/types';
+
+interface ExampleThingWithExpressions {
+  notAnExpr: boolean;
+  hidden: ExpressionOr<'boolean'>;
+  innerObject: {
+    label: string;
+    readOnly: ExpressionOr<'boolean'>;
+  };
+}
+
+const components = {
+  topLayer: {
+    id: 'topLayer',
+    type: 'Input',
+    dataModelBindings: { simpleBinding: 'Model.TopLayer' },
+  } as ILayoutComponent,
+  group: {
+    id: 'group',
+    type: 'Group',
+    maxCount: 5,
+    children: ['inGroup1', 'inGroup2', 'nestedGroup'],
+    dataModelBindings: { group: 'Model.Group' },
+  } as ILayoutGroup,
+  inGroup1: {
+    id: 'inGroup1',
+    type: 'Input',
+    dataModelBindings: { simpleBinding: 'Model.Group.Field1' },
+  } as ILayoutComponent,
+  inGroup2: {
+    id: 'inGroup2',
+    type: 'Input',
+    dataModelBindings: { simpleBinding: 'Model.Group.Field2' },
+  } as ILayoutComponent,
+  nestedGroup: {
+    id: 'nestedGroup',
+    type: 'Group',
+    maxCount: 5,
+    children: ['nested1', 'nested2'],
+    dataModelBindings: { group: 'Model.Group.Nested' },
+  } as ILayoutGroup,
+  nested1: {
+    id: 'nested1',
+    type: 'Input',
+    dataModelBindings: { simpleBinding: 'Model.Group.Nested.Field1' },
+  } as ILayoutComponent,
+  nested2: {
+    id: 'inGroup2',
+    type: 'Input',
+    dataModelBindings: { simpleBinding: 'Model.Group.Nested.Field2' },
+  } as ILayoutComponent,
+};
+
+const layout: ILayout = [
+  components.topLayer,
+  components.group,
+  components.inGroup1,
+  components.inGroup2,
+  components.nestedGroup,
+  components.nested1,
+  components.nested2,
+];
+
+const getState = (formData: IFormData = {}): IRuntimeState => {
+  const state = getInitialStateMock();
+  state.formLayout.layouts['myLayout'] = layout;
+  state.formLayout.uiConfig.currentView = 'myLayout';
+  state.formData.formData = {
+    'Model.TopLayer': 'hello world',
+    'Model.Group[0].Field1': 'row1-f1',
+    'Model.Group[0].Field2': 'row1-f2',
+    'Model.Group[0].FromServer': 'true',
+    'Model.Group[0].Nested[0].Field1': 'row1-nested1-f1',
+    'Model.Group[0].Nested[0].Field2': 'row1-nested1-f2',
+    'Model.Group[1].Field1': 'row2-f1',
+    'Model.Group[1].Field2': 'row2-f2',
+    'Model.Group[1].Nested[0].Field1': 'row2-nested1-f1',
+    'Model.Group[1].Nested[0].Field2': 'row2-nested1-f2',
+    'Model.Group[1].Nested[1].Field1': 'row2-nested2-f1',
+    'Model.Group[1].Nested[1].Field2': 'row2-nested2-f2',
+    'Model.Group[1].Nested[2].Field1': 'row2-nested3-f1',
+    'Model.Group[1].Nested[2].Field2': 'row2-nested3-f2',
+    ...formData,
+  };
+
+  return state;
+};
+
+const thingWithExpressions = (
+  expr1: ExpressionOr<'boolean'> = [
+    'equals',
+    ['component', components.topLayer.id],
+    'hello world',
+  ],
+  expr2: ExpressionOr<'boolean'> = [
+    'equals',
+    ['component', components.topLayer.id],
+    'foo bar',
+  ],
+): ExampleThingWithExpressions => ({
+  notAnExpr: false,
+  hidden: expr1,
+  innerObject: {
+    label: 'hello world',
+    readOnly: expr2,
+  },
+});
+
+const thingWithoutExpressions = (
+  result1: boolean,
+  result2: boolean,
+): ExampleThingWithExpressions => thingWithExpressions(result1, result2);
+
+function render<
+  T extends ExampleThingWithExpressions | ExampleThingWithExpressions[],
+>(thing: T, options: UseExpressionsOptions<T>, state = getState()) {
+  let error: Error = undefined;
+  const store = setupStore(state);
+  const rendered = renderHook(() => useExpressions(thing, options), {
+    wrapper: class Wrapper extends React.Component<
+      React.PropsWithChildren,
+      { hasError: boolean }
+    > {
+      constructor(props) {
+        super(props);
+        this.state = { hasError: false };
+      }
+
+      static getDerivedStateFromError() {
+        return { hasError: true };
+      }
+
+      componentDidCatch(err: Error) {
+        error = err;
+      }
+
+      render() {
+        if (this.state.hasError) {
+          return <span>Something went wrong</span>;
+        }
+
+        return <Provider store={store}>{this.props.children}</Provider>;
+      }
+    },
+  });
+
+  return {
+    ...rendered,
+    store,
+    error,
+  };
+}
+
+describe('useExpressions', () => {
+  const consoleRef: {
+    log: MockInstance;
+    error: MockInstance;
+  } = console as any;
+
+  beforeAll(() => {
+    jest.spyOn(console, 'error').mockImplementation();
+    jest.spyOn(console, 'log').mockImplementation();
+  });
+  afterEach(() => {
+    jest.spyOn(console, 'error').mockClear();
+    jest.spyOn(console, 'log').mockClear();
+  });
+  afterAll(() => {
+    jest.spyOn(console, 'error').mockRestore();
+    jest.spyOn(console, 'log').mockRestore();
+  });
+
+  it('should not do anything when not given any expressions', () => {
+    const obj = thingWithoutExpressions(true, false);
+    const { result } = render(obj, {
+      forComponentId: `${components.inGroup1.id}-0`,
+    });
+
+    expect(result.current.hidden).toEqual(true);
+    expect(result.current.innerObject.readOnly).toEqual(false);
+    expect(result.current).toEqual(obj);
+    expect(consoleRef.error).toBeCalledTimes(0);
+    expect(consoleRef.log).toBeCalledTimes(0);
+  });
+
+  it('should skip evaluating null value', () => {
+    const { result } = render(null as ExampleThingWithExpressions, {
+      forComponentId: components.topLayer.id,
+    });
+
+    expect(result.current).toBeNull();
+    expect(consoleRef.error).toBeCalledTimes(0);
+    expect(consoleRef.log).toBeCalledTimes(0);
+  });
+
+  it('should resolve expressions', () => {
+    const { result, store, rerender } = render(thingWithExpressions(), {
+      forComponentId: components.topLayer.id,
+    });
+
+    expect(result.current.notAnExpr).toEqual(false);
+    expect(result.current.hidden).toEqual(true);
+    expect(result.current).toEqual(thingWithoutExpressions(true, false));
+
+    act(() => {
+      store.dispatch(
+        FormDataActions.setFulfilled({
+          formData: getState({
+            'Model.TopLayer': 'foo bar',
+          }).formData.formData,
+        }),
+      );
+      rerender();
+    });
+
+    expect(result.current.notAnExpr).toEqual(false);
+    expect(result.current.hidden).toEqual(false);
+    expect(result.current).toEqual(thingWithoutExpressions(false, true));
+    expect(consoleRef.error).toBeCalledTimes(0);
+    expect(consoleRef.log).toBeCalledTimes(0);
+  });
+
+  const failingExpr: ExpressionOr<'boolean'> = [
+    'greaterThanEq',
+    ['component', components.topLayer.id],
+    '55',
+  ];
+
+  it('should fail hard when evaluation fails and no defaults are provided', () => {
+    const { result, error } = render(thingWithExpressions(failingExpr), {
+      forComponentId: components.topLayer.id,
+    });
+
+    expect(result.current).toBeNull();
+    expect(error.message).toContain('Expected number, got value "hello world"');
+    expect(consoleRef.error).toBeCalledTimes(3);
+    expect((consoleRef.error.mock.calls[0][0] as Error).message).toContain(
+      'Error: Evaluated expression:',
+    );
+    expect((consoleRef.error.mock.calls[0][0] as Error).message).toContain(
+      'Expected number, got value "hello world"',
+    );
+    expect(consoleRef.error.mock.calls[2][0]).toContain(
+      'The above error occurred in the <TestComponent> component',
+    );
+    expect(consoleRef.log).toBeCalledTimes(0);
+  });
+
+  it('should fail softly when evaluation fails and defaults are provided', () => {
+    const { result, error } = render(thingWithExpressions(failingExpr), {
+      forComponentId: components.topLayer.id,
+      defaults: {
+        hidden: true,
+        innerObject: {
+          readOnly: false,
+        },
+      },
+    });
+
+    expect(result.current).toEqual(thingWithoutExpressions(true, false));
+    expect(error).toBeUndefined();
+    expect(consoleRef.error).toBeCalledTimes(0);
+    expect(consoleRef.log).toBeCalledTimes(1);
+
+    const log = consoleRef.log.mock.calls[0][0];
+    expect(log).toContain(
+      "Evaluated expression for 'hidden' in component 'topLayer'",
+    );
+    expect(log).toContain('Expected number, got value "hello world"');
+    expect(log).toMatch(/Using default value instead:\n\s+%ctrue%c/);
+  });
+
+  it('should fail when source component could not be found', () => {
+    const { result, error } = render(thingWithExpressions(), {
+      forComponentId: `${components.topLayer.id}-0`,
+      defaults: {
+        hidden: true,
+        innerObject: {
+          readOnly: false,
+        },
+      },
+    });
+
+    expect(result.current).toEqual(thingWithoutExpressions(true, false));
+    expect(error).toBeUndefined();
+    expect(consoleRef.error).toBeCalledTimes(0);
+    expect(consoleRef.log).toBeCalledTimes(2);
+
+    const log = consoleRef.log.mock.calls[0][0];
+    expect(log).toContain(
+      "Evaluated expression for 'hidden' in component 'topLayer-0'",
+    );
+    expect(log).toContain(
+      `Unable to evaluate expressions in context of the "topLayer-0" component (it could not be found)`,
+    );
+    expect(log).toMatch(/Using default value instead:\n\s+%ctrue%c/);
+  });
+
+  it('should fail when target component could not be found', () => {
+    const { result, error } = render(
+      thingWithExpressions([
+        'equals',
+        ['component', `${components.topLayer.id}-0`],
+        'hello world',
+      ]),
+      {
+        forComponentId: components.topLayer.id,
+        defaults: {
+          hidden: true,
+          innerObject: {
+            readOnly: false,
+          },
+        },
+      },
+    );
+
+    expect(result.current).toEqual(thingWithoutExpressions(true, false));
+    expect(error).toBeUndefined();
+    expect(consoleRef.error).toBeCalledTimes(0);
+    expect(consoleRef.log).toBeCalledTimes(1);
+
+    const log = consoleRef.log.mock.calls[0][0];
+    expect(log).toContain(
+      "Evaluated expression for 'hidden' in component 'topLayer'",
+    );
+    expect(log).toContain(
+      `Unable to find component with identifier topLayer-0 or it does not have a simpleBinding`,
+    );
+    expect(log).toMatch(/Using default value instead:\n\s+%ctrue%c/);
+  });
+
+  it('should not fail when source component could not be found, if it is never referenced', () => {
+    const { result, error } = render(
+      thingWithExpressions(
+        ['equals', 'foo bar', 'hello world'],
+        ['greaterThan', 8, 5],
+      ),
+      {
+        forComponentId: `${components.topLayer.id}-0`,
+      },
+    );
+
+    expect(result.current).toEqual(thingWithoutExpressions(false, true));
+    expect(error).toBeUndefined();
+    expect(consoleRef.error).toBeCalledTimes(0);
+    expect(consoleRef.log).toBeCalledTimes(0);
+  });
+
+  it('should evaluate expressions inside arrays', () => {
+    const { result } = render(
+      [
+        thingWithExpressions(),
+        thingWithoutExpressions(false, true),
+        thingWithExpressions(),
+      ],
+      {
+        forComponentId: components.topLayer.id,
+      },
+    );
+
+    expect(result.current[0]).toEqual(thingWithoutExpressions(true, false));
+    expect(result.current[1]).toEqual(thingWithoutExpressions(false, true));
+    expect(result.current[2]).toEqual(thingWithoutExpressions(true, false));
+    expect(consoleRef.error).toBeCalledTimes(0);
+    expect(consoleRef.log).toBeCalledTimes(0);
+  });
+});

--- a/src/altinn-app-frontend/src/features/expressions/useExpressions.ts
+++ b/src/altinn-app-frontend/src/features/expressions/useExpressions.ts
@@ -1,0 +1,108 @@
+import { useContext, useMemo } from 'react';
+
+import { useAppSelector } from 'src/common/hooks';
+import { FormComponentContext } from 'src/components';
+import { NodeNotFoundWithoutContext } from 'src/features/expressions/errors';
+import {
+  evalExprInObj,
+  ExprDefaultsForComponent,
+  ExprDefaultsForGroup,
+} from 'src/features/expressions/index';
+import { useLayoutsAsNodes } from 'src/utils/layout/useLayoutsAsNodes';
+import type { ContextDataSources } from 'src/features/expressions/ExprContext';
+import type { EvalExprInObjArgs } from 'src/features/expressions/index';
+import type {
+  ExprDefaultValues,
+  ExprResolved,
+} from 'src/features/expressions/types';
+import type { ILayoutComponentOrGroup } from 'src/features/form/layout';
+
+import { buildInstanceContext } from 'altinn-shared/utils/instanceContext';
+
+export interface UseExpressionsOptions<T> {
+  /**
+   * The component ID for the current component context. Usually optional, as it will be fetched from
+   * the FormComponentContext if not given.
+   */
+  forComponentId?: string;
+
+  /**
+   * Default values in case the expression evaluation fails. If this is not given, a failing expression will throw
+   * an exception and fail hard. If you provide default values for your expressions, a failing expression will instead
+   * print out a pretty error message to the console explaining what went wrong - and continue by using the default
+   * value instead.
+   */
+  defaults?: ExprDefaultValues<T>;
+}
+
+/**
+ * React hook used to resolve expressions from a component (usually in layout definitions). This
+ * should be used inside a form component context.
+ *
+ * @param input Any input, object, value from the layout definitions, possibly containing expressions somewhere.
+ *  This hook will look through the input (and recurse through objects), looking for expressions and resolve
+ *  them to provide you with the base out value for the current component context.
+ * @param options Optional options (see their own docs)
+ */
+export function useExpressions<T>(
+  input: T,
+  options?: UseExpressionsOptions<T>,
+): ExprResolved<T> {
+  const component = useContext(FormComponentContext);
+  const nodes = useLayoutsAsNodes();
+  const formData = useAppSelector((state) => state.formData?.formData);
+  const applicationSettings = useAppSelector(
+    (state) => state.applicationSettings?.applicationSettings,
+  );
+  const instance = useAppSelector((state) => state.instanceData?.instance);
+  const instanceContext = buildInstanceContext(instance);
+  const id = (options && options.forComponentId) || component.id;
+
+  const node = useMemo(() => {
+    const foundNode = nodes.findComponentById(id);
+    if (foundNode) {
+      return foundNode;
+    }
+
+    return new NodeNotFoundWithoutContext(id);
+  }, [nodes, id]);
+
+  const dataSources = useMemo(
+    (): ContextDataSources => ({
+      instanceContext,
+      applicationSettings,
+      formData,
+    }),
+    [instanceContext, applicationSettings, formData],
+  );
+
+  return useMemo(() => {
+    return evalExprInObj({
+      ...(options as Pick<UseExpressionsOptions<T>, 'defaults'>),
+      input,
+      node,
+      dataSources,
+    } as EvalExprInObjArgs<T>) as ExprResolved<T>;
+  }, [dataSources, input, node, options]);
+}
+
+const componentDefaults: any = {
+  ...ExprDefaultsForComponent,
+  ...ExprDefaultsForGroup,
+};
+
+export function useExpressionsForComponent<T extends ILayoutComponentOrGroup>(
+  input: T,
+  options?: Omit<UseExpressionsOptions<T>, 'defaults'>,
+): ExprResolved<T> {
+  const newOptions = useMemo(
+    () => ({
+      ...options,
+      defaults: componentDefaults,
+    }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    Object.values(options),
+  );
+
+  return useExpressions(input, newOptions);
+}

--- a/src/altinn-app-frontend/src/features/expressions/validation.test.ts
+++ b/src/altinn-app-frontend/src/features/expressions/validation.test.ts
@@ -1,0 +1,143 @@
+import {
+  evalExprInObj,
+  ExprDefaultsForComponent,
+  ExprDefaultsForGroup,
+} from 'src/features/expressions/index';
+import { getSharedTests } from 'src/features/expressions/shared';
+import {
+  asExpression,
+  preProcessLayout,
+} from 'src/features/expressions/validation';
+import { nodesInLayout } from 'src/utils/layout/hierarchy';
+import type { Layouts } from 'src/features/expressions/shared';
+import type {
+  ILayout,
+  ILayoutComponentOrGroup,
+  ILayoutGroup,
+} from 'src/features/form/layout';
+import type { IRepeatingGroups } from 'src/types';
+
+function isRepeatingGroup(
+  component?: ILayoutComponentOrGroup,
+): component is ILayoutGroup {
+  return component && component.type === 'Group' && component.maxCount > 1;
+}
+
+function generateRepeatingGroups(layout: ILayout) {
+  const repeatingGroups: IRepeatingGroups = {};
+  for (const component of layout) {
+    if (isRepeatingGroup(component)) {
+      repeatingGroups[component.id] = {
+        index: 1,
+        editIndex: -1,
+      };
+      for (const child of component.children) {
+        const childElm = layout.find((c) => c.id === child);
+        if (isRepeatingGroup(childElm)) {
+          repeatingGroups[`${childElm.id}-0`] = {
+            index: 1,
+            editIndex: -1,
+          };
+        }
+      }
+    }
+  }
+
+  return repeatingGroups;
+}
+
+function evalAllExpressions(layouts: Layouts) {
+  for (const page of Object.values(layouts)) {
+    const repeatingGroups = generateRepeatingGroups(page.data.layout);
+    const nodes = nodesInLayout(page.data.layout, repeatingGroups);
+    for (const node of nodes.flat(true)) {
+      evalExprInObj({
+        input: node.item,
+        node,
+        defaults: {
+          ...ExprDefaultsForComponent,
+          ...ExprDefaultsForGroup,
+        },
+        dataSources: {
+          formData: {},
+          applicationSettings: {} as any,
+          instanceContext: {} as any,
+        },
+      });
+    }
+  }
+}
+
+describe('Expression validation', () => {
+  describe('Shared tests for invalid expressions', () => {
+    const invalidSharedTests = getSharedTests('invalid');
+    it.each(invalidSharedTests.content)('$name', (invalid) => {
+      expect(() => asExpression(invalid.expression)).toThrow(
+        invalid.expectsFailure,
+      );
+    });
+  });
+
+  describe('Shared tests for layout preprocessor', () => {
+    const tests = getSharedTests('layout-preprocessor');
+    it.each(tests.content)('$name', (t) => {
+      const warningsExpected = t.expectsWarnings || [];
+      const logSpy = jest.spyOn(console, 'log');
+      if (warningsExpected.length > 0) {
+        logSpy.mockImplementation(() => {
+          return undefined;
+        });
+      }
+
+      const result: typeof tests['content'][number]['layouts'] = {};
+      for (const page of Object.keys(t.layouts)) {
+        const layout = t.layouts[page].data.layout;
+        preProcessLayout(layout);
+        result[page] = {
+          $schema: t.layouts[page].$schema,
+          data: { layout },
+        };
+      }
+
+      expect(result).toEqual(t.expects);
+
+      // Runs all the expressions inside the layout. This is done so that we have shared tests that make sure to
+      // check that evaluating expressions in a component/node context works (i.e. that "triggers": ["validation"]
+      // is not interpreted as an expression). This will throw errors if anything goes wrong, which should make the
+      // test fail.
+      evalAllExpressions(result);
+
+      const warningsFound = [];
+      for (const call of logSpy.mock.calls) {
+        for (const warning of warningsExpected) {
+          if ((call[0] as string).includes(`%c${warning}%c`)) {
+            warningsFound.push(warning);
+          }
+        }
+      }
+      expect(warningsFound.sort()).toEqual(warningsExpected.sort());
+
+      logSpy.mockRestore();
+    });
+  });
+
+  describe('Some values/objects should not validate', () => {
+    it.each([
+      '',
+      null,
+      false,
+      undefined,
+      5,
+      new Date(),
+      {},
+      { hello: 'world' },
+      { expr: 'hello world' },
+      { expr: '5 == 5', and: 'other property' },
+    ])(
+      'should validate %p as an invalid expression (non-throwing)',
+      (maybeExpr) => {
+        expect(asExpression(maybeExpr)).toBeUndefined();
+      },
+    );
+  });
+});

--- a/src/altinn-app-frontend/src/features/expressions/validation.ts
+++ b/src/altinn-app-frontend/src/features/expressions/validation.ts
@@ -1,0 +1,317 @@
+import dot from 'dot-object';
+
+import {
+  argTypeAt,
+  ExprDefaultsForComponent,
+  ExprDefaultsForGroup,
+  ExprFunctions,
+  ExprTypes,
+} from 'src/features/expressions';
+import {
+  prettyErrors,
+  prettyErrorsToConsole,
+} from 'src/features/expressions/prettyErrors';
+import type {
+  BaseValue,
+  Expression,
+  ExprFunction,
+  FuncDef,
+} from 'src/features/expressions/types';
+import type { ILayout } from 'src/features/form/layout';
+
+enum ValidationErrorMessage {
+  InvalidType = 'Invalid type "%s"',
+  FuncNotImpl = 'Function "%s" not implemented',
+  ArgUnexpected = 'Unexpected argument',
+  ArgWrongType = 'Expected argument to be %s, got %s',
+  ArgsWrongNum = 'Expected %s argument(s), got %s',
+  FuncMissing = 'Missing function name in expression',
+  FuncNotString = 'Function name in expression should be string',
+}
+
+export interface ValidationContext {
+  errors: {
+    [key: string]: string[];
+  };
+}
+
+const validBasicTypes: { [key: string]: BaseValue } = {
+  boolean: 'boolean',
+  string: 'string',
+  bigint: 'number',
+  number: 'number',
+};
+
+export class InvalidExpression extends Error {}
+
+export function addError(
+  ctx: ValidationContext,
+  path: string[],
+  message: ValidationErrorMessage | string,
+  ...params: string[]
+) {
+  let paramIdx = 0;
+  const newMessage = message.replaceAll('%s', () => params[paramIdx++]);
+  const stringPath = path.join('');
+  if (ctx.errors[stringPath]) {
+    ctx.errors[stringPath].push(newMessage);
+  } else {
+    ctx.errors[stringPath] = [newMessage];
+  }
+}
+
+function validateFunctionArg(
+  func: ExprFunction,
+  idx: number,
+  actual: (BaseValue | undefined)[],
+  ctx: ValidationContext,
+  path: string[],
+) {
+  const expectedType = argTypeAt(func, idx);
+  const actualType = actual[idx];
+  if (expectedType === undefined) {
+    addError(ctx, [...path, `[${idx}]`], ValidationErrorMessage.ArgUnexpected);
+  } else {
+    const targetType = ExprTypes[expectedType];
+
+    if (actualType === undefined) {
+      if (targetType.nullable) {
+        return;
+      }
+      addError(
+        ctx,
+        [...path, `[${idx}]`],
+        ValidationErrorMessage.ArgWrongType,
+        expectedType,
+        'null',
+      );
+    }
+
+    if (!targetType.accepts.includes(actualType)) {
+      addError(
+        ctx,
+        [...path, `[${idx}]`],
+        ValidationErrorMessage.ArgWrongType,
+        expectedType,
+        'null',
+      );
+    }
+  }
+}
+
+function validateFunctionArgs(
+  func: ExprFunction,
+  actual: (BaseValue | undefined)[],
+  ctx: ValidationContext,
+  path: string[],
+) {
+  const expected = ExprFunctions[func].args;
+
+  let minExpected = ExprFunctions[func]?.minArguments;
+  if (minExpected === undefined) {
+    minExpected = expected.length;
+  }
+  const canSpread = ExprFunctions[func].lastArgSpreads;
+
+  const maxIdx = Math.max(expected.length, actual.length);
+  for (let idx = 0; idx < maxIdx; idx++) {
+    validateFunctionArg(func, idx, actual, ctx, path);
+  }
+
+  if (canSpread && actual.length >= minExpected) {
+    return;
+  }
+
+  if (actual.length !== minExpected) {
+    addError(
+      ctx,
+      path,
+      ValidationErrorMessage.ArgsWrongNum,
+      `${minExpected}${canSpread ? '+' : ''}`,
+      `${actual.length}`,
+    );
+  }
+}
+
+function validateFunction(
+  funcName: any,
+  rawArgs: any[],
+  argTypes: (BaseValue | undefined)[],
+  ctx: ValidationContext,
+  path: string[],
+): BaseValue | undefined {
+  if (typeof funcName !== 'string') {
+    addError(ctx, path, ValidationErrorMessage.InvalidType, typeof funcName);
+    return;
+  }
+
+  const pathArgs = [...path.slice(0, path.length - 1)];
+
+  if (funcName in ExprFunctions) {
+    validateFunctionArgs(funcName as ExprFunction, argTypes, ctx, pathArgs);
+
+    const def = ExprFunctions[funcName] as FuncDef<any, any>;
+    if (def.validator) {
+      def.validator({ rawArgs, argTypes, ctx, path: pathArgs });
+    }
+
+    return def.returns;
+  }
+
+  addError(ctx, path, ValidationErrorMessage.FuncNotImpl, funcName);
+}
+
+function validateExpr(expr: any[], ctx: ValidationContext, path: string[]) {
+  if (expr.length < 1) {
+    addError(ctx, path, ValidationErrorMessage.FuncMissing);
+    return undefined;
+  }
+
+  if (typeof expr[0] !== 'string') {
+    addError(ctx, path, ValidationErrorMessage.FuncNotString);
+    return undefined;
+  }
+
+  const [func, ...rawArgs] = expr;
+  const args: (BaseValue | undefined)[] = [];
+
+  for (const argIdx in rawArgs) {
+    const idx = parseInt(argIdx) + 1;
+    args.push(validateRecursively(rawArgs[argIdx], ctx, [...path, `[${idx}]`]));
+  }
+
+  return validateFunction(func, rawArgs, args, ctx, [...path, '[0]']);
+}
+
+function validateRecursively(
+  expr: any,
+  ctx: ValidationContext,
+  path: string[],
+): BaseValue | undefined {
+  if (validBasicTypes[typeof expr]) {
+    return validBasicTypes[typeof expr];
+  }
+
+  if (typeof expr === 'undefined' || expr === null) {
+    return;
+  }
+
+  if (Array.isArray(expr)) {
+    return validateExpr(expr, ctx, path);
+  }
+
+  addError(ctx, path, ValidationErrorMessage.InvalidType, typeof expr);
+}
+
+/**
+ * Checks anything and returns true if it _could_ be an expression (but is not guaranteed to be one, and does not
+ * validate the expression). This is `asExpression` light, without any error logging to console if it fails.
+ */
+export function canBeExpression(expr: any): expr is [] {
+  return Array.isArray(expr) && expr.length >= 1 && typeof expr[0] === 'string';
+}
+
+/**
+ * Takes the input object, validates it to make sure it is a valid expression, returns either a fully
+ * parsed expression (ready to pass to evalExpr()), or undefined (if not a valid expression).
+ *
+ * @param obj Input, can be anything
+ * @param defaultValue Default value (returned if the expression fails to validate)
+ * @param errorText Error intro text used when printing to console or throwing an error
+ */
+export function asExpression(
+  obj: any,
+  defaultValue: any = undefined,
+  errorText = 'Invalid expression',
+): Expression | undefined {
+  if (typeof obj !== 'object' || obj === null || !Array.isArray(obj)) {
+    return undefined;
+  }
+
+  const ctx: ValidationContext = { errors: {} };
+  validateRecursively(obj, ctx, []);
+
+  if (Object.keys(ctx.errors).length) {
+    if (typeof defaultValue !== 'undefined') {
+      const prettyPrinted = prettyErrorsToConsole({
+        input: obj,
+        errors: ctx.errors,
+        indentation: 1,
+        defaultStyle: '',
+      });
+
+      // eslint-disable-next-line no-console
+      console.log(
+        [
+          `${errorText}:`,
+          prettyPrinted.lines,
+          '%cUsing default value instead:',
+          `  %c${defaultValue.toString()}%c`,
+        ].join('\n'),
+        ...prettyPrinted.css,
+        ...['', 'color: red;', ''],
+      );
+
+      return defaultValue;
+    }
+
+    const pretty = prettyErrors({
+      input: obj,
+      errors: ctx.errors,
+      indentation: 1,
+    });
+    throw new InvalidExpression(`${errorText}:\n${pretty}`);
+  }
+
+  return obj as unknown as Expression;
+}
+
+export function preProcessItem(
+  input: any,
+  defaults: Record<string, any>,
+  componentPath: string[],
+  componentId: string,
+): any {
+  const pathStr = componentPath.join('.');
+  if (pathStr in defaults) {
+    if (typeof input === 'object' && input !== null) {
+      const errText = `Invalid expression when parsing ${pathStr} for "${componentId}"`;
+      return asExpression(input, defaults[pathStr], errText);
+    }
+
+    return input;
+  }
+
+  if (typeof input === 'object' && !Array.isArray(input) && input !== null) {
+    for (const property of Object.keys(input)) {
+      input[property] = preProcessItem(
+        input[property],
+        defaults,
+        [...componentPath, property],
+        componentId,
+      );
+    }
+  }
+
+  return input;
+}
+
+/**
+ * Pre-process a layout array. This iterates all components and makes sure to validate expressions (making sure they
+ * are valid according to the Expression TypeScript type, ready to pass to evalExpr()).
+ *
+ * If/when expressions inside components does not validate correctly, a warning is printed to the console, and the
+ * expression is substituted with the appropriate default value.
+ *
+ * Please note: This mutates the layout array passed to the function, and returns nothing.
+ */
+export function preProcessLayout(layout: ILayout) {
+  const defaults = dot.dot({
+    ...ExprDefaultsForComponent,
+    ...ExprDefaultsForGroup,
+  });
+
+  for (const comp of layout) {
+    preProcessItem(comp, defaults, [], comp.id);
+  }
+}

--- a/src/altinn-app-frontend/src/features/form/layout/index.ts
+++ b/src/altinn-app-frontend/src/features/form/layout/index.ts
@@ -63,6 +63,7 @@ export interface ILayoutCompBase<Type extends ComponentTypes = ComponentTypes>
   dataModelBindings?: IDataModelBindings;
   readOnly?: boolean;
   required?: boolean;
+  hidden?: any; // Temporary while merging expressions PRs
   textResourceBindings?: ITextResourceBindings;
   grid?: IGrid;
   triggers?: Triggers[];

--- a/src/altinn-app-frontend/src/utils/databindings/DataBinding.ts
+++ b/src/altinn-app-frontend/src/utils/databindings/DataBinding.ts
@@ -1,0 +1,54 @@
+/**
+ * Simple class to let you work with (and mutate) a data model binding (possibly including array index accessors)
+ * It breaks the data binding into DataBindingPart classes.
+ */
+export class DataBinding {
+  public readonly parts: DataBindingPart[];
+
+  public constructor(public readonly binding: string) {
+    this.parts = binding
+      .split('.')
+      .map((part, index) => new DataBindingPart(this, index, part));
+  }
+
+  public at(index: number): DataBindingPart | undefined {
+    return this.parts[index];
+  }
+
+  public toString(): string {
+    return this.parts.map((part) => part.toString()).join('.');
+  }
+}
+
+export class DataBindingPart {
+  public readonly base: string;
+  public arrayIndex: number | undefined = undefined;
+
+  public constructor(
+    public readonly parent: DataBinding,
+    public readonly parentIndex: number,
+    raw: string,
+  ) {
+    const arrayIndex = raw.match(/(\[\d+])?$/);
+    if (arrayIndex && arrayIndex[1]) {
+      this.arrayIndex = parseInt(
+        arrayIndex[1].substring(1, arrayIndex[1].length - 1),
+      );
+      this.base = raw.substring(0, raw.length - arrayIndex[1].length);
+    } else {
+      this.base = raw;
+    }
+  }
+
+  public hasArrayIndex(): boolean {
+    return this.arrayIndex !== undefined;
+  }
+
+  public toString(): string {
+    if (this.arrayIndex !== undefined) {
+      return `${this.base}[${this.arrayIndex}]`;
+    }
+
+    return this.base;
+  }
+}

--- a/src/altinn-app-frontend/src/utils/formLayout.ts
+++ b/src/altinn-app-frontend/src/utils/formLayout.ts
@@ -278,10 +278,16 @@ export const getRepeatingGroupStartStopIndex = (
   repeatingGroupIndex: number,
   edit: IGroupEditProperties | undefined,
 ) => {
+  if (typeof repeatingGroupIndex === 'undefined') {
+    return { startIndex: 0, stopIndex: -1 };
+  }
+
   const start = edit?.filter?.find(({ key }) => key === 'start')?.value;
   const stop = edit?.filter?.find(({ key }) => key === 'stop')?.value;
   const startIndex = start ? parseInt(start) : 0;
-  const stopIndex = stop ? parseInt(stop) - 1 : repeatingGroupIndex;
+  const stopIndex = stop
+    ? Math.min(parseInt(stop) - 1, repeatingGroupIndex)
+    : repeatingGroupIndex;
   return { startIndex, stopIndex };
 };
 

--- a/src/altinn-app-frontend/src/utils/layout/hierarchy.test.ts
+++ b/src/altinn-app-frontend/src/utils/layout/hierarchy.test.ts
@@ -1,0 +1,627 @@
+import {
+  layoutAsHierarchy,
+  layoutAsHierarchyWithRows,
+  LayoutNode,
+  LayoutRootNode,
+  LayoutRootNodeCollection,
+  nodesInLayout,
+  resolvedNodesInLayout,
+} from 'src/utils/layout/hierarchy';
+import type { ContextDataSources } from 'src/features/expressions/ExprContext';
+import type {
+  ILayout,
+  ILayoutCompHeader,
+  ILayoutCompInput,
+  ILayoutGroup,
+} from 'src/features/form/layout';
+import type { IRepeatingGroups } from 'src/types';
+import type { AnyNode } from 'src/utils/layout/hierarchy.types';
+
+describe('Hierarchical layout tools', () => {
+  const header: Omit<ILayoutCompHeader, 'id'> = { type: 'Header', size: 'L' };
+  const input: Omit<ILayoutCompInput, 'id'> = {
+    type: 'Input',
+    hidden: ['equals', ['dataModel', 'Model.ShouldBeTrue'], 'true'],
+  };
+  const group: Omit<ILayoutGroup, 'id' | 'children'> = { type: 'Group' };
+  const repGroup: Omit<ILayoutGroup, 'id' | 'children'> = {
+    type: 'Group',
+    maxCount: 3,
+    hidden: ['equals', ['dataModel', 'Model.ShouldBeFalse'], 'false'],
+  };
+  const components = {
+    top1: { id: 'top1', ...header },
+    top2: { id: 'top2', ...input },
+    group1: { id: 'group1', ...group },
+    group1h: { id: 'group1_header', ...header },
+    group1i: { id: 'group1_input', ...input },
+    group2: {
+      id: 'group2',
+      dataModelBindings: {
+        group: 'MyModel.Group2',
+      },
+      ...repGroup,
+    },
+    group2h: { id: 'group2_header', ...header },
+    group2i: {
+      id: 'group2_input',
+      ...input,
+      dataModelBindings: {
+        simpleBinding: 'MyModel.Group2.Input',
+      },
+    },
+    group2n: {
+      id: 'group2nested',
+      ...repGroup,
+      dataModelBindings: {
+        group: 'MyModel.Group2.Nested',
+      },
+    },
+    group2nh: { id: 'group2nested_header', ...header },
+    group2ni: {
+      id: 'group2nested_input',
+      ...input,
+      dataModelBindings: {
+        simpleBinding: 'MyModel.Group2.Nested.Input',
+      },
+    },
+    group3: {
+      id: 'group3',
+      ...repGroup,
+      edit: {
+        multiPage: true,
+        filter: [
+          { key: 'start', value: '1' },
+          { key: 'stop', value: '2' },
+        ],
+      },
+    } as Omit<ILayoutGroup, 'children'>,
+    group3h: { id: 'group3_header', ...header },
+    group3i: { id: 'group3_input', ...input },
+    group3n: { id: 'group3nested', ...repGroup },
+    group3nh: { id: 'group3nested_header', ...header },
+    group3ni: { id: 'group3nested_input', ...input },
+  };
+
+  const layout: ILayout = [
+    components.top1,
+    components.top2,
+    {
+      ...components.group1,
+      children: [components.group1h.id, components.group1i.id],
+    },
+    components.group1h,
+    components.group1i,
+    {
+      ...components.group2,
+      children: [
+        components.group2h.id,
+        components.group2i.id,
+        components.group2n.id,
+      ],
+    },
+    components.group2h,
+    components.group2i,
+    {
+      ...components.group2n,
+      children: [components.group2nh.id, components.group2ni.id],
+    },
+    components.group2nh,
+    components.group2ni,
+    {
+      ...components.group3,
+      children: [
+        `0:${components.group3h.id}`,
+        `1:${components.group3i.id}`,
+        `2:${components.group3n.id}`,
+      ],
+    },
+    components.group3h,
+    components.group3i,
+    {
+      ...components.group3n,
+      children: [components.group3nh.id, components.group3ni.id],
+    },
+    components.group3nh,
+    components.group3ni,
+  ];
+
+  describe('layoutAsHierarchy', () => {
+    it('should turn a layout into a hierarchy', () => {
+      const result = layoutAsHierarchy(layout);
+      expect(result).toEqual([
+        components.top1,
+        components.top2,
+        {
+          ...components.group1,
+          childComponents: [components.group1h, components.group1i],
+        },
+        {
+          ...components.group2,
+          childComponents: [
+            components.group2h,
+            components.group2i,
+            {
+              ...components.group2n,
+              childComponents: [components.group2nh, components.group2ni],
+            },
+          ],
+        },
+        {
+          ...components.group3,
+          childComponents: [
+            components.group3h,
+            components.group3i,
+            {
+              ...components.group3n,
+              childComponents: [components.group3nh, components.group3ni],
+            },
+          ],
+        },
+      ]);
+    });
+  });
+
+  const repeatingGroups: IRepeatingGroups = {
+    [components.group2.id]: {
+      index: 1,
+      baseGroupId: components.group2.id,
+    },
+    [`${components.group2n.id}-0`]: {
+      index: 1,
+      baseGroupId: components.group2n.id,
+    },
+    [`${components.group2n.id}-1`]: {
+      index: 0,
+      baseGroupId: components.group2n.id,
+    },
+  };
+
+  const manyRepeatingGroups: IRepeatingGroups = {
+    [components.group2.id]: {
+      index: 3,
+      baseGroupId: components.group2.id,
+    },
+    [`${components.group2n.id}-0`]: {
+      index: 3,
+      baseGroupId: components.group2n.id,
+    },
+    [`${components.group2n.id}-1`]: {
+      index: 3,
+      baseGroupId: components.group2n.id,
+    },
+    [`${components.group2n.id}-2`]: {
+      index: 3,
+      baseGroupId: components.group2n.id,
+    },
+    [`${components.group2n.id}-3`]: {
+      index: 3,
+      baseGroupId: components.group2n.id,
+    },
+    [components.group3.id]: {
+      index: 4,
+    },
+    [`${components.group3n.id}-0`]: {
+      index: 4,
+      baseGroupId: components.group3n.id,
+    },
+    [`${components.group3n.id}-1`]: {
+      index: 4,
+      baseGroupId: components.group3n.id,
+    },
+    [`${components.group3n.id}-2`]: {
+      index: 4,
+      baseGroupId: components.group3n.id,
+    },
+    [`${components.group3n.id}-3`]: {
+      index: 4,
+      baseGroupId: components.group3n.id,
+    },
+  };
+
+  describe('layoutAsHierarchyWithRows', () => {
+    it('should generate a hierarchy for a simple layout', () => {
+      const commonComponents = (row: number) => [
+        {
+          ...components.group2h,
+          id: `${components.group2h.id}-${row}`,
+          baseComponentId: components.group2h.id,
+        },
+        {
+          ...components.group2i,
+          id: `${components.group2i.id}-${row}`,
+          baseComponentId: components.group2i.id,
+          dataModelBindings: {
+            simpleBinding: `MyModel.Group2[${row}].Input`,
+          },
+          baseDataModelBindings: components.group2i.dataModelBindings,
+        },
+      ];
+
+      const nestedComponents = (row: number, nestedRow: number) => [
+        {
+          ...components.group2nh,
+          id: `${components.group2nh.id}-${row}-${nestedRow}`,
+          baseComponentId: components.group2nh.id,
+        },
+        {
+          ...components.group2ni,
+          id: `${components.group2ni.id}-${row}-${nestedRow}`,
+          baseComponentId: components.group2ni.id,
+          dataModelBindings: {
+            simpleBinding: `MyModel.Group2[${row}].Nested[${nestedRow}].Input`,
+          },
+          baseDataModelBindings: components.group2ni.dataModelBindings,
+        },
+      ];
+
+      const result = layoutAsHierarchyWithRows(layout, repeatingGroups);
+      expect(result).toEqual([
+        components.top1,
+        components.top2,
+        {
+          ...components.group1,
+          // This group is not repeating, so it should not output any rows:
+          childComponents: [components.group1h, components.group1i],
+        },
+        {
+          ...components.group2,
+          rows: [
+            [
+              ...commonComponents(0),
+              {
+                ...components.group2n,
+                id: `${components.group2n.id}-0`,
+                baseComponentId: components.group2n.id,
+                baseDataModelBindings: components.group2n.dataModelBindings,
+                dataModelBindings: { group: 'MyModel.Group2[0].Nested' },
+                rows: [nestedComponents(0, 0), nestedComponents(0, 1)],
+              },
+            ],
+            [
+              ...commonComponents(1),
+              {
+                ...components.group2n,
+                id: `${components.group2n.id}-1`,
+                baseComponentId: components.group2n.id,
+                baseDataModelBindings: components.group2n.dataModelBindings,
+                dataModelBindings: { group: 'MyModel.Group2[1].Nested' },
+                rows: [nestedComponents(1, 0)],
+              },
+            ],
+          ],
+        },
+        { ...components.group3, rows: [] },
+      ]);
+    });
+  });
+
+  describe('nodesInLayout', () => {
+    it('should resolve a very simple layout', () => {
+      const root = new LayoutRootNode();
+      const top1 = new LayoutNode(components.top1, root);
+      const top2 = new LayoutNode(components.top2, root);
+      root._addChild(top1);
+      root._addChild(top2);
+
+      const result = nodesInLayout([components.top1, components.top2], {});
+      expect(result).toEqual(root);
+    });
+
+    it('should resolve a complex layout without groups', () => {
+      const nodes = nodesInLayout(layout, repeatingGroups);
+      const flatNoGroups = nodes.flat(false);
+      expect(flatNoGroups.map((n) => n.item.id)).toEqual([
+        // Top-level nodes:
+        components.top1.id,
+        components.top2.id,
+        components.group1h.id,
+        components.group1i.id,
+
+        // First row in group2
+        `${components.group2h.id}-0`,
+        `${components.group2i.id}-0`,
+        `${components.group2nh.id}-0-0`,
+        `${components.group2ni.id}-0-0`,
+        `${components.group2nh.id}-0-1`,
+        `${components.group2ni.id}-0-1`,
+
+        // Second row in group2
+        `${components.group2h.id}-1`,
+        `${components.group2i.id}-1`,
+        `${components.group2nh.id}-1-0`,
+        `${components.group2ni.id}-1-0`,
+
+        // Note: No group components
+        // Note: No rows in group 3
+      ]);
+    });
+
+    it('should resolve a complex layout with groups', () => {
+      const nodes = nodesInLayout(layout, repeatingGroups);
+      const flatWithGroups = nodes.flat(true);
+      expect(flatWithGroups.map((n) => n.item.id)).toEqual([
+        // Top-level nodes:
+        components.top1.id,
+        components.top2.id,
+        components.group1h.id,
+        components.group1i.id,
+        components.group1.id,
+
+        // First row in group2
+        `${components.group2h.id}-0`,
+        `${components.group2i.id}-0`,
+        `${components.group2nh.id}-0-0`,
+        `${components.group2ni.id}-0-0`,
+        `${components.group2nh.id}-0-1`,
+        `${components.group2ni.id}-0-1`,
+        `${components.group2n.id}-0`,
+
+        // Second row in group2
+        `${components.group2h.id}-1`,
+        `${components.group2i.id}-1`,
+        `${components.group2nh.id}-1-0`,
+        `${components.group2ni.id}-1-0`,
+        `${components.group2n.id}-1`,
+
+        components.group2.id,
+        components.group3.id,
+      ]);
+    });
+
+    it('should enable traversal of layout', () => {
+      const nodes = nodesInLayout(layout, manyRepeatingGroups);
+      const flatWithGroups = nodes.flat(true);
+      const deepComponent = flatWithGroups.find(
+        (node) => node.item.id === `${components.group2nh.id}-2-2`,
+      );
+      expect(deepComponent.item.id).toEqual(`${components.group2nh.id}-2-2`);
+      expect(deepComponent.parent?.item.id).toEqual(
+        `${components.group2n.id}-2`,
+      );
+      expect(deepComponent.parent?.item.type).toEqual(`Group`);
+      expect(deepComponent.closest((c) => c.type === 'Input').item.id).toEqual(
+        `${components.group2ni.id}-2-2`,
+      );
+
+      expect(
+        nodes.findAllById(components.group2ni.id).map((c) => c.item.id),
+      ).toEqual([
+        `${components.group2ni.id}-0-0`,
+        `${components.group2ni.id}-0-1`,
+        `${components.group2ni.id}-0-2`,
+        `${components.group2ni.id}-0-3`,
+        `${components.group2ni.id}-1-0`,
+        `${components.group2ni.id}-1-1`,
+        `${components.group2ni.id}-1-2`,
+        `${components.group2ni.id}-1-3`,
+        `${components.group2ni.id}-2-0`,
+        `${components.group2ni.id}-2-1`,
+        `${components.group2ni.id}-2-2`,
+        `${components.group2ni.id}-2-3`,
+        `${components.group2ni.id}-3-0`,
+        `${components.group2ni.id}-3-1`,
+        `${components.group2ni.id}-3-2`,
+        `${components.group2ni.id}-3-3`,
+      ]);
+
+      expect(
+        nodes.findAllById(components.group3ni.id).map((c) => c.item.id),
+      ).toEqual([
+        `${components.group3ni.id}-1-0`,
+        `${components.group3ni.id}-1-1`,
+        `${components.group3ni.id}-1-2`,
+        `${components.group3ni.id}-1-3`,
+        `${components.group3ni.id}-1-4`,
+      ]);
+
+      expect(nodes.findById(components.group2ni.id).item.id).toEqual(
+        `${components.group2ni.id}-0-0`,
+      );
+      expect(nodes.findById(`${components.group2ni.id}-1-1`).item.id).toEqual(
+        `${components.group2ni.id}-1-1`,
+      );
+
+      const otherDeepComponent = nodes.findById(
+        `${components.group2nh.id}-3-3`,
+      );
+      expect(
+        otherDeepComponent.closest((c) => c.type === 'Input').item.id,
+      ).toEqual(`${components.group2ni.id}-3-3`);
+      expect(
+        otherDeepComponent.closest((c) => c.type === 'Group').item.id,
+      ).toEqual(`${components.group2n.id}-3`);
+      expect(
+        otherDeepComponent.closest(
+          (c) => c.baseComponentId === components.group2i.id,
+        ).item.id,
+      ).toEqual(`${components.group2i.id}-3`);
+      expect(
+        otherDeepComponent.closest((c) => c.id === components.top1.id).item.id,
+      ).toEqual(components.top1.id);
+
+      const insideNonRepeatingGroup = nodes.findById(components.group1i.id);
+      expect(
+        insideNonRepeatingGroup.closest((n) => n.id === components.group1h.id)
+          .item.id,
+      ).toEqual(components.group1h.id);
+
+      const group2 = flatWithGroups.find(
+        (node) => node.item.id === components.group2.id,
+      );
+      expect(group2.children((n) => n.type === 'Input').item.id).toEqual(
+        `${components.group2i.id}-0`,
+      );
+      expect(group2.children((n) => n.type === 'Input', 1).item.id).toEqual(
+        `${components.group2i.id}-1`,
+      );
+
+      expect(
+        otherDeepComponent.closest((c) => c.id === 'not-found'),
+      ).toBeUndefined();
+    });
+  });
+
+  describe('resolvedNodesInLayout', () => {
+    const dataSources: ContextDataSources = {
+      formData: {
+        'Model.ShouldBeTrue': 'true',
+        'Model.ShouldBeFalse': 'false',
+      },
+      instanceContext: {
+        instanceId: 'test',
+        instanceOwnerPartyId: 'test',
+        appId: 'test',
+      },
+      applicationSettings: {},
+    };
+
+    const nodes = resolvedNodesInLayout(layout, repeatingGroups, dataSources);
+
+    const topInput = nodes.findById(components.top2.id);
+    const group2 = nodes.findById(components.group2.id);
+    const group2i = nodes.findById(`${components.group2i.id}-0`);
+    const group2ni = nodes.findById(`${components.group2ni.id}-0-1`);
+
+    function uniqueHidden(nodes: AnyNode<any>[]): any[] {
+      return [...new Set(nodes.map((n) => n.item.hidden))].sort();
+    }
+    const plain = [true, undefined];
+
+    // Tests to make sure all children also have their expressions resolved
+    expect(topInput.item.hidden).toEqual(true);
+    expect(group2i.item.hidden).toEqual(true);
+    expect(group2ni.item.hidden).toEqual(true);
+    expect(group2i.parent.item.hidden).toEqual(true);
+    expect(group2ni.parent.parent.item.hidden).toEqual(true);
+    expect(uniqueHidden(group2.children())).toEqual(plain);
+    expect(uniqueHidden(group2i.parent.children())).toEqual(plain);
+    expect(uniqueHidden(group2ni.parent.children())).toEqual(plain);
+    expect(uniqueHidden(group2ni.parent.parent.children())).toEqual(plain);
+    expect(uniqueHidden(group2.flat(true))).toEqual(plain);
+    expect(uniqueHidden(group2.flat(false))).toEqual(plain);
+    expect(uniqueHidden(nodes.flat(true))).toEqual(plain);
+    expect(uniqueHidden(nodes.children())).toEqual(plain);
+
+    if (group2.item.type === 'Group' && 'rows' in group2.item) {
+      expect(group2.item.rows[0][1].hidden).toEqual(true);
+      expect(group2.item.rows[0][2].hidden).toEqual(true);
+      const group2n = group2.item.rows[0][2];
+      if (group2n.type === 'Group' && 'rows' in group2n) {
+        expect(group2n.rows[0][1].hidden).toEqual(true);
+      } else {
+        expect(false).toEqual(true);
+      }
+    } else {
+      expect(false).toEqual(true);
+    }
+  });
+
+  describe('LayoutRootNodeCollection', () => {
+    const layout1: ILayout = [components.top1, components.top2];
+
+    const layout2: ILayout = [
+      { ...components.top1, readOnly: true },
+      { ...components.top2, readOnly: true },
+    ];
+
+    const layouts = {
+      l1: nodesInLayout(layout1, {}),
+      l2: nodesInLayout(layout2, {}),
+    };
+
+    const collection1 = new LayoutRootNodeCollection('l1', layouts);
+    const collection2 = new LayoutRootNodeCollection('l2', layouts);
+
+    it('should find the component in the current layout first', () => {
+      expect(
+        collection1.findComponentById(components.top1.id).item.readOnly,
+      ).toBeUndefined();
+      expect(
+        collection2.findComponentById(components.top1.id).item.readOnly,
+      ).toEqual(true);
+    });
+
+    it('should find the current layout', () => {
+      expect(collection1.current()).toEqual(layouts['l1']);
+      expect(collection2.current()).toEqual(layouts['l2']);
+    });
+
+    it('should find a named layout', () => {
+      expect(collection1.findLayout('l1')).toEqual(layouts['l1']);
+      expect(collection1.findLayout('l2')).toEqual(layouts['l2']);
+    });
+
+    it('should find all components in multiple layouts', () => {
+      expect(
+        collection1
+          .findAllComponentsById(components.top1.id)
+          .map((c) => c.item.id),
+      ).toEqual([components.top1.id, components.top1.id]);
+    });
+  });
+
+  describe('transposeDataModel', () => {
+    const nodes = nodesInLayout(layout, manyRepeatingGroups);
+    const inputNode = nodes.findById(`${components.group2ni.id}-2-2`);
+    const topHeaderNode = nodes.findById(components.top1.id);
+
+    expect(inputNode.transposeDataModel('MyModel.Group2.Nested.Age')).toEqual(
+      'MyModel.Group2[2].Nested[2].Age',
+    );
+    expect(
+      inputNode.transposeDataModel('MyModel.Group2.Other.Parents'),
+    ).toEqual('MyModel.Group2[2].Other.Parents');
+
+    const headerNode = nodes.findById(`${components.group2nh.id}-2-2`);
+
+    // Header component does not have any data binding, but its parent does
+    expect(headerNode.transposeDataModel('MyModel.Group2.Nested.Age')).toEqual(
+      'MyModel.Group2[2].Nested[2].Age',
+    );
+
+    // Existing indexes are not removed:
+    expect(
+      headerNode.transposeDataModel('MyModel.Group2[1].Nested[1].Age'),
+    ).toEqual('MyModel.Group2[1].Nested[1].Age');
+    expect(
+      headerNode.transposeDataModel('MyModel.Group2.Nested[1].Age'),
+    ).toEqual('MyModel.Group2[2].Nested[1].Age');
+
+    // This is a broken reference: We cannot know exactly which row in the nested
+    // group you want to refer to, as you never specified:
+    expect(
+      headerNode.transposeDataModel('MyModel.Group2[3].Nested.Age'),
+    ).toEqual('MyModel.Group2[3].Nested.Age');
+
+    // This still doesn't make sense. Even though we're on the same row now, we should behave the same all the time
+    // and fail to resolve the nested row.
+    expect(
+      headerNode.transposeDataModel('MyModel.Group2[2].Nested.Age'),
+    ).toEqual('MyModel.Group2[2].Nested.Age');
+
+    // Tricks to make sure we don't just compare using startsWith()
+    expect(
+      inputNode.transposeDataModel('MyModel.Group22.NestedOtherValue.Key'),
+    ).toEqual('MyModel.Group22.NestedOtherValue.Key');
+    expect(inputNode.transposeDataModel('MyModel.Gro.Nes[1].Key')).toEqual(
+      'MyModel.Gro.Nes[1].Key',
+    );
+    expect(inputNode.transposeDataModel('MyModel.Gro[0].Nes.Key')).toEqual(
+      'MyModel.Gro[0].Nes.Key',
+    );
+
+    // There are no data model bindings in group3, so this should not do anything
+    expect(
+      nodes
+        .findById(`${components.group3ni.id}-1-1`)
+        .transposeDataModel('Main.Parent[0].Child[1]'),
+    ).toEqual('Main.Parent[0].Child[1]');
+
+    // This component doesn't have any repeating group reference point, so it cannot
+    // provide any insights (but it should not fail)
+    expect(
+      topHeaderNode.transposeDataModel('MyModel.Group2.Nested.Age'),
+    ).toEqual('MyModel.Group2.Nested.Age');
+  });
+});

--- a/src/altinn-app-frontend/src/utils/layout/hierarchy.ts
+++ b/src/altinn-app-frontend/src/utils/layout/hierarchy.ts
@@ -1,0 +1,749 @@
+import {
+  evalExprInObj,
+  ExprDefaultsForComponent,
+  ExprDefaultsForGroup,
+} from 'src/features/expressions';
+import { DataBinding } from 'src/utils/databindings/DataBinding';
+import { getRepeatingGroupStartStopIndex } from 'src/utils/formLayout';
+import type { ContextDataSources } from 'src/features/expressions/ExprContext';
+import type {
+  ILayout,
+  ILayoutComponent,
+  ILayoutGroup,
+} from 'src/features/form/layout';
+import type { IRepeatingGroups, IRuntimeState } from 'src/types';
+import type {
+  AnyChildNode,
+  AnyItem,
+  AnyNode,
+  AnyParentNode,
+  AnyTopLevelItem,
+  AnyTopLevelNode,
+  ComponentOf,
+  HierarchyWithRows,
+  LayoutGroupHierarchy,
+  NodeType,
+  RepeatingGroupExtensions,
+  RepeatingGroupHierarchy,
+  RepeatingGroupLayoutComponent,
+} from 'src/utils/layout/hierarchy.types';
+
+import { buildInstanceContext } from 'altinn-shared/utils/instanceContext';
+
+export const childrenWithoutMultiPagePrefix = (group: ILayoutGroup) =>
+  group.edit?.multiPage
+    ? group.children.map((componentId) => componentId.replace(/^\d+:/g, ''))
+    : group.children;
+
+function componentsAndGroupsInGroup(
+  layout: ILayout,
+  filter: (component: ILayoutComponent | ILayoutGroup) => boolean,
+): (ILayoutComponent | LayoutGroupHierarchy)[] {
+  const all = layout.filter(filter);
+  const groups = all.filter(
+    (component) => component.type === 'Group',
+  ) as ILayoutGroup[];
+  const components = all.filter(
+    (component) => component.type !== 'Group',
+  ) as ILayoutComponent[];
+
+  return [
+    ...components,
+    ...groups.map((group) => {
+      const out: LayoutGroupHierarchy = {
+        ...group,
+        childComponents: componentsAndGroupsInGroup(layout, (component) =>
+          childrenWithoutMultiPagePrefix(group).includes(component.id),
+        ),
+      };
+      delete out['children'];
+
+      return out;
+    }),
+  ];
+}
+
+/**
+ * Takes a flat layout and turns it into a hierarchy. That means, each group component will not have
+ * references to each component inside the group, it will have the component definitions themselves
+ * nested inside the 'childComponents' property.
+ *
+ * If this abstraction level is not fine enough for you, you might want to look into these utils:
+ *    layoutAsHierarchyWithRows() takes this further by giving you a all the components as a hierarchy,
+ *        but also includes every component in a repeating group multiple times (for each row in the group).
+ *        It will also give you proper componentIds and dataModelBindings for the component so you
+ *        can reference validations, attachments, formData, etc.
+ *    nodesInLayout() takes it even further, but also simplifies the structure by giving you
+ *        a flat list. This list includes all components (multiple instances of them for rows in
+ *        repeating groups), but wraps them in a class which is aware of the component location
+ *        inside the whole layout, allowing you to, for example, find a sibling instance of a
+ *        component inside a repeating group - complete with proper componentId and dataModelBindings.
+ *
+ * Note: This strips away multiPage functionality and treats every component of a multiPage group
+ * as if every component is on the same page.
+ */
+export function layoutAsHierarchy(
+  layout: ILayout,
+): (ILayoutComponent | LayoutGroupHierarchy)[] {
+  const allGroups = layout.filter((value) => value.type === 'Group');
+  const inGroups = allGroups.map(childrenWithoutMultiPagePrefix).flat();
+  const topLevelFields = layout
+    .filter(
+      (component) =>
+        component.type !== 'Group' && !inGroups.includes(component.id),
+    )
+    .map((component) => component.id);
+  const topLevelGroups = allGroups
+    .filter((group) => !inGroups.includes(group.id))
+    .map((group) => group.id);
+
+  return componentsAndGroupsInGroup(
+    layout,
+    (component) =>
+      topLevelFields.includes(component.id) ||
+      topLevelGroups.includes(component.id),
+  );
+}
+
+interface HierarchyParent {
+  index: number;
+  binding: string;
+}
+
+/**
+ * This function takes the logic from layoutAsHierarchy() further by giving you a all the components as a hierarchy,
+ * but it also includes every component in a repeating group multiple times (for each row in the group). It will also
+ * give you proper componentIds and dataModelBindings for the component so you can reference validations, attachments,
+ * formData, etc.
+ *
+ * If this abstraction level is not the right one for your needs, you might want to look into these utils:
+ *    layoutAsHierarchy() is a bit simpler, as it converts a simple flat layout into a hierarchy
+ *        of components - although it doesn't know anything about repeating groups and their rows.
+ *    nodesInLayout() takes it even further, but also simplifies the structure by giving you
+ *        a flat list. This list includes all components (multiple instances of them for rows in
+ *        repeating groups), but wraps them in a class which is aware of the component location
+ *        inside the whole layout, allowing you to, for example, find a sibling instance of a
+ *        component inside a repeating group - complete with proper componentId and dataModelBindings.
+ *
+ * Note: This strips away multiPage functionality and treats every component of a multiPage group
+ * as if every component is on the same page.
+ */
+export function layoutAsHierarchyWithRows(
+  formLayout: ILayout,
+  repeatingGroups: IRepeatingGroups,
+): HierarchyWithRows[] {
+  const rewriteBindings = (
+    main: LayoutGroupHierarchy,
+    child: LayoutGroupHierarchy | ILayoutComponent,
+    newChild: RepeatingGroupLayoutComponent,
+    parent: HierarchyParent,
+    index: number,
+  ) => {
+    const baseGroupBinding =
+      (main as RepeatingGroupExtensions).baseDataModelBindings?.group ||
+      main.dataModelBindings?.group;
+
+    let binding = main.dataModelBindings?.group;
+    if (binding && parent) {
+      binding = binding.replace(baseGroupBinding, `${parent.binding}`);
+    }
+
+    newChild.baseDataModelBindings = { ...child.dataModelBindings };
+    for (const key of Object.keys(child.dataModelBindings)) {
+      newChild.dataModelBindings[key] = child.dataModelBindings[key].replace(
+        baseGroupBinding,
+        `${binding}[${index}]`,
+      );
+    }
+  };
+
+  const recurse = (
+    main: ILayoutComponent | LayoutGroupHierarchy,
+    parent?: HierarchyParent,
+  ) => {
+    if (main.type === 'Group' && main.maxCount > 1) {
+      const rows: RepeatingGroupHierarchy['rows'] = [];
+      const { startIndex, stopIndex } = getRepeatingGroupStartStopIndex(
+        repeatingGroups[main.id]?.index,
+        main.edit,
+      );
+      for (let index = startIndex; index <= stopIndex; index++) {
+        const row = main.childComponents.map((child) => {
+          const suffix = parent ? `-${parent.index}-${index}` : `-${index}`;
+          const newId = `${child.id}${suffix}`;
+          const newChild: RepeatingGroupLayoutComponent = {
+            ...JSON.parse(JSON.stringify(child)),
+            id: newId,
+            baseComponentId: child.id,
+          };
+
+          if (child.dataModelBindings) {
+            rewriteBindings(main, child, newChild, parent, index);
+          }
+
+          return recurse(newChild, {
+            index,
+            binding: main.dataModelBindings?.group,
+          });
+        });
+        rows.push(row);
+      }
+
+      const out: RepeatingGroupHierarchy = { ...main, rows };
+      delete out['childComponents'];
+      return out;
+    }
+
+    return main as RepeatingGroupLayoutComponent;
+  };
+
+  return layoutAsHierarchy(formLayout).map((child) => recurse(child));
+}
+
+/**
+ * A layout object describes functionality implemented for both a LayoutRootNode (aka a page, or layout) and a
+ * LayoutNode (aka an instance of a component inside a layout, or possibly inside a repeating group).
+ */
+export interface LayoutObject<
+  NT extends NodeType = 'unresolved',
+  Item extends AnyItem<NT> = AnyItem<NT>,
+  Child extends AnyNode<NT> = AnyNode<NT>,
+> {
+  /**
+   * Looks for a matching component upwards in the hierarchy, returning the first one (or undefined if
+   * none can be found)
+   */
+  closest(matching: (item: Item) => boolean): Child | undefined;
+
+  /**
+   * Returns a list of direct children, or finds the first node matching a given criteria
+   */
+  children(): Child[];
+  children(matching: (item: Item) => boolean): Child | undefined;
+
+  /**
+   * This returns all the child nodes (including duplicate components for repeating groups) as a flat list of
+   * LayoutNode objects.
+   *
+   * @param includeGroups If true, also includes the group nodes
+   */
+  flat(includeGroups: true): AnyChildNode<NT>[];
+  flat(includeGroups: false): LayoutNode<NT, ComponentOf<NT>>[];
+  flat(includeGroups: boolean): AnyChildNode<NT>[];
+}
+
+/**
+ * The layout root node is a class containing an entire page/form layout, with all components/nodes within it. It
+ * allows for fast/indexed searching, i.e. looking up an exact node in constant time.
+ */
+export class LayoutRootNode<NT extends NodeType = 'unresolved'>
+  implements LayoutObject<NT, AnyTopLevelItem<NT>, AnyTopLevelNode<NT>>
+{
+  public item: AnyItem<NT> | undefined;
+  public parent: this;
+
+  private directChildren: AnyTopLevelNode<NT>[] = [];
+  private allChildren: AnyChildNode<NT>[] = [];
+  private idMap: { [id: string]: number[] } = {};
+
+  /**
+   * Adds a child to the collection. For internal use only.
+   */
+  public _addChild(child: AnyChildNode<NT>) {
+    if (child.parent === this) {
+      this.directChildren.push(child as AnyTopLevelNode<NT>);
+    }
+    const idx = this.allChildren.length;
+    this.allChildren.push(child);
+
+    this.idMap[child.item.id] = this.idMap[child.item.id] || [];
+    this.idMap[child.item.id].push(idx);
+
+    if (child.item.baseComponentId) {
+      this.idMap[child.item.baseComponentId] =
+        this.idMap[child.item.baseComponentId] || [];
+      this.idMap[child.item.baseComponentId].push(idx);
+    }
+  }
+
+  /**
+   * Looks for a matching component upwards in the hierarchy, returning the first one (or undefined if
+   * none can be found). Implemented here for parity with LayoutNode
+   */
+  public closest(
+    matching: (item: AnyTopLevelItem<NT>) => boolean,
+  ): AnyTopLevelNode<NT> | undefined {
+    return this.children(matching);
+  }
+
+  /**
+   * Returns a list of direct children, or finds the first node matching a given criteria. Implemented
+   * here for parity with LayoutNode.
+   */
+  public children(): AnyTopLevelNode<NT>[];
+  public children(
+    matching: (item: AnyTopLevelItem<NT>) => boolean,
+  ): AnyTopLevelNode<NT> | undefined;
+  public children(matching?: (item: AnyTopLevelItem<NT>) => boolean): any {
+    if (!matching) {
+      return this.directChildren;
+    }
+
+    for (const item of this.directChildren) {
+      if (matching(item.item)) {
+        return item;
+      }
+    }
+
+    return undefined;
+  }
+
+  /**
+   * This returns all the child nodes (including duplicate components for repeating groups) as a flat list of
+   * LayoutNode objects.
+   *
+   * @param includeGroups If true, also includes the group nodes
+   */
+  public flat(includeGroups: true): AnyChildNode<NT>[];
+  public flat(includeGroups: false): LayoutNode<NT, ComponentOf<NT>>[];
+  public flat(includeGroups: boolean): AnyChildNode<NT>[] {
+    if (!includeGroups) {
+      return this.allChildren.filter((c) => c.item.type !== 'Group');
+    }
+
+    return this.allChildren;
+  }
+
+  public findById(id: string): AnyChildNode<NT> {
+    if (this.idMap[id] && this.idMap[id].length) {
+      return this.allChildren[this.idMap[id][0]];
+    }
+
+    return undefined;
+  }
+
+  public findAllById(id: string): AnyChildNode<NT>[] {
+    if (this.idMap[id] && this.idMap[id].length) {
+      return this.idMap[id].map((idx) => this.allChildren[idx]);
+    }
+
+    return [];
+  }
+}
+
+/**
+ * A LayoutNode wraps a component with information about its parent, allowing you to traverse a component (or an
+ * instance of a component inside a repeating group), finding other components near it.
+ */
+export class LayoutNode<
+  NT extends NodeType = 'unresolved',
+  Item extends AnyItem<NT> = AnyItem<NT>,
+> implements LayoutObject<NT, AnyItem<NT>, AnyNode<NT>>
+{
+  public constructor(
+    public item: Item,
+    public parent: AnyParentNode<NT>,
+    public readonly rowIndex?: number,
+  ) {}
+
+  /**
+   * Looks for a matching component upwards in the hierarchy, returning the first one (or undefined if
+   * none can be found).
+   */
+  public closest(
+    matching: (item: AnyItem<NT>) => boolean,
+  ): this | AnyNode<NT> | undefined {
+    if (matching(this.item)) {
+      return this;
+    }
+
+    const sibling = this.parent.children(matching, this.rowIndex);
+    if (sibling) {
+      return sibling as AnyNode<NT>;
+    }
+
+    return this.parent.closest(matching);
+  }
+
+  private recurseParents(callback: (item: AnyParentNode<NT>) => void) {
+    callback(this.parent);
+    if (!(this.parent instanceof LayoutRootNode)) {
+      this.parent.recurseParents(callback);
+    }
+  }
+
+  /**
+   * Like children(), but will only match upwards along the tree towards the top (LayoutRootNode)
+   */
+  public parents(
+    matching?: (item: AnyParentNode<NT>) => boolean,
+  ): AnyParentNode<NT>[] {
+    const parents = [];
+    this.recurseParents((item) => parents.push(item));
+
+    if (matching) {
+      return parents.filter(matching);
+    }
+
+    return parents;
+  }
+
+  private childrenAsList(onlyInRowIndex?: number) {
+    let list: AnyItem<NT>[];
+    if (this.item.type === 'Group' && 'rows' in this.item) {
+      if (typeof onlyInRowIndex === 'number') {
+        list = this.item.rows[onlyInRowIndex];
+      } else {
+        // Beware: In most cases this will just match the first row.
+        list = this.item.rows.flat();
+      }
+    } else if (this.item.type === 'Group' && 'childComponents' in this.item) {
+      list = this.item.childComponents;
+    }
+
+    return list;
+  }
+
+  /**
+   * Looks for a matching component inside the children of this node (only makes sense for a group node). Beware that
+   * matching inside a repeating group with multiple rows, you should provide a second argument to specify the row
+   * number, otherwise you'll most likely just find a component on the first row.
+   */
+  public children(): AnyNode<NT>[];
+  public children(
+    matching: (item: AnyItem<NT>) => boolean,
+    onlyInRowIndex?: number,
+  ): AnyNode<NT> | undefined;
+  public children(
+    matching?: (item: AnyItem<NT>) => boolean,
+    onlyInRowIndex?: number,
+  ): any {
+    const list = this.childrenAsList(onlyInRowIndex);
+
+    if (!matching) {
+      if (!list) {
+        return [];
+      }
+      return list.map((item) => new LayoutNode(item, this));
+    }
+
+    if (typeof list !== 'undefined') {
+      for (const item of list) {
+        if (matching(item)) {
+          return new LayoutNode(item, this);
+        }
+      }
+    }
+
+    return undefined;
+  }
+
+  /**
+   * This returns all the child nodes (including duplicate components for repeating groups) as a flat list of
+   * LayoutNode objects. Implemented here for parity with LayoutRootNode.
+   *
+   * @param includeGroups If true, also includes the group nodes (which also includes self, when this node is a group)
+   */
+  public flat(includeGroups: true): AnyChildNode<NT>[];
+  public flat(includeGroups: false): LayoutNode<NT, ComponentOf<NT>>[];
+  public flat(includeGroups: boolean): AnyChildNode<NT>[] {
+    const out: AnyChildNode<NT>[] = [];
+    const recurse = (item: AnyChildNode<NT>) => {
+      if (includeGroups || item.item.type !== 'Group') {
+        out.push(item);
+      }
+      for (const child of item.children()) {
+        recurse(child);
+      }
+    };
+
+    recurse(this);
+    return out;
+  }
+
+  /**
+   * Checks if this field should be hidden. This also takes into account the group this component is in, so the
+   * methods returns true if the component is inside a hidden group.
+   */
+  public isHidden(hiddenFieldIds: Set<string>): boolean {
+    if (this.item.hidden === true || hiddenFieldIds.has(this.item.id)) {
+      return true;
+    }
+    if (
+      this.item.baseComponentId &&
+      hiddenFieldIds.has(this.item.baseComponentId)
+    ) {
+      return true;
+    }
+
+    const parentGroups = this.parents(
+      (parent) => parent.item && parent.item.type === 'Group',
+    );
+
+    for (const parent of parentGroups) {
+      if (parent.item.hidden === true || hiddenFieldIds.has(parent.item.id)) {
+        return true;
+      }
+      if (
+        parent.item.baseComponentId &&
+        hiddenFieldIds.has(parent.item.baseComponentId)
+      ) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  private firstDataModelBinding() {
+    const firstBinding = Object.keys(this.item.dataModelBindings || {}).shift();
+    if (firstBinding) {
+      return this.item.dataModelBindings[firstBinding];
+    }
+
+    return undefined;
+  }
+
+  /**
+   * This takes a dataModel path (without indexes) and alters it to add indexes such that the data model path refers
+   * to an item in the same repeating group row (or nested repeating group row) as the data model for the current
+   * component.
+   *
+   * Example: Let's say this component is in the second row of the first repeating group, and inside the third row
+   * of a nested repeating group. Our data model binding is such:
+   *    simpleBinding: 'MyModel.Group[1].NestedGroup[2].FirstName'
+   *
+   * If you pass the argument 'MyModel.Group.NestedGroup.Age' to this function, you'll get the
+   * transposed binding back: 'MyModel.Group[1].NestedGroup[2].Age'.
+   *
+   * If you pass the argument 'MyModel.Group[2].NestedGroup[3].Age' to this function, it will still be transposed to
+   * the current row indexes: 'MyModel.Group[1].NestedGroup[2].Age' unless you pass overwriteOtherIndices = false.
+   */
+  public transposeDataModel(dataModel: string, rowIndex?: number): string {
+    const firstBinding = this.firstDataModelBinding();
+    if (!firstBinding) {
+      if (this.parent instanceof LayoutNode) {
+        return this.parent.transposeDataModel(dataModel, this.rowIndex);
+      }
+
+      return dataModel;
+    }
+
+    const ourBinding = new DataBinding(firstBinding);
+    const theirBinding = new DataBinding(dataModel);
+    const lastIdx = ourBinding.parts.length - 1;
+
+    for (const ours of ourBinding.parts) {
+      const theirs = theirBinding.at(ours.parentIndex);
+
+      if (ours.base !== theirs.base) {
+        break;
+      }
+
+      const arrayIndex =
+        ours.parentIndex === lastIdx && this.item.type === 'Group'
+          ? rowIndex
+          : ours.arrayIndex;
+
+      if (arrayIndex === undefined) {
+        continue;
+      }
+
+      if (theirs.hasArrayIndex()) {
+        // Stop early. We cannot add our row index here, because it makes no sense when an earlier group
+        // index changed.we cannot possibly
+        break;
+      }
+
+      theirs.arrayIndex = arrayIndex;
+    }
+
+    return theirBinding.toString();
+  }
+}
+
+/**
+ * Takes the layoutAsHierarchyWithRows() tool a bit further, but returns a flat list. This list includes all components
+ * (multiple instances of them for rows in repeating groups), but wraps them in a LayoutNode object which is aware of the
+ * component location inside the whole layout, allowing you to, for example, find a sibling instance of a component
+ * inside a repeating group - complete with proper componentId and dataModelBindings.
+ *
+ * If this abstraction level is overkill for you, you might want to look into these utils:
+ *    layoutAsHierarchy() is much simpler, as it converts a simple flat layout into a hierarchy
+ *        of components - although it doesn't know anything about repeating groups and their rows.
+ *    layoutAsHierarchyWithRows() is a bit simpler by giving you a all the components as a hierarchy,
+ *        but also includes every component in a repeating group multiple times (for each row in the group).
+ *        It will also give you proper componentIds and dataModelBindings for the component so you
+ *        can reference validations, attachments, formData, etc. However, it might be harder to
+ *        use if you know exactly which component you're looking for, if recursive iteration makes
+ *        things more difficult, or if you need to traverse through the layout more than once.
+ *
+ * Note: This strips away multiPage functionality and treats every component of a multiPage group
+ * as if every component is on the same page.
+ *
+ * @see resolvedNodesInLayout
+ *  An alternative that also resolves expressions for all nodes in the layout
+ */
+export function nodesInLayout(
+  formLayout: ILayout,
+  repeatingGroups: IRepeatingGroups,
+): LayoutRootNode {
+  const root = new LayoutRootNode();
+
+  const recurse = (
+    list: (ILayoutComponent | LayoutGroupHierarchy | RepeatingGroupHierarchy)[],
+    parent?: AnyParentNode,
+    rowIndex?: number,
+  ) => {
+    for (const component of list) {
+      if (component.type === 'Group' && 'rows' in component) {
+        const group: AnyParentNode = new LayoutNode(
+          component,
+          parent,
+          rowIndex,
+        );
+        component.rows.forEach((row, rowIndex) =>
+          recurse(row, group, rowIndex),
+        );
+        root._addChild(group);
+      } else if (component.type === 'Group' && 'childComponents' in component) {
+        const group = new LayoutNode(component, parent, rowIndex);
+        recurse(component.childComponents, group);
+        root._addChild(group);
+      } else {
+        const node = new LayoutNode(component, parent, rowIndex);
+        root._addChild(node);
+      }
+    }
+  };
+
+  recurse(layoutAsHierarchyWithRows(formLayout, repeatingGroups), root);
+
+  return root;
+}
+
+/**
+ * This is the same tool as the one above, but additionally it will iterate each component/group in the layout
+ * and resolve all expressions for it.
+ *
+ * @see nodesInLayout
+ */
+export function resolvedNodesInLayout(
+  formLayout: ILayout,
+  repeatingGroups: IRepeatingGroups,
+  dataSources: ContextDataSources,
+): LayoutRootNode<'resolved'> {
+  const unresolved = nodesInLayout(formLayout, repeatingGroups);
+
+  for (const node of unresolved.flat(true)) {
+    const input = { ...node.item };
+    delete input['children'];
+    delete input['rows'];
+    delete input['childComponents'];
+
+    const resolvedItem = evalExprInObj({
+      input,
+      node,
+      dataSources,
+      defaults: {
+        ...ExprDefaultsForComponent,
+        ...ExprDefaultsForGroup,
+      } as any,
+    }) as unknown as AnyItem<'resolved'>;
+
+    for (const key of Object.keys(resolvedItem)) {
+      // Mutates node.item directly - this also mutates references to it and makes sure
+      // we resolve expressions deep inside recursive structures.
+      node.item[key] = resolvedItem[key];
+    }
+  }
+
+  return unresolved as unknown as LayoutRootNode<'resolved'>;
+}
+
+/**
+ * A tool when you have more than one LayoutRootNode (i.e. a full layout set). It can help you look up components
+ * by ID, and if you have colliding component IDs in multiple layouts it will prefer the one in the current layout.
+ */
+export class LayoutRootNodeCollection<
+  NT extends NodeType = 'unresolved',
+  Collection extends { [layoutKey: string]: LayoutRootNode<NT> } = {
+    [layoutKey: string]: LayoutRootNode<NT>;
+  },
+> {
+  public constructor(
+    private currentView: keyof Collection,
+    private objects: Collection,
+  ) {}
+
+  public findComponentById(id: string): LayoutNode<NT> | undefined {
+    const current = this.current();
+    if (current) {
+      const inCurrent = this.current().findById(id);
+      if (inCurrent) {
+        return inCurrent;
+      }
+    }
+
+    for (const otherLayoutKey of Object.keys(this.objects)) {
+      if (otherLayoutKey === this.currentView) {
+        continue;
+      }
+      const inOther = this.objects[otherLayoutKey].findById(id);
+      if (inOther) {
+        return inOther;
+      }
+    }
+
+    return undefined;
+  }
+
+  public findAllComponentsById(id: string): LayoutNode<NT>[] {
+    const out: LayoutNode<NT>[] = [];
+
+    for (const key of Object.keys(this.objects)) {
+      out.push(...this.objects[key].findAllById(id));
+    }
+
+    return out;
+  }
+
+  public findLayout(key: keyof Collection): LayoutRootNode<NT> {
+    return this.objects[key];
+  }
+
+  public current(): LayoutRootNode<NT> {
+    return this.objects[this.currentView];
+  }
+
+  public all(): Collection {
+    return this.objects;
+  }
+}
+
+export function dataSourcesFromState(state: IRuntimeState): ContextDataSources {
+  return {
+    formData: state.formData.formData,
+    applicationSettings: state.applicationSettings.applicationSettings,
+    instanceContext: buildInstanceContext(state.instanceData?.instance),
+  };
+}
+
+export function resolvedLayoutsFromState(
+  state: IRuntimeState,
+): LayoutRootNodeCollection<'resolved'> {
+  const layoutsAsNodes = {};
+  const dataSources = dataSourcesFromState(state);
+  for (const key of Object.keys(state.formLayout.layouts)) {
+    layoutsAsNodes[key] = resolvedNodesInLayout(
+      state.formLayout.layouts[key],
+      state.formLayout.uiConfig.repeatingGroups,
+      dataSources,
+    );
+  }
+
+  return new LayoutRootNodeCollection(
+    state.formLayout.uiConfig.currentView as keyof typeof layoutsAsNodes,
+    layoutsAsNodes,
+  );
+}

--- a/src/altinn-app-frontend/src/utils/layout/hierarchy.ts
+++ b/src/altinn-app-frontend/src/utils/layout/hierarchy.ts
@@ -633,7 +633,10 @@ export function resolvedNodesInLayout(
   repeatingGroups: IRepeatingGroups,
   dataSources: ContextDataSources,
 ): LayoutRootNode<'resolved'> {
-  const unresolved = nodesInLayout(formLayout, repeatingGroups);
+  // A full copy is needed here because formLayout comes from the redux store, and in production code (not the
+  // development server!) the properties are not mutable (but we have to mutate them below).
+  const layoutCopy = JSON.parse(JSON.stringify(formLayout));
+  const unresolved = nodesInLayout(layoutCopy, repeatingGroups);
 
   for (const node of unresolved.flat(true)) {
     const input = { ...node.item };

--- a/src/altinn-app-frontend/src/utils/layout/hierarchy.types.d.ts
+++ b/src/altinn-app-frontend/src/utils/layout/hierarchy.types.d.ts
@@ -1,0 +1,93 @@
+import type { ExprResolved } from 'src/features/expressions/types';
+import type {
+  IDataModelBindings,
+  ILayoutComponent,
+  ILayoutGroup,
+} from 'src/features/form/layout';
+import type { LayoutNode, LayoutRootNode } from 'src/utils/layout/hierarchy';
+
+export type NodeType =
+  // Plain/unresolved nodes include (unresolved) expressions
+  | 'unresolved'
+  // Resolved nodes have their expressions resolved, leaving only the results
+  | 'resolved';
+
+export type ComponentOf<NT extends NodeType> = NT extends 'unresolved'
+  ? ILayoutComponent
+  : ExprResolved<ILayoutComponent>;
+
+export type GroupOf<NT extends NodeType> = NT extends 'unresolved'
+  ? ILayoutGroup
+  : ExprResolved<ILayoutGroup>;
+
+export type LayoutGroupHierarchy<NT extends NodeType = 'unresolved'> = Omit<
+  GroupOf<NT>,
+  'children'
+> & {
+  childComponents: (ComponentOf<NT> | LayoutGroupHierarchy<NT>)[];
+};
+
+export interface RepeatingGroupExtensions {
+  baseDataModelBindings?: IDataModelBindings;
+}
+
+export type RepeatingGroupLayoutComponent<NT extends NodeType = 'unresolved'> =
+  RepeatingGroupExtensions & ComponentOf<NT>;
+
+export type RepeatingGroupHierarchy<NT extends NodeType = 'unresolved'> = Omit<
+  LayoutGroupHierarchy<NT>,
+  'childComponents' | 'children'
+> &
+  RepeatingGroupExtensions & {
+    rows: HierarchyWithRowsChildren<NT>[][];
+  };
+
+/**
+ * Types of possible components on the top level of a repeating group hierarchy with rows
+ */
+export type HierarchyWithRows<NT extends NodeType = 'unresolved'> =
+  | ComponentOf<NT>
+  | LayoutGroupHierarchy<NT> // Non-repeating groups
+  | RepeatingGroupHierarchy<NT>;
+
+/**
+ * Types of possible components inside rows. Note that no unresolved 'ILayoutComponent' is valid here,
+ * as all components inside repeating group rows needs to have a baseComponentId, etc.
+ */
+export type HierarchyWithRowsChildren<NT extends NodeType = 'unresolved'> =
+  | RepeatingGroupLayoutComponent<NT>
+  | LayoutGroupHierarchy<NT> // Non-repeating groups
+  | RepeatingGroupHierarchy<NT>;
+
+export type AnyItem<NT extends NodeType = 'unresolved'> =
+  | ComponentOf<NT>
+  | GroupOf<NT>
+  | RepeatingGroupLayoutComponent<NT>
+  | LayoutGroupHierarchy<NT>
+  | RepeatingGroupHierarchy<NT>;
+
+export type AnyNode<NT extends NodeType = 'unresolved'> = LayoutNode<
+  NT,
+  AnyItem<NT>
+>;
+
+export type AnyParentItem<NT extends NodeType = 'unresolved'> = Exclude<
+  AnyItem<NT>,
+  ComponentOf<NT> | GroupOf<NT> | RepeatingGroupLayoutComponent<NT>
+>;
+
+export type AnyParentNode<NT extends NodeType = 'unresolved'> =
+  | LayoutNode<NT>
+  | LayoutRootNode<NT>;
+
+export type AnyTopLevelItem<NT extends NodeType> = Exclude<
+  AnyItem<NT>,
+  GroupOf<NT>
+>;
+
+export type AnyTopLevelNode<NT extends NodeType> = LayoutNode<
+  NT,
+  AnyTopLevelItem<NT>
+>;
+
+export type AnyChildNode<NT extends NodeType> = LayoutNode<NT, AnyItem<NT>>;

--- a/src/altinn-app-frontend/src/utils/layout/useLayoutsAsNodes.test.tsx
+++ b/src/altinn-app-frontend/src/utils/layout/useLayoutsAsNodes.test.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+
+import { getInitialStateMock } from '__mocks__/mocks';
+import { renderHook } from '@testing-library/react';
+
+import { setupStore } from 'src/store';
+import { useLayoutsAsNodes } from 'src/utils/layout/useLayoutsAsNodes';
+import type { ContextDataSources } from 'src/features/expressions/ExprContext';
+import type { ILayouts } from 'src/features/form/layout';
+import type { IRepeatingGroups } from 'src/types';
+
+const mockLayouts: ILayouts = {
+  page1: [
+    {
+      id: 'comp1',
+      type: 'Input',
+      dataModelBindings: { simpleBinding: 'topLevel' },
+    },
+    { id: 'duplicateComponent', type: 'Header', size: 'L' },
+    {
+      id: 'group1',
+      type: 'Group',
+      maxCount: 3,
+      children: ['child1'],
+      dataModelBindings: { group: 'group1' },
+    },
+    {
+      id: 'child1',
+      type: 'Input',
+      dataModelBindings: { simpleBinding: 'group1.child1' },
+      hidden: ['equals', ['dataModel', 'group1.isHidden'], 'true'],
+    },
+  ],
+  page2: [
+    { id: 'comp2', type: 'Input' },
+    { id: 'duplicateComponent', type: 'Header', size: 'M' },
+  ],
+};
+
+const mockRepGroups: IRepeatingGroups = {
+  group1: {
+    index: 1,
+    editIndex: -1,
+  },
+};
+
+interface RenderProps {
+  currentView?: string;
+  repeatingGroups?: IRepeatingGroups;
+  layouts?: ILayouts;
+  dataSources?: ContextDataSources;
+}
+
+function render(options: RenderProps = {}) {
+  const {
+    currentView = 'page1',
+    repeatingGroups = mockRepGroups,
+    layouts = mockLayouts,
+    dataSources,
+  } = options;
+
+  const state = getInitialStateMock();
+  state.formLayout.uiConfig.currentView = currentView;
+  state.formLayout.uiConfig.repeatingGroups = repeatingGroups;
+  state.formLayout.layouts = layouts;
+  const store = setupStore(state);
+
+  const rendered = renderHook(() => useLayoutsAsNodes(dataSources), {
+    wrapper: (props) => <Provider store={store}>{props.children}</Provider>,
+  });
+
+  return {
+    ...rendered,
+    store,
+  };
+}
+
+describe('useLayoutsAsNodes', () => {
+  it('should generate recursive layouts', () => {
+    const { result } = render();
+    const component = result.current.findComponentById('duplicateComponent');
+    expect(
+      component.item.type === 'Header' && component.item.size === 'L',
+    ).toEqual(true);
+  });
+
+  it("should understand which page it's on", () => {
+    const { result } = render({ currentView: 'page2' });
+    const component = result.current.findComponentById('duplicateComponent');
+    expect(
+      component.item.type === 'Header' && component.item.size === 'M',
+    ).toEqual(true);
+  });
+
+  it('should not try to resolve layout expressions when dataSources is undefined', () => {
+    const { result } = render();
+    const component = result.current.findComponentById('child1');
+    expect(typeof component.item.hidden).toEqual('object');
+  });
+
+  it('should resolve layout expressions when dataSources it set', () => {
+    const { result } = render({
+      dataSources: {
+        formData: {
+          'group1[0].isHidden': 'true',
+          'group1[1].isHidden': 'false',
+        },
+      } as unknown as ContextDataSources,
+    });
+    expect(result.current.findComponentById('child1-0').item.hidden).toEqual(
+      true,
+    );
+    expect(result.current.findComponentById('child1-1').item.hidden).toEqual(
+      false,
+    );
+  });
+});

--- a/src/altinn-app-frontend/src/utils/layout/useLayoutsAsNodes.ts
+++ b/src/altinn-app-frontend/src/utils/layout/useLayoutsAsNodes.ts
@@ -1,0 +1,57 @@
+import { useMemo } from 'react';
+
+import { useAppSelector } from 'src/common/hooks';
+import {
+  LayoutRootNodeCollection,
+  nodesInLayout,
+  resolvedNodesInLayout,
+} from 'src/utils/layout/hierarchy';
+import type { ContextDataSources } from 'src/features/expressions/ExprContext';
+
+/**
+ * React hook used for getting a memoized LayoutRootNodeCollection where you can look up components.
+ *
+ * It can optionally also resolve expressions, if provided with expression data sources. If you only
+ * want to resolve expressions for a single component, it is more efficient to use the hook specific
+ * for that.
+ *
+ * @see useExpressions
+ * @see useExpressionsForComponent
+ */
+export function useLayoutsAsNodes(
+  dataSources?: undefined,
+): LayoutRootNodeCollection;
+export function useLayoutsAsNodes(
+  dataSources?: ContextDataSources,
+): LayoutRootNodeCollection<'resolved'>;
+export function useLayoutsAsNodes(
+  dataSources?: ContextDataSources | undefined,
+): LayoutRootNodeCollection<any> {
+  const repeatingGroups = useAppSelector(
+    (state) => state.formLayout.uiConfig.repeatingGroups,
+  );
+  const layouts = useAppSelector((state) => state.formLayout.layouts);
+  const current = useAppSelector(
+    (state) => state.formLayout.uiConfig.currentView,
+  );
+
+  return useMemo(() => {
+    const asNodes = {};
+    for (const key of Object.keys(layouts || {})) {
+      if (dataSources) {
+        asNodes[key] = resolvedNodesInLayout(
+          layouts[key],
+          repeatingGroups,
+          dataSources,
+        );
+      } else {
+        asNodes[key] = nodesInLayout(layouts[key], repeatingGroups);
+      }
+    }
+
+    return new LayoutRootNodeCollection(
+      current as keyof typeof asNodes,
+      asNodes,
+    );
+  }, [layouts, current, repeatingGroups, dataSources]);
+}

--- a/src/yarn.lock
+++ b/src/yarn.lock
@@ -5225,6 +5225,7 @@ __metadata:
     ts-jest: 29.0.3
     ts-loader: 9.4.1
     typescript: 4.8.4
+    utility-types: ^3.10.0
     uuid: 9.0.0
     webpack: 5.74.0
     webpack-cli: 4.10.0
@@ -15489,6 +15490,13 @@ __metadata:
   dependencies:
     inherits: 2.0.1
   checksum: bd800f5d237a82caddb61723a6cbe45297d25dd258651a31335a4d5d981fd033cb4771f82db3d5d59b582b187cb69cfe727dc6f4d8d7826f686ee6c07ce611e0
+  languageName: node
+  linkType: hard
+
+"utility-types@npm:^3.10.0":
+  version: 3.10.0
+  resolution: "utility-types@npm:3.10.0"
+  checksum: 8f274415c6196ab62883b8bd98c9d2f8829b58016e4269aaa1ebd84184ac5dda7dc2ca45800c0d5e0e0650966ba063bf9a412aaeaea6850ca4440a391283d5c8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description
Splitting up the massive #540 into smaller parts. After #553 and #554, this PR is the big one with the whole engine for evaluating expressions, and everything needed to at last implement support for expressions in `app-frontend-react`. The last PR will utilize the functionality implemented here into `GenericComponent` etc (and that PR will arrive when this has been merged).

The overview of the functionality in this PR can be seen from the folder structure:
- The expression engine in `src/features/expressions`
	- The runtime expression evaluation engine, with functions and type-casting in `index.ts`
  - `prettyErrors`, which allows for listing multiple errors deep into a structured object and printing them colored to the console
  - `useExpressions` as a react hook, which lets you evaluate expressions (also inside an object) in your component
  - Validation code to make sure expressions are well-formed at the point they are loaded from layout files (gives an error message if expressions are invalid, and replaces the expression with a default value).
  - Shared tests for the expressions engine
- Utilities for traversing and mutating the string in a data model binding in `src/utils/databindings/Databinding.ts`
- Utilities for converting a flat layout to a hierarchical structure in `src/utils/layout/hierarchy*`
- React hooks for reading the entire layout (or all layouts), converting them to a hierarchical structure and (optionally) resolve expressions inside the nodes. 

A core concept in this structure is a new term for `app-frontend-react`; a `node`. Currently we have used the name `component` for the components defined in the layout definitions. And we often refer to a specific `component`, even when that component is possibly rendered multiple times (in a repeating group). I use the term `node` here for that case - and my definition of a node is that it's an instance of a `component` (for which there might be multiple `nodes` when dealing with repeating groups).

The work around converting a flat layout into a hierarchical structure with nodes as component instances can be seen as a precursor to what's needed to implement #345. The tools in `src/utils/layout/hierarchy*` are optional now, and will be used in expressions and validation, but in time I believe these concepts should replace the structure of our current redux store and should be used everywhere.

## Related Issue(s)
- #540
- #355

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- ~~[ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~
