### PR TITLE
Expressions: `any` type and shared tests sync

### DIFF
--- a/src/altinn-app-frontend/src/features/expressions/index.ts
+++ b/src/altinn-app-frontend/src/features/expressions/index.ts
@@ -171,27 +171,18 @@ function innerEvalExpr(context: ExprContext) {
   const [func, ...args] = context.getExpr();
 
   const returnType = ExprFunctions[func].returns;
-  const neverCastIndexes = new Set(ExprFunctions[func].neverCastArguments || []);
 
   const computedArgs = args.map((arg, idx) => {
     const realIdx = idx + 1;
     const argContext = ExprContext.withPath(context, [...context.path, `[${realIdx}]`]);
 
     const argValue = Array.isArray(arg) ? innerEvalExpr(argContext) : arg;
-    if (neverCastIndexes.has(idx)) {
-      return argValue;
-    }
-
     const argType = argTypeAt(func, idx);
     return castValue(argValue, argType, argContext);
   });
 
   const actualFunc: (...args: any) => any = ExprFunctions[func].impl;
   const returnValue = actualFunc.apply(context, computedArgs);
-
-  if (ExprFunctions[func].castReturnValue === false) {
-    return returnValue;
-  }
 
   return castValue(returnValue, returnType, context);
 }
@@ -325,9 +316,9 @@ export const ExprFunctions = {
     lastArgSpreads: true,
   }),
   if: defineFunc({
-    impl: function (...args) {
+    impl: function (...args): any {
       const [condition, result] = args;
-      if (condition === 'true') {
+      if (condition === true) {
         return result;
       }
 
@@ -345,11 +336,8 @@ export const ExprFunctions = {
       }
       addError(ctx, path, 'Expected either 2 arguments (if) or 4 (if + else), got %s', `${rawArgs.length}`);
     },
-    args: ['string', 'string'],
-    returns: 'string',
-    lastArgSpreads: true,
-    neverCastArguments: [1, 3],
-    castReturnValue: false,
+    args: ['boolean', 'any', 'string', 'any'],
+    returns: 'any',
   }),
   instanceContext: defineFunc({
     impl: function (key): string | null {
@@ -367,7 +355,7 @@ export const ExprFunctions = {
     returns: 'string',
   }),
   frontendSettings: defineFunc({
-    impl: function (key): string | null {
+    impl: function (key): any {
       if (key === null) {
         throw new LookupNotFound(this, `Cannot lookup property null`);
       }
@@ -375,10 +363,10 @@ export const ExprFunctions = {
       return (this.dataSources.applicationSettings && this.dataSources.applicationSettings[key]) || null;
     },
     args: ['string'] as const,
-    returns: 'string',
+    returns: 'any',
   }),
   component: defineFunc({
-    impl: function (id): string | null {
+    impl: function (id): any {
       if (id === null) {
         throw new LookupNotFound(this, `Cannot lookup component null`);
       }
@@ -395,10 +383,10 @@ export const ExprFunctions = {
       );
     },
     args: ['string'] as const,
-    returns: 'string',
+    returns: 'any',
   }),
   dataModel: defineFunc({
-    impl: function (path): string | null {
+    impl: function (path): any {
       if (path === null) {
         throw new LookupNotFound(this, `Cannot lookup data model null`);
       }
@@ -414,7 +402,7 @@ export const ExprFunctions = {
       return this.dataSources.formData[path] || null;
     },
     args: ['string'] as const,
-    returns: 'string',
+    returns: 'any',
   }),
 };
 
@@ -442,7 +430,7 @@ export const ExprTypes: {
 } = {
   boolean: {
     nullable: true,
-    accepts: ['boolean', 'string', 'number'],
+    accepts: ['boolean', 'string', 'number', 'any'],
     impl: function (arg) {
       if (typeof arg === 'boolean') {
         return arg;
@@ -463,7 +451,7 @@ export const ExprTypes: {
   },
   string: {
     nullable: true,
-    accepts: ['boolean', 'string', 'number'],
+    accepts: ['boolean', 'string', 'number', 'any'],
     impl: function (arg) {
       if (['number', 'bigint', 'boolean'].includes(typeof arg)) {
         return JSON.stringify(arg);
@@ -479,7 +467,7 @@ export const ExprTypes: {
   },
   number: {
     nullable: true,
-    accepts: ['boolean', 'string', 'number'],
+    accepts: ['boolean', 'string', 'number', 'any'],
     impl: function (arg) {
       if (typeof arg === 'number' || typeof arg === 'bigint') {
         return arg as number;
@@ -493,6 +481,11 @@ export const ExprTypes: {
 
       throw new UnexpectedType(this, 'number', arg);
     },
+  },
+  any: {
+    nullable: true,
+    accepts: ['boolean', 'string', 'number'],
+    impl: (arg) => arg,
   },
 };
 

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/component/in-nested-group2.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/component/in-nested-group2.json
@@ -1,0 +1,101 @@
+{
+  "name": "Lookup inside nested repeating group",
+  "expression": ["component", "alder"],
+  "context": {
+    "component": "myndig",
+    "rowIndices": [1, 1],
+    "currentLayout": "Page2"
+  },
+  "expects": 14,
+  "layouts": {
+    "Page1": {
+      "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+      "data": {
+        "layout": []
+      }
+    },
+    "Page2": {
+      "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+      "data": {
+        "layout": [
+          {
+            "id": "bedrifter",
+            "type": "Group",
+            "maxCount": 99,
+            "dataModelBindings": {
+              "group": "Bedrifter"
+            },
+            "children": ["bedriftsNavn", "ansatte"]
+          },
+          {
+            "id": "bedriftsNavn",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "Bedrifter.Navn"
+            }
+          },
+          {
+            "id": "ansatte",
+            "type": "Group",
+            "maxCount": 99,
+            "dataModelBindings": {
+              "group": "Bedrifter.Ansatte"
+            },
+            "children": ["navn", "alder", "myndig"]
+          },
+          {
+            "id": "navn",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "Bedrifter.Ansatte.Navn"
+            }
+          },
+          {
+            "id": "alder",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "Bedrifter.Ansatte.Alder"
+            }
+          },
+          {
+            "id": "myndig",
+            "type": "Paragraph",
+            "textResourceBindings": {
+              "title": "Hurra, den ansatte er myndig!"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "dataModel": {
+    "Bedrifter": [
+      {
+        "Navn": "Hell og lykke AS",
+        "Ansatte": [
+          {
+            "Navn": "Kaare",
+            "Alder": 24
+          },
+          {
+            "Navn": "Per",
+            "Alder": 24
+          }
+        ]
+      },
+      {
+        "Navn": "Nedtur og motgang AS",
+        "Ansatte": [
+          {
+            "Navn": "Arne",
+            "Alder": 24
+          },
+          {
+            "Navn": "Vidar",
+            "Alder": 14
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared.test.ts
+++ b/src/altinn-app-frontend/src/features/expressions/shared.test.ts
@@ -48,7 +48,8 @@ describe('Expressions shared function tests', () => {
             return evalExpr(expr as Expression, component, dataSources);
           }).toThrow(expectsFailure);
         } else {
-          expect(evalExpr(expression, component, dataSources)).toEqual(expects);
+          const expr = asExpression(expression) as Expression;
+          expect(evalExpr(expr, component, dataSources)).toEqual(expects);
         }
       },
     );

--- a/src/altinn-app-frontend/src/features/expressions/types.ts
+++ b/src/altinn-app-frontend/src/features/expressions/types.ts
@@ -11,7 +11,7 @@ type Functions = typeof ExprFunctions;
  */
 export type ExprFunction = keyof Functions;
 
-export type BaseValue = 'string' | 'number' | 'boolean';
+export type BaseValue = 'string' | 'number' | 'boolean' | 'any';
 export type BaseToActual<T extends BaseValue> = T extends 'string'
   ? string
   : T extends 'number'
@@ -34,6 +34,8 @@ export type BaseToActualStrict<T extends BaseValue> = [T] extends ['string']
   ? number
   : [T] extends ['boolean']
   ? boolean
+  : [T] extends ['any']
+  ? any
   : never;
 
 type ArgsToActualOrNull<T extends readonly BaseValue[]> = {
@@ -59,19 +61,13 @@ export interface FuncDef<Args extends readonly BaseValue[], Ret extends BaseValu
     ctx: ValidationContext;
     path: string[];
   }) => void;
-
-  // Optional: Allows a function to specify that certain arguments (at the given indexes) should never be cast on the
-  // way in.
-  neverCastArguments?: number[];
-
-  // Optional: Cast return value to the one specified in the 'returns' property. Setting to false allows for functions
-  // passing through their arguments without knowing (or caring) about their specific types. Defaults to true.
-  castReturnValue?: boolean;
 }
 
 type BaseValueArgsFor<F extends ExprFunction> = F extends ExprFunction ? Functions[F]['args'] : never;
 
-type FunctionsReturning<T extends BaseValue> = keyof PickByValue<Functions, { returns: T }>;
+type FunctionsReturning<T extends BaseValue> =
+  | keyof PickByValue<Functions, { returns: T }>
+  | keyof PickByValue<Functions, { returns: 'any' }>;
 
 export type ExprReturning<T extends BaseValue> = Expression<FunctionsReturning<T>>;
 


### PR DESCRIPTION
## Description
Syncing tests with backend. Adding the `in-nested-group2.json` test breaks, as `"14"` is not equal to `14`. The fundamental problem here was that the `component` function was defined as returning `string`, so types would be cast to string no matter what they were. Introducing an `any` type that avoids casting (which also fixes the peculiarity of the `if` function that required some arguments - and the return type - not to be cast).

## Related Issue(s)
- #355

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- ~~[ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~
