### PR TITLE
Fix saving row with triggers=validation

### DIFF
--- a/src/altinn-app-frontend/src/utils/validation/validation.ts
+++ b/src/altinn-app-frontend/src/utils/validation/validation.ts
@@ -16,7 +16,7 @@ import { getFieldName, getFormDataForComponent } from 'src/utils/formComponentUt
 import { createRepeatingGroupComponents, getVariableTextKeysForRepeatingGroupComponent } from 'src/utils/formLayout';
 import { buildInstanceContext } from 'src/utils/instanceContext';
 import { matchLayoutComponent, setupGroupComponents } from 'src/utils/layout';
-import { resolvedNodesInLayouts } from 'src/utils/layout/hierarchy';
+import { nodesInLayout, resolvedNodesInLayouts } from 'src/utils/layout/hierarchy';
 import type { IFormData } from 'src/features/form/data';
 import type { ILayout, ILayoutComponent, ILayoutGroup, ILayouts } from 'src/features/form/layout';
 import type { ILayoutCompDatePicker } from 'src/features/form/layout/index';
@@ -849,6 +849,33 @@ export function findComponentFromValidationIssue(
     component,
     componentValidations,
   };
+}
+
+export function filterValidationsByRow(
+  validations: IValidations,
+  formLayout: ILayout | null | undefined,
+  repeatingGroups: IRepeatingGroups | null | undefined,
+  groupId: string,
+  rowIndex?: number,
+): IValidations {
+  if (!formLayout || !repeatingGroups || typeof rowIndex === 'undefined') {
+    return validations;
+  }
+
+  const nodes = nodesInLayout(formLayout, repeatingGroups);
+  const groupNode = nodes.findById(groupId);
+  const childIds = groupNode?.flat(false, rowIndex).map((child) => child.item.id);
+  const filteredValidations = JSON.parse(JSON.stringify(validations)) as IValidations;
+
+  Object.keys(filteredValidations).forEach((layout) => {
+    Object.keys(filteredValidations[layout]).forEach((componentId) => {
+      if (!childIds?.includes(componentId)) {
+        delete filteredValidations[layout][componentId];
+      }
+    });
+  });
+
+  return filteredValidations;
 }
 
 /* Function to map the new data element validations to our internal redux structure */

--- a/src/altinn-app-frontend/src/utils/validation/validation.ts
+++ b/src/altinn-app-frontend/src/utils/validation/validation.ts
@@ -864,16 +864,16 @@ export function filterValidationsByRow(
 
   const nodes = nodesInLayout(formLayout, repeatingGroups);
   const groupNode = nodes.findById(groupId);
-  const childIds = groupNode?.flat(false, rowIndex).map((child) => child.item.id);
+  const childIds = new Set(groupNode?.flat(false, rowIndex).map((child) => child.item.id));
   const filteredValidations = JSON.parse(JSON.stringify(validations)) as IValidations;
 
-  Object.keys(filteredValidations).forEach((layout) => {
-    Object.keys(filteredValidations[layout]).forEach((componentId) => {
-      if (!childIds?.includes(componentId)) {
+  for (const layout of Object.keys(filteredValidations)) {
+    for (const componentId of Object.keys(filteredValidations[layout])) {
+      if (!childIds?.has(componentId)) {
         delete filteredValidations[layout][componentId];
       }
-    });
-  });
+    }
+  }
 
   return filteredValidations;
 }

--- a/test/cypress/e2e/integration/app-frontend/group.js
+++ b/test/cypress/e2e/integration/app-frontend/group.js
@@ -166,9 +166,9 @@ describe('Group', () => {
       } else {
         cy.get(appFrontend.errorReport)
           .should('not.exist');
-        cy.get(appFrontend.group.rows[0].editBtn).should('exist').and('be.visible').focus().click();
       }
 
+      cy.get(appFrontend.group.rows[0].editBtn).should('exist').and('be.visible').focus().click();
       cy.get(appFrontend.group.currentValue).should('be.visible').clear().blur();
       cy.get(appFrontend.group.saveMainGroup).focus().should('be.visible').click();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added a function to `validation.ts`: `filterValidationsByRow`. This is used to check validation errors on only the current row when trying to save the row, even with `triggers=validation`. It is also used to filter out serverValidations when using `triggers=validateRow`.

## Related Issue(s)
- #653 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- ~~User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~
