### PR TITLE
Fix delete bug in repeating groups

### DIFF
--- a/src/altinn-app-frontend/src/utils/databindings.test.ts
+++ b/src/altinn-app-frontend/src/utils/databindings.test.ts
@@ -152,6 +152,13 @@ describe('utils/databindings.ts', () => {
       expect('aNull' in result).toBe(false);
     });
 
+    it('should skip empty arrays', () => {
+      testObj.anEmptyArray = [];
+      const result = flattenObject(testObj);
+      expect(typeof result.aNull).toBe('undefined');
+      expect('aNull' in result).toBe(false);
+    });
+
     it('should return boolean as a string', () => {
       testObj.aBool = true;
       const result = flattenObject(testObj);
@@ -223,6 +230,7 @@ describe('utils/databindings.ts', () => {
             ],
           },
         ],
+        EmptyGroup: [],
       };
       const result = flattenObject(testObj);
       expect(result).toEqual(testFormData);

--- a/src/altinn-app-frontend/src/utils/databindings.ts
+++ b/src/altinn-app-frontend/src/utils/databindings.ts
@@ -171,7 +171,7 @@ export function flattenObject(data: any): any {
   for (const key of Object.keys(flat)) {
     if (flat[key] === null) {
       delete flat[key];
-    } else if (flat[key] === '' && key.indexOf('.') > 0) {
+    } else if (flat[key].toString() === '' && key.indexOf('.') > 0) {
       // For backwards compatibility, delete keys inside deeper object that are empty strings. This behaviour is
       // not always consistent, as it is only a case for deeper object (not direct properties).
       delete flat[key];

--- a/src/altinn-app-frontend/src/utils/databindings.ts
+++ b/src/altinn-app-frontend/src/utils/databindings.ts
@@ -169,9 +169,9 @@ export function flattenObject(data: any): any {
   const flat = dot(data);
 
   for (const key of Object.keys(flat)) {
-    if (flat[key] === null) {
+    if (flat[key] === null || (Array.isArray(flat[key]) && flat[key].length === 0)) {
       delete flat[key];
-    } else if (flat[key].toString() === '' && key.indexOf('.') > 0) {
+    } else if (flat[key] === '' && key.indexOf('.') > 0) {
       // For backwards compatibility, delete keys inside deeper object that are empty strings. This behaviour is
       // not always consistent, as it is only a case for deeper object (not direct properties).
       delete flat[key];

--- a/src/altinn-app-frontend/src/utils/formLayout.ts
+++ b/src/altinn-app-frontend/src/utils/formLayout.ts
@@ -106,7 +106,7 @@ export function getRepeatingGroups(formLayout: ILayout, formData: any) {
   });
 
   // filter away groups that should be rendered as child groups
-  const filteredGroups = formLayout.filter((group) => childGroups.indexOf(group.id) === -1);
+  const filteredGroups = groups.filter((group) => childGroups.indexOf(group.id) === -1);
 
   filteredGroups.forEach((groupElement: ILayoutGroup) => {
     if (groupElement.maxCount && groupElement.maxCount > 1) {


### PR DESCRIPTION
Co-authored-by: Magnus Revheim Martinsen <mrmartinsen.96@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Since updating the flattenObject function, empty repeating groups get added to the formData object like this: `'Innflytter.TidligereBosteder': ''`. If there are elements in the repeating groups this does not happen. This is because `[].toString() = ''`. This then causes a problem inside `getRepeatingGroups`: since:
```typescript
if (groupFormData && groupFormData.length > 0) { // Passes this check
  const maxIndex = getMaxIndexInKeys(groupFormData);
  if (maxIndex !== -1) { // Fails this check
```
Results in the group not being added to `uiConfig.repeatingGroups`.

Which again is the cause of the bug @Magnusrm described about deleting elements.