### PR TITLE
Make MultipleChoiceSummary match styling of normal summary

### DIFF
--- a/src/altinn-app-frontend/src/components/summary/MultipleChoiceSummary.tsx
+++ b/src/altinn-app-frontend/src/components/summary/MultipleChoiceSummary.tsx
@@ -29,6 +29,15 @@ const useStyles = makeStyles({
     paddingLeft: 0,
     paddingRight: 0,
   },
+  // Match style in \src\components\summary\SingleInputSummary.tsx
+  data: {
+    fontWeight: 500,
+    fontSize: '1.8rem',
+    '& p': {
+      fontWeight: 500,
+      fontSize: '1.8rem',
+    },
+  },
 });
 
 export default function MultipleChoiceSummary({
@@ -64,6 +73,7 @@ export default function MultipleChoiceSummary({
               >
                 <ListItemText
                   id={key}
+                  primaryTypographyProps={{ classes: { root: classes.data } }}
                   primary={formData[key]}
                 />
               </ListItem>

--- a/src/altinn-app-frontend/src/components/summary/__snapshots__/MultipleChoiceSummary.test.tsx.snap
+++ b/src/altinn-app-frontend/src/components/summary/__snapshots__/MultipleChoiceSummary.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`MultipleChoiceSummary MultipleChoiceSummary 1`] = `
     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2"
   >
     <button
-      class="MuiButtonBase-root MuiIconButton-root makeStyles-editButton-5"
+      class="MuiButtonBase-root MuiIconButton-root makeStyles-editButton-6"
       tabindex="0"
       type="button"
     >
@@ -23,13 +23,13 @@ exports[`MultipleChoiceSummary MultipleChoiceSummary 1`] = `
         class="MuiIconButton-label"
       >
         <p
-          class="MuiTypography-root makeStyles-change-7 MuiTypography-body1"
+          class="MuiTypography-root makeStyles-change-8 MuiTypography-body1"
         >
           <span>
             Endre
           </span>
           <i
-            class="fa fa-editing-file makeStyles-editIcon-6"
+            class="fa fa-editing-file makeStyles-editIcon-7"
           />
         </p>
       </span>
@@ -53,7 +53,7 @@ exports[`MultipleChoiceSummary MultipleChoiceSummary 1`] = `
           id="1"
         >
           <span
-            class="MuiTypography-root MuiListItemText-primary MuiTypography-body1 MuiTypography-displayBlock"
+            class="MuiTypography-root makeStyles-data-3 MuiListItemText-primary MuiTypography-body1 MuiTypography-displayBlock"
           >
             This is a text
           </span>
@@ -67,7 +67,7 @@ exports[`MultipleChoiceSummary MultipleChoiceSummary 1`] = `
           id="2"
         >
           <span
-            class="MuiTypography-root MuiListItemText-primary MuiTypography-body1 MuiTypography-displayBlock"
+            class="MuiTypography-root makeStyles-data-3 MuiListItemText-primary MuiTypography-body1 MuiTypography-displayBlock"
           >
             This is another text
           </span>


### PR DESCRIPTION


### Screenshots
See that 3.1 (`"type": "Checkboxes"`) has the wrong font weight on summary page.
![image](https://user-images.githubusercontent.com/131616/199478282-369467c7-171a-4206-be04-6290298da391.png)
![a99bfb73-5328-4a45-81fd-931a6806007d](https://user-images.githubusercontent.com/131616/199478375-c9d56554-2084-4b35-83ff-0bbf24bef619.jpg)
