### PR TITLE
Bugfix: Missing 'required' property on component was interpreted as 'true'

### DIFF
--- a/src/altinn-app-frontend/src/utils/validation/validation.ts
+++ b/src/altinn-app-frontend/src/utils/validation/validation.ts
@@ -215,6 +215,7 @@ export function validateEmptyFieldsForNodes(
       node.item.type === 'FileUpload' ||
       node.item.type === 'FileUploadWithTag' ||
       node.item.required === false ||
+      node.item.required === undefined ||
       node.isHidden(hiddenFields)
     ) {
       continue;


### PR DESCRIPTION
## Description
Test case added by removing a `"required": false` in `frontend-test`. 

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
