### PR TITLE
Custom web component: Converting React elements to HTML

### DIFF
--- a/schemas/json/layout/layout.schema.v1.json
+++ b/schemas/json/layout/layout.schema.v1.json
@@ -42,7 +42,7 @@
           "type": "string",
           "title": "Type",
           "description": "The component type.",
-          "enum": ["AddressComponent", "AttachmentList", "Button", "Checkboxes", "Datepicker", "Dropdown", "FileUpload", "FileUploadWithTag", "Group", "Header", "Image", "Input", "InstantiationButton", "Likert", "MultipleSelect", "NavigationButtons", "NavigationBar", "Panel", "Paragraph", "PrintButton", "RadioButtons", "Summary", "TextArea"]
+          "enum": ["AddressComponent", "AttachmentList", "Button", "Checkboxes", "Custom", "Datepicker", "Dropdown", "FileUpload", "FileUploadWithTag", "Group", "Header", "Image", "Input", "InstantiationButton", "Likert", "MultipleSelect", "NavigationButtons", "NavigationBar", "Panel", "Paragraph", "PrintButton", "RadioButtons", "Summary", "TextArea"]
         },
         "required": {
           "title": "Required",
@@ -122,6 +122,7 @@
         { "if": {"properties": {"type": { "const": "AddressComponent"}}}, "then": { "$ref": "#/definitions/addressComponent"}},
         { "if": {"properties": {"type": { "const": "AttachmentList"}}}, "then": { "$ref": "#/definitions/attachmentListComponent"}},
         { "if": {"properties": {"type": { "const": "Checkboxes"}}}, "then": { "$ref": "#/definitions/radioAndCheckboxComponents"}},
+        { "if": {"properties": {"type": { "const": "Custom"}}}, "then": { "$ref": "#/definitions/customComponent"}},
         { "if": {"properties": {"type": { "const": "Datepicker"}}}, "then": { "$ref": "#/definitions/datepickerComponent"}},
         { "if": {"properties": {"type": { "const": "Dropdown"}}}, "then": { "$ref": "#/definitions/selectionComponents"}},
         { "if": {"properties": {"type": { "const": "FileUpload"}}}, "then": { "$ref": "#/definitions/fileUploadComponent"}},
@@ -597,6 +598,16 @@
           "$ref": "#/definitions/saveWhileTyping"
         }
       }
+    },
+    "customComponent": {
+      "properties": {
+        "tagName": {
+          "type": "string",
+          "title": "Tag name",
+          "description": "Web component tag name to use"
+        }
+      },
+      "required": ["tagName"]
     },
     "summaryComponent": {
       "properties": {

--- a/src/altinn-app-frontend/setupTests.ts
+++ b/src/altinn-app-frontend/setupTests.ts
@@ -1,5 +1,6 @@
 import 'jest';
 import '@testing-library/jest-dom/extend-expect';
+import { TextEncoder, TextDecoder } from 'util';
 
 import type { IAltinnWindow } from 'src/types';
 
@@ -25,3 +26,6 @@ altinnWindow.app = 'test';
 jest.setTimeout(10000);
 
 jest.mock('axios');
+
+(global as any).TextEncoder = TextEncoder;
+(global as any).TextDecoder = TextDecoder;

--- a/src/altinn-app-frontend/src/components/custom/CustomWebComponent.test.tsx
+++ b/src/altinn-app-frontend/src/components/custom/CustomWebComponent.test.tsx
@@ -21,6 +21,7 @@ describe('CustomWebComponent', () => {
     const element = screen.getByTestId('test-component');
     expect(element.id).toEqual('test-component');
     expect(element.getAttribute('data-CustomAttributeWithJson')).toEqual(JSON.stringify(jsonAttributeValue));
+    expect(element.getAttribute('data-CustomAttributeWithReact')).toEqual('<span>Hello world</span>');
   });
 
   it('should render the component with passed props as attributes', () => {
@@ -58,6 +59,7 @@ describe('CustomWebComponent', () => {
         title: 'title',
       },
       'data-CustomAttributeWithJson': jsonAttributeValue,
+      'data-CustomAttributeWithReact': <span>Hello world</span>,
     };
 
     const resources = [

--- a/src/altinn-app-frontend/src/components/custom/CustomWebComponent.tsx
+++ b/src/altinn-app-frontend/src/components/custom/CustomWebComponent.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactDOMServer from 'react-dom/server';
 
 import { useAppSelector } from 'src/common/hooks';
 import type { PropsFromGenericComponent } from 'src/components';
@@ -64,7 +65,9 @@ function CustomWebComponent({
   const propsAsAttributes: any = {};
   Object.keys(passThroughProps).forEach((key) => {
     let prop = passThroughProps[key];
-    if (['object', 'array'].includes(typeof prop)) {
+    if (React.isValidElement(prop)) {
+      prop = ReactDOMServer.renderToStaticMarkup(prop);
+    } else if (['object', 'array'].includes(typeof prop)) {
       prop = JSON.stringify(passThroughProps[key]);
     }
     propsAsAttributes[key] = prop;


### PR DESCRIPTION
## Description
This bug was caused by React elements being passed to a component, which tried to JSON serialize the object. Solved by converting react elements to static HTML before passing them to the web component.

The inclusion of `react-dom/server` increases the bundle size from `2.87 MiB` to `2.93 MiB`.

## Related Issue(s)
- closes #596

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- ~~[ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~
