### PR TITLE
Fix date-format inconsistency

### DIFF
--- a/src/altinn-app-frontend/src/components/base/DatepickerComponent.tsx
+++ b/src/altinn-app-frontend/src/components/base/DatepickerComponent.tsx
@@ -14,10 +14,13 @@ import {
 } from '@material-ui/pickers';
 import moment from 'moment';
 
-import { getFlagBasedDate, getISOString } from 'src/utils/dateHelpers';
+import {
+  getDateFormat,
+  getFlagBasedDate,
+  getISOString,
+} from 'src/utils/dateHelpers';
 import { renderValidationMessagesForComponent } from 'src/utils/render';
 import {
-  DatePickerFormatDefault,
   DatePickerMaxDateDefault,
   DatePickerMinDateDefault,
   DatePickerSaveFormatNoTimestamp,
@@ -106,11 +109,6 @@ function DatepickerComponent({
   const [validDate, setValidDate] = React.useState<boolean>(true);
   const [validationMessages, setValidationMessages] =
     React.useState<IComponentBindingValidation | null>(null);
-  const locale =
-    window.navigator?.language ||
-    (window.navigator as any)?.userLanguage ||
-    'nb';
-  moment.locale(locale);
 
   const calculatedMinDate =
     getFlagBasedDate(minDate as DateFlags) ||
@@ -121,10 +119,7 @@ function DatepickerComponent({
     getISOString(maxDate) ||
     DatePickerMaxDateDefault;
 
-  const calculatedFormat =
-    moment.localeData().longDateFormat('L') ||
-    format ||
-    DatePickerFormatDefault;
+  const calculatedFormat = getDateFormat(format);
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 

--- a/src/altinn-app-frontend/src/utils/dateHelpers.ts
+++ b/src/altinn-app-frontend/src/utils/dateHelpers.ts
@@ -1,6 +1,7 @@
 import moment from 'moment';
 
 import { DateFlags } from 'src/types';
+import { DatePickerFormatDefault } from 'src/utils/validation';
 
 /*
   Creates a specific date based on different flags (DatepickerRestrictionFlags)
@@ -28,4 +29,14 @@ export function getISOString(
 
   const momentDate = moment(potentialDate);
   return momentDate.isValid() ? momentDate.toISOString() : undefined;
+}
+
+const locale =
+  window.navigator?.language || (window.navigator as any)?.userLanguage || 'nb';
+moment.locale(locale);
+
+export function getDateFormat(format?: string): string {
+  return (
+    moment.localeData().longDateFormat('L') || format || DatePickerFormatDefault
+  );
 }

--- a/src/altinn-app-frontend/src/utils/formComponentUtils.ts
+++ b/src/altinn-app-frontend/src/utils/formComponentUtils.ts
@@ -1,9 +1,9 @@
 import type React from 'react';
 
 import { formatNumericText } from '@altinn/altinn-design-system';
-import moment from 'moment';
 
 import { AsciiUnitSeparator } from 'src/utils/attachment';
+import { getDateFormat } from 'src/utils/dateHelpers';
 import { setMappingForRepeatingGroupComponent } from 'src/utils/formLayout';
 import {
   getOptionLookupKey,
@@ -11,7 +11,6 @@ import {
   setupSourceOptions,
 } from 'src/utils/options';
 import { getTextFromAppOrDefault } from 'src/utils/textResource';
-import { DatePickerFormatDefault } from 'src/utils/validation';
 import type { IFormData } from 'src/features/form/data';
 import type {
   IGridStyling,
@@ -318,10 +317,7 @@ export const getDisplayFormData = (
       return formatNumericText(formDataValue, component.formatting.number);
     }
     if (component.type === 'DatePicker') {
-      const dateFormat =
-        moment.localeData().longDateFormat('L') ||
-        component.format ||
-        DatePickerFormatDefault;
+      const dateFormat = getDateFormat(component.format);
       return formatISOString(formDataValue, dateFormat);
     }
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The global moment locale was previously set inside of the date-picker component, so this was moved to the dateHelper instead along with the calculatedFormat logic so that anyone using the same date-format as the datepicker will also get the correct locale.

## Related Issue(s)
- #607

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- ~~Relevant automated test added (if you find this hard, leave it and we'll help out)~~
- [ ] All tests run green

## Documentation
- ~~User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~
