### PR TITLE
Possibly fixing navigation issue

### DIFF
--- a/src/altinn-app-frontend/src/features/form/layout/formLayoutSlice.ts
+++ b/src/altinn-app-frontend/src/features/form/layout/formLayoutSlice.ts
@@ -154,6 +154,11 @@ const formLayoutSlice = createSagaSlice((mkAction: MkActionType<ILayoutState>) =
       takeLatest: updateCurrentViewSaga,
     }),
     updateCurrentViewFulfilled: mkAction<LayoutTypes.IUpdateCurrentViewFulfilled>({
+      takeEvery: (action) => {
+        if (!action.payload.focusComponentId) {
+          window.scrollTo({ top: 0 });
+        }
+      },
       reducer: (state, action) => {
         state.uiConfig.currentView = action.payload.newView;
         state.uiConfig.returnToView = action.payload.returnToView;

--- a/src/altinn-app-frontend/src/features/form/layout/formLayoutSlice.ts
+++ b/src/altinn-app-frontend/src/features/form/layout/formLayoutSlice.ts
@@ -8,6 +8,7 @@ import {
 import {
   calculatePageOrderAndMoveToNextPageSaga,
   findAndMoveToNextVisibleLayout,
+  updateCurrentViewSaga,
   updateFileUploaderWithTagChosenOptionsSaga,
   updateFileUploaderWithTagEditIndexSaga,
   updateRepeatingGroupEditIndexSaga,
@@ -15,7 +16,6 @@ import {
   watchInitialCalculatePageOrderAndMoveToNextPageSaga,
   watchInitRepeatingGroupsSaga,
   watchMapFileUploaderWithTagSaga,
-  watchUpdateCurrentViewSaga,
 } from 'src/features/form/layout/update/updateFormLayoutSagas';
 import { OptionsActions } from 'src/shared/resources/options/optionsSlice';
 import { replaceTextResourcesSaga } from 'src/shared/resources/textResources/replace/replaceTextResourcesSagas';
@@ -151,7 +151,7 @@ const formLayoutSlice = createSagaSlice((mkAction: MkActionType<ILayoutState>) =
       },
     }),
     updateCurrentView: mkAction<LayoutTypes.IUpdateCurrentView>({
-      saga: () => watchUpdateCurrentViewSaga,
+      takeLatest: updateCurrentViewSaga,
     }),
     updateCurrentViewFulfilled: mkAction<LayoutTypes.IUpdateCurrentViewFulfilled>({
       reducer: (state, action) => {

--- a/src/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.test.ts
+++ b/src/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.test.ts
@@ -326,7 +326,7 @@ describe('updateLayoutSagas', () => {
 
       if (expected) {
         ret.put(
-          FormLayoutActions.updateCurrentView({
+          FormLayoutActions.updateCurrentViewFulfilled({
             newView: expected,
           }),
         );

--- a/src/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.test.ts
+++ b/src/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.test.ts
@@ -1,5 +1,5 @@
 import { getInitialStateMock } from '__mocks__/initialStateMock';
-import { actionChannel, call, select, take } from 'redux-saga/effects';
+import { select, take } from 'redux-saga/effects';
 import { expectSaga, testSaga } from 'redux-saga-test-plan';
 import type { PayloadAction } from '@reduxjs/toolkit';
 
@@ -16,12 +16,9 @@ import {
   selectFormData,
   selectFormLayoutState,
   selectOptions,
-  selectUnsavedChanges,
   selectValidations,
-  updateCurrentViewSaga,
   updateRepeatingGroupsSaga,
   watchInitRepeatingGroupsSaga,
-  watchUpdateCurrentViewSaga,
 } from 'src/features/form/layout/update/updateFormLayoutSagas';
 import { ValidationActions } from 'src/features/form/validation/validationSlice';
 import { selectLayoutOrder } from 'src/selectors/getLayoutOrder';
@@ -155,54 +152,6 @@ describe('updateLayoutSagas', () => {
         )
         .put(FormDataActions.setFulfilled({ formData: initialFormData }))
         .put(FormDataActions.save({}))
-        .run();
-    });
-  });
-
-  describe('watchUpdateCurrentViewSaga', () => {
-    const fakeChannel = {
-      take: jest.fn(),
-      flush: jest.fn(),
-      close: jest.fn(),
-    };
-    const mockSaga = jest.fn();
-    const mockAction = FormLayoutActions.updateCurrentView({
-      newView: 'test',
-    });
-    const takeChannel = {
-      take({ channel }, next) {
-        if (channel === fakeChannel) {
-          return mockAction;
-        }
-        return next();
-      },
-    };
-    it('should save unsaved changes before updating from layout', () => {
-      return expectSaga(watchUpdateCurrentViewSaga)
-        .provide([
-          [actionChannel(FormLayoutActions.updateCurrentView), fakeChannel],
-          [select(selectUnsavedChanges), true],
-          takeChannel,
-          [call(updateCurrentViewSaga, mockAction), mockSaga],
-        ])
-        .dispatch(FormLayoutActions.updateCurrentView)
-        .dispatch(FormDataActions.submitFulfilled)
-        .take(fakeChannel)
-        .call(updateCurrentViewSaga, mockAction)
-        .run();
-    });
-    it('should not save unsaved changes before updating form layout when no unsaved changes', () => {
-      return expectSaga(watchUpdateCurrentViewSaga)
-        .provide([
-          [actionChannel(FormLayoutActions.updateCurrentView), fakeChannel],
-          [select(selectUnsavedChanges), false],
-          takeChannel,
-          [call(updateCurrentViewSaga, mockAction), mockSaga],
-        ])
-        .dispatch(FormLayoutActions.updateCurrentView)
-        .not.take(FormDataActions.submitFulfilled)
-        .take(fakeChannel)
-        .call(updateCurrentViewSaga, mockAction)
         .run();
     });
   });

--- a/src/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
+++ b/src/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
@@ -493,7 +493,7 @@ export function* findAndMoveToNextVisibleLayout(): SagaIterator {
 
   if (nextVisiblePage && nextVisiblePage !== current) {
     yield put(
-      FormLayoutActions.updateCurrentView({
+      FormLayoutActions.updateCurrentViewFulfilled({
         newView: nextVisiblePage,
       }),
     );

--- a/src/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
+++ b/src/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
@@ -289,12 +289,24 @@ export function* updateCurrentViewSaga({
     yield waitFor((state) => !state.formData.unsavedChanges);
 
     const state: IRuntimeState = yield select();
+    const visibleLayouts: string[] | null = yield select(selectLayoutOrder);
     const viewCacheKey = state.formLayout.uiConfig.currentViewCacheKey;
     const instanceId = state.instanceData.instance?.id;
     if (!viewCacheKey) {
       yield put(FormLayoutActions.setCurrentViewCacheKey({ key: instanceId }));
     }
     const currentViewCacheKey = viewCacheKey || instanceId;
+
+    if (visibleLayouts && !visibleLayouts.includes(newView)) {
+      yield put(
+        FormLayoutActions.updateCurrentViewRejected({
+          error: null,
+          keepScrollPos,
+        }),
+      );
+      return;
+    }
+
     if (!runValidations) {
       if (!skipPageCaching && currentViewCacheKey) {
         localStorage.setItem(currentViewCacheKey, newView);

--- a/src/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
+++ b/src/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
@@ -1,4 +1,4 @@
-import { actionChannel, all, call, put, race, select, take, takeLatest } from 'redux-saga/effects';
+import { all, call, put, race, select, take, takeLatest } from 'redux-saga/effects';
 import type { PayloadAction } from '@reduxjs/toolkit';
 import type { AxiosRequestConfig } from 'axios';
 import type { SagaIterator } from 'redux-saga';
@@ -31,6 +31,7 @@ import {
 } from 'src/utils/formLayout';
 import { getLayoutsetForDataElement } from 'src/utils/layout';
 import { getOptionLookupKey, removeGroupOptionsByIndex } from 'src/utils/options';
+import { waitFor } from 'src/utils/sagas';
 import {
   canFormBeSaved,
   mapDataElementValidationToRedux,
@@ -77,7 +78,6 @@ export const selectFormData = (state: IRuntimeState) => state.formData;
 export const selectFormLayouts = (state: IRuntimeState) => state.formLayout.layouts;
 export const selectAttachmentState = (state: IRuntimeState) => state.attachments;
 export const selectValidations = (state: IRuntimeState) => state.formValidations.validations;
-export const selectUnsavedChanges = (state: IRuntimeState) => state.formData.unsavedChanges;
 export const selectOptions = (state: IRuntimeState) => state.optionState.options;
 export const selectAllLayouts = (state: IRuntimeState) => state.formLayout.uiConfig.tracks.order;
 export const selectCurrentLayout = (state: IRuntimeState) => state.formLayout.uiConfig.currentView;
@@ -284,6 +284,10 @@ export function* updateCurrentViewSaga({
   payload: { newView, runValidations, returnToView, skipPageCaching, keepScrollPos, focusComponentId },
 }: PayloadAction<IUpdateCurrentView>): SagaIterator {
   try {
+    // When triggering navigation to the next page, we need to make sure there are no unsaved changes. The action to
+    // save it should be triggered elsewhere, but we should wait until the state settles before navigating.
+    yield waitFor((state) => !state.formData.unsavedChanges);
+
     const state: IRuntimeState = yield select();
     const viewCacheKey = state.formLayout.uiConfig.currentViewCacheKey;
     const instanceId = state.instanceData.instance?.id;
@@ -526,19 +530,6 @@ export function* watchInitialCalculatePageOrderAndMoveToNextPageSaga(): SagaIter
         }),
       );
     }
-  }
-}
-
-export function* watchUpdateCurrentViewSaga(): SagaIterator {
-  const requestChan = yield actionChannel(FormLayoutActions.updateCurrentView);
-  while (true) {
-    yield take(FormLayoutActions.updateCurrentView);
-    const hasUnsavedChanges = yield select(selectUnsavedChanges);
-    if (hasUnsavedChanges) {
-      yield take(FormDataActions.submitFulfilled);
-    }
-    const value = yield take(requestChan);
-    yield call(updateCurrentViewSaga, value);
   }
 }
 

--- a/test/cypress/e2e/integration/app-frontend/calculate-page-order.js
+++ b/test/cypress/e2e/integration/app-frontend/calculate-page-order.js
@@ -12,7 +12,13 @@ describe('Calculate Page Order', () => {
   it('Testing combinations of old and new hidden pages functionalities', () => {
     cy.interceptLayout('group', () => {}, (layoutSet) => {
       layoutSet.prefill.data.hidden = ['equals', ['component', 'sendersName'], 'hidePrefill'];
-      layoutSet.repeating.data.hidden = ['equals', ['component', 'sendersName'], 'hideRepeating'];
+      layoutSet.repeating.data.hidden = ['and',
+        ['equals', ['component', 'sendersName'], 'hideRepeating'],
+        ['or',
+          ['equals', ['component', 'choose-group-prefills'], ''],
+          ['equals', ['component', 'choose-group-prefills'], null]
+        ]
+      ];
     });
     cy.intercept('POST', '**/pages/order*').as('getPageOrder');
 
@@ -31,6 +37,7 @@ describe('Calculate Page Order', () => {
     cy.get(appFrontend.navMenuButtons).should('have.length', 3);
     cy.get(appFrontend.group.sendersName).should('not.exist');
     cy.get(appFrontend.group.summaryText).should('be.visible');
+    cy.get(appFrontend.navMenuCurrent).should('have.text', '3. summary');
 
     cy.get(appFrontend.navMenu).find('li > button').eq(1).click();
     cy.get(appFrontend.group.rows[0].editBtn).click();
@@ -40,14 +47,41 @@ describe('Calculate Page Order', () => {
     cy.wait('@getPageOrder');
     cy.get(appFrontend.navMenuButtons).should('have.length', 4);
     cy.get(appFrontend.group.sendersName).should('exist');
+    cy.get(appFrontend.navMenuCurrent).should('have.text', '3. hide');
 
     cy.get(appFrontend.navMenuButtons).should('contain.text', '1. prefill');
     cy.get(appFrontend.group.sendersName).type('hidePrefill');
+    cy.get(appFrontend.navButtons).contains(mui.button, texts.prev).click();
     cy.get(appFrontend.navMenuButtons).should('have.length', 3);
-    cy.get(appFrontend.navMenuButtons).should('contain.text', '1. repeating');
+    cy.get(appFrontend.navMenuCurrent).should('have.text', '1. repeating');
+
+    cy.get(appFrontend.navButtons).contains(mui.button, texts.next).click();
+
+    // Clicking previous here is expected to not have any effect, because the triggered action is rejected when
+    // the 'repeating' page is supposed to be hidden by the change. Clicking too fast leads to a failure...
     cy.get(appFrontend.group.sendersName).clear().type('hideRepeating');
+    cy.get(appFrontend.navButtons).contains(mui.button, texts.prev).click();
+
+    // ...but clicking 'previous' after this point will have updated the components to know that the previous page
+    // now is the 'prefill' page
     cy.get(appFrontend.navMenuButtons).should('have.length', 3);
-    cy.get(appFrontend.navMenuButtons).should('contain.text', '1. prefill');
+    cy.get(appFrontend.navButtons).contains(mui.button, texts.prev).click();
+
+    cy.get(appFrontend.navMenuCurrent).should('have.text', '1. prefill');
     cy.get(appFrontend.navMenuButtons).should('contain.text', '2. hide');
+
+    cy.get(appFrontend.group.prefill.liten).click();
+    cy.get(appFrontend.navButtons).contains(mui.button, texts.next).click();
+
+    // And this is, in essence, a bug. Navigating to the next page should consider what the next page is, even if
+    // just-made-changes affects which page is the next one. Right now the component re-render loop needs to run
+    // for NavigationButtons to know what the next layout is in order to navigate to the correct one.
+    // TODO: Fix this by triggering a 'navigate to the next page' action instead of 'navigate to this exact page'
+    cy.get(appFrontend.navMenuCurrent).should('have.text', '3. hide');
+    cy.get(appFrontend.navMenuButtons).should('contain.text', '2. repeating');
+
+    // TODO: Comment this in and delete the lines above when the bug is fixed:
+    // cy.get(appFrontend.navMenuCurrent).should('have.text', '2. repeating');
+    // cy.get(appFrontend.navMenuButtons).should('contain.text', '3. hide');
   });
 });

--- a/test/cypress/e2e/integration/app-frontend/calculate-page-order.js
+++ b/test/cypress/e2e/integration/app-frontend/calculate-page-order.js
@@ -9,27 +9,45 @@ const appFrontend = new AppFrontend();
 const mui = new Common();
 
 describe('Calculate Page Order', () => {
-  beforeEach(() => {
+  it('Testing combinations of old and new hidden pages functionalities', () => {
+    cy.interceptLayout('group', () => {}, (layoutSet) => {
+      layoutSet.prefill.data.hidden = ['equals', ['component', 'sendersName'], 'hidePrefill'];
+      layoutSet.repeating.data.hidden = ['equals', ['component', 'sendersName'], 'hideRepeating'];
+    });
+    cy.intercept('POST', '**/pages/order*').as('getPageOrder');
+
     cy.goto('group');
     cy.contains(mui.button, texts.next).click();
     cy.get(appFrontend.group.showGroupToContinue).then((checkbox) => {
       cy.get(checkbox).should('be.visible').find('input').check();
     });
-    cy.intercept('POST', '**/pages/order*').as('getPageOrder');
-  });
 
-  it('Page two is hidden on a higher value', () => {
+    cy.get(appFrontend.navMenuButtons).should('have.length', 4);
+
     cy.addItemToGroup(1, 11, 'automation');
     cy.contains(mui.button, texts.next).click();
     cy.wait('@getPageOrder');
+
+    cy.get(appFrontend.navMenuButtons).should('have.length', 3);
     cy.get(appFrontend.group.sendersName).should('not.exist');
     cy.get(appFrontend.group.summaryText).should('be.visible');
-  });
 
-  it('Page two is shown when condition is not satisfied', () => {
-    cy.addItemToGroup(1, 2, 'automation');
-    cy.contains(mui.button, texts.next).click();
+    cy.get(appFrontend.navMenu).find('li > button').eq(1).click();
+    cy.get(appFrontend.group.rows[0].editBtn).click();
+    cy.get(appFrontend.group.newValue).clear().type('2');
+
+    cy.get(appFrontend.navButtons).contains(mui.button, texts.next).click();
     cy.wait('@getPageOrder');
+    cy.get(appFrontend.navMenuButtons).should('have.length', 4);
     cy.get(appFrontend.group.sendersName).should('exist');
+
+    cy.get(appFrontend.navMenuButtons).should('contain.text', '1. prefill');
+    cy.get(appFrontend.group.sendersName).type('hidePrefill');
+    cy.get(appFrontend.navMenuButtons).should('have.length', 3);
+    cy.get(appFrontend.navMenuButtons).should('contain.text', '1. repeating');
+    cy.get(appFrontend.group.sendersName).clear().type('hideRepeating');
+    cy.get(appFrontend.navMenuButtons).should('have.length', 3);
+    cy.get(appFrontend.navMenuButtons).should('contain.text', '1. prefill');
+    cy.get(appFrontend.navMenuButtons).should('contain.text', '2. hide');
   });
 });

--- a/test/cypress/e2e/pageobjects/app-frontend.js
+++ b/test/cypress/e2e/pageobjects/app-frontend.js
@@ -37,6 +37,8 @@ export default class AppFrontend {
     };
 
     this.navMenu = '#navigation-menu';
+    this.navMenuButtons = '#navigation-menu li > button';
+    this.navButtons = '[data-testid=NavigationButtons]';
     this.startAgain = '#startAgain';
 
     //Receipt

--- a/test/cypress/e2e/pageobjects/app-frontend.js
+++ b/test/cypress/e2e/pageobjects/app-frontend.js
@@ -38,6 +38,7 @@ export default class AppFrontend {
 
     this.navMenu = '#navigation-menu';
     this.navMenuButtons = '#navigation-menu li > button';
+    this.navMenuCurrent = '#navigation-menu li > button[aria-current=page]';
     this.navButtons = '[data-testid=NavigationButtons]';
     this.startAgain = '#startAgain';
 


### PR DESCRIPTION
## Description
Experimental fix for the referenced navigation issue. Unsure if this fixes the problem, but it should/could be an improvement.

What this does, in a nutshell:
1. Changing the way we wait before fulfilling navigation to the next page until data is saved. Using `waitFor` instead of saga logic. Since the saga has two `take` calls, I suspected it might take an entirely different (previously triggered?) action in the queue.
2. If we forcibly navigate to another page because the current one is hidden (see #698), skip all logic and just navigate to that page instantly.
3. Useless unit tests for the now removed `watchUpdateCurrentViewSaga` has been removed 
4. Nice-to-have: Scroll to the top when navigation has been fulfilled.

## Related Issue(s)
- closes #712

## Verification
- Manual testing
  - [x] I have tested these changes manually (or: I have tested that my changes still allows navigation between pages)
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added
  - [ ] Cypress E2E test(s) have been added
  - [x] No automatic tests are needed here (or: I can't create automated regression tests for an issue I'm unable to even manually reproduce)
  - [ ] I want someone to help me make some tests
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been updated
   <!--- insert link to PR here -->
  - [x] No changes/updates needed
- Changes/additions to component properties
  - [ ] Changes are reflected in both `layout/index.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
   <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board <!--- If you don't have permissions for this, someone else will do it for you -->
