### PR TITLE
Disabling local/github complexity warning

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,3 +5,16 @@ sonar.sources=src
 sonar.exclusions=**/webpack.config.*.js,**/node_modules,**/dist,**/*.test.ts*,**/setupTests.ts,**/__mocks__/**,src/types/**,src/shared/src/language/texts/**
 
 sonar.javascript.lcov.reportPaths=src/altinn-app-frontend/coverage/lcov.info,src/shared/coverage/lcov.info
+
+# Ignore a few rules
+sonar.issue.ignore.multicriteria=e1,e2
+
+# Cognitive Complexity of functions should not be too high
+# Ignored because we decided not to have a hard complexity limit, as we trust our developers to manage complexity
+sonar.issue.ignore.multicriteria.e1.ruleKey=typescript:S3776
+sonar.issue.ignore.multicriteria.e1.resourceKey=**/*.*
+
+# Redundant casts and non-null assertions should be avoided
+# Ignored because this rule is faulty, and removing 'redundant' casts may in some cases give hard TS-errors
+sonar.issue.ignore.multicriteria.e2.ruleKey=typescript:S4325
+sonar.issue.ignore.multicriteria.e2.resourceKey=**/*.*

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,16 +5,3 @@ sonar.sources=src
 sonar.exclusions=**/webpack.config.*.js,**/node_modules,**/dist,**/*.test.ts*,**/setupTests.ts,**/__mocks__/**,src/types/**,src/shared/src/language/texts/**
 
 sonar.javascript.lcov.reportPaths=src/altinn-app-frontend/coverage/lcov.info,src/shared/coverage/lcov.info
-
-# Ignore a few rules
-sonar.issue.ignore.multicriteria=e1,e2
-
-# Cognitive Complexity of functions should not be too high
-# Ignored because we decided not to have a hard complexity limit, as we trust our developers to manage complexity
-sonar.issue.ignore.multicriteria.e1.ruleKey=typescript:S3776
-sonar.issue.ignore.multicriteria.e1.resourceKey=**/*.*
-
-# Redundant casts and non-null assertions should be avoided
-# Ignored because this rule is faulty, and removing 'redundant' casts may in some cases give hard TS-errors
-sonar.issue.ignore.multicriteria.e2.ruleKey=typescript:S4325
-sonar.issue.ignore.multicriteria.e2.resourceKey=**/*.*

--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -57,15 +57,12 @@
     "jsx-a11y/no-autofocus": ["off"],
     "@typescript-eslint/no-explicit-any": ["off"],
     "import/no-unresolved": ["off"],
-    "@typescript-eslint/no-unused-vars": [
-      "error",
-      { "ignoreRestSiblings": true, "argsIgnorePattern": "^_" }
-    ],
+    "@typescript-eslint/no-unused-vars": ["error", { "ignoreRestSiblings": true, "argsIgnorePattern": "^_" }],
     "@typescript-eslint/consistent-type-imports": ["warn"],
     "react-hooks/exhaustive-deps": ["error"],
     "prefer-template": ["warn"],
     "sonarjs/no-duplicate-string": ["off"],
-    "sonarjs/cognitive-complexity": ["warn", 15],
+    "sonarjs/cognitive-complexity": ["off"],
     "sonarjs/no-collapsible-if": ["warn"],
     "sonarjs/prefer-single-boolean-return": ["warn"],
     "sonarjs/no-identical-functions": ["warn"],
@@ -89,10 +86,7 @@
     {
       "files": ["altinn-app-frontend/src/**"],
       "rules": {
-        "no-relative-import-paths/no-relative-import-paths": [
-          "warn",
-          { "allowSameFolder": false }
-        ],
+        "no-relative-import-paths/no-relative-import-paths": ["warn", { "allowSameFolder": false }],
         "preferred-import-path/preferred-import-path": [
           "warn",
           {


### PR DESCRIPTION
## Description
As discussed on Slack. Disabling the complexity check from SonarCloud locally, as it's more of an annoyance than a big help. It is also annoying to have these bugging us on every PR here on GitHub. Having the check on sonarcloud.io is more than enough.

## Related issue(s)
- #341

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
