### PR TITLE
extract hidden prop for custom components

### DIFF
--- a/src/altinn-app-frontend/src/components/custom/CustomWebComponent.tsx
+++ b/src/altinn-app-frontend/src/components/custom/CustomWebComponent.tsx
@@ -17,6 +17,7 @@ function CustomWebComponent({
   textResourceBindings,
   dataModelBindings,
   language,
+  hidden,
   handleDataChange,
   ...passThroughProps
 }: ICustomComponentProps) {
@@ -62,7 +63,7 @@ function CustomWebComponent({
     }
   }, [formData, componentValidations]);
 
-  if (!Tag || !textResources) {
+  if (hidden || !Tag || !textResources) {
     return null;
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix issue with `hidden="false"` sent to custom (web) component. This was causing browser to interpret that `hidden` was set on the html element, thus hiding it.
Solved by setting the `hidden` logic in the `CustomWebComponent` react component.

#592 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green
