### PR TITLE
Fixing panel with groupReference when used inside repeating group

### DIFF
--- a/src/altinn-app-frontend/src/utils/formLayout.ts
+++ b/src/altinn-app-frontend/src/utils/formLayout.ts
@@ -314,9 +314,11 @@ export function createRepeatingGroupComponentsForIndex({
 }: ICreateRepeatingGroupCoomponentsForIndexProps) {
   return renderComponents.map((component: ILayoutComponent | ILayoutGroup) => {
     if (component.type === 'Group' && component.panel?.groupReference) {
-      // Do not treat as a regular group child as this is merely an option to add elements for another group from this group context
+      // Do not treat as a regular group child as this is merely an option
+      // to add elements for another group from this group context
       return {
         ...component,
+        id: `${component.id}-${index}`,
         baseComponentId: component.id, // used to indicate that it is a child group
       };
     }


### PR DESCRIPTION
## Description
The group with panel + groupReference didn't get the correct component ID set, making it so that hiding the component did not work properly.

## Related Issue(s)
- closes #599

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- ~~[ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~
