### PR TITLE
Fix repeating group header alignment

### DIFF
--- a/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupTable.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupTable.tsx
@@ -439,7 +439,7 @@ export function RepeatingGroupTable({
               <TableRow>
                 {tableComponents.map((component: ILayoutComponent) => (
                   <TableCell
-                    align='left'
+                    align={getTextAlignment(component)}
                     key={component.id}
                   >
                     {getTextResource(getTableTitle(component), textResources)}
@@ -512,9 +512,7 @@ export function RepeatingGroupTable({
                         {tableComponents.map((component: ILayoutComponent) => (
                           <TableCell
                             key={`${component.id}-${index}`}
-                            style={{
-                              textAlign: getTextAlignment(component),
-                            }}
+                            align={getTextAlignment(component)}
                           >
                             <span>
                               {index !== editIndex


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Made the table header in repeating groups get the same alignment as the cells in the table body.

## Related Issue(s)
- #587 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- ~~Relevant automated test added (if you find this hard, leave it and we'll help out)~~
- [x] All tests run green

## Documentation
- ~~User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~
