### PR TITLE
Expressions: Tests for `dataModel` lookups against arrays and null

### DIFF
--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/dataModel/array-is-null.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/dataModel/array-is-null.json
@@ -1,0 +1,32 @@
+{
+  "name": "Looking up an array returns null",
+  "expression": ["dataModel", "a"],
+  "expects": null,
+  "dataModel": {
+    "a": [
+      {
+        "value": "ABC"
+      },
+      {
+        "other": "DEF"
+      }
+    ]
+  },
+  "layouts": {
+    "Page1": {
+      "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+      "data": {
+        "layout": [
+          {
+            "id": "current-component",
+            "type": "Paragraph"
+          }
+        ]
+      }
+    }
+  },
+  "context": {
+    "component": "current-component",
+    "currentLayout": "Page1"
+  }
+}

--- a/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/dataModel/null-is-null.json
+++ b/src/altinn-app-frontend/src/features/expressions/shared-tests/functions/dataModel/null-is-null.json
@@ -1,0 +1,25 @@
+{
+  "name": "Looking up null returns null",
+  "expression": ["dataModel", "a"],
+  "expects": null,
+  "dataModel": {
+    "a": null
+  },
+  "layouts": {
+    "Page1": {
+      "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+      "data": {
+        "layout": [
+          {
+            "id": "current-component",
+            "type": "Paragraph"
+          }
+        ]
+      }
+    }
+  },
+  "context": {
+    "component": "current-component",
+    "currentLayout": "Page1"
+  }
+}


### PR DESCRIPTION
## Description
These lookups should return `null` as long as we don't have support for these data types in expressions (yet).

## Related Issue(s)
- https://github.com/Altinn/app-lib-dotnet/pull/99

## Verification
- Manual testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing
  - [x] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added
  - [ ] Cypress E2E test(s) have been added
  - [ ] No automatic tests are needed here
  - [ ] I want someone to help me make some tests
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [x] Has been updated
   - https://github.com/Altinn/altinn-studio-docs/pull/749
  - [ ] No changes/updates needed
- Changes/additions to component properties
  - [ ] Changes are reflected in both `layout/index.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
   <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board <!--- If you don't have permissions for this, someone else will do it for you -->
