### PR TITLE
Removing validation messages when hiding fields using dynamics

### DIFF
--- a/src/altinn-app-frontend/__mocks__/initialStateMock.ts
+++ b/src/altinn-app-frontend/__mocks__/initialStateMock.ts
@@ -39,7 +39,6 @@ export function getInitialStateMock(customStates?: Partial<IRuntimeState>): IRun
       validations: {},
       error: null,
       invalidDataTypes: [],
-      currentSingleFieldValidation: null,
     },
     instanceData: getInstanceDataStateMock(),
     instantiation: {

--- a/src/altinn-app-frontend/src/components/GenericComponent.tsx
+++ b/src/altinn-app-frontend/src/components/GenericComponent.tsx
@@ -12,7 +12,6 @@ import Label from 'src/features/form/components/Label';
 import Legend from 'src/features/form/components/Legend';
 import { FormDataActions } from 'src/features/form/data/formDataSlice';
 import { FormLayoutActions } from 'src/features/form/layout/formLayoutSlice';
-import { ValidationActions } from 'src/features/form/validation/validationSlice';
 import { makeGetFocus, makeGetHidden } from 'src/selectors/getLayoutData';
 import { LayoutStyle, Triggers } from 'src/types';
 import {
@@ -27,6 +26,7 @@ import {
 import { renderValidationMessagesForComponent } from 'src/utils/render';
 import type { IComponentProps, IFormComponentContext, PropsFromGenericComponent } from 'src/components';
 import type { ExprResolved } from 'src/features/expressions/types';
+import type { ISingleFieldValidation } from 'src/features/form/data/formDataTypes';
 import type {
   ComponentExceptGroup,
   ComponentTypes,
@@ -183,15 +183,13 @@ export function GenericComponent<Type extends ComponentExceptGroup>(_props: IAct
     }
 
     const dataModelBinding = props.dataModelBindings[key];
-    if (props.triggers && props.triggers.includes(Triggers.Validation)) {
-      dispatch(
-        ValidationActions.setCurrentSingleFieldValidation({
-          dataModelBinding,
-          componentId: props.id,
-          layoutId: currentView,
-        }),
-      );
-    }
+    const singleFieldValidation: ISingleFieldValidation | undefined =
+      props.triggers && props.triggers.includes(Triggers.Validation)
+        ? {
+            layoutId: currentView,
+            dataModelBinding,
+          }
+        : undefined;
 
     dispatch(
       FormDataActions.update({
@@ -199,6 +197,7 @@ export function GenericComponent<Type extends ComponentExceptGroup>(_props: IAct
         data: value,
         componentId: props.id,
         skipValidation: !validate,
+        singleFieldValidation,
       }),
     );
   };

--- a/src/altinn-app-frontend/src/components/message/ErrorReport.test.tsx
+++ b/src/altinn-app-frontend/src/components/message/ErrorReport.test.tsx
@@ -15,7 +15,6 @@ describe('ErrorReport', () => {
         ...(validations as any),
       },
       invalidDataTypes: [],
-      currentSingleFieldValidation: null,
       error: null,
     };
     const initialState = getInitialStateMock({

--- a/src/altinn-app-frontend/src/components/summary/SummaryComponent.test.tsx
+++ b/src/altinn-app-frontend/src/components/summary/SummaryComponent.test.tsx
@@ -130,7 +130,6 @@ describe('SummaryComponent', () => {
             validations,
             error: null,
             invalidDataTypes: [],
-            currentSingleFieldValidation: {},
           },
         },
       },

--- a/src/altinn-app-frontend/src/features/form/containers/Form.test.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/Form.test.tsx
@@ -249,7 +249,6 @@ describe('Form', () => {
       formValidations: {
         error: null,
         invalidDataTypes: [],
-        currentSingleFieldValidation: {},
         validations: {
           page1: validations,
         },

--- a/src/altinn-app-frontend/src/features/form/containers/GroupContainerLikertTestUtils.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/GroupContainerLikertTestUtils.tsx
@@ -152,7 +152,6 @@ const createFormValidationsForCurrentView = (validations: ILayoutValidations = {
   return {
     error: null,
     invalidDataTypes: [],
-    currentSingleFieldValidation: {},
     validations: { FormLayout: validations },
   };
 };

--- a/src/altinn-app-frontend/src/features/form/data/formDataTypes.ts
+++ b/src/altinn-app-frontend/src/features/form/data/formDataTypes.ts
@@ -19,14 +19,21 @@ export interface ISubmitDataAction {
   componentId: string;
 }
 
+export interface ISingleFieldValidation {
+  layoutId: string;
+  dataModelBinding: string;
+}
+
 export interface ISaveAction {
   field?: string;
   componentId?: string;
+  singleFieldValidation?: ISingleFieldValidation;
 }
 
 export interface IUpdateFormDataProps {
   skipValidation?: boolean;
   skipAutoSave?: boolean;
+  singleFieldValidation?: ISingleFieldValidation;
 }
 
 export interface IUpdateFormData extends IUpdateFormDataProps {

--- a/src/altinn-app-frontend/src/features/form/data/submit/submitFormDataSagas.ts
+++ b/src/altinn-app-frontend/src/features/form/data/submit/submitFormDataSagas.ts
@@ -149,7 +149,7 @@ function* handleCalculationUpdate(changedFields) {
 }
 
 export function* saveFormDataSaga({
-  payload: { field, componentId },
+  payload: { field, componentId, singleFieldValidation },
 }: PayloadAction<IUpdateFormDataFulfilled>): SagaIterator {
   try {
     const state: IRuntimeState = yield select();
@@ -169,8 +169,14 @@ export function* saveFormDataSaga({
       yield call(putFormData, { state, model, field, componentId });
     }
 
-    if (state.formValidations.currentSingleFieldValidation?.dataModelBinding) {
-      yield sagaPut(ValidationActions.runSingleFieldValidation());
+    if (singleFieldValidation && componentId) {
+      yield sagaPut(
+        ValidationActions.runSingleFieldValidation({
+          componentId,
+          dataModelBinding: singleFieldValidation.dataModelBinding,
+          layoutId: singleFieldValidation.layoutId,
+        }),
+      );
     }
 
     yield sagaPut(FormDataActions.submitFulfilled());
@@ -219,7 +225,7 @@ export function* saveStatelessData({ state, model, field, componentId }: SaveDat
 }
 
 export function* autoSaveSaga({
-  payload: { skipAutoSave, field, componentId },
+  payload: { skipAutoSave, field, componentId, singleFieldValidation },
 }: PayloadAction<IUpdateFormDataFulfilled>): SagaIterator {
   if (skipAutoSave) {
     return;
@@ -228,6 +234,6 @@ export function* autoSaveSaga({
   const uiConfig: IUiConfig = yield select(UIConfigSelector);
   if (uiConfig.autoSave !== false) {
     // undefined should default to auto save
-    yield sagaPut(FormDataActions.save({ field, componentId }));
+    yield sagaPut(FormDataActions.save({ field, componentId, singleFieldValidation }));
   }
 }

--- a/src/altinn-app-frontend/src/features/form/data/update/updateFormDataSagas.ts
+++ b/src/altinn-app-frontend/src/features/form/data/update/updateFormDataSagas.ts
@@ -16,7 +16,7 @@ import type { IAttachments } from 'src/shared/resources/attachments';
 import type { IRuntimeState } from 'src/types';
 
 export function* updateFormDataSaga({
-  payload: { field, data, componentId, skipValidation, skipAutoSave },
+  payload: { field, data, componentId, skipValidation, skipAutoSave, singleFieldValidation },
 }: PayloadAction<IUpdateFormData>): SagaIterator {
   try {
     const state: IRuntimeState = yield select();
@@ -33,6 +33,7 @@ export function* updateFormDataSaga({
           data,
           skipValidation,
           skipAutoSave,
+          singleFieldValidation,
         }),
       );
     }

--- a/src/altinn-app-frontend/src/features/form/dynamics/conditionalRendering/conditionalRenderingSagas.ts
+++ b/src/altinn-app-frontend/src/features/form/dynamics/conditionalRendering/conditionalRenderingSagas.ts
@@ -49,15 +49,17 @@ export function* checkIfConditionalRulesShouldRunSaga(): SagaIterator {
       for (const layout of Object.values(newFormValidations)) {
         for (const componentId of newlyHidden) {
           if (layout[componentId]) {
-            delete newFormValidations[componentId];
+            delete layout[componentId];
             validationsChanged = true;
           }
         }
       }
       if (validationsChanged) {
-        ValidationActions.updateValidations({
-          validations: newFormValidations,
-        });
+        yield put(
+          ValidationActions.updateValidations({
+            validations: newFormValidations,
+          }),
+        );
       }
     }
 

--- a/src/altinn-app-frontend/src/features/form/dynamics/conditionalRendering/conditionalRenderingSagas.ts
+++ b/src/altinn-app-frontend/src/features/form/dynamics/conditionalRendering/conditionalRenderingSagas.ts
@@ -43,14 +43,17 @@ export function* checkIfConditionalRulesShouldRunSaga(): SagaIterator {
         }),
       );
 
-      const newFormValidations = { ...formValidations };
+      const newlyHidden = Array.from(futureHiddenFields).filter((i) => !hiddenFields.has(i));
+      const newFormValidations: IValidations = JSON.parse(JSON.stringify(formValidations));
       let validationsChanged = false;
-      futureHiddenFields.forEach((componentId) => {
-        if (newFormValidations[componentId]) {
-          delete newFormValidations[componentId];
-          validationsChanged = true;
+      for (const layout of Object.values(newFormValidations)) {
+        for (const componentId of newlyHidden) {
+          if (layout[componentId]) {
+            delete newFormValidations[componentId];
+            validationsChanged = true;
+          }
         }
-      });
+      }
       if (validationsChanged) {
         ValidationActions.updateValidations({
           validations: newFormValidations,

--- a/src/altinn-app-frontend/src/features/form/rules/check/checkRulesSagas.ts
+++ b/src/altinn-app-frontend/src/features/form/rules/check/checkRulesSagas.ts
@@ -22,13 +22,12 @@ export interface IResponse {
 }
 
 export function* checkIfRuleShouldRunSaga({
-  payload: { field, skipAutoSave, skipValidation },
+  payload: { field, skipAutoSave, skipValidation, singleFieldValidation },
 }: PayloadAction<IUpdateFormDataFulfilled>): SagaIterator {
   try {
     const ruleConnectionState: IRuleConnections | null = yield select(selectRuleConnection);
     const formDataState: IFormDataState = yield select(selectFormDataConnection);
     const formLayoutState: ILayoutState = yield select(selectFormLayoutConnection);
-
     const rules: IResponse[] = checkIfRuleShouldRun(ruleConnectionState, formDataState, formLayoutState.layouts, field);
 
     if (rules.length > 0) {
@@ -46,6 +45,7 @@ export function* checkIfRuleShouldRunSaga({
               field: rule.dataBindingName,
               skipValidation,
               skipAutoSave,
+              singleFieldValidation,
             }),
           );
         }),

--- a/src/altinn-app-frontend/src/features/form/validation/singleField/singleFieldValidationSagas.test.ts
+++ b/src/altinn-app-frontend/src/features/form/validation/singleField/singleFieldValidationSagas.test.ts
@@ -18,11 +18,6 @@ describe('singleFieldValidationSagas', () => {
 
   beforeEach(() => {
     mockState = getInitialStateMock();
-    mockState.formValidations.currentSingleFieldValidation = {
-      dataModelBinding: mockTriggerField,
-      componentId: 'mockId',
-      layoutId: 'formLayout',
-    };
   });
 
   it('runSingleFieldValidationSaga, single field validation is triggered', () => {
@@ -57,12 +52,18 @@ describe('singleFieldValidationSagas', () => {
       },
     };
 
-    return expectSaga(runSingleFieldValidationSaga)
+    return expectSaga(runSingleFieldValidationSaga, {
+      type: '',
+      payload: {
+        dataModelBinding: mockTriggerField,
+        layoutId: 'FormLayout',
+        componentId: 'field1',
+      },
+    })
       .provide([
         [select(), mockState],
         [call(get, url, options), validationIssues],
       ])
-      .put(ValidationActions.setCurrentSingleFieldValidation({}))
       .put(
         ValidationActions.runSingleFieldValidationFulfilled({
           validations: mappedValidations,
@@ -83,12 +84,18 @@ describe('singleFieldValidationSagas', () => {
       },
     };
     const error = new Error('Error');
-    return expectSaga(runSingleFieldValidationSaga)
+    return expectSaga(runSingleFieldValidationSaga, {
+      type: '',
+      payload: {
+        dataModelBinding: mockTriggerField,
+        layoutId: 'FormLayout',
+        componentId: 'field1',
+      },
+    })
       .provide([
         [select(), mockState],
         [call(get, url, options), throwError(error)],
       ])
-      .put(ValidationActions.setCurrentSingleFieldValidation({}))
       .put(ValidationActions.runSingleFieldValidationRejected({ error }))
       .run();
   });

--- a/src/altinn-app-frontend/src/features/form/validation/validationSlice.test.ts
+++ b/src/altinn-app-frontend/src/features/form/validation/validationSlice.test.ts
@@ -1,12 +1,11 @@
 import slice, { initialState, ValidationActions } from 'src/features/form/validation/validationSlice';
 import type { IValidationState } from 'src/features/form/validation/validationSlice';
-import type { IComponentValidations, ICurrentSingleFieldValidation, IValidations } from 'src/types';
+import type { IComponentValidations, IValidations } from 'src/types';
 
 describe('validationSlice', () => {
   let state: IValidationState;
   let mockValidations: IValidations;
   let mockError: Error;
-  let mockSingleFieldValidationField: ICurrentSingleFieldValidation;
 
   beforeEach(() => {
     state = initialState;
@@ -21,11 +20,6 @@ describe('validationSlice', () => {
       },
     };
     mockError = new Error('Something went wrong');
-    mockSingleFieldValidationField = {
-      dataModelBinding: 'mockField',
-      componentId: 'mockComponent',
-      layoutId: 'formLayout',
-    };
   });
 
   it('handles runSingleFieldValidationFulfilled action', () => {
@@ -41,16 +35,6 @@ describe('validationSlice', () => {
   it('handles runSingleFieldValidationRejected action', () => {
     const nextState = slice.reducer(state, ValidationActions.runSingleFieldValidationRejected({ error: mockError }));
     expect(nextState.error).toEqual(mockError);
-  });
-
-  it('handles setCurrentSingleFieldValidation action', () => {
-    const nextState = slice.reducer(
-      state,
-      ValidationActions.setCurrentSingleFieldValidation({
-        ...mockSingleFieldValidationField,
-      }),
-    );
-    expect(nextState.currentSingleFieldValidation).toEqual(mockSingleFieldValidationField);
   });
 
   it('handles updateComponentValidations action', () => {

--- a/src/altinn-app-frontend/src/features/form/validation/validationSlice.ts
+++ b/src/altinn-app-frontend/src/features/form/validation/validationSlice.ts
@@ -1,13 +1,12 @@
 import { runSingleFieldValidationSaga } from 'src/features/form/validation/singleField/singleFieldValidationSagas';
 import { createSagaSlice } from 'src/shared/resources/utils/sagaSlice';
 import type { MkActionType } from 'src/shared/resources/utils/sagaSlice';
-import type { IComponentValidations, ICurrentSingleFieldValidation, IValidations } from 'src/types';
+import type { IComponentValidations, IValidations } from 'src/types';
 
 export interface IValidationState {
   validations: IValidations;
   invalidDataTypes: string[];
   error: Error | null;
-  currentSingleFieldValidation: ICurrentSingleFieldValidation | null;
 }
 
 export interface IUpdateComponentValidations {
@@ -21,28 +20,27 @@ export interface IUpdateValidations {
   validations: IValidations;
 }
 
-export interface IValidationActionRejected {
-  error: Error;
+export interface IRunSingleFieldValidation {
+  dataModelBinding: string;
+  componentId: string;
+  layoutId: string;
 }
 
-export interface ISetCurrentSingleFieldValidationAction {
-  dataModelBinding?: string;
-  componentId?: string;
-  layoutId?: string;
+export interface IValidationActionRejected {
+  error: Error;
 }
 
 export const initialState: IValidationState = {
   validations: {},
   error: null,
   invalidDataTypes: [],
-  currentSingleFieldValidation: {},
 };
 
 const validationSlice = createSagaSlice((mkAction: MkActionType<IValidationState>) => ({
   name: 'formValidations',
   initialState,
   actions: {
-    runSingleFieldValidation: mkAction<void>({
+    runSingleFieldValidation: mkAction<IRunSingleFieldValidation>({
       takeLatest: runSingleFieldValidationSaga,
     }),
     runSingleFieldValidationFulfilled: mkAction<IUpdateValidations>({
@@ -55,16 +53,6 @@ const validationSlice = createSagaSlice((mkAction: MkActionType<IValidationState
       reducer: (state, action) => {
         const { error } = action.payload;
         state.error = error;
-      },
-    }),
-    setCurrentSingleFieldValidation: mkAction<ISetCurrentSingleFieldValidationAction>({
-      reducer: (state, action) => {
-        const { dataModelBinding, componentId, layoutId } = action.payload;
-        state.currentSingleFieldValidation = {
-          dataModelBinding,
-          componentId,
-          layoutId,
-        };
       },
     }),
     updateComponentValidations: mkAction<IUpdateComponentValidations>({

--- a/src/altinn-app-frontend/src/shared/containers/Presentation.test.tsx
+++ b/src/altinn-app-frontend/src/shared/containers/Presentation.test.tsx
@@ -36,7 +36,6 @@ const stateWithErrorsAndWarnings = getInitialStateMock({
     },
     invalidDataTypes: [],
     error: null,
-    currentSingleFieldValidation: null,
   },
 });
 

--- a/src/altinn-app-frontend/src/types/index.ts
+++ b/src/altinn-app-frontend/src/types/index.ts
@@ -214,12 +214,6 @@ export interface ILayoutValidations {
   [id: string]: IComponentValidations;
 }
 
-export interface ICurrentSingleFieldValidation {
-  dataModelBinding?: string;
-  componentId?: string;
-  layoutId?: string;
-}
-
 export interface IVariable {
   dataSource: string;
   key: string;

--- a/test/cypress/e2e/integration/app-frontend/dynamics.js
+++ b/test/cypress/e2e/integration/app-frontend/dynamics.js
@@ -44,12 +44,18 @@ describe('Dynamics', () => {
       return component;
     });
     cy.navigateToChangeName();
-    cy.get(appFrontend.changeOfName.newFirstName).should('be.visible').type('test');
+    cy.get(appFrontend.changeOfName.newFirstName).type('test');
     cy.get(appFrontend.errorReport)
       .should('exist')
       .should('be.visible')
       .should('contain.text', texts.testIsNotValidValue);
-    cy.get(appFrontend.changeOfName.newLastName).should('be.visible').type('hideFirstName');
+    cy.get(appFrontend.changeOfName.newLastName).type('hideFirstName');
     cy.get(appFrontend.errorReport).should('not.exist');
+    cy.get(appFrontend.changeOfName.newLastName).clear();
+    cy.get(appFrontend.changeOfName.newFirstName).should('be.visible');
+    cy.get(appFrontend.errorReport)
+      .should('exist')
+      .should('be.visible')
+      .should('contain.text', texts.testIsNotValidValue);
   });
 });

--- a/test/cypress/e2e/integration/app-frontend/dynamics.js
+++ b/test/cypress/e2e/integration/app-frontend/dynamics.js
@@ -2,15 +2,13 @@
 /// <reference types="../../support" />
 
 import AppFrontend from '../../pageobjects/app-frontend';
+import * as texts from '../../fixtures/texts.json';
 
 const appFrontend = new AppFrontend();
 
 describe('Dynamics', () => {
-  beforeEach(() => {
-    cy.navigateToChangeName();
-  });
-
   it('Show and hide confirm name change checkbox on changing firstname', () => {
+    cy.navigateToChangeName();
     cy.get(appFrontend.changeOfName.newFirstName)
       .should('be.visible')
       .type('test')
@@ -27,9 +25,31 @@ describe('Dynamics', () => {
   });
 
   it('Show and hide name change reasons radio buttons', () => {
+    cy.navigateToChangeName();
     cy.get(appFrontend.changeOfName.newFirstName).should('be.visible').type('test');
     cy.get(appFrontend.changeOfName.newLastName).should('be.visible').type('test');
     cy.get(appFrontend.changeOfName.confirmChangeName).should('be.visible').find('input').check();
     cy.get(appFrontend.changeOfName.reasons).should('be.visible');
+  });
+
+  it('Remove validation message when field disappears', ()  => {
+    cy.interceptLayout('changename', (component) => {
+      if (component.id === 'newFirstName') {
+        component.hidden = [
+          'equals',
+          'hideFirstName',
+          ['component', 'newLastName'],
+        ];
+      }
+      return component;
+    });
+    cy.navigateToChangeName();
+    cy.get(appFrontend.changeOfName.newFirstName).should('be.visible').type('test');
+    cy.get(appFrontend.errorReport)
+      .should('exist')
+      .should('be.visible')
+      .should('contain.text', texts.testIsNotValidValue);
+    cy.get(appFrontend.changeOfName.newLastName).should('be.visible').type('hideFirstName');
+    cy.get(appFrontend.errorReport).should('not.exist');
   });
 });

--- a/test/cypress/e2e/support/app-frontend.js
+++ b/test/cypress/e2e/support/app-frontend.js
@@ -184,9 +184,11 @@ Cypress.Commands.add('getReduxState', (selector) => {
 Cypress.Commands.add('interceptLayout', (layoutName, mutator) => {
   cy.intercept(`**/api/layouts/${layoutName}`, (req) => {
     req.reply((res) => {
-      const modified = JSON.parse(res.body);
-      modified.repeating.data.layout = modified.repeating.data.layout.map(mutator);
-      res.send(JSON.stringify(modified));
+      const set = JSON.parse(res.body);
+      for (const layout of Object.values(set)) {
+        layout.data.layout = layout.data.layout.map(mutator);
+      }
+      res.send(JSON.stringify(set));
     });
   });
 });


### PR DESCRIPTION
## Description
This change removes validation messages when fields are hidden. This is sub-optimal, as validations should also be hidden along with fields - but implementing such a change is quite a bit riskier (since every location working with validations would have to take into consideration if the validation messages should be hidden or not).

This change is a bit large because:
- It changes the 'single field validation' functionality to pass data/dependencies through other actions instead of relying on global redux state being set in `GenericComponent` which magically gets read by the single field validation action later. That was tied to only being able to work on one field at a time, and it was non-obvious which actions could lead to single-field validation.
- In addition to making sure validation errors disappear, this should also make sure they re-appear when they are removed because the field was hidden for a while.

## Related Issue(s)
- closes #617
- #296
- #628

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- ~~[ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~
