### PR TITLE
Enabling automatic WCAG tests, fixing some issues 

### DIFF
--- a/src/altinn-app-frontend/src/components/base/FileUpload/FileUploadComponent.tsx
+++ b/src/altinn-app-frontend/src/components/base/FileUpload/FileUploadComponent.tsx
@@ -170,11 +170,10 @@ export function FileUploadComponent({
       : getLanguageFromKey('general.loading', language);
 
     return uploaded ? (
-      <div>
+      <div aria-label={status}>
         {mobileView ? null : status}
         <i
           className='ai ai-check-circle'
-          aria-label={status}
           style={mobileView ? { marginLeft: '10px' } : {}}
         />
       </div>
@@ -193,10 +192,11 @@ export function FileUploadComponent({
     return (
       <div
         onClick={handleDeleteFile.bind(this, index)}
-        id={`attachment-delete-${index}`}
         onKeyPress={handleDeleteKeypress.bind(this, index)}
         tabIndex={0}
         role='button'
+        data-testid={`attachment-delete-${index}`}
+        aria-label={getLanguageFromKey('general.delete', language)}
       >
         {attachment.deleting ? (
           <AltinnLoader
@@ -212,10 +212,7 @@ export function FileUploadComponent({
             {mobileView
               ? getLanguageFromKey('general.delete', language)
               : getLanguageFromKey('form_filler.file_uploader_list_delete', language)}
-            <i
-              className='ai ai-trash'
-              aria-label={getLanguageFromKey('general.delete', language)}
-            />
+            <i className='ai ai-trash' />
           </>
         )}
       </div>

--- a/src/altinn-app-frontend/src/components/base/FileUpload/FileUploadWithTag/FileListComponent.tsx
+++ b/src/altinn-app-frontend/src/components/base/FileUpload/FileUploadWithTag/FileListComponent.tsx
@@ -212,10 +212,6 @@ export function FileList(props: FileListProps): JSX.Element | null {
                                 {getLanguageFromKey('form_filler.file_uploader_mb', props.language)}
                                 <i
                                   className='ai ai-check-circle'
-                                  aria-label={getLanguageFromKey(
-                                    'form_filler.file_uploader_list_status_done',
-                                    props.language,
-                                  )}
                                   style={props.mobileView ? { marginLeft: '10px' } : {}}
                                 />
                               </div>
@@ -258,13 +254,7 @@ export function FileList(props: FileListProps): JSX.Element | null {
                         {attachment.uploaded ? (
                           <div>
                             {getLanguageFromKey('form_filler.file_uploader_list_status_done', props.language)}
-                            <i
-                              className='ai ai-check-circle'
-                              aria-label={getLanguageFromKey(
-                                'form_filler.file_uploader_list_status_done',
-                                props.language,
-                              )}
-                            />
+                            <i className='ai ai-check-circle' />
                           </div>
                         ) : (
                           <AltinnLoader

--- a/src/altinn-app-frontend/src/components/base/FileUpload/shared/DropzoneComponent.tsx
+++ b/src/altinn-app-frontend/src/components/base/FileUpload/shared/DropzoneComponent.tsx
@@ -60,10 +60,7 @@ export function DropzoneComponent({
 }: IDropzoneComponentProps): JSX.Element {
   return (
     <div>
-      <div
-        className='file-upload-text-bold-small'
-        id='max-size'
-      >
+      <div className='file-upload-text-bold-small'>
         {`${getLanguageFromKey('form_filler.file_uploader_max_size', language)} ${maxFileSizeInMB} ${getLanguageFromKey(
           'form_filler.file_uploader_mb',
           language,
@@ -120,7 +117,6 @@ export function DropzoneComponent({
                   <label
                     htmlFor={id}
                     className='file-upload-text-bold'
-                    id='file-upload-description'
                   >
                     {isMobile ? (
                       <>{getLanguageFromKey('form_filler.file_uploader_upload', language)}</>
@@ -138,7 +134,6 @@ export function DropzoneComponent({
                   <label
                     htmlFor={id}
                     className='file-upload-text'
-                    id='file-format-description'
                   >
                     {getLanguageFromKey('form_filler.file_uploader_valid_file_format', language)}
                     {hasCustomFileEndings

--- a/src/altinn-app-frontend/src/components/base/FileUpload/shared/render.tsx
+++ b/src/altinn-app-frontend/src/components/base/FileUpload/shared/render.tsx
@@ -38,10 +38,7 @@ export const AttachmentsCounter = ({
   maxNumberOfAttachments,
 }: IAttachmentsCounterProps) => {
   return (
-    <div
-      className='file-upload-text-bold-small'
-      id='number-of-attachments'
-    >
+    <div className='file-upload-text-bold-small'>
       {`${getLanguageFromKey('form_filler.file_uploader_number_of_files', language)} ${
         minNumberOfAttachments ? `${currentNumberOfAttachments}/${maxNumberOfAttachments}` : currentNumberOfAttachments
       }.`}

--- a/src/altinn-app-frontend/src/components/base/ImageComponent.tsx
+++ b/src/altinn-app-frontend/src/components/base/ImageComponent.tsx
@@ -46,6 +46,7 @@ export function ImageComponent(props: IImageProps) {
             type='image/svg+xml'
             id={props.id}
             data={imgSrc}
+            role={'presentation'}
           >
             <img
               src={imgSrc}

--- a/src/altinn-app-frontend/src/components/summary/EditButton.tsx
+++ b/src/altinn-app-frontend/src/components/summary/EditButton.tsx
@@ -35,7 +35,10 @@ export function EditButton(props: IEditButtonProps) {
         className={classes.change}
       >
         <span>{props.editText}</span>
-        <i className={`fa fa-editing-file ${classes.editIcon}`} />
+        <i
+          aria-hidden='true'
+          className={`fa fa-editing-file ${classes.editIcon}`}
+        />
       </Typography>
     </IconButton>
   );

--- a/src/altinn-app-frontend/src/components/summary/__snapshots__/MultipleChoiceSummary.test.tsx.snap
+++ b/src/altinn-app-frontend/src/components/summary/__snapshots__/MultipleChoiceSummary.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`MultipleChoiceSummary MultipleChoiceSummary 1`] = `
             Endre
           </span>
           <i
+            aria-hidden="true"
             class="fa fa-editing-file makeStyles-editIcon-7"
           />
         </p>

--- a/src/altinn-app-frontend/src/components/summary/__snapshots__/SummaryGroupComponent.test.tsx.snap
+++ b/src/altinn-app-frontend/src/components/summary/__snapshots__/SummaryGroupComponent.test.tsx.snap
@@ -33,6 +33,7 @@ exports[`SummaryGroupComponent SummaryGroupComponent -- should match snapshot 1`
               Change
             </span>
             <i
+              aria-hidden="true"
               class="fa fa-editing-file makeStyles-editIcon-6"
             />
           </p>

--- a/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupTable.tsx
+++ b/src/altinn-app-frontend/src/features/form/containers/RepeatingGroupTable.tsx
@@ -453,7 +453,7 @@ export function RepeatingGroupTable({
                           <Button
                             variant={ButtonVariant.Quiet}
                             color={ButtonColor.Secondary}
-                            icon={rowHasErrors ? <WarningIcon /> : <EditIcon />}
+                            icon={rowHasErrors ? <WarningIcon aria-hidden='true' /> : <EditIcon aria-hidden='true' />}
                             iconPlacement='right'
                             onClick={() => handleEditClick(index)}
                             aria-label={`${editButtonText}-${firstCellData}`}
@@ -477,7 +477,7 @@ export function RepeatingGroupTable({
                                 <Button
                                   variant={ButtonVariant.Quiet}
                                   color={ButtonColor.Danger}
-                                  icon={<DeleteIcon />}
+                                  icon={<DeleteIcon aria-hidden='true' />}
                                   iconPlacement='right'
                                   disabled={deleting}
                                   onClick={() => handleDeleteClick(index)}

--- a/test/cypress/e2e/integration/app-frontend/wcag.js
+++ b/test/cypress/e2e/integration/app-frontend/wcag.js
@@ -6,16 +6,30 @@ import AppFrontend from '../../pageobjects/app-frontend';
 const appFrontend = new AppFrontend();
 
 describe('WCAG', () => {
-  it('WCAG test in data app', () => {
-    cy.intercept('**/active', []).as('noActiveInstances');
-    cy.startAppInstance(appFrontend.apps.frontendTest);
-    cy.get(appFrontend.closeButton).should('be.visible');
-    cy.get(appFrontend.message['header']).should('exist');
+  it('WCAG test in changename', () => {
+    cy.gotoAndComplete('changename');
     cy.testWcag();
-    cy.get(appFrontend.sendinButton).click();
-    cy.get(appFrontend.changeOfName.newFirstName).should('be.visible').type('a').blur();
-    cy.get(appFrontend.changeOfName.newLastName).should('be.visible').type('a').blur();
-    cy.get(appFrontend.changeOfName.confirmChangeName).should('be.visible').find('input').check();
+    cy.get(appFrontend.navMenu).find('li > button').last().click();
     cy.testWcag();
   });
+
+  it('WCAG test in group', () => {
+    cy.gotoAndComplete('group');
+    cy.testWcag();
+    cy.get(appFrontend.navMenu).find('li > button').first().click();
+    cy.testWcag();
+
+    /* TODO: Fix the edit/delete buttons
+    cy.get(appFrontend.navMenu).find('li > button').eq(1).click();
+    cy.testWcag();
+    cy.get(appFrontend.group.edit).click();
+    cy.testWcag();
+    cy.get(appFrontend.group.mainGroup)
+      .find(appFrontend.group.editContainer)
+      .find(appFrontend.group.next)
+      .should('be.visible')
+      .click();
+    cy.testWcag();
+     */
+  })
 });

--- a/test/cypress/e2e/integration/app-frontend/wcag.js
+++ b/test/cypress/e2e/integration/app-frontend/wcag.js
@@ -20,6 +20,7 @@ describe('WCAG', () => {
     cy.testWcag();
 
     /* TODO: Fix the edit/delete buttons
+    */
     cy.get(appFrontend.navMenu).find('li > button').eq(1).click();
     cy.testWcag();
     cy.get(appFrontend.group.edit).click();
@@ -30,6 +31,5 @@ describe('WCAG', () => {
       .should('be.visible')
       .click();
     cy.testWcag();
-     */
-  })
+  });
 });

--- a/test/cypress/e2e/integration/app-frontend/wcag.js
+++ b/test/cypress/e2e/integration/app-frontend/wcag.js
@@ -19,8 +19,6 @@ describe('WCAG', () => {
     cy.get(appFrontend.navMenu).find('li > button').first().click();
     cy.testWcag();
 
-    /* TODO: Fix the edit/delete buttons
-    */
     cy.get(appFrontend.navMenu).find('li > button').eq(1).click();
     cy.testWcag();
     cy.get(appFrontend.group.edit).click();

--- a/test/cypress/e2e/pageobjects/app-frontend.js
+++ b/test/cypress/e2e/pageobjects/app-frontend.js
@@ -106,7 +106,7 @@ export default class AppFrontend {
       mobilenummer: '#mobilnummer',
       sources: '#sources',
       uploadingAnimation: '#loader-upload',
-      deleteAttachment: 'div[id^="attachment-delete"]',
+      deleteAttachment: 'div[data-testid^="attachment-delete"]',
       uploadedTable: '#altinn-file-listfileUpload-changename',
       uploadSuccess: '.ai-check-circle',
       uploadDropZone: '#altinn-drop-zone-fileUpload-changename',

--- a/test/cypress/e2e/support/wcag.js
+++ b/test/cypress/e2e/support/wcag.js
@@ -1,13 +1,12 @@
 /// <reference types='cypress' />
 
 Cypress.Commands.add('testWcag', () => {
+  cy.log('Testing WCAG');
   cy.injectAxe();
   cy.checkA11y(
     null,
     {
       includedImpacts: ['critical', 'serious', 'moderate'],
-    },
-    null,
-    { skipFailures: true },
+    }
   );
 });


### PR DESCRIPTION
## Description
Enabling most wcag tests, but disabling tests because 2 SVGs on the group page seems to be missing [alt-attributes/title-tags](https://dequeuniversity.com/rules/axe/4.5/svg-img-alt?application=axeAPI). Passing the rest over to @Magnusrm (I tried adding `title=''` to these icons, but I've scratched my head on why that didn't work for too long now..

## Related Issue(s)
- https://github.com/Altinn/altinn-studio/issues/9273

## Verification
- Manual testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing
  - [x] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added
  - [x] Cypress E2E test(s) have been added
  - [ ] No automatic tests are needed here
  - [ ] I want someone to help me make some tests
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been updated
   <!--- insert link to PR here -->
  - [x] No changes/updates needed
- Changes/additions to component properties
  - [ ] Changes are reflected in both `layout/index.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
   <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board <!--- If you don't have permissions for this, someone else will do it for you -->
