### PR TITLE
Expressions: Adding debug function for ease of expression development

### DIFF
--- a/src/altinn-app-frontend/src/features/expressions/validation.ts
+++ b/src/altinn-app-frontend/src/features/expressions/validation.ts
@@ -230,7 +230,7 @@ export function asExpression(
           `${errorText}:`,
           prettyPrinted.lines,
           '%cUsing default value instead:',
-          `  %c${defaultValue.toString()}%c`,
+          `  %c${defaultValue === null ? 'null' : defaultValue.toString()}%c`,
         ].join('\n'),
         ...prettyPrinted.css,
         ...['', 'color: red;', ''],

--- a/src/altinn-app-frontend/src/store/index.ts
+++ b/src/altinn-app-frontend/src/store/index.ts
@@ -6,6 +6,7 @@ import type { SagaMiddleware } from 'redux-saga';
 
 import reducers from 'src/reducers';
 import { appApi } from 'src/services/AppApi';
+import type { IAltinnWindow } from 'src/types';
 
 export const sagaMiddleware: SagaMiddleware<any> = createSagaMiddleware();
 const middlewares = [sagaMiddleware, appApi.middleware];
@@ -37,12 +38,14 @@ export const setupStore = (preloadedState?: PreloadedState<RootState>) => {
 
 export const store = setupStore();
 
-if (process.env.NODE_ENV === 'development') {
-  // Expose store when running in Cypress. This allows for using cy.getReduxState() to run assertions against the redux
-  // state at various points in the tests. Testing the state directly might expose problems not easily/visibly testable
-  // in the app itself.
-  (window as any).reduxStore = store;
+// Expose store globally. This allows for
+// 1. Using cy.getReduxState() in Cypress to run assertions against the redux state at various points in the tests,
+//    and inject actions when we need to. Testing the state directly might expose problems not easily/visibly testable
+//    in the app itself.
+// 2. Allows the window.evalExpression() test-function to get the current state for testing expressions.
+(window as unknown as IAltinnWindow).reduxStore = store;
 
+if (process.env.NODE_ENV === 'development') {
   // Expose a log containing all dispatched actions. This is useful when Cypress tests fail, so that we can gather
   // the logged actions to re-construct the redux state history using the redux devtools.
   (window as any).reduxActionLog = actionLog;

--- a/src/altinn-app-frontend/src/types/index.ts
+++ b/src/altinn-app-frontend/src/types/index.ts
@@ -1,3 +1,4 @@
+import type { ToolkitStore } from '@reduxjs/toolkit/src/configureStore';
 import type Ajv from 'ajv/dist/core';
 
 import type { ExpressionOr } from 'src/features/expressions/types';
@@ -11,6 +12,8 @@ export interface IAltinnWindow extends Window {
   instanceId: string;
   org: string;
   reportee: string;
+  evalExpression: (maybeExpression: any, forComponentId?: string) => any;
+  reduxStore: ToolkitStore<IRuntimeState>;
 }
 
 export interface IComponentBindingValidation {


### PR DESCRIPTION
## Description
Adding a global function (`evalExpression`) that I will soon add documentation for when documenting the expressions. Having a way to test the engine can be very useful - both for app developers and us.

![20221117_13h48m25s_grim](https://user-images.githubusercontent.com/700139/202450987-e1b07f21-93c5-42d3-bb6c-395e1abf6225.png)

## Related Issue(s)
- closes #{issue number}

## Verification
- Manual testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added
  - [ ] Cypress E2E test(s) have been added
  - [ ] No automatic tests are needed here
  - [ ] I want someone to help me make some tests
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been updated
   <!--- insert link to PR here -->
  - [ ] No changes/updates needed
- Changes/additions to component properties
  - [ ] Changes are reflected in both `layout/index.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [ ] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
   <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board <!--- If you don't have permissions for this, someone else will do it for you -->
