### PR TITLE
Expressions: Adding `not` function

### DIFF
--- a/src/altinn-app-frontend/src/features/expressions/index.ts
+++ b/src/altinn-app-frontend/src/features/expressions/index.ts
@@ -261,6 +261,11 @@ export const ExprFunctions = {
     args: ['string', 'string'] as const,
     returns: 'boolean',
   }),
+  not: defineFunc({
+    impl: (arg) => !arg,
+    args: ['boolean'] as const,
+    returns: 'boolean',
+  }),
   greaterThan: defineFunc({
     impl: (arg1, arg2) => {
       if (arg1 === null || arg2 === null) {

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/not/not-changes-notNull-to-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/not/not-changes-notNull-to-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Not errors on string \"notNull\"",
+  "expression": ["not", "notNull"],
+  "expectsFailure": "Expected boolean, got value \"notNull\""
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/not/not-changes-null-to-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/not/not-changes-null-to-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Not changes not null to true",
+  "expression": ["not", null],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/not/not-errors-on-numbers-not-0-or-1.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/not/not-errors-on-numbers-not-0-or-1.json
@@ -1,0 +1,5 @@
+{
+  "name": "Not errors on numbers not 0 or 1",
+  "expression": ["not", 1337],
+  "expectsFailure": "Expected boolean, got value 1337"
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/not/not-errors-on-two-arguments.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/not/not-errors-on-two-arguments.json
@@ -1,5 +1,5 @@
 {
-  "name": "Not errors zero arguments",
+  "name": "Not errors two arguments",
   "expression": ["not", 3, 34, 5],
   "expectsFailure": "Expected 1 argument(s), got 3"
 }

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/not/not-errors-on-zero-arguments.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/not/not-errors-on-zero-arguments.json
@@ -1,0 +1,5 @@
+{
+  "name": "Not errors zero arguments",
+  "expression": ["not"],
+  "expectsFailure": "Expected 1 argument(s), got 0"
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/not/not-erros-on-two-arguments.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/not/not-erros-on-two-arguments.json
@@ -1,0 +1,5 @@
+{
+  "name": "Not errors zero arguments",
+  "expression": ["not", 3, 34, 5],
+  "expectsFailure": "Expected 1 argument(s), got 3"
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/not/not-handles-numeric-zero-as-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/not/not-handles-numeric-zero-as-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Not handles numeric zero as true",
+  "expression": ["not", 0],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/not/not-inverts-false.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/not/not-inverts-false.json
@@ -1,0 +1,5 @@
+{
+  "name": "Not inverts false",
+  "expression": ["not", false],
+  "expects": true
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/not/not-inverts-true.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/not/not-inverts-true.json
@@ -1,0 +1,5 @@
+{
+  "name": "Not inverts true",
+  "expression": ["not", true],
+  "expects": false
+}


### PR DESCRIPTION
## Description
This adds a `not` function. Tests written by	 @ivarne (slightly modified to fit the common error message when argument length is wrong)

## Related Issue(s)
- #630

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- ~~[ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~
