### PR TITLE
Yet another release script fix

### DIFF
--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -141,7 +141,7 @@ git status --short
 
 if [[ "$COMMIT" == "yes" ]]; then
   echo " * Committing changes"
-  git commit --author="$AUTHOR_NAME <$AUTHOR_EMAIL>" -F "$COMMIT_FILE"
+  git -c user.email="$AUTHOR_EMAIL" -c user.name="$AUTHOR_NAME" commit -F "$COMMIT_FILE"
 else
     echo " * Skipping commit (toggle with --commit)"
 fi


### PR DESCRIPTION
## Description
The release script still fails, and it apparently wasn't failing because of my name before (but rather because `--author` is broken when committing without a default author).

## Related Issue(s)
- #655

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
