### PR TITLE
fix: make sure progress circle is not wrapping

### DIFF
--- a/src/altinn-app-frontend/src/components/presentation/Header.tsx
+++ b/src/altinn-app-frontend/src/components/presentation/Header.tsx
@@ -37,7 +37,7 @@ const Header = ({ type, header, appOwner }: IHeaderProps) => {
           direction='row'
           justifyContent='space-between'
           wrap='nowrap'
-          alignItems='center'
+          spacing={2}
         >
           <Grid item>
             <Grid item>

--- a/src/altinn-app-frontend/src/components/presentation/Header.tsx
+++ b/src/altinn-app-frontend/src/components/presentation/Header.tsx
@@ -36,6 +36,8 @@ const Header = ({ type, header, appOwner }: IHeaderProps) => {
           container
           direction='row'
           justifyContent='space-between'
+          wrap='nowrap'
+          alignItems='center'
         >
           <Grid item>
             <Grid item>


### PR DESCRIPTION
Make sure progress circle is not wrapping

## Description
If header title is too long, the progress circle wraps
![image](https://user-images.githubusercontent.com/554713/199004810-f92068af-42de-4198-9979-c3ae76ff2ab5.png)
by setting nowrap and alignItems center, this looks a bit better
![image](https://user-images.githubusercontent.com/554713/199004908-70dabf84-3e8b-4fba-a56d-d8fd97d1ad6b.png)


## Related Issue(s)
- none

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
