### PR TITLE
Improving the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+<!--- Provide a general summary of your changes in the Title above -->
+
+## Description
+<!--- Describe your changes in detail -->
+
+## Related Issue(s)
+- #{issue number}
+
+## Verification
+- [ ] **Your** code builds clean without any errors or warnings
+- [ ] Manual testing done (required)
+- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
+- [ ] All tests run green
+
+## Documentation
+- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,15 +1,39 @@
-<!--- Provide a general summary of your changes in the Title above -->
-
 ## Description
-<!--- Describe your changes in detail -->
+<!---
+  Provide a general summary of your changes in the Title above
+  Describe your change(s) in detail here
+
+  Also add the relevant label in the column on the right:
+    Breaking changes: kind/breaking-change
+    New features:     kind/product-feature
+    Bug fixes:        kind/bug
+    Dependencies:     kind/dependencies
+    Other changes:    kind/other
+-->
 
 ## Related Issue(s)
-- #{issue number}
+- closes #{issue number}
 
 ## Verification
-- [ ] **Your** code builds clean without any errors or warnings
-- [ ] Manual testing done (required)
-- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
-
-## Documentation
-- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
+- Manual testing
+  - [ ] I have tested these changes manually
+  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing
+  - [ ] No testing done/necessary
+- Automated tests
+  - [ ] Unit test(s) have been added
+  - [ ] Cypress E2E test(s) have been added
+  - [ ] No automatic tests are needed here
+  - [ ] I want someone to help me make some tests
+- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
+  - [ ] Has been updated
+   <!--- insert link to PR here -->
+  - [ ] No changes/updates needed
+- Changes/additions to component properties
+  - [ ] Changes are reflected in both `layout/index.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
+  - [ ] No changes made
+- Support in Altinn Studio
+  - [ ] Issue(s) created for support in Studio
+   <!--- insert link to issue(s) here -->
+  - [ ] This change/feature does not require any changes to Altinn Studio
+- Sprint board
+  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board <!--- If you don't have permissions for this, someone else will do it for you -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,6 @@
 - [ ] **Your** code builds clean without any errors or warnings
 - [ ] Manual testing done (required)
 - [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
-- [ ] All tests run green
 
 ## Documentation
 - [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -14,10 +14,10 @@ changelog:
         - kind/bug
     - title: Other Changes
       labels:
-        - "*"
-      exclude:
-        labels:
-          - kind/dependencies
+        - kind/other
     - title: Dependency Upgrades 📦
       labels:
         - kind/dependencies
+    - title: Uncategorized changes
+      labels:
+        - "*"


### PR DESCRIPTION
I find that the default PR template is not very specific to what we do in this project. Two of the tasks ('your code builds clean' and 'all tests run green') are not needed at all - these things are tested automatically.

This PR template is a lot more specific, and contains a lot more tasks, but I also tried to structure them in a way that makes it so that each 'group' could be interpreted as a radio group, and where at least one checkbox could be checked for any type of PR. For example, there is a big difference between not having ticked off the 'I added documentation for this' checkbox and a change not _needing_ any documentation changes.

@Magnusrm @bjosttveit Do you have any wants, wishes, comments or do you dislike the verbosity of this PR template?