### PR TITLE
Re-introducing brokenness in flattenObject

### DIFF
--- a/src/altinn-app-frontend/src/utils/databindings.test.ts
+++ b/src/altinn-app-frontend/src/utils/databindings.test.ts
@@ -121,6 +121,23 @@ describe('utils/databindings.ts', () => {
   });
 
   describe('flattenObject', () => {
+    it('should return empty string as undefined when inside an object', () => {
+      // Testing brokenness to make sure the re-implementation to simplify flattenObject() keeps the
+      // same behaviour as the older one. This should be fixed when releasing a breaking change to
+      // support more data types.
+      testObj.anEmptyString = '';
+      testObj.anObject = { withEmptyString: '' };
+      testObj.anOtherObject = { withEmptyString: '', withContent: 'content' };
+      testObj.anArray = [{ withEmptyString: '', withContent: 'content' }];
+      const result = flattenObject(testObj);
+      expect(typeof result.anEmptyString).toBe('string');
+      expect(typeof result['anObject.withEmptyString']).toBe('undefined');
+      expect(typeof result['anObject.withContent']).toBe('undefined');
+      expect(typeof result['anOtherObject.withContent']).toBe('string');
+      expect(typeof result['anArray[0].withEmptyString']).toBe('undefined');
+      expect(typeof result['anArray[0].withContent']).toBe('string');
+    });
+
     it('should return property of type number as a string', () => {
       testObj.aNumber = 43;
       const result = flattenObject(testObj);

--- a/src/altinn-app-frontend/src/utils/databindings.ts
+++ b/src/altinn-app-frontend/src/utils/databindings.ts
@@ -215,6 +215,10 @@ export function flattenObject(data: any): any {
   for (const key of Object.keys(flat)) {
     if (flat[key] === null) {
       delete flat[key];
+    } else if (flat[key] === '' && key.indexOf('.') > 0) {
+      // For backwards compatibility, delete keys inside deeper object that are empty strings. This behaviour is
+      // not always consistent, as it is only a case for deeper object (not direct properties).
+      delete flat[key];
     } else {
       // Cast all values to strings, for backwards compatibility. Lots of code already written in frontend
       // expects data to be formatted as strings everywhere, and since this is a web application, even numeric


### PR DESCRIPTION
## Description
@StianVestli found a bug where old-style dynamics did not evaluate correctly after #546 was merged, as empty string values deep inside objects were deleted in the old `flattenObject` implementation, but that quirkyness was not carried over in #546. That caused the newer code to return an empty string (as it should be) to the conditional rendering rule function, which caused it to hide a Paragraph component that did not hide before. Breaking changes should only be released in new major versions (see #339).

## Related Issue(s)
- #546
- #339

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- ~~[ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~
