### PR TITLE
Remove unnecessary extension recommendations for vs-code

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,11 +1,6 @@
 {
   "recommendations": [
     "dbaeumer.vscode-eslint",
-    "github.vscode-pull-request-github",
-    "ms-azuretools.vscode-docker",
-    "ms-dotnettools.csharp",
-    "ms-vscode-remote.remote-containers",
-    "ms-vsliveshare.vsliveshare",
     "esbenp.prettier-vscode",
     "editorconfig.editorconfig"
   ]


### PR DESCRIPTION
There were a lot of recommended extensions in the project that are not really necessary for pure frontend react development like csharp etc. Only kept the ones that are actually needed.