### PR TITLE
Bugfix: Crash when `null` in `textResourceBindings`

### DIFF
--- a/src/altinn-app-frontend/src/features/expressions/index.ts
+++ b/src/altinn-app-frontend/src/features/expressions/index.ts
@@ -55,7 +55,7 @@ export function evalExprInObj<T>(args: EvalExprInObjArgs<T>): ExprResolved<T> {
  * Recurse through an input object/array/any, finds expressions and evaluates them
  */
 function evalExprInObjectRecursive<T>(input: any, args: Omit<EvalExprInObjArgs<T>, 'input'>, path: string[]) {
-  if (typeof input !== 'object') {
+  if (typeof input !== 'object' || input === null) {
     return input;
   }
 


### PR DESCRIPTION
## Description
A `null` here is invalid according to JsonSchema, but it seems Studio puts in a `null` anyway. Adding test-case by putting a `null` in one of the components in `frontend-test`.

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
