### PR TITLE
Fixing flakyness in mocked setTimeout() calls

### DIFF
--- a/src/altinn-app-frontend/src/components/base/CheckboxesContainerComponent.test.tsx
+++ b/src/altinn-app-frontend/src/components/base/CheckboxesContainerComponent.test.tsx
@@ -7,7 +7,6 @@ import { renderWithProviders } from 'testUtils';
 import type { PreloadedState } from 'redux';
 
 import { CheckboxContainerComponent } from 'src/components/base/CheckboxesContainerComponent';
-import { mockDelayBeforeSaving } from 'src/components/hooks/useDelayedSavedState';
 import { LayoutStyle } from 'src/types';
 import type { ICheckboxContainerProps } from 'src/components/base/CheckboxesContainerComponent';
 import type { IOptionsState } from 'src/shared/resources/options';
@@ -85,6 +84,11 @@ const getCheckbox = ({ name, isChecked = false }) => {
 };
 
 describe('CheckboxContainerComponent', () => {
+  jest.useFakeTimers();
+  const user = userEvent.setup({
+    advanceTimers: jest.advanceTimersByTime,
+  });
+
   it('should call handleDataChange with value of preselectedOptionIndex when simpleBinding is not set', () => {
     const handleChange = jest.fn();
     render({
@@ -163,16 +167,13 @@ describe('CheckboxContainerComponent', () => {
     expect(getCheckbox({ name: 'Sweden' })).toBeInTheDocument();
     expect(getCheckbox({ name: 'Denmark' })).toBeInTheDocument();
 
-    mockDelayBeforeSaving(25);
-    await userEvent.click(getCheckbox({ name: 'Denmark' }));
+    await user.click(getCheckbox({ name: 'Denmark' }));
 
     expect(handleChange).not.toHaveBeenCalled();
 
-    await new Promise((r) => setTimeout(r, 25));
+    jest.runOnlyPendingTimers();
 
     expect(handleChange).toHaveBeenCalledWith('norway,denmark');
-
-    mockDelayBeforeSaving(undefined);
   });
 
   it('should call handleDataChange with updated values when deselecting item', async () => {
@@ -192,16 +193,13 @@ describe('CheckboxContainerComponent', () => {
       getCheckbox({ name: 'Denmark', isChecked: true }),
     ).toBeInTheDocument();
 
-    mockDelayBeforeSaving(25);
-    await userEvent.click(getCheckbox({ name: 'Denmark', isChecked: true }));
+    await user.click(getCheckbox({ name: 'Denmark', isChecked: true }));
 
     expect(handleChange).not.toHaveBeenCalled();
 
-    await new Promise((r) => setTimeout(r, 25));
+    jest.runOnlyPendingTimers();
 
     expect(handleChange).toHaveBeenCalledWith('norway');
-
-    mockDelayBeforeSaving(undefined);
   });
 
   it('should call handleDataChange instantly on blur when the value has changed', async () => {
@@ -217,7 +215,7 @@ describe('CheckboxContainerComponent', () => {
 
     expect(denmark).toBeInTheDocument();
 
-    await userEvent.click(denmark);
+    await user.click(denmark);
 
     expect(handleChange).not.toHaveBeenCalled();
 
@@ -253,16 +251,13 @@ describe('CheckboxContainerComponent', () => {
     expect(getCheckbox({ name: 'Sweden' })).toBeInTheDocument();
     expect(getCheckbox({ name: 'Denmark' })).toBeInTheDocument();
 
-    mockDelayBeforeSaving(25);
-    await userEvent.click(getCheckbox({ name: 'Denmark' }));
+    await user.click(getCheckbox({ name: 'Denmark' }));
 
     expect(handleChange).not.toHaveBeenCalled();
 
-    await new Promise((r) => setTimeout(r, 25));
+    jest.runOnlyPendingTimers();
 
     expect(handleChange).toHaveBeenCalledWith('denmark');
-
-    mockDelayBeforeSaving(undefined);
   });
 
   it('should show spinner while waiting for options', () => {
@@ -366,17 +361,14 @@ describe('CheckboxContainerComponent', () => {
       getCheckbox({ name: 'The value from the group is: Label for second' }),
     ).toBeInTheDocument();
 
-    mockDelayBeforeSaving(25);
-    await userEvent.click(
+    await user.click(
       getCheckbox({ name: 'The value from the group is: Label for second' }),
     );
 
     expect(handleDataChange).not.toHaveBeenCalled();
 
-    await new Promise((r) => setTimeout(r, 25));
+    jest.runOnlyPendingTimers();
 
     expect(handleDataChange).toHaveBeenCalledWith('Value for second');
-
-    mockDelayBeforeSaving(undefined);
   });
 });

--- a/src/altinn-app-frontend/src/components/base/DropdownComponent.test.tsx
+++ b/src/altinn-app-frontend/src/components/base/DropdownComponent.test.tsx
@@ -7,7 +7,6 @@ import { renderWithProviders } from 'testUtils';
 import type { PreloadedState } from 'redux';
 
 import DropdownComponent from 'src/components/base/DropdownComponent';
-import { mockDelayBeforeSaving } from 'src/components/hooks/useDelayedSavedState';
 import type { IDropdownProps } from 'src/components/base/DropdownComponent';
 import type { RootState } from 'src/store';
 
@@ -68,25 +67,26 @@ const render = (
 };
 
 describe('DropdownComponent', () => {
+  jest.useFakeTimers();
+  const user = userEvent.setup({
+    advanceTimers: jest.advanceTimersByTime,
+  });
+
   it('should trigger handleDataChange when option is selected', async () => {
     const handleDataChange = jest.fn();
     render({
       handleDataChange,
     });
 
-    mockDelayBeforeSaving(25);
-
-    await userEvent.selectOptions(screen.getByRole('combobox'), [
+    await user.selectOptions(screen.getByRole('combobox'), [
       screen.getByText('Sweden'),
     ]);
 
     expect(handleDataChange).not.toHaveBeenCalled();
 
-    await new Promise((r) => setTimeout(r, 25));
+    jest.runOnlyPendingTimers();
 
     expect(handleDataChange).toHaveBeenCalledWith('sweden');
-
-    mockDelayBeforeSaving(undefined);
   });
 
   it('should show as disabled when readOnly is true', () => {
@@ -130,7 +130,7 @@ describe('DropdownComponent', () => {
     expect(handleDataChange).toHaveBeenCalledWith('denmark');
     const select = screen.getByRole('combobox');
 
-    await userEvent.click(select);
+    await user.click(select);
 
     expect(handleDataChange).toHaveBeenCalledTimes(1);
 
@@ -167,29 +167,25 @@ describe('DropdownComponent', () => {
       },
     });
 
-    mockDelayBeforeSaving(25);
-
-    await userEvent.selectOptions(screen.getByRole('combobox'), [
+    await user.selectOptions(screen.getByRole('combobox'), [
       screen.getByText('The value from the group is: Label for first'),
     ]);
 
     expect(handleDataChange).not.toHaveBeenCalled();
 
-    await new Promise((r) => setTimeout(r, 25));
+    jest.runOnlyPendingTimers();
 
     expect(handleDataChange).toHaveBeenCalledWith('Value for first');
 
-    await userEvent.selectOptions(screen.getByRole('combobox'), [
+    await user.selectOptions(screen.getByRole('combobox'), [
       screen.getByText('The value from the group is: Label for second'),
     ]);
 
     expect(handleDataChange).toHaveBeenCalledTimes(1);
 
-    await new Promise((r) => setTimeout(r, 25));
+    jest.runOnlyPendingTimers();
 
     expect(handleDataChange).toHaveBeenCalledWith('Value for second');
     expect(handleDataChange).toHaveBeenCalledTimes(2);
-
-    mockDelayBeforeSaving(undefined);
   });
 });

--- a/src/altinn-app-frontend/src/components/base/InputComponent.test.tsx
+++ b/src/altinn-app-frontend/src/components/base/InputComponent.test.tsx
@@ -4,12 +4,14 @@ import { render as rtlRender, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { InputComponent } from 'src/components/base/InputComponent';
-import { mockDelayBeforeSaving } from 'src/components/hooks/useDelayedSavedState';
 import type { IInputProps } from 'src/components/base/InputComponent';
 
-const user = userEvent.setup();
-
 describe('InputComponent', () => {
+  jest.useFakeTimers();
+  const user = userEvent.setup({
+    advanceTimers: jest.advanceTimersByTime,
+  });
+
   it('should correct value with no form data provided', () => {
     render();
     const inputComponent = screen.getByRole('textbox');
@@ -45,15 +47,12 @@ describe('InputComponent', () => {
     render({ handleDataChange });
     const inputComponent = screen.getByRole('textbox');
 
-    mockDelayBeforeSaving(25);
     await user.type(inputComponent, typedValue);
 
     expect(inputComponent).toHaveValue(typedValue);
     expect(handleDataChange).not.toHaveBeenCalled();
-
-    await new Promise((r) => setTimeout(r, 25));
+    jest.runOnlyPendingTimers();
     expect(handleDataChange).toHaveBeenCalled();
-    mockDelayBeforeSaving(undefined);
   });
 
   it('should call supplied dataChanged function immediately after onBlur', async () => {

--- a/src/altinn-app-frontend/src/components/base/RadioButtons/RadioButtonsContainerComponent.test.tsx
+++ b/src/altinn-app-frontend/src/components/base/RadioButtons/RadioButtonsContainerComponent.test.tsx
@@ -7,7 +7,6 @@ import { renderWithProviders } from 'testUtils';
 import type { PreloadedState } from 'redux';
 
 import { RadioButtonContainerComponent } from 'src/components/base/RadioButtons/RadioButtonsContainerComponent';
-import { mockDelayBeforeSaving } from 'src/components/hooks/useDelayedSavedState';
 import { LayoutStyle } from 'src/types';
 import type { IRadioButtonsContainerProps } from 'src/components/base/RadioButtons/RadioButtonsContainerComponent';
 import type { IOptionsState } from 'src/shared/resources/options';
@@ -83,6 +82,11 @@ const getRadio = ({ name, isChecked = false }) => {
 };
 
 describe('RadioButtonsContainerComponent', () => {
+  jest.useFakeTimers();
+  const user = userEvent.setup({
+    advanceTimers: jest.advanceTimersByTime,
+  });
+
   it('should call handleDataChange with value of preselectedOptionIndex when simpleBinding is not set', () => {
     const handleChange = jest.fn();
     render({
@@ -137,16 +141,11 @@ describe('RadioButtonsContainerComponent', () => {
     expect(getRadio({ name: 'Sweden' })).toBeInTheDocument();
     expect(getRadio({ name: 'Denmark' })).toBeInTheDocument();
 
-    mockDelayBeforeSaving(25);
-    await userEvent.click(getRadio({ name: 'Denmark' }));
+    await user.click(getRadio({ name: 'Denmark' }));
 
     expect(handleChange).not.toHaveBeenCalled();
-
-    await new Promise((r) => setTimeout(r, 25));
-
+    jest.runOnlyPendingTimers();
     expect(handleChange).toHaveBeenCalledWith('denmark');
-
-    mockDelayBeforeSaving(undefined);
   });
 
   it('should call handleDataChange instantly on blur when the value has changed', async () => {
@@ -162,7 +161,7 @@ describe('RadioButtonsContainerComponent', () => {
 
     expect(denmark).toBeInTheDocument();
 
-    await userEvent.click(denmark);
+    await user.click(denmark);
 
     expect(handleChange).not.toHaveBeenCalled();
 
@@ -294,17 +293,12 @@ describe('RadioButtonsContainerComponent', () => {
       getRadio({ name: 'The value from the group is: Label for second' }),
     ).toBeInTheDocument();
 
-    mockDelayBeforeSaving(25);
-    await userEvent.click(
+    await user.click(
       getRadio({ name: 'The value from the group is: Label for first' }),
     );
 
     expect(handleDataChange).not.toHaveBeenCalled();
-
-    await new Promise((r) => setTimeout(r, 25));
-
+    jest.runOnlyPendingTimers();
     expect(handleDataChange).toHaveBeenCalledWith('Value for first');
-
-    mockDelayBeforeSaving(undefined);
   });
 });

--- a/src/altinn-app-frontend/src/components/hooks/useDelayedSavedState.ts
+++ b/src/altinn-app-frontend/src/components/hooks/useDelayedSavedState.ts
@@ -2,12 +2,6 @@ import * as React from 'react';
 
 import type { IComponentProps } from 'src/components';
 
-let mockDelay: number | undefined = undefined;
-
-export const mockDelayBeforeSaving = (newDelay: number) => {
-  mockDelay = newDelay;
-};
-
 export interface DelayedSavedStateRetVal {
   value: string;
   setValue: (newValue: string, saveImmediately?: boolean) => void;
@@ -33,9 +27,7 @@ export function useDelayedSavedState(
       return;
     }
 
-    const timeout =
-      mockDelay ||
-      ((typeof saveAfter === 'number' ? saveAfter : 400) as number);
+    const timeout = typeof saveAfter === 'number' ? saveAfter : 400;
     const timeoutId = setTimeout(() => {
       if (immediateState !== formValue) {
         handleDataChange(immediateState);

--- a/src/altinn-app-frontend/src/features/form/containers/GroupContainerLikert.test.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/GroupContainerLikert.test.tsx
@@ -1,7 +1,6 @@
 import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { mockDelayBeforeSaving } from 'src/components/hooks/useDelayedSavedState';
 import {
   createFormDataUpdateAction,
   createFormError,
@@ -14,6 +13,11 @@ import {
 } from 'src/features/form/containers/GroupContainerLikertTestUtils';
 
 describe('GroupContainerLikert', () => {
+  jest.useFakeTimers();
+  const user = userEvent.setup({
+    advanceTimers: jest.advanceTimersByTime,
+  });
+
   describe('Desktop', () => {
     it('should render table using options and not optionsId', () => {
       render({
@@ -137,44 +141,36 @@ describe('GroupContainerLikert', () => {
         name: /Dårlig/i,
       });
 
-      mockDelayBeforeSaving(25);
-
       mockStoreDispatch.mockClear();
       expect(btn1).not.toBeChecked();
-      await userEvent.click(btn1);
+      await user.click(btn1);
       expect(mockStoreDispatch).not.toHaveBeenCalled();
-      await new Promise((r) => setTimeout(r, 25));
+      jest.runOnlyPendingTimers();
       expect(mockStoreDispatch).toHaveBeenCalledWith(
         createFormDataUpdateAction(0, '1'),
       );
 
       mockStoreDispatch.mockClear();
       expect(btn2).not.toBeChecked();
-      await userEvent.click(btn2);
+      await user.click(btn2);
       expect(mockStoreDispatch).not.toHaveBeenCalledTimes(2);
-      await new Promise((r) => setTimeout(r, 25));
+      jest.runOnlyPendingTimers();
       expect(mockStoreDispatch).toHaveBeenCalledWith(
         createFormDataUpdateAction(1, '3'),
       );
-
-      mockDelayBeforeSaving(undefined);
     });
 
     it('should render standard view and use keyboard to navigate', async () => {
       const { mockStoreDispatch } = render();
       validateTableLayout(defaultMockQuestions);
 
-      mockDelayBeforeSaving(25);
-
-      await userEvent.tab();
-      await userEvent.keyboard('[Space]');
+      await user.tab();
+      await user.keyboard('[Space]');
       expect(mockStoreDispatch).not.toHaveBeenCalled();
-      await new Promise((r) => setTimeout(r, 25));
+      jest.runOnlyPendingTimers();
       expect(mockStoreDispatch).toHaveBeenCalledWith(
         createFormDataUpdateAction(0, '1'),
       );
-
-      mockDelayBeforeSaving(undefined);
     });
 
     it('should support nested binding for question text in data model', async () => {
@@ -246,12 +242,10 @@ describe('GroupContainerLikert', () => {
         name: /Bra/i,
       });
 
-      mockDelayBeforeSaving(25);
-
       expect(btn1).not.toBeChecked();
-      await userEvent.click(btn1);
+      await user.click(btn1);
       expect(mockStoreDispatch).not.toHaveBeenCalled();
-      await new Promise((r) => setTimeout(r, 25));
+      jest.runOnlyPendingTimers();
       expect(mockStoreDispatch).toHaveBeenCalledWith(
         createFormDataUpdateAction(0, '1'),
       );
@@ -266,14 +260,12 @@ describe('GroupContainerLikert', () => {
       });
 
       expect(btn2).not.toBeChecked();
-      await userEvent.click(btn2);
+      await user.click(btn2);
       expect(mockStoreDispatch).not.toHaveBeenCalledTimes(2);
-      await new Promise((r) => setTimeout(r, 25));
+      jest.runOnlyPendingTimers();
       expect(mockStoreDispatch).toHaveBeenCalledWith(
         createFormDataUpdateAction(1, '3'),
       );
-
-      mockDelayBeforeSaving(undefined);
     });
 
     it('should render mobile view with selected values', () => {


### PR DESCRIPTION
## Description
The setTimeout in useDelayedSaveState was flaky, as sometimes (especially if my computer had more than enough to do), race conditions could occur where timers were not triggered exactly on time. Using fake timers in jest instead hopefully solves the problem.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- ~~[ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~
