### PR TITLE
Fix/save and next button followup

### DIFF
--- a/src/altinn-app-frontend/src/features/form/containers/GroupContainer.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/GroupContainer.tsx
@@ -345,6 +345,7 @@ export function GroupContainer({
           multiPageIndex={multiPageIndex}
           setMultiPageIndex={setMultiPageIndex}
           showSaveAndNextButton={container.edit?.saveAndNextButton === true}
+          filteredIndexes={filteredIndexList}
         />
       )}
       {container.edit?.mode === 'showAll' &&

--- a/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupTable.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupTable.tsx
@@ -373,6 +373,7 @@ export function RepeatingGroupTable({
           multiPageIndex={multiPageIndex}
           setMultiPageIndex={setMultiPageIndex}
           showSaveAndNextButton={container.edit?.saveAndNextButton === true}
+          filteredIndexes={filteredIndexes}
         />
       )
     );

--- a/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupsEditContainer.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupsEditContainer.tsx
@@ -123,19 +123,18 @@ export function RepeatingGroupsEditContainer({
     }
   };
 
-  const getNextIndex = (): number | null => {
-    if (!filteredIndexes) {
-      return editIndex < repeatingGroupIndex ? editIndex + 1 : null;
-    } else {
-      const filteredIndex = filteredIndexes.indexOf(editIndex);
-      return filteredIndexes.slice(filteredIndex).length > 1
+  let nextIndex: number | null = null;
+  if (!filteredIndexes) {
+    nextIndex = editIndex < repeatingGroupIndex ? editIndex + 1 : null;
+  } else {
+    const filteredIndex = filteredIndexes.indexOf(editIndex);
+    nextIndex =
+      filteredIndexes.slice(filteredIndex).length > 1
         ? filteredIndexes[filteredIndex + 1]
         : null;
-    }
-  };
+  }
 
   const nextClicked = () => {
-    const nextIndex = getNextIndex();
     if (nextIndex !== null) {
       setEditIndex(nextIndex, true);
       if (container.edit?.multiPage) {
@@ -242,7 +241,7 @@ export function RepeatingGroupsEditContainer({
             direction='row'
             spacing={2}
           >
-            {showSaveAndNextButton && getNextIndex() !== null && (
+            {showSaveAndNextButton && nextIndex !== null && (
               <Grid item={true}>
                 <Button
                   id={`next-button-grp-${id}`}
@@ -259,7 +258,7 @@ export function RepeatingGroupsEditContainer({
               </Grid>
             )}
             {(!hideSaveButton ||
-              (showSaveAndNextButton && getNextIndex() === null)) && (
+              (showSaveAndNextButton && nextIndex === null)) && (
               <Grid item={true}>
                 <Button
                   id={`add-button-grp-${id}`}

--- a/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupsEditContainer.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupsEditContainer.tsx
@@ -124,14 +124,14 @@ export function RepeatingGroupsEditContainer({
   };
 
   let nextIndex: number | null = null;
-  if (!filteredIndexes) {
-    nextIndex = editIndex < repeatingGroupIndex ? editIndex + 1 : null;
-  } else {
+  if (filteredIndexes) {
     const filteredIndex = filteredIndexes.indexOf(editIndex);
     nextIndex =
       filteredIndexes.slice(filteredIndex).length > 1
         ? filteredIndexes[filteredIndex + 1]
         : null;
+  } else {
+    nextIndex = editIndex < repeatingGroupIndex ? editIndex + 1 : null;
   }
 
   const nextClicked = () => {

--- a/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupsEditContainer.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupsEditContainer.tsx
@@ -226,25 +226,24 @@ export function RepeatingGroupsEditContainer({
             direction='row'
             spacing={2}
           >
-            {!hideSaveButton &&
-              showSaveAndNextButton &&
-              editIndex < repeatingGroupIndex && (
-                <Grid item={true}>
-                  <Button
-                    id={`next-button-grp-${id}`}
-                    onClick={nextClicked}
-                    variant={ButtonVariant.Primary}
-                  >
-                    {container.textResourceBindings?.save_and_next_button
-                      ? getTextResourceByKey(
-                          container.textResourceBindings.save_and_next_button,
-                          textResources,
-                        )
-                      : getLanguageFromKey('general.save_and_next', language)}
-                  </Button>
-                </Grid>
-              )}
-            {!hideSaveButton && (
+            {showSaveAndNextButton && editIndex < repeatingGroupIndex && (
+              <Grid item={true}>
+                <Button
+                  id={`next-button-grp-${id}`}
+                  onClick={nextClicked}
+                  variant={ButtonVariant.Primary}
+                >
+                  {container.textResourceBindings?.save_and_next_button
+                    ? getTextResourceByKey(
+                        container.textResourceBindings.save_and_next_button,
+                        textResources,
+                      )
+                    : getLanguageFromKey('general.save_and_next', language)}
+                </Button>
+              </Grid>
+            )}
+            {(!hideSaveButton ||
+              (showSaveAndNextButton && editIndex === repeatingGroupIndex)) && (
               <Grid item={true}>
                 <Button
                   id={`add-button-grp-${id}`}

--- a/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupsEditContainer.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupsEditContainer.tsx
@@ -36,6 +36,7 @@ export interface IRepeatingGroupsEditContainer {
   multiPageIndex?: number;
   setMultiPageIndex?: (index: number) => void;
   showSaveAndNextButton?: boolean;
+  filteredIndexes?: number[];
 }
 
 const theme = createTheme(altinnAppTheme);
@@ -111,6 +112,7 @@ export function RepeatingGroupsEditContainer({
   multiPageIndex,
   setMultiPageIndex,
   showSaveAndNextButton,
+  filteredIndexes,
 }: IRepeatingGroupsEditContainer): JSX.Element {
   const classes = useStyles();
 
@@ -121,10 +123,24 @@ export function RepeatingGroupsEditContainer({
     }
   };
 
+  const getNextIndex = (): number | null => {
+    if (!filteredIndexes) {
+      return editIndex < repeatingGroupIndex ? editIndex + 1 : null;
+    } else {
+      const filteredIndex = filteredIndexes.indexOf(editIndex);
+      return filteredIndexes.slice(filteredIndex).length > 1
+        ? filteredIndexes[filteredIndex + 1]
+        : null;
+    }
+  };
+
   const nextClicked = () => {
-    setEditIndex(editIndex + 1, true);
-    if (container.edit?.multiPage) {
-      setMultiPageIndex(0);
+    const nextIndex = getNextIndex();
+    if (nextIndex !== null) {
+      setEditIndex(nextIndex, true);
+      if (container.edit?.multiPage) {
+        setMultiPageIndex(0);
+      }
     }
   };
 
@@ -226,7 +242,7 @@ export function RepeatingGroupsEditContainer({
             direction='row'
             spacing={2}
           >
-            {showSaveAndNextButton && editIndex < repeatingGroupIndex && (
+            {showSaveAndNextButton && getNextIndex() !== null && (
               <Grid item={true}>
                 <Button
                   id={`next-button-grp-${id}`}
@@ -243,7 +259,7 @@ export function RepeatingGroupsEditContainer({
               </Grid>
             )}
             {(!hideSaveButton ||
-              (showSaveAndNextButton && editIndex === repeatingGroupIndex)) && (
+              (showSaveAndNextButton && getNextIndex() === null)) && (
               <Grid item={true}>
                 <Button
                   id={`add-button-grp-${id}`}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixed saveAndNextButton so that it uses filters to determine the next item in the group. Made the nextButton independent from `saveButton`. If `saveAndNextButton=true` and `saveButton=false`, only the Save and next button is visible, except for the last item, where the save button is shown.

## Related Issue(s)
- #558 
- #559 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- ~~[ ] Relevant automated test added (if you find this hard, leave it and we'll help out)~~
- [x] All tests run green

## Documentation
- ~~User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~
