### PR TITLE
Fix date-picker appearance to match other components design

### DIFF
--- a/src/altinn-app-frontend/src/components/base/DatepickerComponent.test.tsx
+++ b/src/altinn-app-frontend/src/components/base/DatepickerComponent.test.tsx
@@ -71,7 +71,7 @@ describe('DatepickerComponent', () => {
 
     expect(getCalendarYearHeader()).toBeInTheDocument();
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
-    expect(console.error).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalledTimes(2);
     expect(console.error).toHaveBeenCalledWith(
       expect.stringMatching(
         /Material-UI: The `fade` color utility was renamed to `alpha` to better describe its functionality/,

--- a/src/altinn-app-frontend/src/components/base/DatepickerComponent.tsx
+++ b/src/altinn-app-frontend/src/components/base/DatepickerComponent.tsx
@@ -21,9 +21,11 @@ const iconSize = '30px';
 
 const useStyles = makeStyles((theme) => ({
   root: {
+    backgroundColor: 'white',
     boxSizing: 'border-box',
     height: '36px',
     fontSize: '1.6rem',
+    fontFamily: 'Altinn-DIN',
     borderWidth: '2px',
     borderStyle: 'solid',
     marginBottom: '0px',
@@ -56,12 +58,32 @@ const useStyles = makeStyles((theme) => ({
     marginBottom: '0px',
     marginTop: '0px',
   },
+  dialog: {
+    '& *': {
+      fontFamily: 'Altinn-DIN',
+    },
+    '& .MuiTypography-h4': {
+      fontSize: '2.4rem',
+    },
+    '& .MuiTypography-body1': {
+      fontSize: '1.8rem',
+    },
+    '& .MuiTypography-body2': {
+      fontSize: '1.6rem',
+    },
+    '& .MuiTypography-caption': {
+      fontSize: '1.6rem',
+    },
+    '& .MuiTypography-subtitle1': {
+      fontSize: '1.6rem',
+    },
+  },
 }));
 
 class AltinnMomentUtils extends MomentUtils {
   getDatePickerHeaderText(date: moment.Moment) {
     if (date && date.locale() === 'nb') {
-      return date.format('ddd, D MMM');
+      return date.format('dddd, D. MMMM');
     }
     return super.getDatePickerHeaderText(date);
   }
@@ -162,6 +184,8 @@ function DatepickerComponent({
                 'aria-describedby': `description-${id}`,
               }),
             }}
+            DialogProps={{ className: classes.dialog }}
+            PopoverProps={{ className: classes.dialog }}
             FormHelperTextProps={{
               classes: {
                 root: classes.formHelperText,

--- a/src/altinn-app-frontend/src/components/base/DatepickerComponent.tsx
+++ b/src/altinn-app-frontend/src/components/base/DatepickerComponent.tsx
@@ -28,14 +28,15 @@ const useStyles = makeStyles((theme) => ({
     fontFamily: 'Altinn-DIN',
     borderWidth: '2px',
     borderStyle: 'solid',
+    borderRadius: 'var(--interactive_components-border_radius-normal)',
     marginBottom: '0px',
     borderColor: theme.altinnPalette.primary.blueMedium,
     '&:hover': {
       borderColor: theme.altinnPalette.primary.blueDark,
     },
-    '&:focus-within': {
-      outlineOffset: '0px',
-      outline: `2px solid ${theme.altinnPalette.primary.blueDark}`,
+    '&:has(input:focus-visible)': {
+      outline: 'var(--component-input-color-outline-focus) auto var(--border_width-thin)',
+      outlineOffset: 'calc(var(--border_width-thin) + var(--border_width-standard))',
     },
   },
   input: {
@@ -49,6 +50,17 @@ const useStyles = makeStyles((theme) => ({
   icon: {
     fontSize: iconSize,
     lineHeight: iconSize,
+    color: 'var(--colors-blue-900)',
+  },
+  iconButton: {
+    padding: 3,
+    '&:focus': {
+      outline: 'none',
+    },
+    '&:focus-visible': {
+      outline: 'var(--interactive_components-colors-focus_outline) solid var(--border_width-standard)',
+      outlineOffset: 'var(--border_width-standard)',
+    },
   },
   formHelperText: {
     fontSize: '1.4rem',
@@ -194,6 +206,9 @@ function DatepickerComponent({
             KeyboardButtonProps={{
               'aria-label': getLanguageFromKey('date_picker.aria_label_icon', language),
               id: 'date-icon-button',
+              classes: {
+                root: classes.iconButton,
+              },
             }}
             leftArrowButtonProps={{
               'aria-label': getLanguageFromKey('date_picker.aria_label_left_arrow', language),

--- a/src/altinn-app-frontend/src/utils/dateHelpers.ts
+++ b/src/altinn-app-frontend/src/utils/dateHelpers.ts
@@ -14,6 +14,7 @@ export function getISOString(potentialDate: string | undefined): string | undefi
   }
 
   const momentDate = moment(potentialDate);
+  momentDate.set('hour', 12).set('minute', 0).set('second', 0).set('millisecond', 0);
   return momentDate.isValid() ? momentDate.toISOString() : undefined;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Just a small change to fix the date-pickers weird appearance (mostly background-color and font). Also did the border-radius, focus styles and icon color.

Before:
<img width="345" alt="image" src="https://user-images.githubusercontent.com/47412359/201366535-766522cb-3cd4-4541-a6d7-2dfcb3874104.png">

After:
<img width="345" alt="image" src="https://user-images.githubusercontent.com/47412359/201369731-9190d5a7-6276-4980-a1ab-fa86da07c933.png">

