### PR TITLE
Expressions: Automatically navigating to the next page if current one is hidden

### DIFF
--- a/src/altinn-app-frontend/src/features/form/layout/formLayoutSlice.ts
+++ b/src/altinn-app-frontend/src/features/form/layout/formLayoutSlice.ts
@@ -7,6 +7,7 @@ import {
 } from 'src/features/form/layout/fetch/fetchFormLayoutSagas';
 import {
   calculatePageOrderAndMoveToNextPageSaga,
+  findAndMoveToNextVisibleLayout,
   updateFileUploaderWithTagChosenOptionsSaga,
   updateFileUploaderWithTagEditIndexSaga,
   updateRepeatingGroupEditIndexSaga,
@@ -307,6 +308,7 @@ const formLayoutSlice = createSagaSlice((mkAction: MkActionType<ILayoutState>) =
       },
     }),
     updateHiddenLayouts: mkAction<LayoutTypes.IHiddenLayoutsUpdate>({
+      takeEvery: findAndMoveToNextVisibleLayout,
       reducer: (state, action) => {
         state.uiConfig.tracks.hidden = action.payload.hiddenLayouts;
       },


### PR DESCRIPTION
## Description
I was updating the intro course demo application to use expressions instead of layout tracks, and suddenly stumbled upon a strange problem I had not anticipated when developing the expressions-based tracks alternative. In essence:

1. The app loads all the layouts available in the current layout-set, and automatically navigates to the first page (unless there are settings to automatically navigate to a specific page).
2. Some time after this, the expression engine runs (thus evaluating if a given page is visible or hidden).
3. If that first page (or current setting page) is hidden now, the user would be stuck on a blank page.

Fixing this by automatically moving the user to the next page if the current one is hidden. This is triggered right after step 2, when the expression engine hides some page(s).

## Related Issue(s)
- closes #{issue number}

## Verification
- Manual testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added
  - [ ] Cypress E2E test(s) have been added
  - [ ] No automatic tests are needed here
  - [ ] I want someone to help me make some tests
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been updated
   <!--- insert link to PR here -->
  - [x] No changes/updates needed
- Changes/additions to component properties
  - [ ] Changes are reflected in both `layout/index.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
   <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board <!--- If you don't have permissions for this, someone else will do it for you -->
