### PR TITLE
Fixed openByDefault to use filter

### DIFF
--- a/src/altinn-app-frontend/src/features/form/containers/GroupContainer.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/GroupContainer.tsx
@@ -11,7 +11,10 @@ import { RepeatingGroupTable } from 'src/features/form/containers/RepeatingGroup
 import { FormLayoutActions } from 'src/features/form/layout/formLayoutSlice';
 import { makeGetHidden } from 'src/selectors/getLayoutData';
 import { Triggers } from 'src/types';
-import { createRepeatingGroupComponents } from 'src/utils/formLayout';
+import {
+  createRepeatingGroupComponents,
+  getRepeatingGroupFilteredIndices,
+} from 'src/utils/formLayout';
 import { getHiddenFieldsForGroup } from 'src/utils/layout';
 import { renderValidationMessagesForComponent } from 'src/utils/render';
 import { repeatingGroupHasValidations } from 'src/utils/validation';
@@ -152,26 +155,15 @@ export function GroupContainer({
   );
 
   React.useEffect(() => {
-    if (container.edit?.filter && container.edit.filter.length > 0) {
-      container.edit.filter.forEach((rule) => {
-        const formDataKeys: string[] = Object.keys(formData).filter((key) => {
-          const keyWithoutIndex = key.replaceAll(/\[\d*\]/g, '');
-          return keyWithoutIndex === rule.key && formData[key] === rule.value;
-        });
-        if (formDataKeys && formDataKeys.length > 0) {
-          const filtered = formDataKeys.map((key) => {
-            const match = key.match(/\[(\d*)\]/g);
-            const currentIndex = match[match.length - 1];
-            return parseInt(
-              currentIndex.substring(1, currentIndex.indexOf(']')),
-              10,
-            );
-          });
-          setFilteredIndexList(filtered);
-        }
-      });
+    const filteredIndexList = getRepeatingGroupFilteredIndices(
+      repeatingGroupIndex,
+      formData,
+      container.edit?.filter,
+    );
+    if (filteredIndexList) {
+      setFilteredIndexList(filteredIndexList);
     }
-  }, [formData, container]);
+  }, [repeatingGroupIndex, formData, container]);
 
   const onClickAdd = useCallback(() => {
     dispatch(FormLayoutActions.updateRepeatingGroups({ layoutElementId: id }));

--- a/src/altinn-app-frontend/src/features/form/containers/GroupContainer.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/GroupContainer.tsx
@@ -156,14 +156,13 @@ export function GroupContainer({
 
   React.useEffect(() => {
     const filteredIndexList = getRepeatingGroupFilteredIndices(
-      repeatingGroupIndex,
       formData,
       container.edit?.filter,
     );
     if (filteredIndexList) {
       setFilteredIndexList(filteredIndexList);
     }
-  }, [repeatingGroupIndex, formData, container]);
+  }, [formData, container]);
 
   const onClickAdd = useCallback(() => {
     dispatch(FormLayoutActions.updateRepeatingGroups({ layoutElementId: id }));

--- a/src/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
+++ b/src/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
@@ -678,7 +678,6 @@ export function* initRepeatingGroupsSaga(): SagaIterator {
     ) as ILayoutGroup;
     if (container && group.index >= 0) {
       const filteredIndexList = getRepeatingGroupFilteredIndices(
-        group.index,
         formDataState.formData,
         container.edit?.filter,
       );

--- a/src/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
+++ b/src/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
@@ -38,6 +38,7 @@ import {
 } from 'src/utils/databindings';
 import {
   findChildren,
+  getRepeatingGroupFilteredIndices,
   getRepeatingGroups,
   mapFileUploadersWithTag,
   removeRepeatingGroupFromUIConfig,
@@ -675,12 +676,19 @@ export function* initRepeatingGroupsSaga(): SagaIterator {
     const container = groupContainers.find(
       (element) => element.id === key,
     ) as ILayoutGroup;
-
     if (container && group.index >= 0) {
+      const filteredIndexList = getRepeatingGroupFilteredIndices(
+        group.index,
+        formDataState.formData,
+        container.edit?.filter,
+      );
+
       if (container.edit?.openByDefault === 'first') {
-        group.editIndex = 0;
+        group.editIndex = filteredIndexList ? filteredIndexList[0] : 0;
       } else if (container.edit?.openByDefault === 'last') {
-        group.editIndex = group.index;
+        group.editIndex = filteredIndexList
+          ? filteredIndexList.at(-1)
+          : group.index;
       }
     }
   });

--- a/src/altinn-app-frontend/src/utils/formLayout.ts
+++ b/src/altinn-app-frontend/src/utils/formLayout.ts
@@ -559,50 +559,33 @@ export function behavesLikeDataTask(
 }
 
 /**
- * Returns a list of remaining repeating group element indices after all filters are applied. Returns undefined if no filters are present.
- * @param repeatingGroupIndex IRepeatingGroup.index for the repeating group.
+ * (Deprecate this function) Returns the filtered indices of a repeating group.
+ * This is a buggy implementation, but is used for backward compatibility until a new major version is released.
+ * @see https://github.com/Altinn/app-frontend-react/issues/339#issuecomment-1286624933
  * @param formData IFormData
  * @param filter IGroupEditProperties.filter or undefined.
- * @returns a list of indices for repeating group elements after applying filters, or null if no filters are provided.
+ * @returns a list of indices for repeating group elements after applying filters, or null if no filters are provided or if no elements match.
  */
 export function getRepeatingGroupFilteredIndices(
-  repeatingGroupIndex: number,
   formData: IFormData,
   filter?: IGroupFilter[],
 ): number[] | null {
   if (filter && filter.length > 0) {
-    let filteredIndicies = Array.from(Array(repeatingGroupIndex + 1).keys());
-
-    filter.forEach((rule) => {
-      const formDataKeys: string[] = Object.keys(formData);
-
-      if (formDataKeys && formDataKeys.length > 0) {
-        const matchingSet = new Set<number>();
-
-        formDataKeys
-          .filter((key) => {
-            const keyWithoutIndex = key.replaceAll(/\[\d*\]/g, '');
-            return keyWithoutIndex === rule.key && formData[key] === rule.value;
-          })
-          .forEach((key) => {
-            const match = key.match(/\[(\d*)\]/g);
-            const currentIndex = match[match.length - 1];
-            const matchingIndex = parseInt(
-              currentIndex.substring(1, currentIndex.indexOf(']')),
-              10,
-            );
-            matchingSet.add(matchingIndex);
-          });
-
-        filteredIndicies = filteredIndicies.filter((index) =>
-          matchingSet.has(index),
-        );
-        return Array.from(matchingSet);
-      }
+    const rule = filter.at(-1);
+    const formDataKeys: string[] = Object.keys(formData).filter((key) => {
+      const keyWithoutIndex = key.replaceAll(/\[\d*\]/g, '');
+      return keyWithoutIndex === rule.key && formData[key] === rule.value;
     });
-
-    return filteredIndicies;
+    if (formDataKeys && formDataKeys.length > 0) {
+      return formDataKeys.map((key) => {
+        const match = key.match(/\[(\d*)\]/g);
+        const currentIndex = match[match.length - 1];
+        return parseInt(
+          currentIndex.substring(1, currentIndex.indexOf(']')),
+          10,
+        );
+      });
+    }
   }
-
   return null;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Open by default "first" and "last" is also broken by filters. In order to fix this the saga doing the open by default also needs to compute the `filteredIndexList` like the GroupContainer does. This function has been moved out of the component so that both the saga and the GroupContainer can use the same implementation.

~~I tried to make a general function, but the existing implementation did not make complete sense to me. It did not seem like it would work as documented, but by trying to reimplement it differently it broke some cypress tests.~~
The issues related to filters are documented here: https://github.com/Altinn/app-frontend-react/issues/339#issuecomment-1286624933

## Related Issue(s)
- #569 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- ~~Relevant automated test added (if you find this hard, leave it and we'll help out)~~
- [x] All tests run green

## Documentation
- ~~User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~
