### PR TITLE
Removing `go-to-task` trick in Cypress tests

### DIFF
--- a/test/cypress/e2e/support/app-frontend.js
+++ b/test/cypress/e2e/support/app-frontend.js
@@ -54,6 +54,13 @@ Cypress.Commands.add('getReduxState', (selector) => {
     });
 });
 
+Cypress.Commands.add('reduxDispatch', (action) => {
+  return cy
+    .window()
+    .its('reduxStore')
+    .invoke('dispatch', action);
+});
+
 Cypress.Commands.add('interceptLayout', (layoutName, mutator, wholeLayoutMutator) => {
   cy.intercept({ method: 'GET', url: `**/api/layouts/${layoutName}`, times: 1 }, (req) => {
     req.reply((res) => {

--- a/test/cypress/e2e/support/index.d.ts
+++ b/test/cypress/e2e/support/index.d.ts
@@ -76,6 +76,11 @@ declare namespace Cypress {
     getReduxState(selector?: (state: any) => any): any;
 
     /**
+     * Dispatch a redux action directly
+     */
+    reduxDispatch(action: { type: string; payload?: Record<string, any> }): any;
+
+    /**
      * Allows you to intercept the fetched layout and make changes to it. This makes
      * it possible to add small adjustments to the layout not originally intended in
      * the app you're testing, such as marking some components as required, etc.

--- a/test/cypress/e2e/support/navigation.js
+++ b/test/cypress/e2e/support/navigation.js
@@ -8,76 +8,57 @@ const mui = new Common();
 
 /**
  * This object contains a valid data model for each of the tasks that can be fast-skipped. To produce one such data
- * model, fill out the form with valid data and grab the PUT data body when data is saved to the current data model
- * for each task.
+ * model, fill out the form with valid data and grab the current redux formData state.
  *
  * This is used to inject into the instance data when fast-skipping through an instance to reach the desired task
  * when using goto(..., 'fast')
  */
 const validMinimalData = {
   changeName: {
-    skjemanummer: '1533',
-    spesifikasjonsnummer: '11172',
-    blankettnummer: 'RF-1453',
-    tittel: 'Endring av navn',
-    gruppeid: '9308',
-    Radioknapp: '1',
-    'Innledning-grp-9309': {
-      gruppeid: '9309',
-      'Signerer-grp-9320': {
-        gruppeid: '9320',
-        'SignererEkstraReferanseAltinn-datadef-34751': { orid: '34751', value: 'altinn' },
-        'SignererEkstraArkivDato-datadef-34752': { value: '2022-11-22' },
-      },
-      'Kontaktinformasjon-grp-9311': {
-        gruppeid: '9311',
-        MelderFultnavn: { orid: '34735', value: 'Ola Nordmann' },
-      },
-      'NavneendringenGjelderFor-grp-9310': {
-        'SubjektFornavnFolkeregistrert-datadef-34730': { value: 'hello world task is being skipped' },
-      },
-    },
-    'NyttNavn-grp-9313': {
-      'NyttNavn-grp-9314': {
-        'PersonFornavnNytt-datadef-34758': { value: 'hello world' },
-        'PersonEtternavnNytt-datadef-34757': { value: 'task is being skipped' },
-        PersonBekrefterNyttNavn: { value: 'Ja' },
-      },
-    },
-    'Tilknytning-grp-9315': {
-      'TilknytningTilNavnet-grp-9316': {
-        'TilknytningEtternavn1-grp-9350': { 'PersonEtternavnForste-datadef-34896': { value: 'asdfasdf2' } },
-      },
-    },
+    'skjemanummer': '1533',
+    'spesifikasjonsnummer': '11172',
+    'blankettnummer': 'RF-1453',
+    'tittel': 'Endring av navn',
+    'gruppeid': '9308',
+    'Radioknapp': '1',
+    'Innledning-grp-9309.gruppeid': '9309',
+    'Innledning-grp-9309.Signerer-grp-9320.gruppeid': '9320',
+    'Innledning-grp-9309.Signerer-grp-9320.SignererEkstraReferanseAltinn-datadef-34751.orid': '34751',
+    'Innledning-grp-9309.Signerer-grp-9320.SignererEkstraReferanseAltinn-datadef-34751.value': 'altinn',
+    'Innledning-grp-9309.Signerer-grp-9320.SignererEkstraArkivDato-datadef-34752.value': '2022-11-22',
+    'Innledning-grp-9309.Kontaktinformasjon-grp-9311.gruppeid': '9311',
+    'Innledning-grp-9309.Kontaktinformasjon-grp-9311.MelderFultnavn.orid': '34735',
+    'Innledning-grp-9309.Kontaktinformasjon-grp-9311.MelderFultnavn.value': 'Ola Nordmann',
+    'Innledning-grp-9309.NavneendringenGjelderFor-grp-9310.SubjektFornavnFolkeregistrert-datadef-34730.value': 'hello world task is being skipped',
+    'NyttNavn-grp-9313.NyttNavn-grp-9314.PersonFornavnNytt-datadef-34758.value': 'hello world',
+    'NyttNavn-grp-9313.NyttNavn-grp-9314.PersonEtternavnNytt-datadef-34757.value': 'task is being skipped',
+    'NyttNavn-grp-9313.NyttNavn-grp-9314.PersonBekrefterNyttNavn.value': 'Ja',
+    'Tilknytning-grp-9315.TilknytningTilNavnet-grp-9316.TilknytningEtternavn1-grp-9350.PersonEtternavnForste-datadef-34896.value': 'asdfasdf2'
   },
   group: {
-    skjemanummer: '1603',
-    spesifikasjonsnummer: '12392',
-    blankettnummer: 'RF-1366',
-    tittel: 'Endringsmelding',
-    gruppeid: '9785',
-    'Endringsmelding-grp-9786': {
-      gruppeid: '9786',
-      'Avgiver-grp-9787': {
-        gruppeid: '9787',
-        'KontaktpersonEPost-datadef-27688': { orid: '27688', value: 'Ja' },
-        'OppgavegiverNavn-datadef-68': { value: 'skipping to likert' },
-      },
-    },
+    'skjemanummer': '1603',
+    'spesifikasjonsnummer': '12392',
+    'blankettnummer': 'RF-1366',
+    'tittel': 'Endringsmelding',
+    'gruppeid': '9785',
+    'Endringsmelding-grp-9786.gruppeid': '9786',
+    'Endringsmelding-grp-9786.Avgiver-grp-9787.gruppeid': '9787',
+    'Endringsmelding-grp-9786.Avgiver-grp-9787.KontaktpersonEPost-datadef-27688.orid': '27688',
+    'Endringsmelding-grp-9786.Avgiver-grp-9787.KontaktpersonEPost-datadef-27688.value': 'Ja',
+    'Endringsmelding-grp-9786.Avgiver-grp-9787.OppgavegiverNavn-datadef-68.value': 'skipping to likert'
   },
 };
 
 function endTaskWithData(data) {
-  cy.intercept({ method: 'PUT', times: 1, url: `**/instances/*/*/data/*` }, (req) => {
-    req.body = data;
-    req.continue();
-  }).as('dataIntercepted');
+  cy.get('#toNextTask').should('be.visible');
+  cy.reduxDispatch({
+    type: 'formData/setFulfilled',
+    payload: {
+      formData: data
+    }
+  });
 
-  cy.intercept({ method: 'PUT', url: '**/instances/*/*/process/next?elementId=*', times: 1 }, (req) => {
-    req.continue();
-  }).as('skipTask');
   cy.get('#toNextTask').click();
-  cy.wait('@skipTask');
   cy.get('#toNextTask').should('not.exist');
 }
 
@@ -96,7 +77,9 @@ const completeFormFast = {
     genericSendIn();
   },
   changeName: () => endTaskWithData(validMinimalData.changeName),
-  group: () => endTaskWithData(validMinimalData.group),
+  group: () => {
+    endTaskWithData(validMinimalData.group);
+  },
   likert: () => {
     // TODO: Add fast data and skip button for likert?
     completeFormSlow.likert();


### PR DESCRIPTION
## Description
Hopefully fixing #667 by injecting a redux action instead of relying on a request to be intercepted. This _might_ need chagnes in the `frontend-test` app, but I'll let the tests run first without any changes to see if it works without.

## Related Issue(s)
- closes #667

## Verification
- Manual testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added
  - [x] Cypress E2E test(s) have been added
  - [ ] No automatic tests are needed here
  - [ ] I want someone to help me make some tests
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been updated
   <!--- insert link to PR here -->
  - [x] No changes/updates needed
- Changes/additions to component properties
  - [ ] Changes are reflected in both `layout/index.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
   <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board <!--- If you don't have permissions for this, someone else will do it for you -->
