### PR TITLE
Making unit tests run only when there are changes in `src/`

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -4,17 +4,15 @@ on:
   push:
     branches: [main]
     paths:
-      - 'src/altinn-app-frontend/**'
-      - 'src/shared/**'
+      - 'src/**'
       - 'test/cypress/**'
-      - '.github/workflows/cypress-altinn-app-frontend.yml'
+      - '.github/workflows/cypress.yml'
   pull_request:
     branches: [main]
     paths:
-      - 'src/altinn-app-frontend/**'
-      - 'src/shared/**'
+      - 'src/**'
       - 'test/cypress/**'
-      - '.github/workflows/cypress-altinn-app-frontend.yml'
+      - '.github/workflows/cypress.yml'
 
   workflow_dispatch:
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -3,8 +3,14 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'src/**'
+      - '.github/workflows/unit-tests.yml'
   pull_request:
     types: [opened, synchronize, reopened]
+    paths:
+      - 'src/**'
+      - '.github/workflows/unit-tests.yml'
 
 jobs:
   unit-tests:


### PR DESCRIPTION
## Description
In #623, the unit tests run using github actions, although they're not needed (there are no changes to unit-testable code). This change limits the test so they only run when there are changes to `src/` or the unit-test workflow. This also fixes the wrong path after I renamed the cypress workflow.

## Related Issue(s)
- #623

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
