### PR TITLE
Fix/repeating groups validation

### DIFF
--- a/src/altinn-app-frontend/src/components/message/ErrorReport.tsx
+++ b/src/altinn-app-frontend/src/components/message/ErrorReport.tsx
@@ -9,7 +9,7 @@ import { renderLayoutComponent } from 'src/features/form/containers/Form';
 import { FormLayoutActions } from 'src/features/form/layout/formLayoutSlice';
 import { nodesInLayout } from 'src/utils/layout/hierarchy';
 import { getMappedErrors, getUnmappedErrors } from 'src/utils/validation';
-import type { ILayout, ILayoutGroup } from 'src/features/form/layout';
+import type { ILayout } from 'src/features/form/layout';
 import type { AnyChildNode } from 'src/utils/layout/hierarchy.types';
 import type { FlatError } from 'src/utils/validation';
 
@@ -113,21 +113,8 @@ const ErrorReport = ({ components }: IErrorReportProps) => {
               : (allParents[i - 1] as AnyChildNode<'unresolved'>);
 
           // Go to correct multiPage page if necessary
-          if (parent.edit?.multiPage) {
-            const childrenWithMultiPageIndex = (
-              layouts[error.layout].find(
-                (c) => c.id === (parent.baseComponentId ?? parent.id),
-              ) as ILayoutGroup
-            ).children;
-
-            const childIndex = childrenWithMultiPageIndex.findIndex(
-              (id) => id.split(':')[1] == childNode.item.baseComponentId,
-            );
-
-            const multiPageIndex = parseInt(
-              childrenWithMultiPageIndex[childIndex].split(':')[0],
-            );
-
+          if (parent.edit?.multiPage && 'multiPageIndex' in childNode.item) {
+            const multiPageIndex = childNode.item.multiPageIndex;
             dispatch(
               FormLayoutActions.updateRepeatingGroupsMultiPageIndex({
                 group: parent.id,

--- a/src/altinn-app-frontend/src/components/message/ErrorReport.tsx
+++ b/src/altinn-app-frontend/src/components/message/ErrorReport.tsx
@@ -116,7 +116,7 @@ const ErrorReport = ({ components }: IErrorReportProps) => {
           if (parent.edit?.multiPage) {
             const childrenWithMultiPageIndex = (
               layouts[error.layout].find(
-                (c) => c.id === parent.id,
+                (c) => c.id === (parent.baseComponentId ?? parent.id),
               ) as ILayoutGroup
             ).children;
 

--- a/src/altinn-app-frontend/src/features/form/containers/GroupContainer.test.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/GroupContainer.test.tsx
@@ -186,6 +186,60 @@ describe('GroupContainer', () => {
     expect(item).toBeInTheDocument();
   });
 
+  it('calls setMultiPageIndex when opening a group', async () => {
+    const user = userEvent.setup();
+    const multiPageContainer: ILayoutGroup = {
+      ...mockContainer,
+      edit: {
+        ...mockContainer.edit,
+        multiPage: true,
+      },
+    };
+    const store = render({ container: multiPageContainer });
+
+    const editButton = screen.getAllByRole('button', {
+      name: /Rediger/i,
+    })[0];
+    await user.click(editButton);
+
+    const mockDispatchedAction = {
+      payload: {
+        group: 'container-closed-id',
+        index: 0,
+      },
+      type: FormLayoutActions.updateRepeatingGroupsMultiPageIndex.type,
+    };
+
+    expect(store.dispatch).toHaveBeenLastCalledWith(mockDispatchedAction);
+  });
+
+  it('calls setMultiPageIndex when adding a group element', async () => {
+    const user = userEvent.setup();
+    const multiPageContainer: ILayoutGroup = {
+      ...mockContainer,
+      edit: {
+        ...mockContainer.edit,
+        multiPage: true,
+      },
+    };
+    const store = render({ container: multiPageContainer });
+
+    const addButton = screen.getAllByRole('button', {
+      name: /Legg til ny/i,
+    })[0];
+    await user.click(addButton);
+
+    const mockDispatchedAction = {
+      payload: {
+        group: 'container-closed-id',
+        index: 0,
+      },
+      type: FormLayoutActions.updateRepeatingGroupsMultiPageIndex.type,
+    };
+
+    expect(store.dispatch).toHaveBeenLastCalledWith(mockDispatchedAction);
+  });
+
   it('should trigger validate when closing edit mode if validation trigger is present', async () => {
     const mockContainerInEditModeWithTrigger = {
       ...mockContainer,

--- a/src/altinn-app-frontend/src/features/form/containers/GroupContainer.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/GroupContainer.tsx
@@ -78,7 +78,10 @@ export function GroupContainer({
   );
   const [filteredIndexList, setFilteredIndexList] =
     React.useState<number[]>(null);
-  const [multiPageIndex, setMultiPageIndex] = React.useState<number>(-1);
+  const multiPageIndex = useAppSelector(
+    (state: IRuntimeState) =>
+      state.formLayout.uiConfig.repeatingGroups[id]?.multiPageIndex ?? -1,
+  );
 
   const attachments = useAppSelector(
     (state: IRuntimeState) => state.attachments.attachments,
@@ -137,6 +140,18 @@ export function GroupContainer({
     }
   }, [formData, edit]);
 
+  const setMultiPageIndex = useCallback(
+    (index: number) => {
+      dispatch(
+        FormLayoutActions.updateRepeatingGroupsMultiPageIndex({
+          group: id,
+          index,
+        }),
+      );
+    },
+    [dispatch, id],
+  );
+
   const onClickAdd = useCallback(() => {
     dispatch(FormLayoutActions.updateRepeatingGroups({ layoutElementId: id }));
     if (edit?.mode !== 'showAll') {
@@ -146,8 +161,9 @@ export function GroupContainer({
           index: repeatingGroupIndex + 1,
         }),
       );
+      setMultiPageIndex(0);
     }
-  }, [edit?.mode, dispatch, id, repeatingGroupIndex]);
+  }, [dispatch, id, edit?.mode, repeatingGroupIndex, setMultiPageIndex]);
 
   React.useEffect(() => {
     const { edit } = container;
@@ -155,14 +171,16 @@ export function GroupContainer({
       return;
     }
 
-    if (edit.multiPage) {
-      setMultiPageIndex(0);
-    }
-
     if (edit.openByDefault && repeatingGroupIndex === -1) {
       onClickAdd();
     }
   }, [container, onClickAdd, repeatingGroupIndex]);
+
+  React.useEffect(() => {
+    if (edit?.multiPage && multiPageIndex < 0) {
+      setMultiPageIndex(0);
+    }
+  }, [edit?.multiPage, multiPageIndex, setMultiPageIndex]);
 
   const onKeypressAdd = (event: React.KeyboardEvent<HTMLDivElement>) => {
     if (
@@ -207,6 +225,9 @@ export function GroupContainer({
         validate,
       }),
     );
+    if (edit?.multiPage && index > -1) {
+      setMultiPageIndex(0);
+    }
   };
 
   const classes = useStyles();

--- a/src/altinn-app-frontend/src/features/form/containers/GroupContainer.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/GroupContainer.tsx
@@ -202,17 +202,6 @@ export function GroupContainer({
     );
   };
 
-  const onClickSave = () => {
-    const validate = !!container.triggers?.includes(Triggers.Validation);
-    dispatch(
-      FormLayoutActions.updateRepeatingGroupsEditIndex({
-        group: id,
-        index: -1,
-        validate,
-      }),
-    );
-  };
-
   const setEditIndex = (index: number, forceValidation?: boolean) => {
     // if edit button has been clicked while edit container is open, we trigger validations if present in triggers
     const validate: boolean =
@@ -313,7 +302,6 @@ export function GroupContainer({
           language={language}
           textResources={textResources}
           layout={layout}
-          onClickSave={onClickSave}
           repeatingGroupDeepCopyComponents={repeatingGroupDeepCopyComponents}
           hideSaveButton={edit?.saveButton === false}
           multiPageIndex={multiPageIndex}
@@ -346,7 +334,7 @@ export function GroupContainer({
                 deleting={deletingIndexes.includes(index)}
                 textResources={textResources}
                 layout={layout}
-                onClickSave={onClickSave}
+                setEditIndex={setEditIndex}
                 onClickRemove={onClickRemove}
                 repeatingGroupDeepCopyComponents={
                   repeatingGroupDeepCopyComponents

--- a/src/altinn-app-frontend/src/features/form/containers/GroupContainer.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/GroupContainer.tsx
@@ -3,7 +3,6 @@ import React, { useCallback, useMemo } from 'react';
 import { Grid, makeStyles } from '@material-ui/core';
 
 import { useAppDispatch, useAppSelector } from 'src/common/hooks';
-import ErrorPaper from 'src/components/message/ErrorPaper';
 import { ExprDefaultsForGroup } from 'src/features/expressions';
 import { useExpressions } from 'src/features/expressions/useExpressions';
 import { RepeatingGroupAddButton } from 'src/features/form/components/RepeatingGroupAddButton';
@@ -19,22 +18,14 @@ import {
 } from 'src/utils/formLayout';
 import { getHiddenFieldsForGroup } from 'src/utils/layout';
 import { renderValidationMessagesForComponent } from 'src/utils/render';
-import { repeatingGroupHasValidations } from 'src/utils/validation';
 import type { ILayoutComponent, ILayoutGroup } from 'src/features/form/layout';
 import type { IRuntimeState } from 'src/types';
-
-import { getLanguageFromKey } from 'altinn-shared/utils';
-
 export interface IGroupProps {
   id: string;
   container: ILayoutGroup;
   components: (ILayoutComponent | ILayoutGroup)[];
   triggers?: Triggers[];
 }
-
-const gridStyle = {
-  paddingTop: '12px',
-};
 
 const useStyles = makeStyles({
   minusMargin: {
@@ -133,26 +124,6 @@ export function GroupContainer({
       repeatingGroupIndex,
       textResources,
       hiddenFields,
-    ],
-  );
-
-  const tableHasErrors = useMemo(
-    () =>
-      repeatingGroupHasValidations(
-        container,
-        repeatingGroupDeepCopyComponents,
-        validations,
-        currentView,
-        repeatingGroups,
-        layout,
-      ),
-    [
-      container,
-      repeatingGroupDeepCopyComponents,
-      validations,
-      currentView,
-      repeatingGroups,
-      layout,
     ],
   );
 
@@ -255,17 +226,6 @@ export function GroupContainer({
           textResources={textResources}
           container={container}
         />
-        {tableHasErrors && (
-          <Grid
-            container={true}
-            style={gridStyle}
-            direction='column'
-          >
-            <ErrorPaper
-              message={getLanguageFromKey('group.row_error', language)}
-            />
-          </Grid>
-        )}
       </>
     );
   }
@@ -387,18 +347,6 @@ export function GroupContainer({
             textResources={textResources}
           />
         )}
-      {tableHasErrors && (
-        <Grid
-          container={true}
-          style={gridStyle}
-          direction='column'
-          data-testid={'group-table-errors'}
-        >
-          <ErrorPaper
-            message={getLanguageFromKey('group.row_error', language)}
-          />
-        </Grid>
-      )}
       <Grid
         item={true}
         xs={12}

--- a/src/altinn-app-frontend/src/features/form/containers/GroupContainerLikert.test.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/GroupContainerLikert.test.tsx
@@ -191,7 +191,6 @@ describe('GroupContainerLikert', () => {
         validations: createFormError(1),
       });
       expect(screen.getByRole('alert')).toHaveTextContent('Feltet er påkrevd');
-      screen.getByText(/En av radene er ikke fylt ut riktig/i);
     });
 
     it('should render 2 alerts', async () => {
@@ -199,7 +198,6 @@ describe('GroupContainerLikert', () => {
         validations: { ...createFormError(1), ...createFormError(2) },
       });
       expect(screen.getAllByRole('alert')).toHaveLength(2);
-      screen.getByText(/En av radene er ikke fylt ut riktig/i);
     });
 
     it('should display title and description', async () => {

--- a/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupTable.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupTable.tsx
@@ -11,12 +11,9 @@ import {
 } from '@material-ui/core';
 import cn from 'classnames';
 
-import { useAppDispatch } from 'src/common/hooks';
 import { ExprDefaultsForGroup } from 'src/features/expressions';
 import { useExpressions } from 'src/features/expressions/useExpressions';
 import { RepeatingGroupsEditContainer } from 'src/features/form/containers/RepeatingGroupsEditContainer';
-import { FormLayoutActions } from 'src/features/form/layout/formLayoutSlice';
-import { Triggers } from 'src/types';
 import {
   getFormDataForComponentInRepeatingGroup,
   getTextResource,
@@ -257,7 +254,6 @@ export function RepeatingGroupTable({
   deleting,
   filteredIndexes,
 }: IRepeatingGroupTableProps): JSX.Element {
-  const dispatch = useAppDispatch();
   const classes = useStyles();
   const mobileView = useMediaQuery('(max-width:992px)'); // breakpoint on altinn-modal
 
@@ -334,17 +330,6 @@ export function RepeatingGroupTable({
     }
   };
 
-  const handleSaveClick = () => {
-    const validate = !!container.triggers?.includes(Triggers.Validation);
-    dispatch(
-      FormLayoutActions.updateRepeatingGroupsEditIndex({
-        group: id,
-        index: -1,
-        validate,
-      }),
-    );
-  };
-
   const childElementHasErrors = (
     element: ILayoutGroup | ILayoutComponent,
     index: number,
@@ -396,7 +381,6 @@ export function RepeatingGroupTable({
           language={language}
           textResources={textResources}
           layout={layout}
-          onClickSave={handleSaveClick}
           repeatingGroupDeepCopyComponents={repeatingGroupDeepCopyComponents}
           hideSaveButton={edit?.saveButton === false}
           multiPageIndex={multiPageIndex}

--- a/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupsEditContainer.test.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupsEditContainer.test.tsx
@@ -101,31 +101,14 @@ describe('RepeatingGroupsEditContainer', () => {
     textResources,
   );
 
-  it('calls setMultiPageIndex when save-and-close is pressed for multipage edit-container', async () => {
-    const setMultiPageIndex = jest.fn();
-    render({ setMultiPageIndex: setMultiPageIndex });
-    await user.click(screen.getByRole('button', { name: /save and close/i }));
-    expect(setMultiPageIndex).toHaveBeenCalledTimes(1);
-  });
-
-  it('calls setMultiPageIndex when delete is pressed for multipage edit-container with edit.mode showAll', async () => {
-    const setMultiPageIndex = jest.fn();
-    multiPageGroup.edit.mode = 'showAll';
-    render({ setMultiPageIndex: setMultiPageIndex });
-    await user.click(screen.getByRole('button', { name: /delete/i }));
-    expect(setMultiPageIndex).toHaveBeenCalledTimes(1);
-  });
-
   it('calls setEditIndex when save and open next is pressed when edit.saveAndNextButton is true', async () => {
     const setEditIndex = jest.fn();
     const setMultiPageIndex = jest.fn();
-    const onClickSave = jest.fn();
     multiPageGroup.edit.saveAndNextButton = true;
-    render({ setEditIndex, setMultiPageIndex, onClickSave, editIndex: 0 });
+    render({ setEditIndex, setMultiPageIndex, editIndex: 0 });
     await user.click(
       screen.getByRole('button', { name: /save and open next/i }),
     );
-    expect(onClickSave).not.toHaveBeenCalled();
     expect(setEditIndex).toHaveBeenCalledWith(1, true);
   });
 
@@ -139,7 +122,7 @@ describe('RepeatingGroupsEditContainer', () => {
       layout: layout,
       editIndex: 1,
       repeatingGroupIndex: repeatingGroupIndex,
-      onClickSave: jest.fn(),
+      setEditIndex: jest.fn(),
       onClickRemove: jest.fn(),
       hideDeleteButton: false,
       showSaveAndNextButton: multiPageGroup.edit?.saveAndNextButton === true,

--- a/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupsEditContainer.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupsEditContainer.tsx
@@ -118,9 +118,6 @@ export function RepeatingGroupsEditContainer({
 
   const closeEditContainer = () => {
     onClickSave();
-    if (container.edit?.multiPage) {
-      setMultiPageIndex(0);
-    }
   };
 
   let nextIndex: number | null = null;
@@ -137,17 +134,11 @@ export function RepeatingGroupsEditContainer({
   const nextClicked = () => {
     if (nextIndex !== null) {
       setEditIndex(nextIndex, true);
-      if (container.edit?.multiPage) {
-        setMultiPageIndex(0);
-      }
     }
   };
 
   const removeClicked = () => {
     onClickRemove(editIndex);
-    if (container.edit?.multiPage) {
-      setMultiPageIndex(0);
-    }
   };
 
   return (

--- a/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupsEditContainer.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupsEditContainer.tsx
@@ -27,10 +27,9 @@ export interface IRepeatingGroupsEditContainer {
   layout: ILayout;
   deleting?: boolean;
   editIndex: number;
-  setEditIndex?: (index: number, forceValidation?: boolean) => void;
+  setEditIndex: (index: number, forceValidation?: boolean) => void;
   repeatingGroupIndex: number;
   onClickRemove?: (groupIndex: number) => void;
-  onClickSave: () => void;
   hideSaveButton?: boolean;
   hideDeleteButton?: boolean;
   multiPageIndex?: number;
@@ -106,7 +105,6 @@ export function RepeatingGroupsEditContainer({
   setEditIndex,
   repeatingGroupIndex,
   onClickRemove,
-  onClickSave,
   hideSaveButton,
   hideDeleteButton,
   multiPageIndex,
@@ -115,10 +113,6 @@ export function RepeatingGroupsEditContainer({
   filteredIndexes,
 }: IRepeatingGroupsEditContainer): JSX.Element {
   const classes = useStyles();
-
-  const closeEditContainer = () => {
-    onClickSave();
-  };
 
   let nextIndex: number | null = null;
   if (filteredIndexes) {
@@ -130,6 +124,10 @@ export function RepeatingGroupsEditContainer({
   } else {
     nextIndex = editIndex < repeatingGroupIndex ? editIndex + 1 : null;
   }
+
+  const saveClicked = () => {
+    setEditIndex(-1);
+  };
 
   const nextClicked = () => {
     if (nextIndex !== null) {
@@ -256,7 +254,7 @@ export function RepeatingGroupsEditContainer({
               <Grid item={true}>
                 <Button
                   id={`add-button-grp-${id}`}
-                  onClick={closeEditContainer}
+                  onClick={saveClicked}
                   variant={ButtonVariant.Secondary}
                 >
                   {container.textResourceBindings?.save_button

--- a/src/altinn-app-frontend/src/features/form/layout/formLayoutSlice.ts
+++ b/src/altinn-app-frontend/src/features/form/layout/formLayoutSlice.ts
@@ -226,6 +226,13 @@ const formLayoutSlice = createSagaSlice(
             state.error = error;
           },
         }),
+      updateRepeatingGroupsMultiPageIndex:
+        mkAction<LayoutTypes.IUpdateRepeatingGroupsMultiPageIndex>({
+          reducer: (state, action) => {
+            const { group, index } = action.payload;
+            state.uiConfig.repeatingGroups[group].multiPageIndex = index;
+          },
+        }),
       updateRepeatingGroupsEditIndex:
         mkAction<LayoutTypes.IUpdateRepeatingGroupsEditIndex>({
           takeLatest: updateRepeatingGroupEditIndexSaga,

--- a/src/altinn-app-frontend/src/features/form/layout/formLayoutTypes.ts
+++ b/src/altinn-app-frontend/src/features/form/layout/formLayoutTypes.ts
@@ -76,6 +76,11 @@ export interface IUpdateRepeatingGroupsRemoveCancelled {
   index: number;
 }
 
+export interface IUpdateRepeatingGroupsMultiPageIndex {
+  group: string;
+  index: number;
+}
+
 export interface IUpdateRepeatingGroupsEditIndex {
   group: string;
   index: number;

--- a/src/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
+++ b/src/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
@@ -155,6 +155,7 @@ export function* updateRepeatingGroupsSaga({
           baseGroupId: group.id,
           dataModelBinding: group.dataModelBindings?.group,
           editIndex: -1,
+          multiPageIndex: -1,
         };
       }
     });

--- a/src/altinn-app-frontend/src/types/index.ts
+++ b/src/altinn-app-frontend/src/types/index.ts
@@ -106,6 +106,7 @@ export interface IRepeatingGroup {
   dataModelBinding?: string;
   editIndex?: number;
   deletingIndex?: number[];
+  multiPageIndex?: number;
 }
 
 export interface IRepeatingGroups {

--- a/src/altinn-app-frontend/src/utils/formLayout.test.ts
+++ b/src/altinn-app-frontend/src/utils/formLayout.test.ts
@@ -126,24 +126,28 @@ describe('getRepeatingGroups', () => {
         index: 2,
         dataModelBinding: 'Group1',
         editIndex: -1,
+        multiPageIndex: -1,
       },
       'Group2-0': {
         index: 0,
         baseGroupId: 'Group2',
         dataModelBinding: 'Group1.Group2',
         editIndex: -1,
+        multiPageIndex: -1,
       },
       'Group2-1': {
         index: 4,
         baseGroupId: 'Group2',
         dataModelBinding: 'Group1.Group2',
         editIndex: -1,
+        multiPageIndex: -1,
       },
       'Group2-2': {
         index: 1,
         baseGroupId: 'Group2',
         dataModelBinding: 'Group1.Group2',
         editIndex: -1,
+        multiPageIndex: -1,
       },
     };
     const result = getRepeatingGroups(testLayout, formData);
@@ -175,24 +179,28 @@ describe('getRepeatingGroups', () => {
         index: 2,
         dataModelBinding: 'Group1',
         editIndex: -1,
+        multiPageIndex: -1,
       },
       'Group2-0': {
         index: 0,
         baseGroupId: 'Group2',
         dataModelBinding: 'Group1.Group2',
         editIndex: -1,
+        multiPageIndex: -1,
       },
       'Group2-1': {
         index: 10,
         baseGroupId: 'Group2',
         dataModelBinding: 'Group1.Group2',
         editIndex: -1,
+        multiPageIndex: -1,
       },
       'Group2-2': {
         index: 1,
         baseGroupId: 'Group2',
         dataModelBinding: 'Group1.Group2',
         editIndex: -1,
+        multiPageIndex: -1,
       },
     };
 
@@ -219,24 +227,28 @@ describe('getRepeatingGroups', () => {
         index: 2,
         dataModelBinding: 'Group1',
         editIndex: -1,
+        multiPageIndex: -1,
       },
       'Group2-0': {
         index: 0,
         baseGroupId: 'Group2',
         dataModelBinding: 'Group1.Group2',
         editIndex: -1,
+        multiPageIndex: -1,
       },
       'Group2-1': {
         index: 4,
         baseGroupId: 'Group2',
         dataModelBinding: 'Group1.Group2',
         editIndex: -1,
+        multiPageIndex: -1,
       },
       'Group2-2': {
         index: 1,
         baseGroupId: 'Group2',
         dataModelBinding: 'Group1.Group2',
         editIndex: -1,
+        multiPageIndex: -1,
       },
     };
     const result = getRepeatingGroups(testLayout, formData);
@@ -304,11 +316,13 @@ describe('getRepeatingGroups', () => {
         index: 3,
         dataModelBinding: 'Group1',
         editIndex: -1,
+        multiPageIndex: -1,
       },
       Group2: {
         index: 2,
         dataModelBinding: 'Group2',
         editIndex: -1,
+        multiPageIndex: -1,
       },
     };
     const result = getRepeatingGroups(testLayout, formData);
@@ -354,6 +368,7 @@ describe('getRepeatingGroups', () => {
         index: 12,
         dataModelBinding: 'Group1',
         editIndex: -1,
+        multiPageIndex: -1,
       },
     };
     const result = getRepeatingGroups(testLayout, formData);

--- a/src/altinn-app-frontend/src/utils/formLayout.ts
+++ b/src/altinn-app-frontend/src/utils/formLayout.ts
@@ -129,6 +129,7 @@ export function getRepeatingGroups(formLayout: ILayout, formData: any) {
             index,
             dataModelBinding: groupElement.dataModelBindings?.group,
             editIndex: -1,
+            multiPageIndex: -1,
           };
           const groupElementChildGroups = [];
           groupElement.children?.forEach((id) => {
@@ -157,6 +158,7 @@ export function getRepeatingGroups(formLayout: ILayout, formData: any) {
                   ),
                   baseGroupId: childGroup.id,
                   editIndex: -1,
+                  multiPageIndex: -1,
                   dataModelBinding: childGroup.dataModelBindings?.group,
                 };
               },
@@ -168,6 +170,7 @@ export function getRepeatingGroups(formLayout: ILayout, formData: any) {
           index: -1,
           dataModelBinding: groupElement.dataModelBindings?.group,
           editIndex: -1,
+          multiPageIndex: -1,
         };
       }
     }

--- a/src/altinn-app-frontend/src/utils/layout/hierarchy.test.ts
+++ b/src/altinn-app-frontend/src/utils/layout/hierarchy.test.ts
@@ -151,11 +151,18 @@ describe('Hierarchical layout tools', () => {
         {
           ...components.group3,
           childComponents: [
-            components.group3h,
-            components.group3i,
+            {
+              ...components.group3h,
+              multiPageIndex: 0,
+            },
+            {
+              ...components.group3i,
+              multiPageIndex: 1,
+            },
             {
               ...components.group3n,
               childComponents: [components.group3nh, components.group3ni],
+              multiPageIndex: 2,
             },
           ],
         },

--- a/src/altinn-app-frontend/src/utils/layout/hierarchy.types.d.ts
+++ b/src/altinn-app-frontend/src/utils/layout/hierarchy.types.d.ts
@@ -29,6 +29,7 @@ export type LayoutGroupHierarchy<NT extends NodeType = 'unresolved'> = Omit<
 
 export interface RepeatingGroupExtensions {
   baseDataModelBindings?: IDataModelBindings;
+  multiPageIndex?: number;
 }
 
 export type RepeatingGroupLayoutComponent<NT extends NodeType = 'unresolved'> =

--- a/src/altinn-app-frontend/src/utils/validation/validation.ts
+++ b/src/altinn-app-frontend/src/utils/validation/validation.ts
@@ -288,7 +288,9 @@ export function getGroupChildren(
     (element) => element.id === groupId,
   ) as ILayoutGroup;
   return layout.filter((element) =>
-    layoutGroup?.children?.includes(element.id),
+    layoutGroup?.children
+      ?.map((id) => (layoutGroup.edit?.multiPage ? id.split(':')[1] : id))
+      .includes(element.id),
   );
 }
 

--- a/test/cypress/e2e/fixtures/texts.json
+++ b/test/cypress/e2e/fixtures/texts.json
@@ -7,7 +7,6 @@
   "continueOrStartNew": "Velg om du vil fortsette på et skjema du har begynt på, eller om du vil starte på ny.",
   "dateOfEffect": "Når vil du at navnendringen skal skje?",
   "downloadAttachment": "last ned",
-  "errorInGroup": "En av radene er ikke fylt ut riktig, dette må fikses før skjema kan sendes inn",
   "errorReport": "Du må rette disse feilene før du kan gå videre",
   "feedback": "Du må flytte instansen til neste prosess med et API kall til process/next",
   "goToRightPage": "Gå til riktig side i skjema",

--- a/test/cypress/e2e/integration/app-frontend/attachments-in-group.js
+++ b/test/cypress/e2e/integration/app-frontend/attachments-in-group.js
@@ -56,7 +56,7 @@ describe('Repeating group attachments', () => {
     }
   };
 
-  const uploadFile = ({ item, idx, fileName, verifyTableRow, tableRow, isTaggedUploader }) => {
+  const uploadFile = ({ item, idx, fileName, verifyTableRow, tableRow, isTaggedUploader, secondPage = false }) => {
     cy.get(item.dropZoneContainer).should('be.visible');
     cy.get(item.dropZone).selectFile(makeTestFile(fileName), { force: true });
 
@@ -74,6 +74,9 @@ describe('Repeating group attachments', () => {
       cy.get(tableRow.editBtn).click();
       verifyTableRowPreview(item, fileName);
       cy.get(tableRow.editBtn).click();
+      if (secondPage) {
+        gotoSecondPage();
+      }
     }
   };
 
@@ -182,13 +185,14 @@ describe('Repeating group attachments', () => {
       fileName: filenames[0].single,
       verifyTableRow: true,
       tableRow: appFrontend.group.rows[0],
+      secondPage: true
     });
     getState().should('deep.equal', {
       [appFrontend.group.rows[0].uploadSingle.stateKey]: [filenames[0].single],
     });
 
     filenames[0].multi.forEach((fileName, idx) => {
-      uploadFile({ item: appFrontend.group.rows[0].uploadMulti, idx, fileName, verifyTableRow: true, tableRow: appFrontend.group.rows[0], });
+      uploadFile({ item: appFrontend.group.rows[0].uploadMulti, idx, fileName, verifyTableRow: true, tableRow: appFrontend.group.rows[0], secondPage: true });
       if (idx !== filenames[0].multi.length - 1) {
         cy.get(appFrontend.group.rows[0].uploadMulti.addMoreBtn).click();
       }
@@ -205,6 +209,7 @@ describe('Repeating group attachments', () => {
       fileName: filenames[1].single,
       verifyTableRow: true,
       tableRow: appFrontend.group.rows[1],
+      secondPage: true
     });
     filenames[1].multi.forEach((fileName, idx) => {
       uploadFile({
@@ -213,6 +218,7 @@ describe('Repeating group attachments', () => {
         fileName,
         verifyTableRow: true,
         tableRow: appFrontend.group.rows[1],
+        secondPage: true
       });
       if (idx !== filenames[1].multi.length - 1) {
         cy.get(appFrontend.group.rows[1].uploadMulti.addMoreBtn).click();

--- a/test/cypress/e2e/integration/app-frontend/group.js
+++ b/test/cypress/e2e/integration/app-frontend/group.js
@@ -103,9 +103,6 @@ describe('Group', () => {
       .should('exist')
       .should('be.visible')
       .should('have.text', texts.zeroIsNotValid);
-    cy.get(appFrontend.group.mainGroup)
-      .siblings(appFrontend.group.tableErrors)
-      .should('contain.text', texts.errorInGroup);
     cy.get(appFrontend.group.newValue).should('be.visible').clear().type('1').blur();
     cy.get(appFrontend.fieldValidationError.replace('field', 'newValue')).should('not.exist');
     cy.get(appFrontend.group.mainGroup).siblings(appFrontend.group.tableErrors).should('not.exist');
@@ -120,9 +117,6 @@ describe('Group', () => {
       .should('exist')
       .should('be.visible')
       .should('have.text', texts.testIsNotValidValue);
-    cy.get(appFrontend.group.subGroup)
-      .siblings(appFrontend.group.tableErrors)
-      .should('contain.text', texts.errorInGroup);
     cy.get(appFrontend.group.comments).clear().type('automation').blur();
     cy.get(appFrontend.fieldValidationError.replace('field', 'comments')).should('not.exist');
     cy.get(appFrontend.group.subGroup).siblings(appFrontend.group.tableErrors).should('not.exist');
@@ -215,7 +209,6 @@ describe('Group', () => {
     cy.get(appFrontend.fieldValidationError.replace('field', 'newValue-0'))
       .should('be.visible')
       .should('have.text', texts.requiredFieldToValue);
-    cy.get(appFrontend.group.mainGroup).siblings(appFrontend.group.tableErrors).should('have.text', texts.errorInGroup);
 
     cy.get(appFrontend.group.mainGroup)
       .find(mui.tableBody)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
1. Removed this warning 
![image](https://user-images.githubusercontent.com/47412359/198572576-424ae82b-c05b-48f3-8a8b-31ef2b60f6aa.png)
2. Navigating to error message will now open the repeating group rows for editing and navigate to the correct multiPage
3. Also fixes an issue related to deleting validation when a row (with multiPage) is deleted

Note: One behavior was changed which required updating the cypress tests in `attatchments-in-group`. Previously, clicking save and close in the table row (not edit container) would not reset the multiPageIndex to 0. This would however happen if the save button inside the edit container was clicked. This has been changed so that in both cases, the multiPageindex is set to 0 when clicking save and close. The changes in cypress tests `groups` was just removing the old warning message.


## Related Issue(s)
- #547 
- #548 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- ~~User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~
