### PR TITLE
Fix for navigating with combined PageOrder + dynamics

### DIFF
--- a/src/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
+++ b/src/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
@@ -7,7 +7,7 @@ import { FormDataActions } from 'src/features/form/data/formDataSlice';
 import { FormDynamicsActions } from 'src/features/form/dynamics/formDynamicsSlice';
 import { FormLayoutActions } from 'src/features/form/layout/formLayoutSlice';
 import { ValidationActions } from 'src/features/form/validation/validationSlice';
-import { selectLayoutOrder } from 'src/selectors/getLayoutOrder';
+import { getLayoutOrderFromTracks, selectLayoutOrder } from 'src/selectors/getLayoutOrder';
 import { AttachmentActions } from 'src/shared/resources/attachments/attachmentSlice';
 import { OptionsActions } from 'src/shared/resources/options/optionsSlice';
 import { QueueActions } from 'src/shared/resources/queue/queueSlice';
@@ -457,7 +457,12 @@ export function* calculatePageOrderAndMoveToNextPageSaga({
       return;
     }
     const returnToView = state.formLayout.uiConfig.returnToView;
-    const newView = returnToView || layoutOrder[layoutOrder.indexOf(currentView) + 1];
+    const newOrder =
+      getLayoutOrderFromTracks({
+        ...state.formLayout.uiConfig.tracks,
+        order: layoutOrder,
+      }) || [];
+    const newView = returnToView || newOrder[newOrder.indexOf(currentView) + 1];
     yield put(
       FormLayoutActions.updateCurrentView({
         newView,

--- a/test/cypress/e2e/integration/app-frontend/calculate-page-order.js
+++ b/test/cypress/e2e/integration/app-frontend/calculate-page-order.js
@@ -84,4 +84,28 @@ describe('Calculate Page Order', () => {
     // cy.get(appFrontend.navMenuCurrent).should('have.text', '2. repeating');
     // cy.get(appFrontend.navMenuButtons).should('contain.text', '3. hide');
   });
+
+  it('Testing pageOrder with hidden next page via dynamics', () => {
+    cy.interceptLayout('group', (component) => {
+      if (component.type === 'NavigationButtons' && !component.triggers) {
+        component.triggers = ['calculatePageOrder'];
+      } else if (component.type === 'NavigationButtons' && !component.triggers.includes('calculatePageOrder')) {
+        component.triggers.push('calculatePageOrder');
+      }
+    }, (layoutSet) => {
+      layoutSet.hide.data.hidden = ['equals', ['component', 'choose-group-prefills'], 'stor'];
+      layoutSet.repeating.data.hidden = ['equals', ['component', 'choose-group-prefills'], 'stor'];
+    });
+    cy.intercept('POST', '**/pages/order*').as('getPageOrder');
+
+    cy.goto('group');
+    cy.get(appFrontend.navMenuButtons).should('have.length', 4);
+
+    cy.get(appFrontend.group.prefill.stor).click();
+    cy.get(appFrontend.navButtons).contains(mui.button, texts.next).click();
+
+    // Both pages the 'repeating' and 'hide' pages are now hidden
+    cy.get(appFrontend.navMenuCurrent).should('have.text', '2. summary');
+    cy.get(appFrontend.navMenuButtons).should('have.length', 2);
+  });
 });


### PR DESCRIPTION
## Description
Follow-up to #712, as the `calculatePageOrderAndMoveToNextPageSaga` failed to take into account which page should be the next one when navigating.

## Related Issue(s)
- closes #718

## Verification
- Manual testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added
  - [x] Cypress E2E test(s) have been added
  - [ ] No automatic tests are needed here
  - [ ] I want someone to help me make some tests
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been updated
   <!--- insert link to PR here -->
  - [x] No changes/updates needed
- Changes/additions to component properties
  - [ ] Changes are reflected in both `layout/index.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
   <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board <!--- If you don't have permissions for this, someone else will do it for you -->
