### PR TITLE
Clicking links in help text pop-up causes it to close

### DIFF
--- a/src/altinn-app-frontend/src/features/form/components/HelpTextContainer.tsx
+++ b/src/altinn-app-frontend/src/features/form/components/HelpTextContainer.tsx
@@ -21,8 +21,8 @@ export function HelpTextContainer({ language, helpText }: IHelpTextContainerProp
   };
 
   const handlePopoverKeypress = (event: React.KeyboardEvent): void => {
-    if ((event.key === ' ' || event.key === 'Enter') && !openPopover) {
-      setOpenPopover(true);
+    if (event.key === ' ' || event.key === 'Enter') {
+      setOpenPopover(!openPopover);
     }
   };
 
@@ -30,8 +30,17 @@ export function HelpTextContainer({ language, helpText }: IHelpTextContainerProp
     setOpenPopover(false);
   };
 
+  function onBlur(event: React.FocusEvent<HTMLInputElement>) {
+    if (!event.currentTarget.contains(event.relatedTarget)) {
+      handlePopoverClose();
+    }
+  }
+
   return (
-    <>
+    <div
+      tabIndex={-1}
+      onBlur={onBlur}
+    >
       <HelpTextIcon
         helpIconRef={helpIconRef}
         language={language}
@@ -49,6 +58,6 @@ export function HelpTextContainer({ language, helpText }: IHelpTextContainerProp
         helpText={helpText}
         onClose={handlePopoverClose}
       />
-    </>
+    </div>
   );
 }

--- a/src/shared/src/components/AltinnPopover.tsx
+++ b/src/shared/src/components/AltinnPopover.tsx
@@ -70,13 +70,29 @@ const AltinnPopoverComponent = ({
   closeButton,
 }: IAltinnPopoverProvidedProps) => {
   const classes = useStyles();
+  const ref = React.useRef<HTMLDivElement>();
+
+  React.useEffect(() => {
+    if (ref.current) {
+      for (const child of Array.from(ref.current.children)) {
+        if (child.parentElement && child.getAttribute('tabIndex') === '0') {
+          child.removeAttribute('tabIndex');
+        }
+      }
+    }
+  }, [anchorEl]);
 
   return (
     <>
       <Popover
+        ref={ref}
         open={!!anchorEl}
         anchorEl={anchorEl}
         onClose={handleClose}
+        disablePortal={true}
+        disableAutoFocus={true}
+        disableEnforceFocus={true}
+        disableRestoreFocus={true}
         anchorOrigin={{
           horizontal: anchorOrigin?.horizontal ? anchorOrigin.horizontal : 'left',
           vertical: anchorOrigin?.vertical ? anchorOrigin.vertical : 'top',

--- a/src/shared/src/components/AltinnPopover.tsx
+++ b/src/shared/src/components/AltinnPopover.tsx
@@ -77,7 +77,6 @@ const AltinnPopoverComponent = ({
         open={!!anchorEl}
         anchorEl={anchorEl}
         onClose={handleClose}
-        onBlur={handleClose}
         anchorOrigin={{
           horizontal: anchorOrigin?.horizontal ? anchorOrigin.horizontal : 'left',
           vertical: anchorOrigin?.vertical ? anchorOrigin.vertical : 'top',


### PR DESCRIPTION
## Description
<!---
  Provide a general summary of your changes in the Title above
  Describe your change(s) in detail here

  Also add the relevant label in the column on the right:
    Breaking changes: kind/breaking-change
    New features:     kind/product-feature
    Bug fixes:        kind/bug
    Dependencies:     kind/dependencies
    Other changes:    kind/other
-->
This issue was caused by the popover set to close `onBlur`. Clicking a link inside the popover whould cause `onBlur` to be called and would close the popover, which in some cases, could cause the link not to open. To fix this, the popover itself no longer has an onblur, but only its parent (which checks if the element gaining focus is inside or not). Additionally, the mui popover manages its focus in a kind of annoying way, hence, the new useEffect to deal with this.

## Related Issue(s)
- closes #705 

## Verification
- Manual testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added
  - [ ] Cypress E2E test(s) have been added
  - [x] No automatic tests are needed here
  - [ ] I want someone to help me make some tests
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been updated
   <!--- insert link to PR here -->
  - [x] No changes/updates needed
- Changes/additions to component properties
  - [ ] Changes are reflected in both `layout/index.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
   <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board <!--- If you don't have permissions for this, someone else will do it for you -->
