### PR TITLE
Fixing duplicate startInitialDataTaskQueue action

### DIFF
--- a/src/altinn-app-frontend/src/common/hooks/useProcess.ts
+++ b/src/altinn-app-frontend/src/common/hooks/useProcess.ts
@@ -18,25 +18,28 @@ export function useProcess() {
   const process = useAppSelector((state) => state.process);
   const layoutSets = useAppSelector((state) => state.formLayout.layoutsets);
 
+  const taskType = process?.taskType;
+  const taskId = process?.taskId;
+
   React.useEffect(() => {
     if (!applicationMetadata || !instanceData) {
       return;
     }
 
-    if (!process?.taskType) {
+    if (!taskType) {
       dispatch(ProcessActions.get());
       return;
     }
 
     if (
-      process.taskType === ProcessTaskType.Data ||
-      behavesLikeDataTask(process.taskId, layoutSets)
+      taskType === ProcessTaskType.Data ||
+      behavesLikeDataTask(taskId, layoutSets)
     ) {
       dispatch(QueueActions.startInitialDataTaskQueue());
       return;
     }
 
-    switch (process.taskType) {
+    switch (taskType) {
       case ProcessTaskType.Confirm:
       case ProcessTaskType.Feedback:
         dispatch(QueueActions.startInitialInfoTaskQueue());
@@ -48,7 +51,14 @@ export function useProcess() {
       default:
         break;
     }
-  }, [process, applicationMetadata, instanceData, dispatch, layoutSets]);
+  }, [
+    taskType,
+    taskId,
+    applicationMetadata,
+    instanceData,
+    dispatch,
+    layoutSets,
+  ]);
 
   const appName = useAppSelector(selectAppName);
   const appOwner = useAppSelector(selectAppOwner);


### PR DESCRIPTION
## Description
The `startInitialDataTaskQueue` action is dispatched twice (creating a rush of more actions and requests than we need) because the hook dependencies had changed in some properties that wasn't read here. Moving the specific props out to their own variables.

## Related Issue(s)
- #511 (this _might_ be the root cause for that bug, but testing that hypothesis remains)
- #575

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
