### PR TITLE
Implement design system button into repeating groups

### DIFF
--- a/src/altinn-app-frontend/package.json
+++ b/src/altinn-app-frontend/package.json
@@ -20,7 +20,7 @@
   "author": "Altinn",
   "license": "3-Clause BSD",
   "dependencies": {
-    "@altinn/altinn-design-system": "0.20.0",
+    "@altinn/altinn-design-system": "0.23.0",
     "@babel/polyfill": "7.12.1",
     "@date-io/moment": "1.3.13",
     "@material-ui/core": "4.12.4",

--- a/src/altinn-app-frontend/package.json
+++ b/src/altinn-app-frontend/package.json
@@ -20,7 +20,7 @@
   "author": "Altinn",
   "license": "3-Clause BSD",
   "dependencies": {
-    "@altinn/altinn-design-system": "0.17.1",
+    "@altinn/altinn-design-system": "0.18.0",
     "@babel/polyfill": "7.12.1",
     "@date-io/moment": "1.3.13",
     "@material-ui/core": "4.12.4",

--- a/src/altinn-app-frontend/package.json
+++ b/src/altinn-app-frontend/package.json
@@ -20,7 +20,7 @@
   "author": "Altinn",
   "license": "3-Clause BSD",
   "dependencies": {
-    "@altinn/altinn-design-system": "0.18.0",
+    "@altinn/altinn-design-system": "0.20.0",
     "@babel/polyfill": "7.12.1",
     "@date-io/moment": "1.3.13",
     "@material-ui/core": "4.12.4",

--- a/src/altinn-app-frontend/src/components/base/ButtonComponent/GoToTaskButton.tsx
+++ b/src/altinn-app-frontend/src/components/base/ButtonComponent/GoToTaskButton.tsx
@@ -29,7 +29,7 @@ export const GoToTaskButton = ({ children, taskId, ...props }: Props) => {
       disabled={!canGoToTask}
       onClick={navigateToTask}
       {...props}
-      variant={ButtonVariant.Secondary}
+      variant={ButtonVariant.Outline}
     >
       {children}
     </WrappedButton>

--- a/src/altinn-app-frontend/src/components/base/ButtonComponent/SaveButton.tsx
+++ b/src/altinn-app-frontend/src/components/base/ButtonComponent/SaveButton.tsx
@@ -9,7 +9,7 @@ export const SaveButton = ({ children, ...props }: ButtonProps) => {
   return (
     <WrappedButton
       {...props}
-      variant={ButtonVariant.Secondary}
+      variant={ButtonVariant.Outline}
     >
       {children}
     </WrappedButton>

--- a/src/altinn-app-frontend/src/components/base/ButtonComponent/SubmitButton.tsx
+++ b/src/altinn-app-frontend/src/components/base/ButtonComponent/SubmitButton.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { ButtonVariant } from '@altinn/altinn-design-system';
+import { ButtonColor, ButtonVariant } from '@altinn/altinn-design-system';
 
 import { WrappedButton } from 'src/components/base/ButtonComponent/WrappedButton';
 import type { ButtonProps } from 'src/components/base/ButtonComponent/WrappedButton';
@@ -9,7 +9,8 @@ export const SubmitButton = ({ children, ...props }: ButtonProps) => {
   return (
     <WrappedButton
       {...props}
-      variant={ButtonVariant.Submit}
+      color={ButtonColor.Success}
+      variant={ButtonVariant.Filled}
     >
       {children}
     </WrappedButton>

--- a/src/altinn-app-frontend/src/components/base/ButtonComponent/WrappedButton.tsx
+++ b/src/altinn-app-frontend/src/components/base/ButtonComponent/WrappedButton.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Button, ButtonVariant } from '@altinn/altinn-design-system';
+import { Button, ButtonColor, ButtonVariant } from '@altinn/altinn-design-system';
 import classNames from 'classnames';
 
 import { ButtonLoader } from 'src/components/base/ButtonComponent/ButtonLoader';
@@ -20,10 +20,12 @@ export interface ButtonProps extends ButtonLoaderProps, BaseButtonProps {
 
 interface Props extends ButtonProps {
   variant?: ButtonVariant;
+  color?: ButtonColor;
 }
 
 export const WrappedButton = ({
-  variant = ButtonVariant.Secondary,
+  variant = ButtonVariant.Outline,
+  color = ButtonColor.Primary,
   onClick,
   id,
   children,
@@ -48,6 +50,7 @@ export const WrappedButton = ({
     >
       <Button
         variant={variant}
+        color={color}
         onClick={handleClick}
         id={id}
         disabled={disabled}

--- a/src/altinn-app-frontend/src/components/base/PrintButtonComponent.tsx
+++ b/src/altinn-app-frontend/src/components/base/PrintButtonComponent.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Button, ButtonVariant } from '@altinn/altinn-design-system';
+import { Button, ButtonColor, ButtonVariant } from '@altinn/altinn-design-system';
 
 import { useAppSelector } from 'src/common/hooks';
 import { getTextFromAppOrDefault } from 'src/utils/textResource';
@@ -11,7 +11,8 @@ export const PrintButtonComponent = () => {
 
   return (
     <Button
-      variant={ButtonVariant.Secondary}
+      variant={ButtonVariant.Outline}
+      color={ButtonColor.Primary}
       onClick={window.print}
     >
       {language && getTextFromAppOrDefault('general.print_button_text', textResources, language, undefined, true)}

--- a/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupTable.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupTable.tsx
@@ -139,7 +139,7 @@ const useStyles = makeStyles({
         '&::before': {
           display: 'block',
           content: "' '",
-          marginTop: '-12px',
+          marginTop: '-10px',
           width: '100%',
           position: 'absolute',
           borderTop: `2px dotted ${theme.altinnPalette.primary.blueMedium}`,

--- a/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupTable.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupTable.tsx
@@ -139,7 +139,7 @@ const useStyles = makeStyles({
         '&::before': {
           display: 'block',
           content: "' '",
-          marginTop: '-10px',
+          marginTop: '-12px',
           width: '100%',
           position: 'absolute',
           borderTop: `2px dotted ${theme.altinnPalette.primary.blueMedium}`,
@@ -390,11 +390,11 @@ export function RepeatingGroupTable({
                     {getTextResource(getTableTitle(component), textResources)}
                   </TableCell>
                 ))}
-                <TableCell style={{ width: '170px', padding: 0, paddingRight: '10px' }}>
+                <TableCell style={{ width: '185px', padding: 0, paddingRight: '10px' }}>
                   <span className={classes.visuallyHidden}>{getLanguageFromKey('general.edit', language)}</span>
                 </TableCell>
                 {!hideDeleteButton && (
-                  <TableCell style={{ width: '95px', padding: 0 }}>
+                  <TableCell style={{ width: '120px', padding: 0 }}>
                     <span className={classes.visuallyHidden}>{getLanguageFromKey('general.delete', language)}</span>
                   </TableCell>
                 )}
@@ -445,7 +445,7 @@ export function RepeatingGroupTable({
                         </TableCell>
                       ))}
                       <TableCell
-                        style={{ width: '170px', padding: '4px' }}
+                        style={{ width: '185px', padding: '4px' }}
                         key={`edit-${index}`}
                       >
                         <div className={classes.buttonInCellWrapper}>
@@ -464,7 +464,7 @@ export function RepeatingGroupTable({
                       </TableCell>
                       {!hideDeleteButton && (
                         <TableCell
-                          style={{ width: '95px', padding: '4px' }}
+                          style={{ width: '120px', padding: '4px' }}
                           key={`delete-${index}`}
                           className={cn({
                             [classes.popoverCurrentCell]: index == popoverPanelIndex,

--- a/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupTable.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupTable.tsx
@@ -456,6 +456,7 @@ export function RepeatingGroupTable({
                             iconPlacement='right'
                             onClick={() => handleEditClick(index)}
                             aria-label={`${editButtonText}-${firstCellData}`}
+                            data-testid='edit-button'
                           >
                             {editButtonText}
                           </Button>
@@ -480,6 +481,7 @@ export function RepeatingGroupTable({
                                   disabled={deleting}
                                   onClick={() => handleDeleteClick(index)}
                                   aria-label={`${deleteButtonText}-${firstCellData}`}
+                                  data-testid='delete-button'
                                 >
                                   {deleteButtonText}
                                 </Button>

--- a/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupTable.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupTable.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 
-import { createTheme, Grid, IconButton, makeStyles, TableCell, TableRow, useMediaQuery } from '@material-ui/core';
+import { Button, ButtonColor, ButtonVariant } from '@altinn/altinn-design-system';
+import { createTheme, Grid, makeStyles, TableCell, TableRow, useMediaQuery } from '@material-ui/core';
 import cn from 'classnames';
 
 import { ExprDefaultsForGroup } from 'src/features/expressions';
@@ -138,7 +139,7 @@ const useStyles = makeStyles({
         '&::before': {
           display: 'block',
           content: "' '",
-          marginTop: '-15px',
+          marginTop: '-12px',
           width: '100%',
           position: 'absolute',
           borderTop: `2px dotted ${theme.altinnPalette.primary.blueMedium}`,
@@ -169,6 +170,11 @@ const useStyles = makeStyles({
   popoverCurrentCell: {
     zIndex: 1,
     position: 'relative',
+  },
+  buttonInCellWrapper: {
+    display: 'inline-flex',
+    justifyContent: 'right',
+    width: '100%',
   },
 });
 
@@ -384,11 +390,11 @@ export function RepeatingGroupTable({
                     {getTextResource(getTableTitle(component), textResources)}
                   </TableCell>
                 ))}
-                <TableCell style={{ width: '160px', padding: 0, paddingRight: '10px' }}>
+                <TableCell style={{ width: '170px', padding: 0, paddingRight: '10px' }}>
                   <span className={classes.visuallyHidden}>{getLanguageFromKey('general.edit', language)}</span>
                 </TableCell>
                 {!hideDeleteButton && (
-                  <TableCell style={{ width: '80px', padding: 0 }}>
+                  <TableCell style={{ width: '95px', padding: 0 }}>
                     <span className={classes.visuallyHidden}>{getLanguageFromKey('general.delete', language)}</span>
                   </TableCell>
                 )}
@@ -439,61 +445,55 @@ export function RepeatingGroupTable({
                         </TableCell>
                       ))}
                       <TableCell
-                        align='right'
-                        style={{
-                          width: '160px',
-                          padding: 0,
-                          paddingRight: '10px',
-                        }}
+                        style={{ width: '170px', padding: '4px' }}
                         key={`edit-${index}`}
                       >
-                        <IconButton
-                          className={cn(classes.tableEditButton, {
-                            [classes.editButtonActivated]: editIndex === index,
-                          })}
-                          onClick={() => handleEditClick(index)}
-                          aria-label={`${editButtonText}-${firstCellData}`}
-                        >
-                          <i
-                            className={
-                              rowHasErrors
-                                ? `ai ai-circle-exclamation a-icon ${classes.errorIcon} ${classes.editIcon}`
-                                : `fa fa-edit ${classes.editIcon}`
-                            }
-                          />
-                          {editButtonText}
-                        </IconButton>
+                        <div className={classes.buttonInCellWrapper}>
+                          <Button
+                            variant={ButtonVariant.Quiet}
+                            color={ButtonColor.Secondary}
+                            iconName={rowHasErrors ? 'Warning' : 'Edit'}
+                            iconPlacement='right'
+                            onClick={() => handleEditClick(index)}
+                            aria-label={`${editButtonText}-${firstCellData}`}
+                          >
+                            {editButtonText}
+                          </Button>
+                        </div>
                       </TableCell>
                       {!hideDeleteButton && (
                         <TableCell
-                          align='center'
-                          style={{ width: '80px', padding: 0 }}
+                          style={{ width: '95px', padding: '4px' }}
                           key={`delete-${index}`}
                           className={cn({
                             [classes.popoverCurrentCell]: index == popoverPanelIndex,
                           })}
                         >
-                          <DeleteWarningPopover
-                            trigger={
-                              <IconButton
-                                className={classes.deleteButton}
-                                disabled={deleting}
-                                onClick={() => handleDeleteClick(index)}
-                                aria-label={`${deleteButtonText}-${firstCellData}`}
-                              >
-                                <i className='ai ai-trash' />
-                                {deleteButtonText}
-                              </IconButton>
-                            }
-                            side='left'
-                            language={language}
-                            deleteButtonText={getLanguageFromKey('group.row_popover_delete_button_confirm', language)}
-                            messageText={getLanguageFromKey('group.row_popover_delete_message', language)}
-                            open={popoverPanelIndex == index && popoverOpen}
-                            setPopoverOpen={setPopoverOpen}
-                            onCancelClick={() => onOpenChange(index)}
-                            onPopoverDeleteClick={handlePopoverDeleteClick(index)}
-                          />
+                          <div className={classes.buttonInCellWrapper}>
+                            <DeleteWarningPopover
+                              trigger={
+                                <Button
+                                  variant={ButtonVariant.Quiet}
+                                  color={ButtonColor.Danger}
+                                  iconName='Delete'
+                                  iconPlacement='right'
+                                  disabled={deleting}
+                                  onClick={() => handleDeleteClick(index)}
+                                  aria-label={`${deleteButtonText}-${firstCellData}`}
+                                >
+                                  {deleteButtonText}
+                                </Button>
+                              }
+                              side='left'
+                              language={language}
+                              deleteButtonText={getLanguageFromKey('group.row_popover_delete_button_confirm', language)}
+                              messageText={getLanguageFromKey('group.row_popover_delete_message', language)}
+                              open={popoverPanelIndex == index && popoverOpen}
+                              setPopoverOpen={setPopoverOpen}
+                              onCancelClick={() => onOpenChange(index)}
+                              onPopoverDeleteClick={handlePopoverDeleteClick(index)}
+                            />
+                          </div>
                         </TableCell>
                       )}
                     </AltinnTableRow>
@@ -552,22 +552,12 @@ export function RepeatingGroupTable({
                             container.textResourceBindings,
                           )
                     }
-                    editIconNode={
-                      <i
-                        className={
-                          rowHasErrors
-                            ? `ai ai-circle-exclamation ${classes.errorIcon}`
-                            : `fa fa-edit ${classes.editIcon}`
-                        }
-                      />
-                    }
                     deleteFunctionality={
                       hideDeleteButton
                         ? undefined
                         : {
                             onDeleteClick: () => handleDeleteClick(index),
                             deleteButtonText: getLanguageFromKey('general.delete', language),
-                            deleteIconNode: <i className={'ai ai-trash'} />,
                             popoverPanelIndex,
                             popoverOpen,
                             setPopoverOpen,

--- a/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupsEditContainer.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupsEditContainer.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Button, ButtonColor, ButtonVariant } from '@altinn/altinn-design-system';
-import { createTheme, Grid, IconButton, makeStyles } from '@material-ui/core';
+import { createTheme, Grid, makeStyles } from '@material-ui/core';
 import cn from 'classnames';
 
 import { renderGenericComponent } from 'src/utils/layout';
@@ -60,27 +60,7 @@ const useStyles = makeStyles({
   },
   deleteItem: {
     paddingBottom: '0px !important',
-  },
-  deleteButton: {
-    color: theme.altinnPalette.primary.red,
-    fontWeight: 700,
-    padding: '8px 12px 6px 6px',
-    borderRadius: '0',
-    marginRight: '-12px',
-    '@media (min-width:768px)': {
-      margin: '0',
-    },
-    '&:hover': {
-      background: theme.altinnPalette.primary.red,
-      color: theme.altinnPalette.primary.white,
-    },
-    '&:focus': {
-      outlineColor: theme.altinnPalette.primary.red,
-    },
-    '& .ai': {
-      fontSize: '2em',
-      marginTop: '-3px',
-    },
+    paddingTop: '0px !important',
   },
 });
 
@@ -159,14 +139,16 @@ export function RepeatingGroupsEditContainer({
             className={classes.deleteItem}
           >
             <Grid item={true}>
-              <IconButton
-                classes={{ root: classes.deleteButton }}
+              <Button
+                variant={ButtonVariant.Quiet}
+                color={ButtonColor.Danger}
+                iconName='Delete'
+                iconPlacement='right'
                 disabled={deleting}
                 onClick={removeClicked}
               >
-                <i className='ai ai-trash' />
                 {getLanguageFromKey('general.delete', language)}
-              </IconButton>
+              </Button>
             </Grid>
           </Grid>
         )}

--- a/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupsEditContainer.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupsEditContainer.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Button, ButtonVariant } from '@altinn/altinn-design-system';
+import { Button, ButtonColor, ButtonVariant } from '@altinn/altinn-design-system';
 import { createTheme, Grid, IconButton, makeStyles } from '@material-ui/core';
 import cn from 'classnames';
 
@@ -227,7 +227,8 @@ export function RepeatingGroupsEditContainer({
                 <Button
                   id={`next-button-grp-${id}`}
                   onClick={nextClicked}
-                  variant={ButtonVariant.Primary}
+                  variant={ButtonVariant.Filled}
+                  color={ButtonColor.Primary}
                 >
                   {container.textResourceBindings?.save_and_next_button
                     ? getTextResourceByKey(container.textResourceBindings.save_and_next_button, textResources)
@@ -240,7 +241,8 @@ export function RepeatingGroupsEditContainer({
                 <Button
                   id={`add-button-grp-${id}`}
                   onClick={saveClicked}
-                  variant={ButtonVariant.Secondary}
+                  variant={ButtonVariant.Outline}
+                  color={ButtonColor.Primary}
                 >
                   {container.textResourceBindings?.save_button
                     ? getTextResourceByKey(container.textResourceBindings.save_button, textResources)

--- a/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupsEditContainer.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupsEditContainer.tsx
@@ -146,6 +146,7 @@ export function RepeatingGroupsEditContainer({
                 iconPlacement='right'
                 disabled={deleting}
                 onClick={removeClicked}
+                data-testid='delete-button'
               >
                 {getLanguageFromKey('general.delete', language)}
               </Button>

--- a/src/altinn-app-frontend/src/features/instantiate/containers/InstanceSelection.tsx
+++ b/src/altinn-app-frontend/src/features/instantiate/containers/InstanceSelection.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
-import { Grid, IconButton, TableCell, Typography, useMediaQuery } from '@material-ui/core';
+import { Button, ButtonColor, ButtonVariant } from '@altinn/altinn-design-system';
+import { Grid, TableCell, Typography, useMediaQuery } from '@material-ui/core';
 
 import { useAppSelector } from 'src/common/hooks';
 import { ReadyForPrint } from 'src/shared/components/ReadyForPrint';
@@ -35,23 +36,21 @@ function getDateDisplayString(timeStamp: string) {
   });
 }
 
-const typographyStyle = {
-  color: '#0062BA',
-  marginRight: '4px',
-  fontWeight: 700,
-};
-
-const iconStyle = {
-  color: '#0062BA',
-  fontSize: '24px',
-};
-
 const marginTop12 = {
   marginTop: '12px',
 };
 
 const marginTop26 = {
   marginTop: '26px',
+};
+
+const tableButtonWrapper = {
+  display: 'flex',
+  justifyContent: 'right',
+};
+
+const buttonCell = {
+  padding: '4px 36px 4px 4px',
 };
 
 export default function InstanceSelection({ instances, onNewInstance }: IInstanceSelectionProps) {
@@ -91,12 +90,6 @@ export default function InstanceSelection({ instances, onNewInstance }: IInstanc
                 onEditClick={() => openInstance(instance.id)}
                 key={instance.id}
                 editButtonText={getLanguageFromKey('instance_selection.continue', language)}
-                editIconNode={
-                  <i
-                    className='fa fa-edit'
-                    style={iconStyle}
-                  />
-                }
               />
             );
           })}
@@ -120,19 +113,18 @@ export default function InstanceSelection({ instances, onNewInstance }: IInstanc
               <AltinnTableRow key={instance.id}>
                 <TableCell>{getDateDisplayString(instance.lastChanged)}</TableCell>
                 <TableCell>{instance.lastChangedBy}</TableCell>
-                <TableCell align='right'>
-                  <IconButton onClick={() => openInstance(instance.id)}>
-                    <Typography
-                      variant='body1'
-                      style={typographyStyle}
+                <TableCell style={buttonCell}>
+                  <div style={tableButtonWrapper}>
+                    <Button
+                      variant={ButtonVariant.Quiet}
+                      color={ButtonColor.Secondary}
+                      iconName='Edit'
+                      iconPlacement='right'
+                      onClick={() => openInstance(instance.id)}
                     >
                       {getLanguageFromKey('instance_selection.continue', language)}
-                    </Typography>
-                    <i
-                      className='fa fa-edit'
-                      style={iconStyle}
-                    />
-                  </IconButton>
+                    </Button>
+                  </div>
                 </TableCell>
               </AltinnTableRow>
             );

--- a/src/shared/src/components/molecules/AltinnMobileTableItem.test.tsx
+++ b/src/shared/src/components/molecules/AltinnMobileTableItem.test.tsx
@@ -12,7 +12,6 @@ describe('AltinnMobileTableItem', () => {
       deleteFunctionality: {
         onDeleteClick: jest.fn(),
         deleteButtonText: 'Delete',
-        deleteIconNode: <i></i>,
         popoverOpen: false,
         popoverPanelIndex: -1,
         onPopoverDeleteClick: () => jest.fn(),
@@ -59,7 +58,6 @@ describe('AltinnMobileTableItem', () => {
       deleteFunctionality: {
         onDeleteClick: onDeleteClick,
         deleteButtonText: 'Delete',
-        deleteIconNode: <i></i>,
         popoverOpen: false,
         popoverPanelIndex: -1,
         onPopoverDeleteClick: () => jest.fn(),

--- a/src/shared/src/components/molecules/AltinnMobileTableItem.tsx
+++ b/src/shared/src/components/molecules/AltinnMobileTableItem.tsx
@@ -1,6 +1,5 @@
 import {
   Grid,
-  IconButton,
   makeStyles,
   Table,
   TableBody,
@@ -16,6 +15,7 @@ import cn from 'classnames';
 import { getLanguageFromKey } from '../../utils/language';
 import type { ILanguage } from '../../types';
 import { DeleteWarningPopover } from './DeleteWarningPopover';
+import { Button, ButtonColor, ButtonVariant } from '@altinn/altinn-design-system';
 
 export interface IMobileTableItem {
   key: React.Key;
@@ -30,11 +30,9 @@ export interface IAltinnMobileTableItemProps {
   editIndex: number;
   onEditClick: () => void;
   editButtonText?: string;
-  editIconNode: React.ReactNode;
   deleteFunctionality?: {
     onDeleteClick: () => void;
     deleteButtonText: string;
-    deleteIconNode: React.ReactNode;
     popoverOpen: boolean;
     popoverPanelIndex: number;
     setPopoverOpen: (open: boolean) => void;
@@ -73,90 +71,24 @@ const useStyles = makeStyles({
   labelText: {
     color: theme.altinnPalette.primary.grey,
   },
-  tableEditButton: {
-    color: theme.altinnPalette.primary.blueDark,
-    fontWeight: 700,
-    borderRadius: '5px',
-    padding: '6px 12px',
-    margin: '8px 2px 8px -12px',
-    '@media (max-width: 768px)': {
-      fontSize: '2.5rem',
-      height: '3rem',
-      width: '3rem',
-      margin: '0',
-      padding: '0',
-      borderRadius: '50%',
-      outlineOffset: '-2px',
-    },
-    '&:hover': {
-      background: 'none',
-      outline: `1px dotted ${theme.altinnPalette.primary.blueDark}`,
-    },
-    '&:focus': {
-      background: theme.altinnPalette.primary.blueLighter,
-      outline: `2px dotted ${theme.altinnPalette.primary.blueDark}`,
-    },
-  },
-  editButtonActivated: {
-    background: theme.altinnPalette.primary.blueLighter,
-    outline: `2px dotted ${theme.altinnPalette.primary.blueDark}`,
-    '@media (max-width: 768px)': {
-      fontSize: '2.5rem',
-      height: '3rem',
-      width: '3rem',
-      margin: '0',
-      padding: '0',
-      borderRadius: '50%',
-    },
-    '&:hover': {
-      background: 'none',
-      outline: `1px dotted ${theme.altinnPalette.primary.blueDark}`,
-    },
-  },
-  deleteButton: {
-    color: theme.altinnPalette.primary.red,
-    fontWeight: 700,
-    padding: '8px 12px 6px 6px',
-    borderRadius: '0',
-    marginRight: '-12px',
-    '& .ai': {
-      fontSize: '2em',
-      marginTop: '-3px',
-    },
-    '@media (max-width: 768px)': {
-      height: '3rem',
-      justifySelf: 'right',
-      width: '3rem',
-      margin: '0',
-      marginRight: '2rem',
-      padding: '0',
-      borderRadius: '50%',
-      '& .ai': {
-        fontSize: '2.7rem',
-        marginTop: '0',
-      },
-    },
-    '&:hover': {
-      background: theme.altinnPalette.primary.red,
-      color: theme.altinnPalette.primary.white,
-    },
-    '&:focus': {
-      outlineColor: theme.altinnPalette.primary.red,
-    },
-  },
   editButtonCell: {
-    width: '150px',
-    padding: '0 !important',
+    width: '170px',
+    padding: '4px !important',
     '@media (max-width: 768px)': {
       width: '50px',
     },
   },
   deleteButtonCell: {
-    width: '100px',
-    padding: '0 !important',
+    width: '95px',
+    padding: '4px !important',
     '@media (max-width: 768px)': {
       width: '50px',
     },
+  },
+  tableButtonWrapper: {
+    width: '100%',
+    display: 'flex',
+    justifyContent: 'right',
   },
   textContainer: {
     width: '100%',
@@ -171,6 +103,9 @@ const useStyles = makeStyles({
     marginTop: '-1px',
     borderBottom: 0,
     boxSizing: 'border-box',
+    '& tbody': {
+      backgroundColor: 'rgba(227, 247, 255, 0.5)',
+    },
   },
   aboveEditingRow: {
     borderBottom: 0,
@@ -188,7 +123,6 @@ export default function AltinnMobileTableItem({
   editIndex,
   onEditClick,
   editButtonText,
-  editIconNode,
   deleteFunctionality,
 }: IAltinnMobileTableItemProps) {
   const classes = useStyles();
@@ -196,7 +130,6 @@ export default function AltinnMobileTableItem({
 
   const {
     onDeleteClick,
-    deleteIconNode,
     deleteButtonText,
     popoverOpen,
     popoverPanelIndex,
@@ -246,57 +179,63 @@ export default function AltinnMobileTableItem({
                     {item.value}
                   </Typography>
                 </TableCell>
-                {index == 0 && (
-                  <TableCell
-                    className={classes.editButtonCell}
-                    align='right'
-                  >
-                    <IconButton
-                      className={cn(classes.tableEditButton, {
-                        [classes.editButtonActivated]: editIndex === tableItemIndex,
-                      })}
-                      onClick={onEditClick}
-                      data-testid='edit-button'
-                      aria-label={`${editButtonText}-${item.value}`}
-                    >
-                      {editIconNode}
-                      {!mobileViewSmall && editButtonText}
-                    </IconButton>
-                  </TableCell>
-                )}
-                {index == 0 &&
-                  deleteIconNode &&
-                  setPopoverOpen &&
+                <TableCell
+                  className={classes.editButtonCell}
+                  align='right'
+                >
+                  {index == 0 && (
+                    <div className={classes.tableButtonWrapper}>
+                      <Button
+                        data-testid='edit-button'
+                        variant={ButtonVariant.Quiet}
+                        color={ButtonColor.Secondary}
+                        iconName={valid ? 'Edit' : 'Warning'}
+                        iconPlacement={!mobileViewSmall ? 'right' : 'left'}
+                        onClick={onEditClick}
+                        aria-label={`${editButtonText}-${item.value}`}
+                      >
+                        {!mobileViewSmall && editButtonText}
+                      </Button>
+                    </div>
+                  )}
+                </TableCell>
+                {setPopoverOpen &&
                   onOpenChange &&
                   language &&
                   onPopoverDeleteClick &&
                   typeof popoverOpen === 'boolean' && (
                     <TableCell
-                      align='center'
+                      align='right'
                       className={cn([classes.deleteButtonCell], {
                         [classes.popoverCurrentCell]: tableItemIndex == popoverPanelIndex,
                       })}
                     >
-                      <DeleteWarningPopover
-                        trigger={
-                          <IconButton
-                            className={classes.deleteButton}
-                            onClick={onDeleteClick}
-                            data-testid='delete-button'
-                            aria-label={`${deleteButtonText}-${item.value}`}
-                          >
-                            {deleteIconNode}
-                            {!mobileViewSmall && deleteButtonText}
-                          </IconButton>
-                        }
-                        language={language}
-                        deleteButtonText={getLanguageFromKey('group.row_popover_delete_button_confirm', language)}
-                        messageText={getLanguageFromKey('group.row_popover_delete_message', language)}
-                        open={popoverPanelIndex == tableItemIndex && popoverOpen}
-                        setPopoverOpen={setPopoverOpen}
-                        onCancelClick={() => onOpenChange(tableItemIndex)}
-                        onPopoverDeleteClick={onPopoverDeleteClick(tableItemIndex)}
-                      />
+                      {index == 0 && (
+                        <div className={classes.tableButtonWrapper}>
+                          <DeleteWarningPopover
+                            trigger={
+                              <Button
+                                data-testid='delete-button'
+                                variant={ButtonVariant.Quiet}
+                                color={ButtonColor.Danger}
+                                iconName='Delete'
+                                iconPlacement={!mobileViewSmall ? 'right' : 'left'}
+                                onClick={onDeleteClick}
+                                aria-label={`${deleteButtonText}-${item.value}`}
+                              >
+                                {!mobileViewSmall && deleteButtonText}
+                              </Button>
+                            }
+                            language={language}
+                            deleteButtonText={getLanguageFromKey('group.row_popover_delete_button_confirm', language)}
+                            messageText={getLanguageFromKey('group.row_popover_delete_message', language)}
+                            open={popoverPanelIndex == tableItemIndex && popoverOpen}
+                            setPopoverOpen={setPopoverOpen}
+                            onCancelClick={() => onOpenChange(tableItemIndex)}
+                            onPopoverDeleteClick={onPopoverDeleteClick(tableItemIndex)}
+                          />
+                        </div>
+                      )}
                     </TableCell>
                   )}
               </TableRow>

--- a/src/shared/src/components/molecules/AltinnMobileTableItem.tsx
+++ b/src/shared/src/components/molecules/AltinnMobileTableItem.tsx
@@ -98,13 +98,13 @@ const useStyles = makeStyles({
     textOverflow: 'ellipsis',
   },
   editingRow: {
-    backgroundColor: 'rgba(227, 247, 255, 0.5)',
+    backgroundColor: theme.palette.secondary.transparentBlue,
     borderTop: `2px dotted ${theme.altinnPalette.primary.blueMedium}`,
     marginTop: '-1px',
     borderBottom: 0,
     boxSizing: 'border-box',
     '& tbody': {
-      backgroundColor: 'rgba(227, 247, 255, 0.5)',
+      backgroundColor: theme.palette.secondary.transparentBlue,
     },
   },
   aboveEditingRow: {

--- a/src/shared/src/components/molecules/AltinnMobileTableItem.tsx
+++ b/src/shared/src/components/molecules/AltinnMobileTableItem.tsx
@@ -72,14 +72,14 @@ const useStyles = makeStyles({
     color: theme.altinnPalette.primary.grey,
   },
   editButtonCell: {
-    width: '170px',
+    width: '185px',
     padding: '4px !important',
     '@media (max-width: 768px)': {
       width: '50px',
     },
   },
   deleteButtonCell: {
-    width: '95px',
+    width: '120px',
     padding: '4px !important',
     '@media (max-width: 768px)': {
       width: '50px',

--- a/src/shared/src/components/molecules/DeleteWarningPopover.tsx
+++ b/src/shared/src/components/molecules/DeleteWarningPopover.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Button, ButtonVariant, PanelVariant, PopoverPanel } from '@altinn/altinn-design-system';
+import { Button, ButtonVariant, ButtonColor, PanelVariant, PopoverPanel } from '@altinn/altinn-design-system';
 import { makeStyles } from '@material-ui/core';
 import type { ILanguage } from '../../types';
 import { getLanguageFromKey } from '../../utils/language';
@@ -51,14 +51,16 @@ export function DeleteWarningPopover({
       <div className={classes.popoverButtonContainer}>
         <Button
           data-testid='warning-popover-delete-button'
-          variant={ButtonVariant.Cancel}
+          variant={ButtonVariant.Filled}
+          color={ButtonColor.Danger}
           onClick={onPopoverDeleteClick}
         >
           {deleteButtonText}
         </Button>
         <Button
           data-testid='warning-popover-cancel-button'
-          variant={ButtonVariant.Secondary}
+          variant={ButtonVariant.Quiet}
+          color={ButtonColor.Primary}
           onClick={onCancelClick}
         >
           {getLanguageFromKey('general.cancel', language)}

--- a/src/shared/src/components/molecules/DeleteWarningPopover.tsx
+++ b/src/shared/src/components/molecules/DeleteWarningPopover.tsx
@@ -60,7 +60,7 @@ export function DeleteWarningPopover({
         <Button
           data-testid='warning-popover-cancel-button'
           variant={ButtonVariant.Quiet}
-          color={ButtonColor.Primary}
+          color={ButtonColor.Secondary}
           onClick={onCancelClick}
         >
           {getLanguageFromKey('general.cancel', language)}

--- a/src/shared/src/theme/commonTheme.tsx
+++ b/src/shared/src/theme/commonTheme.tsx
@@ -94,6 +94,7 @@ export const commonTheme = {
     secondary: {
       main: '#000',
       dark: '#d2d2d2',
+      transparentBlue: 'rgba(227, 247, 255, 0.5)',
     },
   },
 };

--- a/src/yarn.lock
+++ b/src/yarn.lock
@@ -12,9 +12,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@altinn/altinn-design-system@npm:0.20.0":
-  version: 0.20.0
-  resolution: "@altinn/altinn-design-system@npm:0.20.0"
+"@altinn/altinn-design-system@npm:0.23.0":
+  version: 0.23.0
+  resolution: "@altinn/altinn-design-system@npm:0.23.0"
   dependencies:
     "@altinn/figma-design-tokens": ^4.3.0
     "@navikt/ds-icons": ^1.3.38
@@ -26,7 +26,7 @@ __metadata:
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 3e5dc4ab0c702301f0734fdcb9628edcf5f6b76eedad729b05a9dc9e559c6f40cce678a789083945fc37e89045efa22b7e5269432daedfb080906fcebe8e668e
+  checksum: d5dd438a06bdb242f79b997a9696a4bad8388f3f750125ad8e7f1363e4d75c7d69a4bed4c269f3e2fe0c332d1fac3f9701d09d0008bfb99ad98e6816393a52e5
   languageName: node
   linkType: hard
 
@@ -5238,7 +5238,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "altinn-app-frontend@workspace:altinn-app-frontend"
   dependencies:
-    "@altinn/altinn-design-system": 0.20.0
+    "@altinn/altinn-design-system": 0.23.0
     "@babel/core": 7.19.6
     "@babel/polyfill": 7.12.1
     "@babel/preset-env": 7.19.4

--- a/src/yarn.lock
+++ b/src/yarn.lock
@@ -12,11 +12,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@altinn/altinn-design-system@npm:0.18.0":
-  version: 0.18.0
-  resolution: "@altinn/altinn-design-system@npm:0.18.0"
+"@altinn/altinn-design-system@npm:0.20.0":
+  version: 0.20.0
+  resolution: "@altinn/altinn-design-system@npm:0.20.0"
   dependencies:
-    "@altinn/figma-design-tokens": ^4.2.0
+    "@altinn/figma-design-tokens": ^4.3.0
     "@navikt/ds-icons": ^1.3.38
     "@radix-ui/react-popover": ^1.0.0
     "@react-hookz/web": ^16.0.0
@@ -26,14 +26,14 @@ __metadata:
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 5edca1108653d3d21853853d8f76979091cc17370a8361fda6a9972de229cae955343d99137c1ab9d60cdccfa8d12ffbde3d4ffdbe7faa11666b3f03a6b18271
+  checksum: 3e5dc4ab0c702301f0734fdcb9628edcf5f6b76eedad729b05a9dc9e559c6f40cce678a789083945fc37e89045efa22b7e5269432daedfb080906fcebe8e668e
   languageName: node
   linkType: hard
 
-"@altinn/figma-design-tokens@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "@altinn/figma-design-tokens@npm:4.2.0"
-  checksum: 9877d101c066e6da8c69ccb70c92e085df06d299a6d280e3a713d67b5c367a917ea4ce3f3bbd209efd57e2b66669131df5b3faa596724994f87c47235c5ef8bd
+"@altinn/figma-design-tokens@npm:^4.3.0":
+  version: 4.3.0
+  resolution: "@altinn/figma-design-tokens@npm:4.3.0"
+  checksum: dac7b1b98a354bafa0ce627ae9fdf34215101fb57669576795d7b40c48dd41761b301ba62ec9026a99a5f21838aee6c4d26c851572ea8f334eb421c94b659a4d
   languageName: node
   linkType: hard
 
@@ -5238,7 +5238,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "altinn-app-frontend@workspace:altinn-app-frontend"
   dependencies:
-    "@altinn/altinn-design-system": 0.18.0
+    "@altinn/altinn-design-system": 0.20.0
     "@babel/core": 7.19.6
     "@babel/polyfill": 7.12.1
     "@babel/preset-env": 7.19.4

--- a/src/yarn.lock
+++ b/src/yarn.lock
@@ -12,11 +12,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@altinn/altinn-design-system@npm:0.17.1":
-  version: 0.17.1
-  resolution: "@altinn/altinn-design-system@npm:0.17.1"
+"@altinn/altinn-design-system@npm:0.18.0":
+  version: 0.18.0
+  resolution: "@altinn/altinn-design-system@npm:0.18.0"
   dependencies:
     "@altinn/figma-design-tokens": ^4.2.0
+    "@navikt/ds-icons": ^1.3.38
     "@radix-ui/react-popover": ^1.0.0
     "@react-hookz/web": ^16.0.0
     leaflet: ^1.8.0
@@ -25,7 +26,7 @@ __metadata:
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 6d6d5e724d64742183a1509b445b47a2ebe8137390be0f56b47bef627f7ae17a0281f2782c0fe58d07c5d538a2d876d7a94cc840fee925653f4dbbd2db09eebd
+  checksum: 5edca1108653d3d21853853d8f76979091cc17370a8361fda6a9972de229cae955343d99137c1ab9d60cdccfa8d12ffbde3d4ffdbe7faa11666b3f03a6b18271
   languageName: node
   linkType: hard
 
@@ -3448,6 +3449,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@navikt/ds-icons@npm:^1.3.38":
+  version: 1.5.4
+  resolution: "@navikt/ds-icons@npm:1.5.4"
+  peerDependencies:
+    "@types/react": ^17.0.30 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 7c2793ca98e49ce261898b05bfcdda5a0816935d8781e44ce001ad1d61a0c3be2bd8e9f97e4986e0563b36888270ceab60ebfcb8537900c4274c2d7fd8267297
+  languageName: node
+  linkType: hard
+
 "@nodelib/fs.scandir@npm:2.1.5":
   version: 2.1.5
   resolution: "@nodelib/fs.scandir@npm:2.1.5"
@@ -5224,7 +5238,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "altinn-app-frontend@workspace:altinn-app-frontend"
   dependencies:
-    "@altinn/altinn-design-system": 0.17.1
+    "@altinn/altinn-design-system": 0.18.0
     "@babel/core": 7.19.6
     "@babel/polyfill": 7.12.1
     "@babel/preset-env": 7.19.4

--- a/test/cypress/e2e/integration/app-frontend/group.js
+++ b/test/cypress/e2e/integration/app-frontend/group.js
@@ -39,7 +39,7 @@ describe('Group', () => {
         .then((table) => {
           cy.get(table).find(mui.tableElement).first().invoke('text').should('equal', 'NOK 1');
           cy.get(table).find(mui.tableElement).eq(1).invoke('text').should('equal', 'NOK 2');
-          cy.get(table).find(mui.tableElement).find(mui.buttonIcon).first().should('be.visible').click();
+          cy.get(table).find(mui.tableElement).find(appFrontend.group.edit).should('be.visible').click();
         });
       cy.get(appFrontend.group.mainGroup)
         .find(appFrontend.group.editContainer)
@@ -50,7 +50,7 @@ describe('Group', () => {
         .find(mui.tableBody)
         .then((table) => {
           cy.get(table).find(mui.tableElement).first().invoke('text').should('equal', 'automation');
-          cy.get(table).find(mui.tableElement).find(mui.buttonIcon).first().should('be.visible').click();
+          cy.get(table).find(mui.tableElement).find(appFrontend.group.edit).should('be.visible').click();
           cy.get(table).find(mui.tableElement).find(appFrontend.group.delete).should('be.visible').click();
         });
 
@@ -388,7 +388,7 @@ describe('Group', () => {
       .then((table) => {
         cy.get(table).find(mui.tableElement).first().invoke('text').should('equal', 'NOK 1');
         cy.get(table).find(mui.tableElement).eq(1).invoke('text').should('equal', 'NOK 2');
-        cy.get(table).find(mui.tableElement).find(mui.buttonIcon).first().should('be.visible').click();
+        cy.get(table).find(mui.tableElement).find(appFrontend.group.edit).should('be.visible').click();
       });
 
     // Navigate to nested group and test delete warning popoup cancel and confirm

--- a/test/cypress/e2e/integration/app-frontend/message.js
+++ b/test/cypress/e2e/integration/app-frontend/message.js
@@ -52,7 +52,7 @@ describe('Message', () => {
       .invoke('outerWidth')
       .then((width) => {
         width = Math.round(width);
-        expect(width).to.equal(96);
+        expect(width).to.equal(105);
       });
   });
 });

--- a/test/cypress/e2e/integration/app-frontend/message.js
+++ b/test/cypress/e2e/integration/app-frontend/message.js
@@ -52,7 +52,7 @@ describe('Message', () => {
       .invoke('outerWidth')
       .then((width) => {
         width = Math.round(width);
-        expect(width).to.equal(105);
+        expect(width).to.equal(98);
       });
   });
 });

--- a/test/cypress/e2e/pageobjects/app-frontend.js
+++ b/test/cypress/e2e/pageobjects/app-frontend.js
@@ -194,8 +194,8 @@ export default class AppFrontend {
       rows: [0, 1].map((idx) => ({
         uploadSingle: makeUploaderSelectors('mainUploaderSingle', idx, 3),
         uploadMulti: makeUploaderSelectors('mainUploaderMulti', idx, 4),
-        editBtn: `#group-mainGroup-table-body > tr:nth-child(${idx + 1}) > td:nth-last-of-type(2n) > button`,
-        deleteBtn: `#group-mainGroup-table-body > tr:nth-child(${idx + 1}) > td:last-of-type > button`,
+        editBtn: `#group-mainGroup-table-body > tr:nth-child(${idx + 1}) > td:nth-last-of-type(2n) > div > button`,
+        deleteBtn: `#group-mainGroup-table-body > tr:nth-child(${idx + 1}) > td:last-of-type > div > button`,
         nestedGroup: {
           rows: [0, 1].map((subIdx) => ({
             uploadTagMulti: makeUploaderSelectors('subUploader', `${idx}-${subIdx}`, 2, true),
@@ -205,8 +205,8 @@ export default class AppFrontend {
               `#nestedOptions-${idx}-${subIdx} input[type=checkbox]:nth(1)`,
               `#nestedOptions-${idx}-${subIdx} input[type=checkbox]:nth(2)`,
             ],
-            editBtn: `#group-subGroup-${idx}-table-body > tr:nth-child(${subIdx + 1}) > td:nth-last-of-type(2n) > button`,
-            deleteBtn: `#group-subGroup-${idx}-table-body > tr:nth-child(${subIdx + 1}) > td:last-of-type > button`,
+            editBtn: `#group-subGroup-${idx}-table-body > tr:nth-child(${subIdx + 1}) > td:nth-last-of-type(2n) > div > button`,
+            deleteBtn: `#group-subGroup-${idx}-table-body > tr:nth-child(${subIdx + 1}) > td:last-of-type > div > button`,
           })),
           groupContainer: `#group-subGroup-${idx}`,
           saveBtn: `#add-button-grp-subGroup-${idx}`,

--- a/test/cypress/e2e/pageobjects/app-frontend.js
+++ b/test/cypress/e2e/pageobjects/app-frontend.js
@@ -177,7 +177,6 @@ export default class AppFrontend {
       addNewItem: '[id^="add-button-mainGroup"]',
       addNewItemSubGroup: '[id*="add-button-subGroup"]',
       comments: 'input[id^="comments"]',
-      delete: 'button[class*="makeStyles-deleteButton"]',
       saveSubGroup: 'button[id*="add-button-grp-subGroup"]',
       saveMainGroup: '#add-button-grp-mainGroup',
       editContainer: '[data-testid=group-edit-container]',
@@ -191,6 +190,8 @@ export default class AppFrontend {
       tableErrors: '[data-testid=group-table-errors]',
       popOverDeleteButton: '[data-testid="warning-popover-delete-button"]',
       popOverCancelButton: '[data-testid="warning-popover-cancel-button"]',
+      edit: '[data-testid=edit-button]',
+      delete: '[data-testid=delete-button]',
       rows: [0, 1].map((idx) => ({
         uploadSingle: makeUploaderSelectors('mainUploaderSingle', idx, 3),
         uploadMulti: makeUploaderSelectors('mainUploaderMulti', idx, 4),


### PR DESCRIPTION
Changes the MUI IconButtons in repeating groups to buttons from the design system. 

## Description
- Changed delete and edit button into design-system buttons.
- Updated design-system buttons used in WrappedButton component, PrintButton component and DeletePopover component

## Related Issue(s)
- #439 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
