### PR TITLE
Fix wordwrapping in new repeating group table

### DIFF
--- a/src/features/form/containers/RepeatingGroupTable.tsx
+++ b/src/features/form/containers/RepeatingGroupTable.tsx
@@ -217,6 +217,9 @@ const useStyles = makeStyles({
   tableButton: {
     width: 'max-content', // Stops column from shrinking too much
   },
+  breakWord: {
+    wordBreak: 'break-word',
+  },
 });
 
 function getEditButtonText(
@@ -437,6 +440,7 @@ export function RepeatingGroupTable({
             <TableRow>
               {tableComponents.map((component: ILayoutComponent) => (
                 <TableCell
+                  className={classes.breakWord}
                   style={{ textAlign: getTextAlignment(component) }}
                   key={component.id}
                 >
@@ -491,13 +495,14 @@ export function RepeatingGroupTable({
                       tableComponents.map((component: ILayoutComponent) => (
                         <TableCell
                           key={`${component.id}-${index}`}
+                          className={classes.breakWord}
                           style={{ textAlign: getTextAlignment(component) }}
                         >
                           <span>{!isEditingRow ? getFormDataForComponent(component, index) : null}</span>
                         </TableCell>
                       ))
                     ) : (
-                      <TableCell>
+                      <TableCell className={classes.breakWord}>
                         {tableComponents.map(
                           (component: ILayoutComponent, i, { length }) =>
                             !isEditingRow && (


### PR DESCRIPTION
## Description
<!---
  Provide a general summary of your changes in the Title above
  Describe your change(s) in detail here

  Also add the relevant label in the column on the right:
    Breaking changes: kind/breaking-change
    New features:     kind/product-feature
    Bug fixes:        kind/bug
    Dependencies:     kind/dependencies
    Other changes:    kind/other
-->

Quick fix to deal with long words in repeating group.

Before:
<img width="866" alt="image" src="https://user-images.githubusercontent.com/47412359/206714183-a23546a4-a36c-4188-92b2-e8a1582c8ac9.png">


After:
<img width="866" alt="image" src="https://user-images.githubusercontent.com/47412359/206714149-79e9bbc7-1913-4de3-a8cf-b6afe2af9ca1.png">

