### PR TITLE
Schema: Require either numeric or pattern format

### DIFF
--- a/schemas/json/component/number-format.schema.v1.json
+++ b/schemas/json/component/number-format.schema.v1.json
@@ -5,7 +5,7 @@
   "description": "Schema that describes the options that can be configured for number formatting on an `input` component, based on react-number-format package. For complete list of available options, see https://s-yadav.github.io/react-number-format/docs/props",
   "type": "object",
   "additionalProperties": true,
-  "oneOf": [
+  "anyOf": [
     {
       "properties": {
         "allowedDecimalSeparators": {

--- a/schemas/json/component/number-format.schema.v1.json
+++ b/schemas/json/component/number-format.schema.v1.json
@@ -2,97 +2,123 @@
   "$id": "https://altinncdn.no/schemas/json/component/number-format.schema.v1.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Input number formatting",
-  "description": "Schema that describes the options that can be configured for number formatting on an `input` component, based on react-number-format package. For complete list of available options, see https://github.com/s-yadav/react-number-format#props",
+  "description": "Schema that describes the options that can be configured for number formatting on an `input` component, based on react-number-format package. For complete list of available options, see https://s-yadav.github.io/react-number-format/docs/props",
   "type": "object",
   "additionalProperties": true,
-  "properties": {
-    "allowedDecimalSeparators": {
-      "title": "Allowed decimal separators",
-      "description": "Characters which when pressed result in a decimal separator. When missing, decimalSeparator and '.' are used",
-      "type": "array",
-      "items": {
-        "type": "string",
-        "maxLength": 1
+  "oneOf": [
+    {
+      "properties": {
+        "allowedDecimalSeparators": {
+          "title": "Allowed decimal separators",
+          "description": "Characters which when pressed result in a decimal separator. When missing, decimalSeparator and '.' are used",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "maxLength": 1
+          },
+          "examples": [[",", ".", "/"]]
+        },
+        "allowEmptyFormatting": false,
+        "allowLeadingZeros": {
+          "title": "Allow leading zeros",
+          "description": "Allow leading zeros at beginning of number",
+          "type": "boolean",
+          "default": false
+        },
+        "allowNegative": {
+          "title": "Allow negative",
+          "description": "Allow negative numbers (Only when format option is not provided)",
+          "type": "boolean",
+          "default": true
+        },
+        "decimalScale": {
+          "title": "Decimal scale",
+          "description": "If defined it limits to given decimal scale.",
+          "type": "number",
+          "examples": [1, 2, 3]
+        },
+        "decimalSeparator": {
+          "title": "Decimal separator",
+          "description": "Support decimal point on a number. Single character string.",
+          "type": "string",
+          "maxLength": 1,
+          "default": "."
+        },
+        "fixedDecimalScale": {
+          "title": "Fixed decimal scale",
+          "description": "Used together with decimalScale. If true it adds 0s to match given decimal scale.",
+          "type": "boolean",
+          "default": false
+        },
+        "format": false,
+        "mask": false,
+        "prefix": {
+          "title": "Prefix",
+          "description": "Add a prefix before the number",
+          "type": "string",
+          "examples": ["$", "kr", "-", "(+47) "]
+        },
+        "suffix": {
+          "title": "Suffix",
+          "description": "Add a suffix after the number",
+          "type": "string",
+          "examples": ["%", "kr", "kg"]
+        },
+        "thousandSeparator": {
+          "title": "Thousand separator",
+          "description": "Add thousand separators on number. Single character string or boolean true (true is default to ,)",
+          "type": ["string", "boolean"],
+          "maxLength": 1,
+          "examples": [true, ",", "."]
+        }
       },
-      "examples": [[",", ".", "/"]]
-    },
-    "allowEmptyFormatting": {
-      "title": "Allow empty formatting",
-      "description": "Apply formatting to empty inputs",
-      "type": "boolean",
-      "default": false
-    },
-    "allowLeadingZeros": {
-      "title": "Allow leading zeros",
-      "description": "Allow leading zeros at beginning of number",
-      "type": "boolean",
-      "default": false
-    },
-    "allowNegative": {
-      "title": "Allow negative",
-      "description": "Allow negative numbers (Only when format option is not provided)",
-      "type": "boolean",
-      "default": true
-    },
-    "decimalScale": {
-      "title": "Decimal scale",
-      "description": "If defined it limits to given decimal scale.",
-      "type": "number",
-      "examples": [1, 2, 3]
-    },
-    "decimalSeparator": {
-      "title": "Decimal separator",
-      "description": "Support decimal point on a number. Single character string.",
-      "type": "string",
-      "maxLength": 1,
-      "default": "."
-    },
-    "fixedDecimalScale": {
-      "title": "Fixed decimal scale",
-      "description": "Used together with decimalScale. If true it adds 0s to match given decimal scale.",
-      "type": "boolean",
-      "default": false
-    },
-    "format": {
-      "title": "Format",
-      "description": "Format given as hash string, to allow number input in place of hash.",
-      "type": "string",
-      "examples": ["### ### ###", "+47 ### ## ###", "##-##-##-##"]
-    },
-    "mask": {
-      "title": "Mask",
-      "description": "Mask to show in place of non-entered values",
-      "type": "string",
-      "examples": ["_"],
-      "default": " "
-    },
-    "prefix": {
-      "title": "Prefix",
-      "description": "Add a prefix before the number",
-      "type": "string",
-      "examples": ["$", "kr", "-", "(+47) "]
-    },
-    "suffix": {
-      "title": "Suffix",
-      "description": "Add a suffix after the number",
-      "type": "string",
-      "examples": ["%", "kr", "kg"]
-    },
-    "thousandSeparator": {
-      "title": "Thousand separator",
-      "description": "Add thousand separators on number. Single character string or boolean true (true is default to ,)",
-      "type": ["string", "boolean"],
-      "maxLength": 1,
-      "examples": [true, ",", "."]
-    }
-  },
-  "allOf": [{
-    "if": {
-      "properties": { "fixedDecimalScale": { "const": true } },
-      "required": ["fixedDecimalScale"]
+      "if": {
+        "required": ["fixedDecimalScale"],
+        "properties": { "fixedDecimalScale": { "const": true } }
       },
-      "then": { 
+      "then": {
         "required": ["decimalScale"]
+      }
+    },
+    {
+      "properties": {
+        "allowedDecimalSeparators": false,
+        "allowEmptyFormatting": {
+          "title": "Allow empty formatting",
+          "description": "Apply formatting to empty inputs",
+          "type": "boolean",
+          "default": false
+        },
+        "allowLeadingZeros": false,
+        "allowNegative": false,
+        "decimalScale": false,
+        "decimalSeparator": false,
+        "fixedDecimalScale": false,
+        "format": {
+          "title": "Format",
+          "description": "Format given as hash string, to allow number input in place of hash.",
+          "type": "string",
+          "examples": ["### ### ###", "+47 ### ## ###", "##-##-##-##"]
+        },
+        "mask": {
+          "title": "Mask",
+          "description": "Mask to show in place of non-entered values",
+          "type": "string",
+          "examples": ["_"],
+          "default": " "
+        },
+        "prefix": false,
+        "suffix": false,
+        "thousandSeparator": false
+      },
+      "if": {
+        "anyOf": [
+          { "required": ["mask"] },
+          { "required": ["allowEmptyFormatting"] }
+        ]
+      },
+      "then": {
+        "required": ["format"]
       }
     }
   ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Since `react-number-format` v5, the split between NumericFormat (thousand-separator, suffix, etc.) and PatternFormat (format, mask, etc.) is more explicit. For backwards compatibility, our implementation ignores this and figures out which component to use based on the props provided. In order to make it easier to set up number-formatting I have updated the schema so that you can either provide props only for NumericFormat, or only for PatternFormat. Additionally, when using PatternFormat, the `format`-prop is required, this can now be enforced in the schema, since there are effectively two sets of allowed properties with their own restrictions.

At first, all properties are valid:

<img width="241" alt="image" src="https://user-images.githubusercontent.com/47412359/199960867-e8e0acaf-2f17-47a8-8b7d-2136d2a00998.png">

If you add `format`, it will now only match the PatternFormat-props:

<img width="241" alt="image" src="https://user-images.githubusercontent.com/47412359/199961060-b77ba280-9738-4cfd-8d23-8d902d37e970.png">

It will also inform that `format` is required for PatternFormat:

<img width="241" alt="image" src="https://user-images.githubusercontent.com/47412359/199961197-8ac15023-ace5-4b7a-9479-08c740c1fb92.png">

If you add props from NumericFormat, it will no longer suggest props from PatternFormat (format, mask, etc.):

<img width="241" alt="image" src="https://user-images.githubusercontent.com/47412359/199961306-f149898f-3bff-4259-9e95-39be4446a089.png">


## Related Issue(s)
- https://github.com/Altinn/altinn-design-system/pull/156

## Verification
- ~~**Your** code builds clean without any errors or warnings~~
- [x] Manual testing done (required)
- ~~Relevant automated test added (if you find this hard, leave it and we'll help out)~~
- ~~All tests run green~~

## Documentation
- ~~User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~
