### PR TITLE
Give server rowIndex for validateRow trigger

### DIFF
--- a/src/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
+++ b/src/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
@@ -29,6 +29,7 @@ import {
   splitDashedKey,
 } from 'src/utils/formLayout';
 import { getLayoutsetForDataElement } from 'src/utils/layout';
+import { nodesInLayouts } from 'src/utils/layout/hierarchy';
 import { getOptionLookupKey, removeGroupOptionsByIndex } from 'src/utils/options';
 import {
   canFormBeSaved,
@@ -510,11 +511,12 @@ export function* updateRepeatingGroupEditIndexSaga({
   payload: { group, index, validate },
 }: PayloadAction<IUpdateRepeatingGroupsEditIndex>): SagaIterator {
   try {
-    if (validate) {
-      const state: IRuntimeState = yield select();
+    const state: IRuntimeState = yield select();
+    const rowIndex = state.formLayout.uiConfig.repeatingGroups?.[group].editIndex;
+
+    if (validate && typeof rowIndex === 'number' && rowIndex > -1) {
       const validations: IValidations = state.formValidations.validations;
       const currentView = state.formLayout.uiConfig.currentView;
-      const rowIndex = state.formLayout.uiConfig.repeatingGroups?.[group].editIndex;
 
       const frontendValidations: IValidations = validateGroup(
         group,
@@ -522,10 +524,16 @@ export function* updateRepeatingGroupEditIndexSaga({
         validate === Triggers.ValidateRow ? rowIndex : undefined,
       );
 
+      // Get group's rowIndices to send to server for validations
+      const nodes = nodesInLayouts(state.formLayout.layouts, currentView, state.formLayout.uiConfig.repeatingGroups);
+      const groupNode = nodes.findById(group);
+      const rowIndices = groupNode?.rowIndices();
+      rowIndices?.push(rowIndex);
+
       const options: AxiosRequestConfig = {
         headers: {
           ComponentId: group,
-          ...(validate === Triggers.ValidateRow ? { RowIndex: rowIndex } : {}),
+          RowIndex: rowIndices?.join(',') ?? '',
         },
       };
 

--- a/src/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
+++ b/src/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
@@ -29,7 +29,6 @@ import {
   splitDashedKey,
 } from 'src/utils/formLayout';
 import { getLayoutsetForDataElement } from 'src/utils/layout';
-import { nodesInLayouts } from 'src/utils/layout/hierarchy';
 import { getOptionLookupKey, removeGroupOptionsByIndex } from 'src/utils/options';
 import {
   canFormBeSaved,
@@ -525,15 +524,13 @@ export function* updateRepeatingGroupEditIndexSaga({
       );
 
       // Get group's rowIndices to send to server for validations
-      const nodes = nodesInLayouts(state.formLayout.layouts, currentView, state.formLayout.uiConfig.repeatingGroups);
-      const groupNode = nodes.findById(group);
-      const rowIndices = groupNode?.rowIndices();
-      rowIndices?.push(rowIndex);
+      const { depth: rowIndices } = splitDashedKey(group);
+      rowIndices.push(rowIndex);
 
       const options: AxiosRequestConfig = {
         headers: {
           ComponentId: group,
-          RowIndex: rowIndices?.join(',') ?? '',
+          RowIndex: rowIndices.join(','),
         },
       };
 

--- a/src/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
+++ b/src/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
@@ -525,6 +525,7 @@ export function* updateRepeatingGroupEditIndexSaga({
       const options: AxiosRequestConfig = {
         headers: {
           ComponentId: group,
+          ...(validate === Triggers.ValidateRow ? { RowIndex: rowIndex } : {}),
         },
       };
 
@@ -562,15 +563,8 @@ export function* updateRepeatingGroupEditIndexSaga({
         state.formLayout.layouts,
         state.textResources.resources,
       );
-      const finalServerValidations: IValidations = filterValidationsByRow(
-        mappedServerValidations,
-        state.formLayout.layouts[currentView],
-        state.formLayout.uiConfig.repeatingGroups,
-        group,
-        validate === Triggers.ValidateRow ? rowIndex : undefined,
-      );
 
-      const combinedValidations = mergeValidationObjects(frontendValidations, finalServerValidations);
+      const combinedValidations = mergeValidationObjects(frontendValidations, mappedServerValidations);
 
       const rowValidations = filterValidationsByRow(
         combinedValidations,

--- a/src/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
+++ b/src/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
@@ -566,15 +566,23 @@ export function* updateRepeatingGroupEditIndexSaga({
 
       const combinedValidations = mergeValidationObjects(frontendValidations, mappedServerValidations);
 
+      // only overwrite validtions specific to the group - leave all other untouched
+      const newValidations = {
+        ...validations,
+        [currentView]: {
+          ...validations[currentView],
+          ...combinedValidations[currentView],
+        },
+      };
+      yield put(ValidationActions.updateValidations({ validations: newValidations }));
+
       const rowValidations = filterValidationsByRow(
         combinedValidations,
         state.formLayout.layouts[currentView],
         state.formLayout.uiConfig.repeatingGroups,
         group,
-        // Only compute if not already filtered
-        validate === Triggers.Validation ? rowIndex : undefined,
+        rowIndex,
       );
-
       if (canFormBeSaved({ validations: rowValidations, invalidDataTypes: false }, 'Complete')) {
         yield put(
           FormLayoutActions.updateRepeatingGroupsEditIndexFulfilled({
@@ -588,17 +596,6 @@ export function* updateRepeatingGroupEditIndexSaga({
             error: null,
           }),
         );
-      }
-      if (!canFormBeSaved({ validations: combinedValidations, invalidDataTypes: false }, 'Complete')) {
-        // only overwrite validtions specific to the group - leave all other untouched
-        const newValidations = {
-          ...validations,
-          [currentView]: {
-            ...validations[currentView],
-            ...combinedValidations[currentView],
-          },
-        };
-        yield put(ValidationActions.updateValidations({ validations: newValidations }));
       }
     } else {
       yield put(

--- a/src/altinn-app-frontend/src/utils/layout/hierarchy.ts
+++ b/src/altinn-app-frontend/src/utils/layout/hierarchy.ts
@@ -426,6 +426,21 @@ export class LayoutNode<NT extends NodeType = 'unresolved', Item extends AnyItem
     return parents;
   }
 
+  /**
+   * Returns a list of rowIndices, sorted by most senior parent's rowIndex first
+   * Useful for accessing the datamodel related to a nested component
+   */
+  public rowIndices(): number[] {
+    const rowIndices = this.parents((node) => typeof (node as AnyChildNode<'unresolved'>).rowIndex != 'undefined')
+      .map((node) => (node as AnyChildNode<'resolved'>).rowIndex)
+      .reverse();
+
+    if (typeof this.rowIndex != 'undefined') {
+      rowIndices.push(this.rowIndex);
+    }
+    return rowIndices as number[];
+  }
+
   private childrenIdsAsList(onlyInRowIndex?: number) {
     let list: AnyItem<NT>[] = [];
     if (this.item.type === 'Group' && 'rows' in this.item) {

--- a/src/altinn-app-frontend/src/utils/layout/hierarchy.ts
+++ b/src/altinn-app-frontend/src/utils/layout/hierarchy.ts
@@ -426,21 +426,6 @@ export class LayoutNode<NT extends NodeType = 'unresolved', Item extends AnyItem
     return parents;
   }
 
-  /**
-   * Returns a list of rowIndices, sorted by most senior parent's rowIndex first
-   * Useful for accessing the datamodel related to a nested component
-   */
-  public rowIndices(): number[] {
-    const rowIndices = this.parents((node) => typeof (node as AnyChildNode<'unresolved'>).rowIndex != 'undefined')
-      .map((node) => (node as AnyChildNode<'resolved'>).rowIndex)
-      .reverse();
-
-    if (typeof this.rowIndex != 'undefined') {
-      rowIndices.push(this.rowIndex);
-    }
-    return rowIndices as number[];
-  }
-
   private childrenIdsAsList(onlyInRowIndex?: number) {
     let list: AnyItem<NT>[] = [];
     if (this.item.type === 'Group' && 'rows' in this.item) {


### PR DESCRIPTION
## Description
<!---
  Provide a general summary of your changes in the Title above
  Describe your change(s) in detail here

  Also add the relevant label in the column on the right:
    Breaking changes: kind/breaking-change
    New features:     kind/product-feature
    Bug fixes:        kind/bug
    Dependencies:     kind/dependencies
    Other changes:    kind/other
-->

- When using `triggers=["validateRow"]` the rowIndex will now be sent to the server for validations. Docs have been updated to reflect this.
- No longer filters out server-validations not related to the current row on validateRow. This was the behaviour only a few days ago, and has been changed back since it is totally legitimate to add validation errors outside of the current group row. The developer is now expected to use the rowIndex in servervalidations to deal with this if necessary. Not really a breaking change, as the validateRow trigger is basically brand new.
- Previously, the group validation trigger would not dispatch an update to validations unless there were new errors present. This was a problem because the server could send back validations that had been fixed, and they would not be updated if there were no new errors. This has been changed so that it always dispatches an update to validations. Also should not be a breaking change, since dispatching no new errors should not make a difference, and no existing tests failed 🤷 

## Related Issue(s)
- [Slack-thread](https://altinn.slack.com/archives/C02ESDSGPN1/p1669016064881859)

## Verification
- Manual testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added
  - [ ] Cypress E2E test(s) have been added
  - [x] No automatic tests are needed here
  - [ ] I want someone to help me make some tests
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [x] Has been updated
    - https://github.com/Altinn/altinn-studio-docs/pull/754
   <!--- insert link to PR here -->
  - [ ] No changes/updates needed
- Changes/additions to component properties
  - [ ] Changes are reflected in both `layout/index.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
   <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board <!--- If you don't have permissions for this, someone else will do it for you -->
