### PR TITLE
Improve the display of headers when referenced in summary

### DIFF
--- a/src/altinn-app-frontend/src/components/base/HeaderComponent.tsx
+++ b/src/altinn-app-frontend/src/components/base/HeaderComponent.tsx
@@ -18,7 +18,7 @@ interface IHeaderSizeProps {
   size?: string;
 }
 
-const HeaderSize = ({ id, size, text }: IHeaderSizeProps) => {
+export const HeaderSize = ({ id, size, text }: IHeaderSizeProps) => {
   switch (size) {
     case 'L':
     case 'h2': {

--- a/src/altinn-app-frontend/src/components/summary/HeaderSummary.tsx
+++ b/src/altinn-app-frontend/src/components/summary/HeaderSummary.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+
+import { Grid } from '@material-ui/core';
+
+import { HeaderSize } from 'src/components/base/HeaderComponent';
+import type { ILayoutCompHeader } from 'src/features/form/layout';
+
+export interface IHeaderSummary {
+  id: string;
+  label: JSX.Element | JSX.Element[] | null | undefined;
+  component: ILayoutCompHeader;
+}
+
+function HeaderSummary({ id, label, component }: IHeaderSummary) {
+  return (
+    <Grid
+      item
+      xs={12}
+      data-testid={'header-summary'}
+    >
+      <HeaderSize
+        id={id}
+        size={component.size}
+        text={label}
+      />
+    </Grid>
+  );
+}
+
+export default HeaderSummary;

--- a/src/altinn-app-frontend/src/components/summary/SummaryComponentSwitch.tsx
+++ b/src/altinn-app-frontend/src/components/summary/SummaryComponentSwitch.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import { AttachmentSummaryComponent } from 'src/components/summary/AttachmentSummaryComponent';
 import { AttachmentWithTagSummaryComponent } from 'src/components/summary/AttachmentWithTagSummaryComponent';
+import HeaderSummary from 'src/components/summary/HeaderSummary';
 import MapComponentSummary from 'src/components/summary/MapComponentSummary';
 import MultipleChoiceSummary from 'src/components/summary/MultipleChoiceSummary';
 import SingleInputSummary from 'src/components/summary/SingleInputSummary';
@@ -17,7 +18,7 @@ export interface ISummaryComponentSwitch extends Omit<ILayoutCompSummary, 'type'
   };
   formComponent?: ExprResolved<ILayoutComponent | ILayoutGroup>;
   hasValidationMessages?: boolean;
-  label?: any;
+  label?: JSX.Element | JSX.Element[] | null | undefined;
   formData?: any;
   groupProps?: {
     parentGroup?: string;
@@ -28,6 +29,7 @@ export interface ISummaryComponentSwitch extends Omit<ILayoutCompSummary, 'type'
 }
 
 export default function SummaryComponentSwitch({
+  id,
   change,
   formComponent,
   label,
@@ -111,6 +113,15 @@ export default function SummaryComponentSwitch({
           formData={formData}
         />
       </>
+    );
+  }
+  if (formComponent.type === 'Header') {
+    return (
+      <HeaderSummary
+        id={id}
+        label={label}
+        component={formComponent}
+      />
     );
   }
 


### PR DESCRIPTION
Headers look ugly when referenced in a `"type": "Summary"` component and the `Edit` button shows up by default.
![image](https://user-images.githubusercontent.com/131616/206468190-21e7f216-3242-4ae8-822d-e224225df40e.png)

This PR makes a custom view for a header component.

![image](https://user-images.githubusercontent.com/131616/206467768-5193b7f5-6a0c-4172-badf-c521a74ee7a0.png)

## Verification
- Manual testing
  - [x] I have tested these changes manually
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added
  - [ ] Cypress E2E test(s) have been added
  - [ ] No automatic tests are needed here
  - [x] I want someone to help me make some tests (if required)
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [x] No changes/updates needed
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board <!--- If you don't have permissions for this, someone else will do it for you -->
