### PR TITLE
Eslint import cleanup

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,7 +24,15 @@
     },
     "sourceType": "module"
   },
-  "plugins": ["@typescript-eslint", "import", "sonarjs", "no-relative-import-paths", "simple-import-sort", "cypress"],
+  "plugins": [
+    "@typescript-eslint",
+    "import",
+    "sonarjs",
+    "no-relative-import-paths",
+    "preferred-import-path",
+    "simple-import-sort",
+    "cypress"
+  ],
   "settings": {
     "import/extensions": [".js", ".jsx", ".ts", ".tsx"],
     "import/parsers": {
@@ -87,9 +95,15 @@
       }
     },
     {
-      "files": ["altinn-app-frontend/src/**"],
+      "files": ["src/**"],
       "rules": {
         "no-relative-import-paths/no-relative-import-paths": ["warn", { "allowSameFolder": false }],
+        "preferred-import-path/preferred-import-path": [
+          "warn",
+          {
+            "^/src": "src"
+          }
+        ],
         "simple-import-sort/imports": [
           "error",
           {
@@ -117,13 +131,6 @@
                 // Our internal packages
                 "^src/[^\\u0000]+$",
                 "^src/.*\\u0000$"
-              ],
-              [
-                // Imports from altinn-app-frontend (mostly mocks and test utilities)
-                "^__mocks__/[^\\u0000]+$",
-                "^__mocks__/.*\\u0000$",
-                "^testUtils[^\\u0000]$",
-                "^testUtils$"
               ],
               [
                 // Lastly, style imports

--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "classnames": "2.3.2",
     "dompurify": "2.4.1",
     "dot-object": "2.1.4",
+    "eslint-plugin-preferred-import-path": "^1.1.0",
     "html-react-parser": "3.0.4",
     "jsonpointer": "5.0.1",
     "marked": "4.2.4",
@@ -172,8 +173,6 @@
       "\\.(css|less|scss)$": "identity-obj-proxy",
       "\\./applicationMetadataMock.json": "<rootDir>/src/__mocks__/applicationMetadataMock.json",
       "^src/(.*)$": "<rootDir>/src/$1",
-      "^__mocks__/(.*)$": "<rootDir>/src/__mocks__/$1",
-      "^testUtils$": "<rootDir>/src/testUtils.tsx",
       "^uuid$": "<rootDir>/node_modules/uuid/dist/index.js"
     },
     "testRegex": "(/__tests__/.*|.*.(test|spec)).(ts|tsx|js|jsx)$",

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 
-import { getInitialStateMock, getInstanceDataStateMock } from '__mocks__/mocks';
 import { screen } from '@testing-library/react';
 import axios from 'axios';
-import { renderWithProviders } from 'testUtils';
 
+import { getInitialStateMock, getInstanceDataStateMock } from 'src/__mocks__/mocks';
 import { App } from 'src/App';
 import * as appSelector from 'src/common/hooks/useAppSelector';
 import * as anonymousSelector from 'src/selectors/getAllowAnonymous';
+import { renderWithProviders } from 'src/testUtils';
 import { ProcessTaskType } from 'src/types';
 import type { IRuntimeState } from 'src/types';
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,8 +9,8 @@ import { makeGetAllowAnonymousSelector } from 'src/selectors/getAllowAnonymous';
 import { makeGetHasErrorsSelector } from 'src/selectors/getErrors';
 import ProcessWrapper from 'src/shared/containers/ProcessWrapper';
 import { QueueActions } from 'src/shared/resources/queue/queueSlice';
-import { getEnvironmentLoginUrl, refreshJwtTokenUrl } from 'src/utils/urls/appUrlHelper';
 import { get } from 'src/utils/network/networking';
+import { getEnvironmentLoginUrl, refreshJwtTokenUrl } from 'src/utils/urls/appUrlHelper';
 
 // 1 minute = 60.000ms
 const TEN_MINUTE_IN_MILLISECONDS: number = 60000 * 10;

--- a/src/__mocks__/formLayoutStateMock.ts
+++ b/src/__mocks__/formLayoutStateMock.ts
@@ -1,5 +1,5 @@
+import { getUiConfigStateMock } from 'src/__mocks__/uiConfigStateMock';
 import type { ILayoutState } from 'src/features/form/layout/formLayoutSlice';
-import { getUiConfigStateMock } from './uiConfigStateMock';
 
 export function getFormLayoutStateMock(customStates?: Partial<ILayoutState>): ILayoutState {
   const mockFormLayoutState: ILayoutState = {

--- a/src/__mocks__/initialStateMock.ts
+++ b/src/__mocks__/initialStateMock.ts
@@ -1,12 +1,12 @@
+import { applicationMetadataMock } from 'src/__mocks__/applicationMetadataMock';
+import { applicationSettingsMock } from 'src/__mocks__/applicationSettingsMock';
+import { getFormDataStateMock } from 'src/__mocks__/formDataStateMock';
+import { getFormLayoutStateMock } from 'src/__mocks__/formLayoutStateMock';
+import { getInstanceDataStateMock } from 'src/__mocks__/instanceDataStateMock';
+import { partyMock } from 'src/__mocks__/partyMock';
+import { getProfileStateMock } from 'src/__mocks__/profileStateMock';
 import { getLanguageFromCode } from 'src/language/languages';
 import type { IRuntimeState } from 'src/types';
-import { getFormLayoutStateMock } from './formLayoutStateMock';
-import { getFormDataStateMock } from './formDataStateMock';
-import { applicationMetadataMock } from './applicationMetadataMock';
-import { applicationSettingsMock } from './applicationSettingsMock';
-import { getInstanceDataStateMock } from './instanceDataStateMock';
-import { partyMock } from './partyMock';
-import { getProfileStateMock } from './profileStateMock';
 
 export function getInitialStateMock(customStates?: Partial<IRuntimeState>): IRuntimeState {
   const initialState: IRuntimeState = {

--- a/src/__mocks__/profileStateMock.ts
+++ b/src/__mocks__/profileStateMock.ts
@@ -1,5 +1,5 @@
+import { partyMock } from 'src/__mocks__/partyMock';
 import type { IProfileState } from 'src/shared/resources/profile';
-import { partyMock } from './partyMock';
 
 export function getProfileStateMock(customStates?: Partial<IProfileState>): IProfileState {
   const profileStateMock = {

--- a/src/__mocks__/statelessAndAllowAnonymousMock.ts
+++ b/src/__mocks__/statelessAndAllowAnonymousMock.ts
@@ -1,6 +1,6 @@
+import { getInitialStateMock } from 'src/__mocks__/initialStateMock';
 import type { IApplicationMetadata } from 'src/shared/resources/applicationMetadata';
 import type { IRuntimeState } from 'src/types';
-import { getInitialStateMock } from './initialStateMock';
 
 export const statelessAndAllowAnonymousMock = (allowAnonymous: boolean | undefined) => {
   const initialState = getInitialStateMock();

--- a/src/__mocks__/validationStateMock.ts
+++ b/src/__mocks__/validationStateMock.ts
@@ -1,5 +1,5 @@
-import type { IValidations } from 'src/types';
 import { getTextResourceByKey } from 'src/utils/sharedUtils';
+import type { IValidations } from 'src/types';
 
 export function getMockValidationState(withFixed = false): IValidations {
   const fixed = withFixed ? [] : undefined;

--- a/src/common/hooks/useInstanceIdParams.test.tsx
+++ b/src/common/hooks/useInstanceIdParams.test.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { Route, useLocation } from 'react-router-dom';
 
-import { instanceIdExample } from '__mocks__/mocks';
 import { render, screen } from '@testing-library/react';
-import { MemoryRouterWithRedirectingRoot } from 'testUtils';
 
+import { instanceIdExample } from 'src/__mocks__/mocks';
 import { useInstanceIdParams } from 'src/common/hooks/useInstanceIdParams';
+import { MemoryRouterWithRedirectingRoot } from 'src/testUtils';
 
 const TestComponent = () => {
   const { instanceId, partyId, instanceGuid } = useInstanceIdParams();

--- a/src/components/AltinnButton.tsx
+++ b/src/components/AltinnButton.tsx
@@ -1,7 +1,9 @@
+import * as React from 'react';
+
 import { Button, createTheme } from '@material-ui/core';
 import { createStyles, makeStyles } from '@material-ui/core/styles';
 import classNames from 'classnames';
-import * as React from 'react';
+
 import altinnTheme from 'src/theme/altinnStudioTheme';
 
 export interface IAltinnButtonComponentProvidedProps {

--- a/src/components/AltinnCheckBox.test.tsx
+++ b/src/components/AltinnCheckBox.test.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { render as rtlRender, screen, act } from '@testing-library/react';
-import userEvent, { PointerEventsCheckLevel } from '@testing-library/user-event';
+
 import { createTheme, MuiThemeProvider } from '@material-ui/core';
+import { act, render as rtlRender, screen } from '@testing-library/react';
+import userEvent, { PointerEventsCheckLevel } from '@testing-library/user-event';
 
 import AltinnCheckBoxComponent from 'src/components/AltinnCheckBox';
 import { AltinnAppTheme } from 'src/theme';

--- a/src/components/AltinnCollapsableList.tsx
+++ b/src/components/AltinnCollapsableList.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Collapse, Grid } from '@material-ui/core';
 
 export interface IAltinnCollapsableListProps {

--- a/src/components/AltinnIcon.tsx
+++ b/src/components/AltinnIcon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import classNames from 'classnames';
 
 export interface IAltinnIconCompontentProvidedProps {

--- a/src/components/AltinnInput.test.tsx
+++ b/src/components/AltinnInput.test.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
-import { render as rtlRender, screen, act } from '@testing-library/react';
+
+import { act, render as rtlRender, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import type { IAltinnInputProps } from './AltinnInput';
-import AltinnInput from './AltinnInput';
+import AltinnInput from 'src/components/AltinnInput';
+import type { IAltinnInputProps } from 'src/components/AltinnInput';
 
 const render = (props: Partial<IAltinnInputProps> = {}) => {
   const allProps = {

--- a/src/components/AltinnInput.tsx
+++ b/src/components/AltinnInput.tsx
@@ -1,7 +1,9 @@
-import { createTheme, createStyles, Grid, Input, InputLabel, makeStyles } from '@material-ui/core';
 import * as React from 'react';
-import altinnTheme from 'src/theme/altinnStudioTheme';
+
+import { createStyles, createTheme, Grid, Input, InputLabel, makeStyles } from '@material-ui/core';
 import cn from 'classnames';
+
+import altinnTheme from 'src/theme/altinnStudioTheme';
 
 const theme = createTheme(altinnTheme);
 const styles = createStyles({

--- a/src/components/AltinnLoader.test.tsx
+++ b/src/components/AltinnLoader.test.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
+
 import { render as rtlRender, screen } from '@testing-library/react';
-import type { IAltinnLoaderProps } from './AltinnLoader';
-import AltinnLoader from './AltinnLoader';
+
+import AltinnLoader from 'src/components/AltinnLoader';
+import type { IAltinnLoaderProps } from 'src/components/AltinnLoader';
 
 describe('AltinnLoader', () => {
   it('should not show the hidden text, but should be in the document', () => {

--- a/src/components/AltinnLogo.test.tsx
+++ b/src/components/AltinnLogo.test.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
+
 import { render as rtlRender, screen } from '@testing-library/react';
-import type { IAltinnLogoProps } from './AltinnLogo';
-import { AltinnLogo } from './AltinnLogo';
+
+import { AltinnLogo } from 'src/components/AltinnLogo';
 import altinnTheme from 'src/theme/altinnAppTheme';
+import type { IAltinnLogoProps } from 'src/components/AltinnLogo';
 
 describe('AltinnLogo', () => {
   it('should have black image src and custom color as filter class when passing a custom color string', () => {

--- a/src/components/AltinnLogo.tsx
+++ b/src/components/AltinnLogo.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+
 import appTheme from 'src/theme/altinnAppTheme';
+
 import 'src/styles/shared.css';
 
 export interface IAltinnLogoProps {

--- a/src/components/AltinnPopover.tsx
+++ b/src/components/AltinnPopover.tsx
@@ -1,9 +1,11 @@
-import type { PopoverProps } from '@material-ui/core';
-import { createTheme, createStyles, Grid, makeStyles, Popover, Typography } from '@material-ui/core';
-import classNames from 'classnames';
 import * as React from 'react';
+
+import { createStyles, createTheme, Grid, makeStyles, Popover, Typography } from '@material-ui/core';
+import classNames from 'classnames';
+import type { PopoverProps } from '@material-ui/core';
+
+import { AltinnButton } from 'src/components/AltinnButton';
 import altinnTheme from 'src/theme/altinnAppTheme';
-import { AltinnButton } from './AltinnButton';
 
 export interface IAnchorOrigin {
   horizontal: 'left' | 'center' | 'right' | number;

--- a/src/components/AltinnSpinner.tsx
+++ b/src/components/AltinnSpinner.tsx
@@ -1,7 +1,9 @@
-import { CircularProgress, createTheme, createStyles, makeStyles, Typography } from '@material-ui/core';
-import type { ArgumentArray } from 'classnames';
-import classNames from 'classnames';
 import * as React from 'react';
+
+import { CircularProgress, createStyles, createTheme, makeStyles, Typography } from '@material-ui/core';
+import classNames from 'classnames';
+import type { ArgumentArray } from 'classnames';
+
 import altinnTheme from 'src/theme/altinnStudioTheme';
 
 export interface IAltinnSpinnerComponentProvidedProps {

--- a/src/components/EditIconButton.tsx
+++ b/src/components/EditIconButton.tsx
@@ -1,6 +1,7 @@
-import { IconButton, makeStyles } from '@material-ui/core';
-import type { ReactNode } from 'react';
 import React from 'react';
+import type { ReactNode } from 'react';
+
+import { IconButton, makeStyles } from '@material-ui/core';
 import cn from 'classnames';
 
 export interface IEditIconButtonProps {

--- a/src/components/GenericComponent.test.tsx
+++ b/src/components/GenericComponent.test.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 
-import { getFormDataStateMock, getFormLayoutStateMock, getInitialStateMock } from '__mocks__/mocks';
 import { screen } from '@testing-library/react';
-import { mockComponentProps, renderWithProviders } from 'testUtils';
 
+import { getFormDataStateMock, getFormLayoutStateMock, getInitialStateMock } from 'src/__mocks__/mocks';
 import { GenericComponent } from 'src/components/GenericComponent';
+import { mockComponentProps, renderWithProviders } from 'src/testUtils';
 import type { IActualGenericComponentProps } from 'src/components/GenericComponent';
 
 const render = (props: Partial<IActualGenericComponentProps<any>> = {}) => {

--- a/src/components/GenericComponent.tsx
+++ b/src/components/GenericComponent.tsx
@@ -24,6 +24,7 @@ import {
   selectComponentTexts,
 } from 'src/utils/formComponentUtils';
 import { renderValidationMessagesForComponent } from 'src/utils/render';
+import { getTextResourceByKey } from 'src/utils/sharedUtils';
 import type { IComponentProps, IFormComponentContext, PropsFromGenericComponent } from 'src/components';
 import type { ExprResolved } from 'src/features/expressions/types';
 import type { ISingleFieldValidation } from 'src/features/form/data/formDataTypes';
@@ -35,8 +36,6 @@ import type {
   ILayoutComponent,
 } from 'src/features/form/layout';
 import type { IComponentValidations, ILabelSettings } from 'src/types';
-
-import { getTextResourceByKey } from 'src/utils/sharedUtils';
 import type { ILanguage } from 'src/types/shared';
 
 export interface IGenericComponentProps {

--- a/src/components/LandmarkShortcuts.test.tsx
+++ b/src/components/LandmarkShortcuts.test.tsx
@@ -1,8 +1,10 @@
+import React from 'react';
+
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import React from 'react';
-import type { ILandmarkShortcutsProps } from './LandmarkShortcuts';
-import { LandmarkShortcuts } from './LandmarkShortcuts';
+
+import { LandmarkShortcuts } from 'src/components/LandmarkShortcuts';
+import type { ILandmarkShortcutsProps } from 'src/components/LandmarkShortcuts';
 
 describe('LandmarkShortcuts.tsx', () => {
   it('should render supplied text', () => {

--- a/src/components/LandmarkShortcuts.tsx
+++ b/src/components/LandmarkShortcuts.tsx
@@ -1,5 +1,6 @@
-import { makeStyles } from '@material-ui/core';
 import React from 'react';
+
+import { makeStyles } from '@material-ui/core';
 import cn from 'classnames';
 
 export interface ILandmarkShortcutsProps {

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -1,7 +1,10 @@
+import * as React from 'react';
+
 import { makeStyles } from '@material-ui/core/styles';
 import cn from 'classnames';
-import * as React from 'react';
+
 import { AltinnAppTheme } from 'src/theme/index';
+
 import 'src/styles/shared.css';
 
 const useStyles = makeStyles({

--- a/src/components/SuccessIconButton.tsx
+++ b/src/components/SuccessIconButton.tsx
@@ -1,6 +1,7 @@
-import { makeStyles, IconButton } from '@material-ui/core';
-import type { ReactNode } from 'react';
 import React from 'react';
+import type { ReactNode } from 'react';
+
+import { IconButton, makeStyles } from '@material-ui/core';
 
 export interface ISuccessIconButtonProps {
   label: ReactNode;

--- a/src/components/ThemeWrapper.tsx
+++ b/src/components/ThemeWrapper.tsx
@@ -4,9 +4,8 @@ import type { ReactNode } from 'react';
 import { createTheme, ThemeProvider } from '@material-ui/core';
 
 import { useAppSelector } from 'src/common/hooks';
-import { appLanguageStateSelector } from 'src/selectors/appLanguageStateSelector';
-
 import { rightToLeftISOLanguageCodes } from 'src/language/languages';
+import { appLanguageStateSelector } from 'src/selectors/appLanguageStateSelector';
 import { AltinnAppTheme } from 'src/theme/index';
 
 type ThemeWrapperProps = {

--- a/src/components/advanced/AddressComponent.test.tsx
+++ b/src/components/advanced/AddressComponent.test.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import { Provider } from 'react-redux';
 
-import { fireEvent, render as rtlRender, screen, act } from '@testing-library/react';
+import { act, fireEvent, render as rtlRender, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import mockAxios from 'jest-mock-axios';
 import configureStore from 'redux-mock-store';
-import { mockComponentProps } from 'testUtils';
 
 import { AddressComponent } from 'src/components/advanced/AddressComponent';
+import { mockComponentProps } from 'src/testUtils';
 import type { IAddressComponentProps } from 'src/components/advanced/AddressComponent';
 
 const render = (props: Partial<IAddressComponentProps> = {}) => {

--- a/src/components/advanced/AddressComponent.tsx
+++ b/src/components/advanced/AddressComponent.tsx
@@ -6,10 +6,9 @@ import axios from 'axios';
 import { AddressLabel } from 'src/components/advanced/AddressLabel';
 import { useDelayedSavedState } from 'src/components/hooks/useDelayedSavedState';
 import { renderValidationMessagesForComponent } from 'src/utils/render';
+import { get, getLanguageFromKey } from 'src/utils/sharedUtils';
 import type { PropsFromGenericComponent } from 'src/components';
 import type { IComponentValidations } from 'src/types';
-
-import { get, getLanguageFromKey } from 'src/utils/sharedUtils';
 
 import 'src/components/advanced/AddressComponent.css';
 

--- a/src/components/advanced/AddressLabel.tsx
+++ b/src/components/advanced/AddressLabel.tsx
@@ -2,9 +2,8 @@ import * as React from 'react';
 
 import { OptionalIndicator } from 'src/features/form/components/OptionalIndicator';
 import { RequiredIndicator } from 'src/features/form/components/RequiredIndicator';
-import type { ILabelSettings } from 'src/types';
-
 import { getLanguageFromKey } from 'src/utils/sharedUtils';
+import type { ILabelSettings } from 'src/types';
 import type { ILanguage } from 'src/types/shared';
 
 interface IAddressLabel {

--- a/src/components/atoms/AltinnAttachment.tsx
+++ b/src/components/atoms/AltinnAttachment.tsx
@@ -1,10 +1,11 @@
-import { Typography, makeStyles, List, ListItem, ListItemIcon, ListItemText } from '@material-ui/core';
-import cn from 'classnames';
 import React from 'react';
 
+import { List, ListItem, ListItemIcon, ListItemText, makeStyles, Typography } from '@material-ui/core';
+import cn from 'classnames';
+
+import { AltinnIcon } from 'src/components/AltinnIcon';
 import { makeUrlRelativeIfSameDomain } from 'src/utils/urls/urlHelper';
 import type { IAttachment } from 'src/types/shared';
-import { AltinnIcon } from '../AltinnIcon';
 
 const useStyles = makeStyles(() => ({
   a: {

--- a/src/components/base/AttachmentListComponent.test.tsx
+++ b/src/components/base/AttachmentListComponent.test.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
 
-import { applicationMetadataMock, getInitialStateMock, getInstanceDataStateMock } from '__mocks__/mocks';
 import { screen } from '@testing-library/react';
-import { renderWithProviders } from 'testUtils';
 
+import { applicationMetadataMock, getInitialStateMock, getInstanceDataStateMock } from 'src/__mocks__/mocks';
 import { AttachmentListComponent } from 'src/components/base/AttachmentListComponent';
+import { renderWithProviders } from 'src/testUtils';
 import type { IAttachmentListProps } from 'src/components/base/AttachmentListComponent';
 import type { IInstanceDataState } from 'src/shared/resources/instanceData';
-
 import type { IData } from 'src/types/shared';
 
 describe('FileUploadComponent', () => {

--- a/src/components/base/AttachmentListComponent.tsx
+++ b/src/components/base/AttachmentListComponent.tsx
@@ -3,10 +3,9 @@ import * as React from 'react';
 import { Grid, Typography } from '@material-ui/core';
 
 import { useAppSelector } from 'src/common/hooks';
-import type { PropsFromGenericComponent } from 'src/components';
-
 import { AltinnAttachment } from 'src/components/shared';
 import { mapInstanceAttachments } from 'src/utils/sharedUtils';
+import type { PropsFromGenericComponent } from 'src/components';
 
 export type IAttachmentListProps = PropsFromGenericComponent<'AttachmentList'>;
 

--- a/src/components/base/ButtonComponent/ButtonComponent.test.tsx
+++ b/src/components/base/ButtonComponent/ButtonComponent.test.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 
-import { getInitialStateMock } from '__mocks__/mocks';
 import { screen } from '@testing-library/react';
-import { renderWithProviders } from 'testUtils';
 
+import { getInitialStateMock } from 'src/__mocks__/mocks';
 import { ButtonComponent } from 'src/components/base/ButtonComponent/ButtonComponent';
+import { renderWithProviders } from 'src/testUtils';
 import type { IButtonProvidedProps } from 'src/components/base/ButtonComponent/ButtonComponent';
 
 const submitBtnText = 'Submit form';

--- a/src/components/base/ButtonComponent/ButtonComponent.tsx
+++ b/src/components/base/ButtonComponent/ButtonComponent.tsx
@@ -7,12 +7,11 @@ import { SaveButton } from 'src/components/base/ButtonComponent/SaveButton';
 import { SubmitButton } from 'src/components/base/ButtonComponent/SubmitButton';
 import { FormDataActions } from 'src/features/form/data/formDataSlice';
 import { ProcessActions } from 'src/shared/resources/process/processSlice';
+import { getLanguageFromKey } from 'src/utils/sharedUtils';
 import type { IComponentProps } from 'src/components';
 import type { ButtonMode } from 'src/components/base/ButtonComponent/getComponentFromMode';
 import type { ILayoutCompButton } from 'src/features/form/layout';
 import type { IAltinnWindow } from 'src/types';
-
-import { getLanguageFromKey } from 'src/utils/sharedUtils';
 
 export interface IButtonProvidedProps extends IComponentProps, ILayoutCompButton {
   disabled: boolean;

--- a/src/components/base/ButtonComponent/ButtonLoader.tsx
+++ b/src/components/base/ButtonComponent/ButtonLoader.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import css from 'src/components/base/ButtonComponent/ButtonLoader.module.css';
-
 import { AltinnLoader } from 'src/components/shared';
 import { getLanguageFromKey } from 'src/utils/sharedUtils';
 import type { ILanguage } from 'src/types/shared';

--- a/src/components/base/ButtonComponent/GoToTaskButton.test.tsx
+++ b/src/components/base/ButtonComponent/GoToTaskButton.test.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
-import { getInitialStateMock } from '__mocks__/mocks';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { renderWithProviders } from 'testUtils';
 
+import { getInitialStateMock } from 'src/__mocks__/mocks';
 import { GoToTaskButton } from 'src/components/base/ButtonComponent/GoToTaskButton';
 import { setupStore } from 'src/store';
+import { renderWithProviders } from 'src/testUtils';
 import type { Props as GoToTaskButtonProps } from 'src/components/base/ButtonComponent/GoToTaskButton';
 
 const render = ({ props = {}, dispatch = jest.fn() } = {}) => {

--- a/src/components/base/ButtonComponent/InstantiationButton.test.tsx
+++ b/src/components/base/ButtonComponent/InstantiationButton.test.tsx
@@ -1,14 +1,14 @@
 import * as React from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
-import { getInitialStateMock } from '__mocks__/mocks';
 import { act, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import mockAxios from 'jest-mock-axios';
-import { renderWithProviders } from 'testUtils';
 
+import { getInitialStateMock } from 'src/__mocks__/mocks';
 import { InstantiationButton } from 'src/components/base/ButtonComponent/InstantiationButton';
 import { setupStore } from 'src/store';
+import { renderWithProviders } from 'src/testUtils';
 import type { InstantiationButtonProps as InstantiationButtonProps } from 'src/components/base/ButtonComponent/InstantiationButton';
 
 const render = ({ props = {} }) => {

--- a/src/components/base/CheckboxesContainerComponent.test.tsx
+++ b/src/components/base/CheckboxesContainerComponent.test.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
-import { getInitialStateMock } from '__mocks__/initialStateMock';
 import { act, fireEvent, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { mockComponentProps, renderWithProviders } from 'testUtils';
 import type { PreloadedState } from 'redux';
 
+import { getInitialStateMock } from 'src/__mocks__/initialStateMock';
 import { CheckboxContainerComponent } from 'src/components/base/CheckboxesContainerComponent';
+import { mockComponentProps, renderWithProviders } from 'src/testUtils';
 import { LayoutStyle } from 'src/types';
 import type { ICheckboxContainerProps } from 'src/components/base/CheckboxesContainerComponent';
 import type { IOptionsState } from 'src/shared/resources/options';

--- a/src/components/base/CheckboxesContainerComponent.tsx
+++ b/src/components/base/CheckboxesContainerComponent.tsx
@@ -10,13 +10,12 @@ import type { CheckboxProps } from '@material-ui/core/Checkbox';
 import { useAppSelector, useHasChangedIgnoreUndefined } from 'src/common/hooks';
 import { useGetOptions } from 'src/components/hooks';
 import { useDelayedSavedState } from 'src/components/hooks/useDelayedSavedState';
+import { AltinnSpinner } from 'src/components/shared';
 import { shouldUseRowLayout } from 'src/utils/layout';
 import { getOptionLookupKey } from 'src/utils/options';
 import { renderValidationMessagesForComponent } from 'src/utils/render';
 import type { PropsFromGenericComponent } from 'src/components';
 import type { IComponentValidations, IOption } from 'src/types';
-
-import { AltinnSpinner } from 'src/components/shared';
 
 export interface ICheckboxContainerProps extends PropsFromGenericComponent<'Checkboxes'> {
   validationMessages: IComponentValidations;

--- a/src/components/base/DatepickerComponent.test.tsx
+++ b/src/components/base/DatepickerComponent.test.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 
-import { fireEvent, screen, act } from '@testing-library/react';
+import { act, fireEvent, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { mockComponentProps, mockMediaQuery, renderWithProviders } from 'testUtils';
 import type { PreloadedState } from 'redux';
 
 import DatepickerComponent from 'src/components/base/DatepickerComponent';
+import { mockComponentProps, mockMediaQuery, renderWithProviders } from 'src/testUtils';
 import type { IDatePickerProps } from 'src/components/base/DatepickerComponent';
 import type { RootState } from 'src/store';
 

--- a/src/components/base/DatepickerComponent.tsx
+++ b/src/components/base/DatepickerComponent.tsx
@@ -8,9 +8,8 @@ import type { MaterialUiPickersDate } from '@material-ui/pickers/typings/date';
 
 import { useDelayedSavedState } from 'src/components/hooks/useDelayedSavedState';
 import { getDateConstraint, getDateFormat, getDateString } from 'src/utils/dateHelpers';
-import type { PropsFromGenericComponent } from 'src/components';
-
 import { getLanguageFromKey } from 'src/utils/sharedUtils';
+import type { PropsFromGenericComponent } from 'src/components';
 
 import 'src/components/base/DatepickerComponent.css';
 import 'src/styles/shared.css';

--- a/src/components/base/DropdownComponent.test.tsx
+++ b/src/components/base/DropdownComponent.test.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
-import { getInitialStateMock } from '__mocks__/initialStateMock';
 import { act, fireEvent, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { mockComponentProps, renderWithProviders } from 'testUtils';
 import type { PreloadedState } from 'redux';
 
+import { getInitialStateMock } from 'src/__mocks__/initialStateMock';
 import DropdownComponent from 'src/components/base/DropdownComponent';
+import { mockComponentProps, renderWithProviders } from 'src/testUtils';
 import type { IDropdownProps } from 'src/components/base/DropdownComponent';
 import type { RootState } from 'src/store';
 

--- a/src/components/base/DropdownComponent.tsx
+++ b/src/components/base/DropdownComponent.tsx
@@ -3,10 +3,9 @@ import React from 'react';
 import { useAppSelector, useHasChangedIgnoreUndefined } from 'src/common/hooks';
 import { useGetOptions } from 'src/components/hooks';
 import { useDelayedSavedState } from 'src/components/hooks/useDelayedSavedState';
+import { AltinnSpinner, Select } from 'src/components/shared';
 import { getOptionLookupKey } from 'src/utils/options';
 import type { PropsFromGenericComponent } from 'src/components';
-
-import { AltinnSpinner, Select } from 'src/components/shared';
 
 export type IDropdownProps = PropsFromGenericComponent<'Dropdown'>;
 

--- a/src/components/base/FileUpload/FileUploadComponent.test.tsx
+++ b/src/components/base/FileUpload/FileUploadComponent.test.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 
-import { getAttachments } from '__mocks__/attachmentsMock';
-import { getInitialStateMock } from '__mocks__/initialStateMock';
 import { screen } from '@testing-library/react';
-import { mockComponentProps, renderWithProviders } from 'testUtils';
 
+import { getAttachments } from 'src/__mocks__/attachmentsMock';
+import { getInitialStateMock } from 'src/__mocks__/initialStateMock';
 import { FileUploadComponent } from 'src/components/base/FileUpload/FileUploadComponent';
+import { mockComponentProps, renderWithProviders } from 'src/testUtils';
 import type { IFileUploadProps } from 'src/components/base/FileUpload/FileUploadComponent';
 import type { IAttachment } from 'src/shared/resources/attachments';
 

--- a/src/components/base/FileUpload/FileUploadComponent.tsx
+++ b/src/components/base/FileUpload/FileUploadComponent.tsx
@@ -8,15 +8,14 @@ import { v4 as uuidv4 } from 'uuid';
 import { useAppDispatch, useAppSelector } from 'src/common/hooks';
 import { DropzoneComponent, handleRejectedFiles } from 'src/components/base/FileUpload/shared';
 import { AttachmentsCounter, FileName } from 'src/components/base/FileUpload/shared/render';
+import { AltinnLoader } from 'src/components/shared';
 import { AttachmentActions } from 'src/shared/resources/attachments/attachmentSlice';
+import { AltinnAppTheme } from 'src/theme/index';
 import { renderValidationMessagesForComponent } from 'src/utils/render';
+import { getLanguageFromKey } from 'src/utils/sharedUtils';
 import type { PropsFromGenericComponent } from 'src/components';
 import type { IAttachment } from 'src/shared/resources/attachments';
 import type { IComponentValidations } from 'src/types';
-
-import { AltinnLoader } from 'src/components/shared';
-import { AltinnAppTheme } from 'src/theme/index';
-import { getLanguageFromKey } from 'src/utils/sharedUtils';
 
 import 'src/components/base/FileUpload/FileUploadComponent.css';
 

--- a/src/components/base/FileUpload/FileUploadWithTag/EditWindowComponent.tsx
+++ b/src/components/base/FileUpload/FileUploadWithTag/EditWindowComponent.tsx
@@ -5,15 +5,14 @@ import classNames from 'classnames';
 
 import { useAppDispatch } from 'src/common/hooks';
 import { FileName } from 'src/components/base/FileUpload/shared/render';
+import { AltinnButton, AltinnLoader } from 'src/components/shared';
 import { AttachmentActions } from 'src/shared/resources/attachments/attachmentSlice';
+import { AltinnAppTheme } from 'src/theme/index';
 import { renderValidationMessages } from 'src/utils/render';
+import { getLanguageFromKey } from 'src/utils/sharedUtils';
 import type { PropsFromGenericComponent } from 'src/components';
 import type { IAttachment } from 'src/shared/resources/attachments';
 import type { IOption } from 'src/types';
-
-import { AltinnButton, AltinnLoader } from 'src/components/shared';
-import { AltinnAppTheme } from 'src/theme/index';
-import { getLanguageFromKey } from 'src/utils/sharedUtils';
 
 const useStyles = makeStyles({
   textContainer: {

--- a/src/components/base/FileUpload/FileUploadWithTag/FileListComponent.tsx
+++ b/src/components/base/FileUpload/FileUploadWithTag/FileListComponent.tsx
@@ -14,14 +14,13 @@ import {
 
 import { EditWindowComponent } from 'src/components/base/FileUpload/FileUploadWithTag/EditWindowComponent';
 import { FileName } from 'src/components/base/FileUpload/shared/render';
+import { AltinnLoader } from 'src/components/shared';
+import { AltinnAppTheme } from 'src/theme';
 import { atleastOneTagExists } from 'src/utils/formComponentUtils';
+import { getLanguageFromKey } from 'src/utils/sharedUtils';
 import type { PropsFromGenericComponent } from 'src/components';
 import type { IAttachment } from 'src/shared/resources/attachments';
 import type { IDataModelBindings, IOption } from 'src/types';
-
-import { AltinnLoader } from 'src/components/shared';
-import { AltinnAppTheme } from 'src/theme';
-import { getLanguageFromKey } from 'src/utils/sharedUtils';
 
 const useStyles = makeStyles({
   table: {

--- a/src/components/base/FileUpload/FileUploadWithTag/FileUploadWithTagComponent.test.tsx
+++ b/src/components/base/FileUpload/FileUploadWithTag/FileUploadWithTagComponent.test.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 
-import { getAttachments } from '__mocks__/attachmentsMock';
-import { getFormLayoutStateMock } from '__mocks__/formLayoutStateMock';
-import { getInitialStateMock } from '__mocks__/initialStateMock';
-import { getUiConfigStateMock } from '__mocks__/uiConfigStateMock';
 import { screen } from '@testing-library/react';
-import { mockComponentProps, renderWithProviders } from 'testUtils';
 
+import { getAttachments } from 'src/__mocks__/attachmentsMock';
+import { getFormLayoutStateMock } from 'src/__mocks__/formLayoutStateMock';
+import { getInitialStateMock } from 'src/__mocks__/initialStateMock';
+import { getUiConfigStateMock } from 'src/__mocks__/uiConfigStateMock';
 import { FileUploadWithTagComponent } from 'src/components/base/FileUpload/FileUploadWithTag/FileUploadWithTagComponent';
+import { mockComponentProps, renderWithProviders } from 'src/testUtils';
 import { AsciiUnitSeparator } from 'src/utils/attachment';
 import type { IFileUploadWithTagProps } from 'src/components/base/FileUpload/FileUploadWithTag/FileUploadWithTagComponent';
 import type { IAttachment } from 'src/shared/resources/attachments';

--- a/src/components/base/FileUpload/FileUploadWithTag/FileUploadWithTagComponent.tsx
+++ b/src/components/base/FileUpload/FileUploadWithTag/FileUploadWithTagComponent.tsx
@@ -19,11 +19,10 @@ import {
 } from 'src/utils/formComponentUtils';
 import { getOptionLookupKey } from 'src/utils/options';
 import { renderValidationMessagesForComponent } from 'src/utils/render';
+import { getLanguageFromKey } from 'src/utils/sharedUtils';
 import type { PropsFromGenericComponent } from 'src/components';
 import type { IAttachment } from 'src/shared/resources/attachments';
 import type { IRuntimeState } from 'src/types';
-
-import { getLanguageFromKey } from 'src/utils/sharedUtils';
 
 export type IFileUploadWithTagProps = PropsFromGenericComponent<'FileUploadWithTag'>;
 

--- a/src/components/base/FileUpload/shared/DropzoneComponent.tsx
+++ b/src/components/base/FileUpload/shared/DropzoneComponent.tsx
@@ -3,11 +3,10 @@ import DropZone from 'react-dropzone';
 import type { FileRejection } from 'react-dropzone';
 
 import { mapExtensionToAcceptMime } from 'src/components/base/FileUpload/shared/mapExtensionToAcceptMime';
-import type { ILayoutCompFileUpload } from 'src/features/form/layout';
-import type { ITextResourceBindings } from 'src/types';
-
 import { AltinnAppTheme } from 'src/theme';
 import { getLanguageFromKey } from 'src/utils/sharedUtils';
+import type { ILayoutCompFileUpload } from 'src/features/form/layout';
+import type { ITextResourceBindings } from 'src/types';
 
 export interface IDropzoneComponentProps {
   id: string;

--- a/src/components/base/FileUpload/shared/render.tsx
+++ b/src/components/base/FileUpload/shared/render.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 
 import { getFileEnding, removeFileEnding } from 'src/utils/attachment';
-
 import { getLanguageFromKey } from 'src/utils/sharedUtils';
 
 export const FileName = ({ children }: { children: string | undefined }) => {

--- a/src/components/base/ListComponent.test.tsx
+++ b/src/components/base/ListComponent.test.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
-import { getInitialStateMock } from '__mocks__/initialStateMock';
 import { SortDirection } from '@altinn/altinn-design-system';
 import { screen } from '@testing-library/react';
-import { mockComponentProps, renderWithProviders } from 'testUtils';
 import type { PreloadedState } from 'redux';
 
+import { getInitialStateMock } from 'src/__mocks__/initialStateMock';
 import { ListComponent } from 'src/components/base/ListComponent';
+import { mockComponentProps, renderWithProviders } from 'src/testUtils';
 import type { IListProps } from 'src/components/base/ListComponent';
 import type { IDataListsState } from 'src/shared/resources/dataLists';
 import type { RootState } from 'src/store';

--- a/src/components/base/ListComponent.tsx
+++ b/src/components/base/ListComponent.tsx
@@ -18,7 +18,6 @@ import type { PropsFromGenericComponent } from '..';
 import { useAppDispatch, useAppSelector } from 'src/common/hooks';
 import { useGetDataList } from 'src/components/hooks';
 import { DataListsActions } from 'src/shared/resources/dataLists/dataListsSlice';
-
 import { getLanguageFromKey } from 'src/utils/sharedUtils';
 
 export type IListProps = PropsFromGenericComponent<'List'>;

--- a/src/components/base/MapComponent.test.tsx
+++ b/src/components/base/MapComponent.test.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
 import { render as rtlRender, screen } from '@testing-library/react';
-import { mockComponentProps } from 'testUtils';
 
 import { MapComponent } from 'src/components/base/MapComponent';
+import { mockComponentProps } from 'src/testUtils';
 import type { IMapComponentProps } from 'src/components/base/MapComponent';
 
 const render = (props: Partial<IMapComponentProps> = {}) => {

--- a/src/components/base/MapComponent.tsx
+++ b/src/components/base/MapComponent.tsx
@@ -4,9 +4,8 @@ import { Map } from '@altinn/altinn-design-system';
 import { makeStyles, Typography } from '@material-ui/core';
 import type { Location } from '@altinn/altinn-design-system';
 
-import type { PropsFromGenericComponent } from 'src/components';
-
 import { getLanguageFromKey, getParsedLanguageFromKey } from 'src/utils/sharedUtils';
+import type { PropsFromGenericComponent } from 'src/components';
 
 export type IMapComponentProps = PropsFromGenericComponent<'Map'>;
 

--- a/src/components/base/MultipleSelect.test.tsx
+++ b/src/components/base/MultipleSelect.test.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 
-import { getInitialStateMock } from '__mocks__/initialStateMock';
 import { fireEvent, screen } from '@testing-library/react';
-import { mockComponentProps, renderWithProviders } from 'testUtils';
 import type { PreloadedState } from 'redux';
 
+import { getInitialStateMock } from 'src/__mocks__/initialStateMock';
 import { MultipleSelect } from 'src/components/base/MultipleSelect';
+import { mockComponentProps, renderWithProviders } from 'src/testUtils';
 import type { IMultipleSelectProps } from 'src/components/base/MultipleSelect';
 import type { RootState } from 'src/store';
 

--- a/src/components/base/MultipleSelect.tsx
+++ b/src/components/base/MultipleSelect.tsx
@@ -6,9 +6,8 @@ import type { PropsFromGenericComponent } from '..';
 
 import { useAppSelector } from 'src/common/hooks';
 import { useGetOptions } from 'src/components/hooks';
-import type { IOption } from 'src/types';
-
 import { getLanguageFromKey } from 'src/utils/sharedUtils';
+import type { IOption } from 'src/types';
 
 import 'src/components/base/MultipleSelect.css';
 

--- a/src/components/base/NavigationBar.test.tsx
+++ b/src/components/base/NavigationBar.test.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
-import { screen, act } from '@testing-library/react';
+import { act, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { mockMediaQuery, renderWithProviders } from 'testUtils';
 
 import { NavigationBar } from 'src/components/base/NavigationBar';
 import { FormLayoutActions } from 'src/features/form/layout/formLayoutSlice';
 import { setupStore } from 'src/store';
+import { mockMediaQuery, renderWithProviders } from 'src/testUtils';
 import type { INavigationBar } from 'src/components/base/NavigationBar';
 
 const { setScreenWidth } = mockMediaQuery(600);

--- a/src/components/base/PrintButtonComponent.test.tsx
+++ b/src/components/base/PrintButtonComponent.test.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 
-import { getInitialStateMock } from '__mocks__/initialStateMock';
 import { screen } from '@testing-library/react';
-import { renderWithProviders } from 'testUtils';
 
+import { getInitialStateMock } from 'src/__mocks__/initialStateMock';
 import { PrintButtonComponent } from 'src/components/base/PrintButtonComponent';
+import { renderWithProviders } from 'src/testUtils';
 
 const render = (preloaded = {}) => {
   const preloadedState = {

--- a/src/components/base/RadioButtons/ControlledRadioGroup.tsx
+++ b/src/components/base/RadioButtons/ControlledRadioGroup.tsx
@@ -9,12 +9,11 @@ import cn from 'classnames';
 
 import { useRadioStyles } from 'src/components/base/RadioButtons/radioButtonsUtils';
 import { StyledRadio } from 'src/components/base/RadioButtons/StyledRadio';
+import { AltinnSpinner } from 'src/components/shared';
 import { shouldUseRowLayout } from 'src/utils/layout';
 import { renderValidationMessagesForComponent } from 'src/utils/render';
 import type { IRadioButtonsContainerProps } from 'src/components/base/RadioButtons/RadioButtonsContainerComponent';
 import type { IOption } from 'src/types';
-
-import { AltinnSpinner } from 'src/components/shared';
 
 export interface IControlledRadioGroupProps extends IRadioButtonsContainerProps {
   fetchingOptions: boolean | undefined;

--- a/src/components/base/RadioButtons/RadioButtonsContainerComponent.test.tsx
+++ b/src/components/base/RadioButtons/RadioButtonsContainerComponent.test.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
-import { getInitialStateMock } from '__mocks__/initialStateMock';
 import { act, fireEvent, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { mockComponentProps, renderWithProviders } from 'testUtils';
 import type { PreloadedState } from 'redux';
 
+import { getInitialStateMock } from 'src/__mocks__/initialStateMock';
 import { RadioButtonContainerComponent } from 'src/components/base/RadioButtons/RadioButtonsContainerComponent';
+import { mockComponentProps, renderWithProviders } from 'src/testUtils';
 import { LayoutStyle } from 'src/types';
 import type { IRadioButtonsContainerProps } from 'src/components/base/RadioButtons/RadioButtonsContainerComponent';
 import type { IOptionsState } from 'src/shared/resources/options';

--- a/src/components/base/TextAreaComponent.test.tsx
+++ b/src/components/base/TextAreaComponent.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { render as rtlRender, screen, act } from '@testing-library/react';
+import { act, render as rtlRender, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { TextAreaComponent } from 'src/components/base/TextAreaComponent';

--- a/src/components/custom/CustomWebComponent.test.tsx
+++ b/src/components/custom/CustomWebComponent.test.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
 
-import { mockComponentProps, renderWithProviders } from 'testUtils';
-
 import CustomWebComponent from 'src/components/custom/CustomWebComponent';
+import { mockComponentProps, renderWithProviders } from 'src/testUtils';
 import type { ICustomComponentProps } from 'src/components/custom/CustomWebComponent';
-
 import type { ITextResource } from 'src/types/shared';
 
 const jsonAttributeValue = { customKey: 'customValue' };

--- a/src/components/custom/CustomWebComponent.tsx
+++ b/src/components/custom/CustomWebComponent.tsx
@@ -2,10 +2,9 @@ import React from 'react';
 import ReactDOMServer from 'react-dom/server';
 
 import { useAppSelector } from 'src/common/hooks';
+import { getTextResourceByKey } from 'src/utils/sharedUtils';
 import type { PropsFromGenericComponent } from 'src/components';
 import type { ITextResource, ITextResourceBindings } from 'src/types';
-
-import { getTextResourceByKey } from 'src/utils/sharedUtils';
 
 export type ICustomComponentProps = PropsFromGenericComponent<'Custom'> & {
   [key: string]: string | number | boolean | object | null | undefined;

--- a/src/components/hooks/index.ts
+++ b/src/components/hooks/index.ts
@@ -5,7 +5,6 @@ import { useAppSelector } from 'src/common/hooks';
 import { buildInstanceContext } from 'src/utils/instanceContext';
 import { getOptionLookupKey, getRelevantFormDataForOptionSource, setupSourceOptions } from 'src/utils/options';
 import type { IMapping, IOption, IOptionSource } from 'src/types';
-
 import type { IDataSources } from 'src/types/shared';
 
 interface IUseGetOptionsParams {

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -32,9 +32,8 @@ import type {
   IGrid,
   ILayoutComponent,
 } from 'src/features/form/layout';
-import type { IComponentFormData } from 'src/utils/formComponentUtils';
-
 import type { ILanguage } from 'src/types/shared';
+import type { IComponentFormData } from 'src/utils/formComponentUtils';
 
 const components: {
   [Type in ComponentExceptGroupAndSummary]: (props: any) => JSX.Element | null;

--- a/src/components/message/ErrorReport.test.tsx
+++ b/src/components/message/ErrorReport.test.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 
-import { getInitialStateMock } from '__mocks__/mocks';
 import { screen } from '@testing-library/react';
-import { renderWithProviders } from 'testUtils';
 
+import { getInitialStateMock } from 'src/__mocks__/mocks';
 import ErrorReport from 'src/components/message/ErrorReport';
+import { renderWithProviders } from 'src/testUtils';
 import type { IValidationState } from 'src/features/form/validation/validationSlice';
 import type { IValidations } from 'src/types';
 

--- a/src/components/message/ErrorReport.tsx
+++ b/src/components/message/ErrorReport.tsx
@@ -8,12 +8,11 @@ import { FullWidthWrapper } from 'src/features/form/components/FullWidthWrapper'
 import { renderLayoutComponent } from 'src/features/form/containers/Form';
 import { FormLayoutActions } from 'src/features/form/layout/formLayoutSlice';
 import { nodesInLayouts } from 'src/utils/layout/hierarchy';
+import { getLanguageFromKey, getParsedLanguageFromText } from 'src/utils/sharedUtils';
 import { getMappedErrors, getUnmappedErrors } from 'src/utils/validation';
 import type { ILayout } from 'src/features/form/layout';
 import type { AnyChildNode } from 'src/utils/layout/hierarchy.types';
 import type { FlatError } from 'src/utils/validation';
-
-import { getLanguageFromKey, getParsedLanguageFromText } from 'src/utils/sharedUtils';
 
 export interface IErrorReportProps {
   components: ILayout;

--- a/src/components/molecules/AltinnCollapsibleAttachments.tsx
+++ b/src/components/molecules/AltinnCollapsibleAttachments.tsx
@@ -1,10 +1,11 @@
-import { Typography, makeStyles, Collapse, List, ListItem, ListItemIcon, ListItemText } from '@material-ui/core';
 import React from 'react';
+
+import { Collapse, List, ListItem, ListItemIcon, ListItemText, makeStyles, Typography } from '@material-ui/core';
 import cn from 'classnames';
 
+import { AltinnIcon } from 'src/components/AltinnIcon';
+import AltinnAttachmentComponent from 'src/components/atoms/AltinnAttachment';
 import type { IAttachment } from 'src/types/shared';
-import { AltinnIcon } from '../AltinnIcon';
-import AltinnAttachmentComponent from '../atoms/AltinnAttachment';
 
 const useStyles = makeStyles(() => ({
   listItemTextPadding: {

--- a/src/components/molecules/AltinnContentLoader.test.tsx
+++ b/src/components/molecules/AltinnContentLoader.test.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
+
 import { render as rtlRender, screen } from '@testing-library/react';
 
-import { AltinnContentLoader } from './AltinnContentLoader';
+import { AltinnContentLoader } from 'src/components/molecules/AltinnContentLoader';
 
 const render = (props = {}) => {
   const allProps = {

--- a/src/components/molecules/AltinnContentLoader.tsx
+++ b/src/components/molecules/AltinnContentLoader.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import ContentLoader from 'react-content-loader';
-import { AltinnContentIcon } from '../atoms/AltinnContentIcon';
+
+import { AltinnContentIcon } from 'src/components/atoms/AltinnContentIcon';
 
 export interface IAltinnContentLoaderProps {
   height?: number | string;

--- a/src/components/molecules/AltinnInformationPaper.tsx
+++ b/src/components/molecules/AltinnInformationPaper.tsx
@@ -1,6 +1,8 @@
+import * as React from 'react';
+
 import { createTheme, Paper } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
-import * as React from 'react';
+
 import altinnTheme from 'src/theme/altinnStudioTheme';
 
 const theme = createTheme(altinnTheme);

--- a/src/components/molecules/AltinnMobileTable.tsx
+++ b/src/components/molecules/AltinnMobileTable.tsx
@@ -1,7 +1,9 @@
-import { Grid, makeStyles } from '@material-ui/core';
 import React from 'react';
-import theme from 'src/theme/altinnStudioTheme';
+
+import { Grid, makeStyles } from '@material-ui/core';
 import cn from 'classnames';
+
+import theme from 'src/theme/altinnStudioTheme';
 
 export interface IAltinnMobileTableProps {
   children: React.ReactNode;

--- a/src/components/molecules/AltinnMobileTableItem.test.tsx
+++ b/src/components/molecules/AltinnMobileTableItem.test.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
+
 import { render as renderRtl, screen } from '@testing-library/react';
-import type { IAltinnMobileTableItemProps, IMobileTableItem } from './AltinnMobileTableItem';
-import AltinnMobileTableItem from './AltinnMobileTableItem';
 import userEvent from '@testing-library/user-event';
+
+import AltinnMobileTableItem from 'src/components/molecules/AltinnMobileTableItem';
+import type { IAltinnMobileTableItemProps, IMobileTableItem } from 'src/components/molecules/AltinnMobileTableItem';
 
 const user = userEvent.setup();
 

--- a/src/components/molecules/AltinnMobileTableItem.tsx
+++ b/src/components/molecules/AltinnMobileTableItem.tsx
@@ -1,4 +1,6 @@
-import { Delete as DeleteIcon, Edit as EditIcon, Warning as WarningIcon } from '@navikt/ds-icons';
+import React from 'react';
+
+import { Button, ButtonColor, ButtonVariant } from '@altinn/altinn-design-system';
 import {
   Grid,
   makeStyles,
@@ -10,13 +12,13 @@ import {
   Typography,
   useMediaQuery,
 } from '@material-ui/core';
-import React from 'react';
-import theme from 'src/theme/altinnStudioTheme';
+import { Delete as DeleteIcon, Edit as EditIcon, Warning as WarningIcon } from '@navikt/ds-icons';
 import cn from 'classnames';
+
+import { DeleteWarningPopover } from 'src/components/molecules/DeleteWarningPopover';
 import { getLanguageFromKey } from 'src/language/sharedLanguage';
+import theme from 'src/theme/altinnStudioTheme';
 import type { ILanguage } from 'src/types/shared';
-import { DeleteWarningPopover } from './DeleteWarningPopover';
-import { Button, ButtonColor, ButtonVariant } from '@altinn/altinn-design-system';
 
 export interface IMobileTableItem {
   key: React.Key;

--- a/src/components/molecules/AltinnSubstatusPaper.test.tsx
+++ b/src/components/molecules/AltinnSubstatusPaper.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
+
 import { render, screen } from '@testing-library/react';
-import AltinnSubstatusPaper from './AltinnSubstatusPaper';
+
+import AltinnSubstatusPaper from 'src/components/molecules/AltinnSubstatusPaper';
 
 describe('AltinnSubstatusPaper', () => {
   it('should render label and description', () => {

--- a/src/components/molecules/AltinnSubstatusPaper.tsx
+++ b/src/components/molecules/AltinnSubstatusPaper.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
+
 import { Grid, Typography } from '@material-ui/core';
-import AltinnInformationPaper from './AltinnInformationPaper';
+
+import AltinnInformationPaper from 'src/components/molecules/AltinnInformationPaper';
 
 export interface IInformationPaperProps {
   label: string;

--- a/src/components/molecules/AltinnSummaryTable.tsx
+++ b/src/components/molecules/AltinnSummaryTable.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { Table, TableBody, TableRow, TableCell, Typography, makeStyles } from '@material-ui/core';
+
+import { makeStyles, Table, TableBody, TableCell, TableRow, Typography } from '@material-ui/core';
 import classNames from 'classnames';
 
 const returnGridRow = (name: string, prop: string, classes: any, index: number) => {

--- a/src/components/molecules/AltinnTableBody.tsx
+++ b/src/components/molecules/AltinnTableBody.tsx
@@ -1,5 +1,6 @@
-import { makeStyles, TableBody } from '@material-ui/core';
 import React from 'react';
+
+import { makeStyles, TableBody } from '@material-ui/core';
 
 export interface IAltinnTableBody {
   children: React.ReactNode;

--- a/src/components/molecules/AltinnTableHeader.tsx
+++ b/src/components/molecules/AltinnTableHeader.tsx
@@ -1,7 +1,9 @@
-import { makeStyles, TableHead } from '@material-ui/core';
 import React from 'react';
-import theme from 'src/theme/altinnAppTheme';
+
+import { makeStyles, TableHead } from '@material-ui/core';
 import cn from 'classnames';
+
+import theme from 'src/theme/altinnAppTheme';
 
 export interface IAltinnTableHeaderProps {
   id: string;

--- a/src/components/molecules/AltinnTableRow.tsx
+++ b/src/components/molecules/AltinnTableRow.tsx
@@ -1,7 +1,9 @@
-import type { TableRowProps } from '@material-ui/core';
+import React from 'react';
+
 import { makeStyles, TableRow } from '@material-ui/core';
 import cn from 'classnames';
-import React from 'react';
+import type { TableRowProps } from '@material-ui/core';
+
 import theme from 'src/theme/altinnAppTheme';
 
 export interface IAltinnTableRow {

--- a/src/components/molecules/DeleteWarningPopover.tsx
+++ b/src/components/molecules/DeleteWarningPopover.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 
-import { Button, ButtonVariant, ButtonColor, PanelVariant, PopoverPanel } from '@altinn/altinn-design-system';
+import { Button, ButtonColor, ButtonVariant, PanelVariant, PopoverPanel } from '@altinn/altinn-design-system';
 import { makeStyles } from '@material-ui/core';
-import type { ILanguage } from 'src/types/shared';
+
 import { getLanguageFromKey } from 'src/language/sharedLanguage';
+import type { ILanguage } from 'src/types/shared';
 
 const useStyles = makeStyles({
   popoverButtonContainer: {

--- a/src/components/organisms/AltinnAppHeader.test.tsx
+++ b/src/components/organisms/AltinnAppHeader.test.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
+
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
 import { AltinnAppHeader } from 'src/components/shared';
 import type { IParty } from 'src/types/shared';
-import { render, screen, act } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 
 describe('organisms/AltinnAppHeader', () => {
   const partyPerson = {

--- a/src/components/organisms/AltinnAppHeader.tsx
+++ b/src/components/organisms/AltinnAppHeader.tsx
@@ -1,12 +1,13 @@
-import { AppBar, Grid, Typography, makeStyles } from '@material-ui/core';
 import React from 'react';
 
-import type { ILanguage, IParty } from 'src/types/shared';
-import { getLanguageFromKey } from 'src/utils/sharedUtils';
+import { AppBar, Grid, makeStyles, Typography } from '@material-ui/core';
+
+import { AltinnLogo } from 'src/components/AltinnLogo';
+import { LandmarkShortcuts } from 'src/components/LandmarkShortcuts';
+import AltinnAppHeaderMenu from 'src/components/organisms/AltinnAppHeaderMenu';
 import { renderPartyName } from 'src/utils/party';
-import { AltinnLogo } from '../AltinnLogo';
-import { LandmarkShortcuts } from '../LandmarkShortcuts';
-import AltinnAppHeaderMenu from './AltinnAppHeaderMenu';
+import { getLanguageFromKey } from 'src/utils/sharedUtils';
+import type { ILanguage, IParty } from 'src/types/shared';
 
 export interface IAltinnAppHeaderProps {
   /** The party of the instance owner */

--- a/src/components/organisms/AltinnAppHeaderMenu.tsx
+++ b/src/components/organisms/AltinnAppHeaderMenu.tsx
@@ -1,8 +1,10 @@
-import { IconButton, makeStyles, Menu, MenuItem } from '@material-ui/core';
 import * as React from 'react';
+
+import { IconButton, makeStyles, Menu, MenuItem } from '@material-ui/core';
+
 import { AltinnIcon } from 'src/components/shared';
-import type { IParty } from 'src/types/shared';
 import { logoutUrlAltinn } from 'src/utils/sharedUtils';
+import type { IParty } from 'src/types/shared';
 
 export interface IAltinnAppHeaderMenuProps {
   party: IParty | undefined;

--- a/src/components/organisms/AltinnReceipt.test.tsx
+++ b/src/components/organisms/AltinnReceipt.test.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
+
 import { render as rtlRender, screen } from '@testing-library/react';
 
-import AltinnReceipt from './AltinnReceipt';
+import AltinnReceipt from 'src/components/organisms/AltinnReceipt';
 
 const render = (props = {}) => {
   const allProps = {

--- a/src/components/organisms/AltinnReceipt.tsx
+++ b/src/components/organisms/AltinnReceipt.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { Typography, makeStyles } from '@material-ui/core';
+
+import { makeStyles, Typography } from '@material-ui/core';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 
+import AltinnAttachmentComponent from 'src/components/atoms/AltinnAttachment';
+import AltinnCollapsibleAttachmentsComponent from 'src/components/molecules/AltinnCollapsibleAttachments';
+import AltinnSummaryTable from 'src/components/molecules/AltinnSummaryTable';
 import type { IAttachment, IAttachmentGrouping } from 'src/types/shared';
-import AltinnAttachmentComponent from '../atoms/AltinnAttachment';
-import AltinnCollapsibleAttachmentsComponent from '../molecules/AltinnCollapsibleAttachments';
-import AltinnSummaryTable from '../molecules/AltinnSummaryTable';
 
 export interface IReceiptComponentProps {
   attachmentGroupings?: IAttachmentGrouping;

--- a/src/components/organisms/AltinnReceiptSimple.tsx
+++ b/src/components/organisms/AltinnReceiptSimple.tsx
@@ -1,5 +1,6 @@
-import { Typography, makeStyles } from '@material-ui/core';
 import React from 'react';
+
+import { makeStyles, Typography } from '@material-ui/core';
 
 export interface IReceiptComponentProps {
   body: string | JSX.Element | JSX.Element[];

--- a/src/components/organisms/AltinnTable.tsx
+++ b/src/components/organisms/AltinnTable.tsx
@@ -1,6 +1,7 @@
-import type { TableProps } from '@material-ui/core';
-import { Grid, makeStyles, Table, TableContainer } from '@material-ui/core';
 import React from 'react';
+
+import { Grid, makeStyles, Table, TableContainer } from '@material-ui/core';
+import type { TableProps } from '@material-ui/core';
 
 export interface IAltinnTableProps {
   tableLayout?: 'fixed' | 'auto';

--- a/src/components/presentation/CloseButton.tsx
+++ b/src/components/presentation/CloseButton.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 
 import { useAppSelector } from 'src/common/hooks';
-
 import { getLanguageFromKey } from 'src/utils/sharedUtils';
 
 interface CloseButtonProps {

--- a/src/components/presentation/Header.test.tsx
+++ b/src/components/presentation/Header.test.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 
-import { getFormLayoutStateMock } from '__mocks__/formLayoutStateMock';
-import { getInitialStateMock } from '__mocks__/initialStateMock';
 import { screen } from '@testing-library/react';
-import { renderWithProviders } from 'testUtils';
 
+import { getFormLayoutStateMock } from 'src/__mocks__/formLayoutStateMock';
+import { getInitialStateMock } from 'src/__mocks__/initialStateMock';
 import Header from 'src/components/presentation/Header';
+import { renderWithProviders } from 'src/testUtils';
 import { ProcessTaskType } from 'src/types';
 
 describe('Header', () => {

--- a/src/components/presentation/Header.tsx
+++ b/src/components/presentation/Header.tsx
@@ -6,9 +6,8 @@ import classNames from 'classnames';
 import { useAppSelector } from 'src/common/hooks';
 import { Progress } from 'src/components/presentation/Progress';
 import { ProcessTaskType } from 'src/types';
-import type { PresentationType } from 'src/types';
-
 import { getLanguageFromKey } from 'src/utils/sharedUtils';
+import type { PresentationType } from 'src/types';
 
 export interface IHeaderProps {
   type: ProcessTaskType | PresentationType;

--- a/src/components/presentation/LanguageSelector.tsx
+++ b/src/components/presentation/LanguageSelector.tsx
@@ -3,12 +3,11 @@ import * as React from 'react';
 import { Box } from '@material-ui/core';
 
 import { useAppDispatch, useAppSelector } from 'src/common/hooks';
+import { AltinnSpinner, Select } from 'src/components/shared';
 import { appLanguageStateSelector } from 'src/selectors/appLanguageStateSelector';
 import { useGetAppLanguageQuery } from 'src/services/LanguageApi';
 import { LanguageActions } from 'src/shared/resources/language/languageSlice';
 import { getTextFromAppOrDefault } from 'src/utils/textResource';
-
-import { AltinnSpinner, Select } from 'src/components/shared';
 
 export const LanguageSelector = () => {
   const language = useAppSelector((state) => state.language.language || {});

--- a/src/components/presentation/NavBar.test.tsx
+++ b/src/components/presentation/NavBar.test.tsx
@@ -1,16 +1,15 @@
 import React from 'react';
 
-import { getFormLayoutStateMock } from '__mocks__/formLayoutStateMock';
-import { getUiConfigStateMock } from '__mocks__/uiConfigStateMock';
-import { screen, waitForElementToBeRemoved, act } from '@testing-library/react';
+import { act, screen, waitForElementToBeRemoved } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import mockAxios from 'jest-mock-axios';
-import { renderWithProviders } from 'testUtils';
 
+import { getFormLayoutStateMock } from 'src/__mocks__/formLayoutStateMock';
+import { getUiConfigStateMock } from 'src/__mocks__/uiConfigStateMock';
 import NavBar from 'src/components/presentation/NavBar';
-import type { ITextResource } from 'src/types';
-
 import { getLanguageFromCode } from 'src/language/languages';
+import { renderWithProviders } from 'src/testUtils';
+import type { ITextResource } from 'src/types';
 import type { IAppLanguage } from 'src/types/shared';
 
 afterEach(() => mockAxios.reset());

--- a/src/components/presentation/NavBar.tsx
+++ b/src/components/presentation/NavBar.tsx
@@ -5,7 +5,6 @@ import { Box, useTheme } from '@material-ui/core';
 import { useAppSelector } from 'src/common/hooks';
 import { CloseButton } from 'src/components/presentation/CloseButton';
 import { LanguageSelector } from 'src/components/presentation/LanguageSelector';
-
 import { getLanguageFromKey } from 'src/utils/sharedUtils';
 
 export interface INavBarProps {

--- a/src/components/presentation/NavigationButtons.test.tsx
+++ b/src/components/presentation/NavigationButtons.test.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import { Provider } from 'react-redux';
 
-import { getFormLayoutStateMock, getInitialStateMock } from '__mocks__/mocks';
 import { render, screen } from '@testing-library/react';
 import configureStore from 'redux-mock-store';
 
+import { getFormLayoutStateMock, getInitialStateMock } from 'src/__mocks__/mocks';
 import { NavigationButtons } from 'src/components/presentation/NavigationButtons';
 import type { INavigationButtons } from 'src/components/presentation/NavigationButtons';
 

--- a/src/components/presentation/NavigationButtons.tsx
+++ b/src/components/presentation/NavigationButtons.tsx
@@ -5,14 +5,13 @@ import { Grid } from '@material-ui/core';
 import type { PropsFromGenericComponent } from '..';
 
 import { useAppDispatch, useAppSelector } from 'src/common/hooks';
+import { AltinnButton } from 'src/components/shared';
 import { FormLayoutActions } from 'src/features/form/layout/formLayoutSlice';
 import { selectLayoutOrder } from 'src/selectors/getLayoutOrder';
 import { Triggers } from 'src/types';
 import { getTextFromAppOrDefault } from 'src/utils/textResource';
 import type { IKeepComponentScrollPos } from 'src/features/form/layout/formLayoutTypes';
 import type { ILayoutNavigation, INavigationConfig } from 'src/types';
-
-import { AltinnButton } from 'src/components/shared';
 
 export type INavigationButtons = PropsFromGenericComponent<'NavigationButtons'>;
 

--- a/src/components/summary/AttachmentWithTagSummaryComponent.test.tsx
+++ b/src/components/summary/AttachmentWithTagSummaryComponent.test.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 
-import { getInitialStateMock } from '__mocks__/initialStateMock';
 import { screen } from '@testing-library/react';
-import { renderWithProviders } from 'testUtils';
 
+import { getInitialStateMock } from 'src/__mocks__/initialStateMock';
 import { AttachmentWithTagSummaryComponent } from 'src/components/summary/AttachmentWithTagSummaryComponent';
+import { renderWithProviders } from 'src/testUtils';
 import type { ILayoutCompFileUploadWithTag } from 'src/features/form/layout';
 import type { RootState } from 'src/store';
 

--- a/src/components/summary/MapComponentSummary.tsx
+++ b/src/components/summary/MapComponentSummary.tsx
@@ -5,9 +5,8 @@ import { Typography } from '@material-ui/core';
 
 import { useAppSelector } from 'src/common/hooks';
 import { parseLocation, useStyles } from 'src/components/base/MapComponent';
-import type { ILayoutCompMap } from 'src/features/form/layout';
-
 import { getLanguageFromKey, getParsedLanguageFromKey } from 'src/utils/sharedUtils';
+import type { ILayoutCompMap } from 'src/features/form/layout';
 
 export interface IMapComponentSummary {
   component: ILayoutCompMap;

--- a/src/components/summary/SummaryBoilerplate.tsx
+++ b/src/components/summary/SummaryBoilerplate.tsx
@@ -4,9 +4,8 @@ import { Grid, makeStyles, Typography } from '@material-ui/core';
 import cn from 'classnames';
 
 import { EditButton } from 'src/components/summary/EditButton';
-import type { ILayoutCompSummary } from 'src/features/form/layout';
-
 import appTheme from 'src/theme/altinnAppTheme';
+import type { ILayoutCompSummary } from 'src/features/form/layout';
 
 export interface SummaryBoilerplateProps extends Omit<ILayoutCompSummary, 'type' | 'id'> {
   hasValidationMessages?: boolean;

--- a/src/components/summary/SummaryComponent.test.tsx
+++ b/src/components/summary/SummaryComponent.test.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 
-import { getFormLayoutStateMock, getInitialStateMock } from '__mocks__/mocks';
 import { fireEvent, screen } from '@testing-library/react';
-import { renderWithProviders } from 'testUtils';
 
+import { getFormLayoutStateMock, getInitialStateMock } from 'src/__mocks__/mocks';
 import { SummaryComponent } from 'src/components/summary/SummaryComponent';
 import { FormLayoutActions } from 'src/features/form/layout/formLayoutSlice';
+import { renderWithProviders } from 'src/testUtils';
 import type { ISummaryComponent } from 'src/components/summary/SummaryComponent';
 import type { ILayoutComponent } from 'src/features/form/layout';
 import type { ILayoutState } from 'src/features/form/layout/formLayoutSlice';

--- a/src/components/summary/SummaryGroupComponent.test.tsx
+++ b/src/components/summary/SummaryGroupComponent.test.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import { Provider } from 'react-redux';
 
-import { getFormDataStateMock, getFormLayoutStateMock, getInitialStateMock } from '__mocks__/mocks';
 import { render } from '@testing-library/react';
 import configureStore from 'redux-mock-store';
 
+import { getFormDataStateMock, getFormLayoutStateMock, getInitialStateMock } from 'src/__mocks__/mocks';
 import SummaryGroupComponent from 'src/components/summary/SummaryGroupComponent';
 import type { ISummaryGroupComponent } from 'src/components/summary/SummaryGroupComponent';
 

--- a/src/components/summary/SummaryGroupComponent.tsx
+++ b/src/components/summary/SummaryGroupComponent.tsx
@@ -10,19 +10,18 @@ import { EditButton } from 'src/components/summary/EditButton';
 import GroupInputSummary from 'src/components/summary/GroupInputSummary';
 import { DisplayGroupContainer } from 'src/features/form/containers/DisplayGroupContainer';
 import { renderLayoutComponent } from 'src/features/form/containers/Form';
+import appTheme from 'src/theme/altinnAppTheme';
 import { getDisplayFormDataForComponent, getFormDataForComponentInRepeatingGroup } from 'src/utils/formComponentUtils';
 import {
   getRepeatingGroupStartStopIndex,
   getVariableTextKeysForRepeatingGroupComponent,
   setMappingForRepeatingGroupComponent,
 } from 'src/utils/formLayout';
+import { getLanguageFromKey } from 'src/utils/sharedUtils';
 import { getTextFromAppOrDefault } from 'src/utils/textResource';
 import type { ComponentFromSummary } from 'src/features/form/containers/DisplayGroupContainer';
 import type { ILayout, ILayoutComponent, ILayoutGroup, SummaryDisplayProperties } from 'src/features/form/layout';
 import type { IRuntimeState } from 'src/types';
-
-import appTheme from 'src/theme/altinnAppTheme';
-import { getLanguageFromKey } from 'src/utils/sharedUtils';
 
 export interface ISummaryGroupComponent {
   pageRef?: string;

--- a/src/features/confirm/components/ConfirmButton.tsx
+++ b/src/features/confirm/components/ConfirmButton.tsx
@@ -5,13 +5,12 @@ import { SubmitButton } from 'src/components/base/ButtonComponent';
 import { ValidationActions } from 'src/features/form/validation/validationSlice';
 import { ProcessActions } from 'src/shared/resources/process/processSlice';
 import { ProcessTaskType } from 'src/types';
-import { getValidationUrl } from 'src/utils/urls/appUrlHelper';
 import { get } from 'src/utils/network/networking';
 import { getTextFromAppOrDefault } from 'src/utils/textResource';
+import { getValidationUrl } from 'src/utils/urls/appUrlHelper';
 import { mapDataElementValidationToRedux } from 'src/utils/validation';
 import type { BaseButtonProps } from 'src/components/base/ButtonComponent/WrappedButton';
 import type { IAltinnWindow } from 'src/types';
-
 import type { ILanguage } from 'src/types/shared';
 
 export const ConfirmButton = (props: Omit<BaseButtonProps, 'onClick'> & { id: string; language: ILanguage }) => {

--- a/src/features/confirm/containers/Confirm.test.tsx
+++ b/src/features/confirm/containers/Confirm.test.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 
-import { getInstanceDataStateMock } from '__mocks__/instanceDataStateMock';
-import { partyMock } from '__mocks__/partyMock';
 import { screen } from '@testing-library/react';
-import { renderWithProviders } from 'testUtils';
 
+import { getInstanceDataStateMock } from 'src/__mocks__/instanceDataStateMock';
+import { partyMock } from 'src/__mocks__/partyMock';
 import { Confirm } from 'src/features/confirm/containers/Confirm';
+import { renderWithProviders } from 'src/testUtils';
 
 describe('Confirm', () => {
   it('should show spinner when loading required data', () => {

--- a/src/features/confirm/containers/Confirm.tsx
+++ b/src/features/confirm/containers/Confirm.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 
 import { useAppDispatch, useAppSelector, useInstanceIdParams } from 'src/common/hooks';
+import { AltinnContentIconReceipt, AltinnContentLoader } from 'src/components/shared';
 import { ConfirmPage } from 'src/features/confirm/containers/ConfirmPage';
 import { selectAppName } from 'src/selectors/language';
 import { InstanceDataActions } from 'src/shared/resources/instanceData/instanceDataSlice';
-
-import { AltinnContentIconReceipt, AltinnContentLoader } from 'src/components/shared';
 
 export const Confirm = () => {
   const { instanceId } = useInstanceIdParams();

--- a/src/features/confirm/containers/ConfirmPage.test.tsx
+++ b/src/features/confirm/containers/ConfirmPage.test.tsx
@@ -1,15 +1,14 @@
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 
-import { getInitialStateMock } from '__mocks__/initialStateMock';
-import { applicationMetadataMock, getInstanceDataStateMock } from '__mocks__/mocks';
-import { screen, act } from '@testing-library/react';
+import { act, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { renderWithProviders } from 'testUtils';
 
+import { getInitialStateMock } from 'src/__mocks__/initialStateMock';
+import { applicationMetadataMock, getInstanceDataStateMock } from 'src/__mocks__/mocks';
 import { type Props as IConfirmPage, ConfirmPage } from 'src/features/confirm/containers/ConfirmPage';
-
 import { nb } from 'src/language/texts/nb';
+import { renderWithProviders } from 'src/testUtils';
 import type { IInstance } from 'src/types/shared';
 
 describe('ConfirmPage', () => {

--- a/src/features/confirm/containers/ConfirmPage.tsx
+++ b/src/features/confirm/containers/ConfirmPage.tsx
@@ -1,15 +1,14 @@
 import React from 'react';
 
 import { ProcessNavigation } from 'src/components/presentation/ProcessNavigation';
+import { AltinnReceipt } from 'src/components/shared';
 import { returnConfirmSummaryObject } from 'src/features/confirm/helpers/returnConfirmSummaryObject';
 import { ReadyForPrint } from 'src/shared/components/ReadyForPrint';
+import { getAttachmentGroupings, getInstancePdf } from 'src/utils/attachmentsUtils';
+import { mapInstanceAttachments } from 'src/utils/sharedUtils';
 import { getTextFromAppOrDefault } from 'src/utils/textResource';
 import type { IApplicationMetadata } from 'src/shared/resources/applicationMetadata';
 import type { ITextResource } from 'src/types';
-
-import { AltinnReceipt } from 'src/components/shared';
-import { mapInstanceAttachments } from 'src/utils/sharedUtils';
-import { getAttachmentGroupings, getInstancePdf } from 'src/utils/attachmentsUtils';
 import type { IInstance, ILanguage, IParty } from 'src/types/shared';
 
 export interface Props {

--- a/src/features/confirm/helpers/returnConfirmSummaryObject.test.ts
+++ b/src/features/confirm/helpers/returnConfirmSummaryObject.test.ts
@@ -1,5 +1,4 @@
 import { returnConfirmSummaryObject } from 'src/features/confirm/helpers/returnConfirmSummaryObject';
-
 import type { IParty } from 'src/types/shared';
 
 describe('returnConfirmSummaryObject', () => {

--- a/src/features/confirm/helpers/returnConfirmSummaryObject.ts
+++ b/src/features/confirm/helpers/returnConfirmSummaryObject.ts
@@ -1,5 +1,4 @@
 import { getTextFromAppOrDefault } from 'src/utils/textResource';
-
 import type { ILanguage, IParty, ITextResource } from 'src/types/shared';
 
 export interface ISummaryData {

--- a/src/features/entrypoint/Entrypoint.test.tsx
+++ b/src/features/entrypoint/Entrypoint.test.tsx
@@ -1,17 +1,16 @@
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
-import mockAxios from 'jest-mock-axios';
 
-import { getInitialStateMock } from '__mocks__/initialStateMock';
 import { act, screen, waitFor } from '@testing-library/react';
+import mockAxios from 'jest-mock-axios';
 import { createStore } from 'redux';
-import { renderWithProviders } from 'testUtils';
 import type { AxiosError } from 'axios';
 
+import { getInitialStateMock } from 'src/__mocks__/initialStateMock';
 import Entrypoint from 'src/features/entrypoint/Entrypoint';
+import { renderWithProviders } from 'src/testUtils';
 import type { IApplicationMetadata } from 'src/shared/resources/applicationMetadata';
 import type { IRuntimeState } from 'src/types';
-
 import type { IApplicationLogic } from 'src/types/shared';
 
 describe('Entrypoint', () => {

--- a/src/features/entrypoint/Entrypoint.tsx
+++ b/src/features/entrypoint/Entrypoint.tsx
@@ -4,6 +4,7 @@ import { Navigate } from 'react-router-dom';
 import type { AxiosError } from 'axios';
 
 import { useAppDispatch, useAppSelector } from 'src/common/hooks';
+import { AltinnContentIconFormData, AltinnContentLoader } from 'src/components/shared';
 import { Form } from 'src/features/form/containers/Form';
 import { ValidationActions } from 'src/features/form/validation/validationSlice';
 import InstanceSelection from 'src/features/instantiate/containers/InstanceSelection';
@@ -15,12 +16,10 @@ import Presentation from 'src/shared/containers/Presentation';
 import { QueueActions } from 'src/shared/resources/queue/queueSlice';
 import { PresentationType, ProcessTaskType } from 'src/types';
 import { isStatelessApp } from 'src/utils/appMetadata';
-import { getActiveInstancesUrl, getPartyValidationUrl } from 'src/utils/urls/appUrlHelper';
 import { checkIfAxiosError, get, HttpStatusCodes, post } from 'src/utils/network/networking';
+import { getActiveInstancesUrl, getPartyValidationUrl } from 'src/utils/urls/appUrlHelper';
 import type { ShowTypes } from 'src/shared/resources/applicationMetadata';
 import type { ISimpleInstance } from 'src/types';
-
-import { AltinnContentIconFormData, AltinnContentLoader } from 'src/components/shared';
 
 export default function Entrypoint({ allowAnonymous }: any) {
   const [action, setAction] = React.useState<ShowTypes | null>(null);

--- a/src/features/expressions/ExprContext.ts
+++ b/src/features/expressions/ExprContext.ts
@@ -4,9 +4,8 @@ import { ExprRuntimeError, NodeNotFound, NodeNotFoundWithoutContext } from 'src/
 import { prettyErrors, prettyErrorsToConsole } from 'src/features/expressions/prettyErrors';
 import type { Expression } from 'src/features/expressions/types';
 import type { IFormData } from 'src/features/form/data';
-import type { LayoutNode, LayoutRootNode } from 'src/utils/layout/hierarchy';
-
 import type { IApplicationSettings, IInstanceContext } from 'src/types/shared';
+import type { LayoutNode, LayoutRootNode } from 'src/utils/layout/hierarchy';
 
 export interface ContextDataSources {
   instanceContext: IInstanceContext | null;

--- a/src/features/expressions/index.ts
+++ b/src/features/expressions/index.ts
@@ -24,7 +24,6 @@ import type {
 } from 'src/features/expressions/types';
 import type { ILayoutComponent, ILayoutGroup } from 'src/features/form/layout';
 import type { IAltinnWindow } from 'src/types';
-
 import type { IInstanceContext } from 'src/types/shared';
 
 export interface EvalExprOptions {

--- a/src/features/expressions/shared.test.ts
+++ b/src/features/expressions/shared.test.ts
@@ -10,9 +10,8 @@ import type { ContextDataSources } from 'src/features/expressions/ExprContext';
 import type { FunctionTest, SharedTestContext, SharedTestContextList } from 'src/features/expressions/shared';
 import type { Expression } from 'src/features/expressions/types';
 import type { IRepeatingGroups } from 'src/types';
-import type { LayoutNode } from 'src/utils/layout/hierarchy';
-
 import type { IApplicationSettings, IInstanceContext } from 'src/types/shared';
+import type { LayoutNode } from 'src/utils/layout/hierarchy';
 
 function toComponentId({ component, rowIndices }: Exclude<FunctionTest['context'], undefined>) {
   return (component || 'no-component') + (rowIndices ? `-${rowIndices.join('-')}` : '');

--- a/src/features/expressions/shared.ts
+++ b/src/features/expressions/shared.ts
@@ -2,7 +2,6 @@ import fs from 'node:fs';
 
 import type { Expression } from 'src/features/expressions/types';
 import type { ILayout, ILayouts } from 'src/features/form/layout';
-
 import type { IApplicationSettings, IInstanceContext } from 'src/types/shared';
 
 export interface Layouts {

--- a/src/features/expressions/useExpressions.test.tsx
+++ b/src/features/expressions/useExpressions.test.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 
-import { getInitialStateMock } from '__mocks__/initialStateMock';
 import { act, renderHook } from '@testing-library/react';
 import type { MockInstance } from 'jest-mock';
 
+import { getInitialStateMock } from 'src/__mocks__/initialStateMock';
 import { useExpressions } from 'src/features/expressions/useExpressions';
 import { FormDataActions } from 'src/features/form/data/formDataSlice';
 import { setupStore } from 'src/store';

--- a/src/features/expressions/useExpressions.ts
+++ b/src/features/expressions/useExpressions.ts
@@ -10,7 +10,6 @@ import type { ContextDataSources } from 'src/features/expressions/ExprContext';
 import type { EvalExprInObjArgs } from 'src/features/expressions/index';
 import type { ExprDefaultValues, ExprResolved } from 'src/features/expressions/types';
 import type { ILayoutComponentOrGroup } from 'src/features/form/layout';
-
 import type { IInstanceContext } from 'src/types/shared';
 
 export interface UseExpressionsOptions<T> {

--- a/src/features/feedback/Feedback.tsx
+++ b/src/features/feedback/Feedback.tsx
@@ -5,9 +5,8 @@ import { createTheme, MuiThemeProvider, Typography } from '@material-ui/core';
 import { useAppDispatch, useAppSelector } from 'src/common/hooks';
 import { ReadyForPrint } from 'src/shared/components/ReadyForPrint';
 import { ProcessActions } from 'src/shared/resources/process/processSlice';
-import { getTextFromAppOrDefault } from 'src/utils/textResource';
-
 import { AltinnAppTheme } from 'src/theme';
+import { getTextFromAppOrDefault } from 'src/utils/textResource';
 
 const theme = createTheme(AltinnAppTheme);
 

--- a/src/features/form/components/HelpTextContainer.tsx
+++ b/src/features/form/components/HelpTextContainer.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 import HelpTextIcon from 'src/features/form/components/HelpTextIcon';
 import HelpTextPopover from 'src/features/form/components/HelpTextPopover';
-
 import type { ILanguage } from 'src/types/shared';
 
 export interface IHelpTextContainerProps {

--- a/src/features/form/components/Label.tsx
+++ b/src/features/form/components/Label.tsx
@@ -6,7 +6,6 @@ import { HelpTextContainer } from 'src/features/form/components/HelpTextContaine
 import { OptionalIndicator } from 'src/features/form/components/OptionalIndicator';
 import { RequiredIndicator } from 'src/features/form/components/RequiredIndicator';
 import type { ILabelSettings } from 'src/types';
-
 import type { ILanguage } from 'src/types/shared';
 
 export interface IFormLabelProps {

--- a/src/features/form/components/Legend.tsx
+++ b/src/features/form/components/Legend.tsx
@@ -6,7 +6,6 @@ import { OptionalIndicator } from 'src/features/form/components/OptionalIndicato
 import { RequiredIndicator } from 'src/features/form/components/RequiredIndicator';
 import { LayoutStyle } from 'src/types';
 import type { ILabelSettings } from 'src/types';
-
 import type { ILanguage } from 'src/types/shared';
 
 export interface IFormLegendProps {

--- a/src/features/form/components/MessageBanner.test.tsx
+++ b/src/features/form/components/MessageBanner.test.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import { render } from '@testing-library/react';
 
 import MessageBanner from 'src/features/form/components/MessageBanner';
-
 import { AltinnAppTheme } from 'src/theme';
 import type { ILanguage } from 'src/types/shared';
 

--- a/src/features/form/components/OptionalIndicator.tsx
+++ b/src/features/form/components/OptionalIndicator.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 
-import type { ILabelSettings } from 'src/types';
-
 import { getLanguageFromKey } from 'src/language/sharedLanguage';
+import type { ILabelSettings } from 'src/types';
 import type { ILanguage } from 'src/types/shared';
 
 interface IOptionalIndicatorProps {

--- a/src/features/form/components/Panel.test.tsx
+++ b/src/features/form/components/Panel.test.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 
-import { getInitialStateMock } from '__mocks__/initialStateMock';
 import { screen } from '@testing-library/react';
-import { renderWithProviders } from 'testUtils';
 
+import { getInitialStateMock } from 'src/__mocks__/initialStateMock';
 import { FormComponentContext } from 'src/components';
 import { getVariant, Panel, PanelVariant } from 'src/features/form/components/Panel';
+import { renderWithProviders } from 'src/testUtils';
 import type { IFormComponentContext } from 'src/components';
 import type { IPanelProps } from 'src/features/form/components/Panel';
 import type { IRuntimeState } from 'src/types';

--- a/src/features/form/components/RepeatingGroupAddButton.tsx
+++ b/src/features/form/components/RepeatingGroupAddButton.tsx
@@ -2,11 +2,10 @@ import React from 'react';
 
 import { createTheme, Grid, makeStyles } from '@material-ui/core';
 
-import type { ILayoutGroup } from 'src/features/form/layout';
-import type { ITextResource } from 'src/types';
-
 import altinnAppTheme from 'src/theme/altinnAppTheme';
 import { getLanguageFromKey, getTextResourceByKey } from 'src/utils/sharedUtils';
+import type { ILayoutGroup } from 'src/features/form/layout';
+import type { ITextResource } from 'src/types';
 import type { ILanguage } from 'src/types/shared';
 
 export interface IRepeatingGroupAddButton {

--- a/src/features/form/components/SoftValidations.test.tsx
+++ b/src/features/form/components/SoftValidations.test.tsx
@@ -1,16 +1,15 @@
 import React from 'react';
 
-import { getInitialStateMock } from '__mocks__/initialStateMock';
 import { screen } from '@testing-library/react';
-import { renderWithProviders } from 'testUtils';
 
+import { getInitialStateMock } from 'src/__mocks__/initialStateMock';
 import { FormComponentContext } from 'src/components';
 import { getPanelTitle, SoftValidations } from 'src/features/form/components/SoftValidations';
+import { nb } from 'src/language/texts/nb';
+import { renderWithProviders } from 'src/testUtils';
 import type { IFormComponentContext } from 'src/components';
 import type { ISoftValidationProps, SoftValidationVariant } from 'src/features/form/components/SoftValidations';
 import type { IRuntimeState, ITextResource } from 'src/types';
-
-import { nb } from 'src/language/texts/nb';
 
 const render = (
   props: Partial<ISoftValidationProps> = {},

--- a/src/features/form/components/SoftValidations.tsx
+++ b/src/features/form/components/SoftValidations.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { useAppSelector } from 'src/common/hooks';
 import { Panel } from 'src/features/form/components/Panel';
 import { getTextFromAppOrDefault } from 'src/utils/textResource';
-
 import type { ILanguage, ITextResource } from 'src/types/shared';
 
 export interface ISoftValidationProps {

--- a/src/features/form/containers/Form.test.tsx
+++ b/src/features/form/containers/Form.test.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import { Route } from 'react-router-dom';
 
-import { getFormLayoutStateMock } from '__mocks__/formLayoutStateMock';
-import { getInitialStateMock } from '__mocks__/mocks';
 import { screen, within } from '@testing-library/react';
-import { MemoryRouterWithRedirectingRoot, renderWithProviders } from 'testUtils';
 import type { PreloadedState } from 'redux';
 
+import { getFormLayoutStateMock } from 'src/__mocks__/formLayoutStateMock';
+import { getInitialStateMock } from 'src/__mocks__/mocks';
 import { Form } from 'src/features/form/containers/Form';
+import { MemoryRouterWithRedirectingRoot, renderWithProviders } from 'src/testUtils';
 import type { ILayout, ILayoutComponent, ILayoutEntry } from 'src/features/form/layout';
 import type { RootState } from 'src/store';
 

--- a/src/features/form/containers/GroupContainer.test.tsx
+++ b/src/features/form/containers/GroupContainer.test.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 
-import { getFormLayoutGroupMock, getInitialStateMock } from '__mocks__/mocks';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { mockMediaQuery, renderWithProviders } from 'testUtils';
 import type { PayloadAction } from '@reduxjs/toolkit';
 
+import { getFormLayoutGroupMock, getInitialStateMock } from 'src/__mocks__/mocks';
 import { GroupContainer } from 'src/features/form/containers/GroupContainer';
 import { FormLayoutActions } from 'src/features/form/layout/formLayoutSlice';
 import { setupStore } from 'src/store';
+import { mockMediaQuery, renderWithProviders } from 'src/testUtils';
 import { Triggers } from 'src/types';
 import type { ILayoutGroup } from 'src/features/form/layout';
 import type {

--- a/src/features/form/containers/GroupContainerLikertTestUtils.tsx
+++ b/src/features/form/containers/GroupContainerLikertTestUtils.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 
-import { getInitialStateMock } from '__mocks__/initialStateMock';
 import { screen, within } from '@testing-library/react';
-import { mockMediaQuery, renderWithProviders } from 'testUtils';
 import type { PayloadAction } from '@reduxjs/toolkit';
 
+import { getInitialStateMock } from 'src/__mocks__/initialStateMock';
 import { GroupContainer } from 'src/features/form/containers/GroupContainer';
 import { FormDataActions } from 'src/features/form/data/formDataSlice';
 import { setupStore } from 'src/store';
+import { mockMediaQuery, renderWithProviders } from 'src/testUtils';
 import type { IFormDataState } from 'src/features/form/data';
 import type { IUpdateFormData } from 'src/features/form/data/formDataTypes';
 import type { ILayoutCompLikert, ILayoutComponent, ILayoutGroup } from 'src/features/form/layout';

--- a/src/features/form/containers/PanelGroupContainer.test.tsx
+++ b/src/features/form/containers/PanelGroupContainer.test.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
-import { getInitialStateMock } from '__mocks__/initialStateMock';
-import { screen, act } from '@testing-library/react';
+import { act, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { renderWithProviders } from 'testUtils';
 import type { PreloadedState } from 'redux';
 
+import { getInitialStateMock } from 'src/__mocks__/initialStateMock';
 import { PanelGroupContainer } from 'src/features/form/containers/PanelGroupContainer';
+import { renderWithProviders } from 'src/testUtils';
 import type { IPanelGroupContainerProps } from 'src/features/form/containers/PanelGroupContainer';
 import type { ILayout, ILayoutGroup } from 'src/features/form/layout';
 import type { ILayoutState } from 'src/features/form/layout/formLayoutSlice';

--- a/src/features/form/containers/PanelGroupContainer.tsx
+++ b/src/features/form/containers/PanelGroupContainer.tsx
@@ -5,6 +5,8 @@ import { Grid } from '@material-ui/core';
 
 import { useAppDispatch, useAppSelector } from 'src/common/hooks';
 import { ConditionalWrapper } from 'src/components/ConditionalWrapper';
+import { EditIconButton } from 'src/components/EditIconButton';
+import { SuccessIconButton } from 'src/components/SuccessIconButton';
 import { FullWidthGroupWrapper } from 'src/features/form/components/FullWidthGroupWrapper';
 import { FullWidthWrapper } from 'src/features/form/components/FullWidthWrapper';
 import { getVariant } from 'src/features/form/components/Panel';
@@ -14,11 +16,8 @@ import { makeGetHidden } from 'src/selectors/getLayoutData';
 import { getTextResource } from 'src/utils/formComponentUtils';
 import { createRepeatingGroupComponentsForIndex } from 'src/utils/formLayout';
 import { getLayoutComponentById } from 'src/utils/layout';
-import type { ILayoutComponent, ILayoutGroup } from 'src/features/form/layout';
-
-import { EditIconButton } from 'src/components/EditIconButton';
-import { SuccessIconButton } from 'src/components/SuccessIconButton';
 import { getLanguageFromKey } from 'src/utils/sharedUtils';
+import type { ILayoutComponent, ILayoutGroup } from 'src/features/form/layout';
 
 export interface IPanelGroupContainerProps {
   container: ILayoutGroup;

--- a/src/features/form/containers/RepeatingGroupTable.tsx
+++ b/src/features/form/containers/RepeatingGroupTable.tsx
@@ -17,6 +17,12 @@ import cn from 'classnames';
 import { DeleteWarningPopover } from 'src/components/molecules/DeleteWarningPopover';
 import { ExprDefaultsForGroup } from 'src/features/expressions';
 import { useExpressions } from 'src/features/expressions/useExpressions';
+import {
+  fullWidthWrapper,
+  xPaddingLarge,
+  xPaddingMedium,
+  xPaddingSmall,
+} from 'src/features/form/components/FullWidthWrapper';
 import { RepeatingGroupsEditContainer } from 'src/features/form/containers/RepeatingGroupsEditContainer';
 import altinnAppTheme from 'src/theme/altinnAppTheme';
 import { getFormDataForComponentInRepeatingGroup, getTextResource } from 'src/utils/formComponentUtils';
@@ -29,13 +35,6 @@ import type { ILayout, ILayoutCompInput, ILayoutComponent, ILayoutGroup } from '
 import type { IAttachments } from 'src/shared/resources/attachments';
 import type { IOptions, IRepeatingGroups, ITextResource, ITextResourceBindings, IValidations } from 'src/types';
 import type { ILanguage } from 'src/types/shared';
-
-import {
-  fullWidthWrapper,
-  xPaddingLarge,
-  xPaddingMedium,
-  xPaddingSmall,
-} from '/src/features/form/components/FullWidthWrapper';
 
 export interface IRepeatingGroupTableProps {
   id: string;

--- a/src/features/form/containers/RepeatingGroupTable.tsx
+++ b/src/features/form/containers/RepeatingGroupTable.tsx
@@ -5,18 +5,7 @@ import { createTheme, Grid, makeStyles, TableCell, TableRow, useMediaQuery } fro
 import { Delete as DeleteIcon, Edit as EditIcon, Warning as WarningIcon } from '@navikt/ds-icons';
 import cn from 'classnames';
 
-import { ExprDefaultsForGroup } from 'src/features/expressions';
-import { useExpressions } from 'src/features/expressions/useExpressions';
-import { RepeatingGroupsEditContainer } from 'src/features/form/containers/RepeatingGroupsEditContainer';
-import { getFormDataForComponentInRepeatingGroup, getTextResource } from 'src/utils/formComponentUtils';
-import { createRepeatingGroupComponents } from 'src/utils/formLayout';
-import { setupGroupComponents } from 'src/utils/layout';
-import { componentHasValidations, repeatingGroupHasValidations } from 'src/utils/validation';
-import type { IFormData } from 'src/features/form/data';
-import type { ILayout, ILayoutCompInput, ILayoutComponent, ILayoutGroup } from 'src/features/form/layout';
-import type { IAttachments } from 'src/shared/resources/attachments';
-import type { IOptions, IRepeatingGroups, ITextResource, ITextResourceBindings, IValidations } from 'src/types';
-
+import { DeleteWarningPopover } from 'src/components/molecules/DeleteWarningPopover';
 import {
   AltinnMobileTable,
   AltinnMobileTableItem,
@@ -25,10 +14,20 @@ import {
   AltinnTableHeader,
   AltinnTableRow,
 } from 'src/components/shared';
-import { DeleteWarningPopover } from 'src/components/molecules/DeleteWarningPopover';
+import { ExprDefaultsForGroup } from 'src/features/expressions';
+import { useExpressions } from 'src/features/expressions/useExpressions';
+import { RepeatingGroupsEditContainer } from 'src/features/form/containers/RepeatingGroupsEditContainer';
 import altinnAppTheme from 'src/theme/altinnAppTheme';
+import { getFormDataForComponentInRepeatingGroup, getTextResource } from 'src/utils/formComponentUtils';
+import { createRepeatingGroupComponents } from 'src/utils/formLayout';
+import { setupGroupComponents } from 'src/utils/layout';
 import { getLanguageFromKey, getTextResourceByKey } from 'src/utils/sharedUtils';
+import { componentHasValidations, repeatingGroupHasValidations } from 'src/utils/validation';
 import type { IMobileTableItem } from 'src/components/molecules/AltinnMobileTableItem';
+import type { IFormData } from 'src/features/form/data';
+import type { ILayout, ILayoutCompInput, ILayoutComponent, ILayoutGroup } from 'src/features/form/layout';
+import type { IAttachments } from 'src/shared/resources/attachments';
+import type { IOptions, IRepeatingGroups, ITextResource, ITextResourceBindings, IValidations } from 'src/types';
 import type { ILanguage } from 'src/types/shared';
 
 export interface IRepeatingGroupTableProps {

--- a/src/features/form/containers/RepeatingGroupsEditContainer.test.tsx
+++ b/src/features/form/containers/RepeatingGroupsEditContainer.test.tsx
@@ -1,16 +1,15 @@
 import * as React from 'react';
 
-import { getMultiPageGroupMock } from '__mocks__/formLayoutGroupMock';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { renderWithProviders } from 'testUtils';
 
+import { getMultiPageGroupMock } from 'src/__mocks__/formLayoutGroupMock';
 import { RepeatingGroupsEditContainer } from 'src/features/form/containers/RepeatingGroupsEditContainer';
+import { renderWithProviders } from 'src/testUtils';
 import { createRepeatingGroupComponents } from 'src/utils/formLayout';
 import type { IRepeatingGroupsEditContainer } from 'src/features/form/containers/RepeatingGroupsEditContainer';
 import type { ILayout, ILayoutComponent, ILayoutGroup, ISelectionComponentProps } from 'src/features/form/layout';
 import type { IOption } from 'src/types';
-
 import type { ILanguage, ITextResource } from 'src/types/shared';
 
 const user = userEvent.setup();

--- a/src/features/form/containers/RepeatingGroupsEditContainer.tsx
+++ b/src/features/form/containers/RepeatingGroupsEditContainer.tsx
@@ -5,13 +5,12 @@ import { createTheme, Grid, makeStyles } from '@material-ui/core';
 import { Delete as DeleteIcon } from '@navikt/ds-icons';
 import cn from 'classnames';
 
-import { renderGenericComponent } from 'src/utils/layout';
-import type { ILayout, ILayoutComponent, ILayoutGroup } from 'src/features/form/layout';
-import type { ITextResource } from 'src/types';
-
 import { AltinnButton } from 'src/components/shared';
 import altinnAppTheme from 'src/theme/altinnAppTheme';
+import { renderGenericComponent } from 'src/utils/layout';
 import { getLanguageFromKey, getTextResourceByKey } from 'src/utils/sharedUtils';
+import type { ILayout, ILayoutComponent, ILayoutGroup } from 'src/features/form/layout';
+import type { ITextResource } from 'src/types';
 import type { ILanguage } from 'src/types/shared';
 
 export interface IRepeatingGroupsEditContainer {

--- a/src/features/form/containers/RepeatingGroupsLikertContainer.tsx
+++ b/src/features/form/containers/RepeatingGroupsLikertContainer.tsx
@@ -6,14 +6,13 @@ import useMediaQuery from '@material-ui/core/useMediaQuery';
 import { useAppSelector } from 'src/common/hooks';
 import { GenericComponent } from 'src/components/GenericComponent';
 import { useGetOptions } from 'src/components/hooks';
+import { AltinnSpinner, AltinnTable, AltinnTableBody, AltinnTableHeader, AltinnTableRow } from 'src/components/shared';
 import { LayoutStyle } from 'src/types';
 import { getTextResource } from 'src/utils/formComponentUtils';
 import { getOptionLookupKey } from 'src/utils/options';
 import type { IRadioButtonsContainerProps } from 'src/components/base/RadioButtons/RadioButtonsContainerComponent';
 import type { ILayoutComponent, ILayoutGroup } from 'src/features/form/layout';
 import type { ITextResource } from 'src/types';
-
-import { AltinnSpinner, AltinnTable, AltinnTableBody, AltinnTableHeader, AltinnTableRow } from 'src/components/shared';
 
 type RepeatingGroupsLikertContainerProps = {
   id: string;

--- a/src/features/form/containers/RepeatingGroupsTable.test.tsx
+++ b/src/features/form/containers/RepeatingGroupsTable.test.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
-import { getFormLayoutGroupMock } from '__mocks__/mocks';
 import { act, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as ResizeObserverModule from 'resize-observer-polyfill';
-import { mockMediaQuery, renderWithProviders } from 'testUtils';
 
+import { getFormLayoutGroupMock } from 'src/__mocks__/mocks';
 import { RepeatingGroupTable } from 'src/features/form/containers/RepeatingGroupTable';
+import { mockMediaQuery, renderWithProviders } from 'src/testUtils';
 import { createRepeatingGroupComponents } from 'src/utils/formLayout';
 import type { IRepeatingGroupTableProps } from 'src/features/form/containers/RepeatingGroupTable';
 import type { IFormData } from 'src/features/form/data';
@@ -14,7 +14,6 @@ import type { ILayoutComponent, ILayoutGroup, ISelectionComponentProps } from 's
 import type { ILayoutState } from 'src/features/form/layout/formLayoutSlice';
 import type { IAttachments } from 'src/shared/resources/attachments';
 import type { IOption, ITextResource } from 'src/types';
-
 import type { ILanguage } from 'src/types/shared';
 
 (global as any).ResizeObserver = ResizeObserverModule.default;

--- a/src/features/form/containers/formUtils.test.ts
+++ b/src/features/form/containers/formUtils.test.ts
@@ -1,5 +1,4 @@
-import { getFormLayoutGroupMock, getFormLayoutStateMock, getMultiPageGroupMock } from '__mocks__/mocks';
-
+import { getFormLayoutGroupMock, getFormLayoutStateMock, getMultiPageGroupMock } from 'src/__mocks__/mocks';
 import { mapGroupComponents } from 'src/features/form/containers/formUtils';
 import type { ILayout, ILayoutGroup } from 'src/features/form/layout';
 

--- a/src/features/form/data/fetch/fetchFormDataSagas.test.ts
+++ b/src/features/form/data/fetch/fetchFormDataSagas.test.ts
@@ -1,8 +1,8 @@
-import { getInitialStateMock } from '__mocks__/initialStateMock';
 import { call, select } from 'redux-saga/effects';
 import { expectSaga } from 'redux-saga-test-plan';
 import type { AxiosError } from 'axios';
 
+import { getInitialStateMock } from 'src/__mocks__/initialStateMock';
 import {
   fetchFormDataInitialSaga,
   fetchFormDataSaga,
@@ -21,11 +21,10 @@ import {
 import { InstanceDataActions } from 'src/shared/resources/instanceData/instanceDataSlice';
 import { QueueActions } from 'src/shared/resources/queue/queueSlice';
 import { getCurrentTaskDataElementId, getDataTypeByLayoutSetId } from 'src/utils/appMetadata';
+import * as networking from 'src/utils/network/sharedNetworking';
 import * as appUrlHelper from 'src/utils/urls/appUrlHelper';
 import type { IApplicationMetadata } from 'src/shared/resources/applicationMetadata';
 import type { ILayoutSets } from 'src/types';
-
-import * as networking from 'src/utils/network/sharedNetworking';
 import type { IApplication } from 'src/types/shared';
 
 describe('fetchFormDataSagas', () => {

--- a/src/features/form/data/fetch/fetchFormDataSagas.ts
+++ b/src/features/form/data/fetch/fetchFormDataSagas.ts
@@ -16,20 +16,19 @@ import {
 import { InstanceDataActions } from 'src/shared/resources/instanceData/instanceDataSlice';
 import { QueueActions } from 'src/shared/resources/queue/queueSlice';
 import { getCurrentTaskDataElementId, getDataTypeByLayoutSetId, isStatelessApp } from 'src/utils/appMetadata';
+import { convertModelToDataBinding } from 'src/utils/databindings';
+import { putWithoutConfig } from 'src/utils/network/networking';
+import { waitFor } from 'src/utils/sagas';
+import { get } from 'src/utils/sharedUtils';
 import {
   getFetchFormDataUrl,
   getStatelessFormDataUrl,
   invalidateCookieUrl,
   redirectToUpgrade,
 } from 'src/utils/urls/appUrlHelper';
-import { convertModelToDataBinding } from 'src/utils/databindings';
-import { putWithoutConfig } from 'src/utils/network/networking';
-import { waitFor } from 'src/utils/sagas';
 import type { IApplicationMetadata } from 'src/shared/resources/applicationMetadata';
 import type { IProcessState } from 'src/shared/resources/process';
 import type { ILayoutSets } from 'src/types';
-
-import { get } from 'src/utils/sharedUtils';
 import type { IInstance } from 'src/types/shared';
 
 export function* fetchFormDataSaga(): SagaIterator {

--- a/src/features/form/data/submit/submitFormDataSagas.test.ts
+++ b/src/features/form/data/submit/submitFormDataSagas.test.ts
@@ -1,20 +1,19 @@
-import { getFormDataStateMock, getInitialStateMock, getInstanceDataStateMock } from '__mocks__/mocks';
 import { call, select } from 'redux-saga/effects';
 import { expectSaga } from 'redux-saga-test-plan';
 
+import { getFormDataStateMock, getInitialStateMock, getInstanceDataStateMock } from 'src/__mocks__/mocks';
 import { FormDataActions } from 'src/features/form/data/formDataSlice';
 import { putFormData, saveFormDataSaga, saveStatelessData } from 'src/features/form/data/submit/submitFormDataSagas';
 import { FormDynamicsActions } from 'src/features/form/dynamics/formDynamicsSlice';
 import { makeGetAllowAnonymousSelector } from 'src/selectors/getAllowAnonymous';
 import { getCurrentDataTypeForApplication, getCurrentTaskDataElementId } from 'src/utils/appMetadata';
-import { dataElementUrl, getStatelessFormDataUrl } from 'src/utils/urls/appUrlHelper';
 import { convertDataBindingToModel } from 'src/utils/databindings';
 import { post } from 'src/utils/network/networking';
+import { put } from 'src/utils/network/sharedNetworking';
+import { dataElementUrl, getStatelessFormDataUrl } from 'src/utils/urls/appUrlHelper';
 import type { IApplicationMetadata } from 'src/shared/resources/applicationMetadata';
 import type { IInstanceDataState } from 'src/shared/resources/instanceData';
 import type { IRuntimeState } from 'src/types';
-
-import { put } from 'src/utils/network/sharedNetworking';
 import type { IData, IInstance } from 'src/types/shared';
 
 describe('submitFormDataSagas', () => {

--- a/src/features/form/data/submit/submitFormDataSagas.ts
+++ b/src/features/form/data/submit/submitFormDataSagas.ts
@@ -11,9 +11,10 @@ import { makeGetAllowAnonymousSelector } from 'src/selectors/getAllowAnonymous';
 import { ProcessActions } from 'src/shared/resources/process/processSlice';
 import { Severity } from 'src/types';
 import { getCurrentDataTypeForApplication, getCurrentTaskDataElementId, isStatelessApp } from 'src/utils/appMetadata';
-import { dataElementUrl, getStatelessFormDataUrl, getValidationUrl } from 'src/utils/urls/appUrlHelper';
 import { convertDataBindingToModel, convertModelToDataBinding, filterOutInvalidData } from 'src/utils/databindings';
 import { post } from 'src/utils/network/networking';
+import { get, put } from 'src/utils/sharedUtils';
+import { dataElementUrl, getStatelessFormDataUrl, getValidationUrl } from 'src/utils/urls/appUrlHelper';
 import {
   canFormBeSaved,
   hasValidationsOfSeverity,
@@ -24,8 +25,6 @@ import {
 import type { ISubmitDataAction, IUpdateFormDataFulfilled } from 'src/features/form/data/formDataTypes';
 import type { ILayoutState } from 'src/features/form/layout/formLayoutSlice';
 import type { IRuntimeState, IRuntimeStore, IUiConfig, IValidationIssue } from 'src/types';
-
-import { get, put } from 'src/utils/sharedUtils';
 
 const LayoutSelector: (store: IRuntimeStore) => ILayoutState = (store: IRuntimeStore) => store.formLayout;
 const UIConfigSelector: (store: IRuntimeStore) => IUiConfig = (store: IRuntimeStore) => store.formLayout.uiConfig;

--- a/src/features/form/data/update/updateFormDataSagas.test.ts
+++ b/src/features/form/data/update/updateFormDataSagas.test.ts
@@ -1,8 +1,8 @@
-import { getInitialStateMock } from '__mocks__/mocks';
 import { select } from 'redux-saga/effects';
 import { expectSaga } from 'redux-saga-test-plan';
 import type { PayloadAction } from '@reduxjs/toolkit';
 
+import { getInitialStateMock } from 'src/__mocks__/mocks';
 import { FormDataActions } from 'src/features/form/data/formDataSlice';
 import {
   deleteAttachmentReferenceSaga,

--- a/src/features/form/datamodel/fetch/fetchFormDatamodelSagas.ts
+++ b/src/features/form/datamodel/fetch/fetchFormDatamodelSagas.ts
@@ -7,11 +7,10 @@ import { ApplicationMetadataActions } from 'src/shared/resources/applicationMeta
 import { InstanceDataActions } from 'src/shared/resources/instanceData/instanceDataSlice';
 import { QueueActions } from 'src/shared/resources/queue/queueSlice';
 import { getCurrentDataTypeForApplication, isStatelessApp } from 'src/utils/appMetadata';
-import { getJsonSchemaUrl } from 'src/utils/urls/appUrlHelper';
 import { get } from 'src/utils/network/networking';
+import { getJsonSchemaUrl } from 'src/utils/urls/appUrlHelper';
 import type { IApplicationMetadata } from 'src/shared/resources/applicationMetadata';
 import type { ILayoutSets, IRuntimeState } from 'src/types';
-
 import type { IInstance } from 'src/types/shared';
 
 const AppMetadataSelector: (state: IRuntimeState) => IApplicationMetadata | null = (state: IRuntimeState) =>

--- a/src/features/form/dynamics/fetch/fetchFormDynamicsSagas.ts
+++ b/src/features/form/dynamics/fetch/fetchFormDynamicsSagas.ts
@@ -4,11 +4,10 @@ import type { SagaIterator } from 'redux-saga';
 import { FormDynamicsActions } from 'src/features/form/dynamics/formDynamicsSlice';
 import { QueueActions } from 'src/shared/resources/queue/queueSlice';
 import { getLayoutSetIdForApplication } from 'src/utils/appMetadata';
-import { getFetchFormDynamicsUrl } from 'src/utils/urls/appUrlHelper';
 import { get } from 'src/utils/network/networking';
+import { getFetchFormDynamicsUrl } from 'src/utils/urls/appUrlHelper';
 import type { IApplicationMetadata } from 'src/shared/resources/applicationMetadata';
 import type { ILayoutSets, IRuntimeState } from 'src/types';
-
 import type { IInstance } from 'src/types/shared';
 
 const layoutSetsSelector = (state: IRuntimeState) => state.formLayout.layoutsets;

--- a/src/features/form/layout/fetch/fetchFormLayoutSagas.test.ts
+++ b/src/features/form/layout/fetch/fetchFormLayoutSagas.test.ts
@@ -12,7 +12,6 @@ import { FormLayoutActions } from 'src/features/form/layout/formLayoutSlice';
 import * as networking from 'src/utils/network/networking';
 import type { ILayoutCompFileUploadWithTag, ILayoutCompSummary, ILayoutGroup } from 'src/features/form/layout';
 import type { IHiddenLayoutsExpressions } from 'src/types';
-
 import type { IApplication, IInstance } from 'src/types/shared';
 
 describe('fetchFormLayoutSagas', () => {

--- a/src/features/form/layout/fetch/fetchFormLayoutSagas.ts
+++ b/src/features/form/layout/fetch/fetchFormLayoutSagas.ts
@@ -7,12 +7,11 @@ import { FormDataActions } from 'src/features/form/data/formDataSlice';
 import { FormLayoutActions } from 'src/features/form/layout/formLayoutSlice';
 import { QueueActions } from 'src/shared/resources/queue/queueSlice';
 import { getLayoutSetIdForApplication } from 'src/utils/appMetadata';
-import { getLayoutSetsUrl, getLayoutSettingsUrl, getLayoutsUrl } from 'src/utils/urls/appUrlHelper';
 import { get } from 'src/utils/network/networking';
+import { getLayoutSetsUrl, getLayoutSettingsUrl, getLayoutsUrl } from 'src/utils/urls/appUrlHelper';
 import type { ComponentTypes, ILayout, ILayouts } from 'src/features/form/layout';
 import type { IApplicationMetadata } from 'src/shared/resources/applicationMetadata';
 import type { IHiddenLayoutsExpressions, ILayoutSets, ILayoutSettings, IRuntimeState } from 'src/types';
-
 import type { IInstance } from 'src/types/shared';
 
 export const layoutSetsSelector = (state: IRuntimeState) => state.formLayout.layoutsets;

--- a/src/features/form/layout/update/updateFormLayoutSagas.test.ts
+++ b/src/features/form/layout/update/updateFormLayoutSagas.test.ts
@@ -1,10 +1,9 @@
-import { getInitialStateMock } from '__mocks__/initialStateMock';
+import mockAxios from 'jest-mock-axios';
 import { select, take } from 'redux-saga/effects';
 import { expectSaga, testSaga } from 'redux-saga-test-plan';
 import type { PayloadAction } from '@reduxjs/toolkit';
 
-import mockAxios from 'jest-mock-axios';
-
+import { getInitialStateMock } from 'src/__mocks__/initialStateMock';
 import { FormDataActions } from 'src/features/form/data/formDataSlice';
 import { FormDynamicsActions } from 'src/features/form/dynamics/formDynamicsSlice';
 import { FormLayoutActions } from 'src/features/form/layout/formLayoutSlice';

--- a/src/features/form/layout/update/updateFormLayoutSagas.ts
+++ b/src/features/form/layout/update/updateFormLayoutSagas.ts
@@ -18,7 +18,6 @@ import {
   getCurrentTaskDataElementId,
   isStatelessApp,
 } from 'src/utils/appMetadata';
-import { getCalculatePageOrderUrl, getDataValidationUrl } from 'src/utils/urls/appUrlHelper';
 import { shiftAttachmentRowInRepeatingGroup } from 'src/utils/attachment';
 import { convertDataBindingToModel, findChildAttachments, removeGroupData } from 'src/utils/databindings';
 import {
@@ -32,6 +31,8 @@ import {
 import { getLayoutsetForDataElement } from 'src/utils/layout';
 import { getOptionLookupKey, removeGroupOptionsByIndex } from 'src/utils/options';
 import { waitFor } from 'src/utils/sagas';
+import { get, post } from 'src/utils/sharedUtils';
+import { getCalculatePageOrderUrl, getDataValidationUrl } from 'src/utils/urls/appUrlHelper';
 import {
   canFormBeSaved,
   mapDataElementValidationToRedux,
@@ -70,8 +71,6 @@ import type {
   IValidationIssue,
   IValidations,
 } from 'src/types';
-
-import { get, post } from 'src/utils/sharedUtils';
 
 export const selectFormLayoutState = (state: IRuntimeState) => state.formLayout;
 export const selectFormData = (state: IRuntimeState) => state.formData;

--- a/src/features/form/rules/fetch/fetchRulesSagas.ts
+++ b/src/features/form/rules/fetch/fetchRulesSagas.ts
@@ -4,12 +4,11 @@ import type { SagaIterator } from 'redux-saga';
 import { FormRulesActions } from 'src/features/form/rules/rulesSlice';
 import { QueueActions } from 'src/shared/resources/queue/queueSlice';
 import { getLayoutSetIdForApplication } from 'src/utils/appMetadata';
-import { getRulehandlerUrl } from 'src/utils/urls/appUrlHelper';
 import { get } from 'src/utils/network/networking';
 import { getRuleModelFields } from 'src/utils/rules';
+import { getRulehandlerUrl } from 'src/utils/urls/appUrlHelper';
 import type { IApplicationMetadata } from 'src/shared/resources/applicationMetadata';
 import type { ILayoutSets, IRuntimeState } from 'src/types';
-
 import type { IInstance } from 'src/types/shared';
 
 const layoutSetsSelector = (state: IRuntimeState) => state.formLayout.layoutsets;

--- a/src/features/form/validation/singleField/singleFieldValidationSagas.test.ts
+++ b/src/features/form/validation/singleField/singleFieldValidationSagas.test.ts
@@ -1,14 +1,14 @@
-import { getInitialStateMock } from '__mocks__/initialStateMock';
 import { call, select } from 'redux-saga/effects';
 import { expectSaga } from 'redux-saga-test-plan';
 import { throwError } from 'redux-saga-test-plan/providers';
 import type { AxiosRequestConfig } from 'axios';
 
+import { getInitialStateMock } from 'src/__mocks__/initialStateMock';
 import { runSingleFieldValidationSaga } from 'src/features/form/validation/singleField/singleFieldValidationSagas';
 import { ValidationActions } from 'src/features/form/validation/validationSlice';
 import { Severity } from 'src/types';
-import { getDataValidationUrl } from 'src/utils/urls/appUrlHelper';
 import { get } from 'src/utils/network/networking';
+import { getDataValidationUrl } from 'src/utils/urls/appUrlHelper';
 import type { IRuntimeState, IValidationIssue, IValidations } from 'src/types';
 
 describe('singleFieldValidationSagas', () => {

--- a/src/features/form/validation/singleField/singleFieldValidationSagas.ts
+++ b/src/features/form/validation/singleField/singleFieldValidationSagas.ts
@@ -5,8 +5,8 @@ import type { SagaIterator } from 'redux-saga';
 
 import { ValidationActions } from 'src/features/form/validation/validationSlice';
 import { getCurrentTaskDataElementId } from 'src/utils/appMetadata';
-import { getDataValidationUrl } from 'src/utils/urls/appUrlHelper';
 import { get } from 'src/utils/network/networking';
+import { getDataValidationUrl } from 'src/utils/urls/appUrlHelper';
 import { mapDataElementValidationToRedux, mergeValidationObjects } from 'src/utils/validation';
 import type { IRunSingleFieldValidation } from 'src/features/form/validation/validationSlice';
 import type { IRuntimeState, IValidationIssue } from 'src/types';

--- a/src/features/instantiate/containers/InstanceSelection.test.tsx
+++ b/src/features/instantiate/containers/InstanceSelection.test.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 
-import { getInitialStateMock } from '__mocks__/initialStateMock';
-import { screen, within, act } from '@testing-library/react';
+import { act, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import configureStore from 'redux-mock-store';
-import { mockMediaQuery, renderWithProviders } from 'testUtils';
 import type { Store } from 'redux';
 
+import { getInitialStateMock } from 'src/__mocks__/initialStateMock';
 import InstanceSelection from 'src/features/instantiate/containers/InstanceSelection';
+import { mockMediaQuery, renderWithProviders } from 'src/testUtils';
 import type { IInstanceSelectionProps } from 'src/features/instantiate/containers/InstanceSelection';
 import type { IRuntimeState, ISimpleInstance } from 'src/types';
 

--- a/src/features/instantiate/containers/InstanceSelection.tsx
+++ b/src/features/instantiate/containers/InstanceSelection.tsx
@@ -5,10 +5,6 @@ import { Grid, TableCell, Typography, useMediaQuery } from '@material-ui/core';
 import { Edit as EditIcon } from '@navikt/ds-icons';
 
 import { useAppSelector } from 'src/common/hooks';
-import { ReadyForPrint } from 'src/shared/components/ReadyForPrint';
-import { getInstanceUiUrl } from 'src/utils/urls/appUrlHelper';
-import type { ISimpleInstance } from 'src/types';
-
 import {
   AltinnButton,
   AltinnMobileTable,
@@ -18,7 +14,10 @@ import {
   AltinnTableHeader,
   AltinnTableRow,
 } from 'src/components/shared';
+import { ReadyForPrint } from 'src/shared/components/ReadyForPrint';
 import { getLanguageFromKey } from 'src/utils/sharedUtils';
+import { getInstanceUiUrl } from 'src/utils/urls/appUrlHelper';
+import type { ISimpleInstance } from 'src/types';
 
 export interface IInstanceSelectionProps {
   instances: ISimpleInstance[];

--- a/src/features/instantiate/containers/InstantiateContainer.test.tsx
+++ b/src/features/instantiate/containers/InstantiateContainer.test.tsx
@@ -1,18 +1,17 @@
 import React from 'react';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 
-import { getInitialStateMock } from '__mocks__/initialStateMock';
 import { createTheme, MuiThemeProvider } from '@material-ui/core';
 import { screen, waitFor, within } from '@testing-library/react';
-import { renderWithProviders } from 'testUtils';
 
+import { getInitialStateMock } from 'src/__mocks__/initialStateMock';
 import { InstantiateContainer } from 'src/features/instantiate/containers';
 import { InstantiationActions } from 'src/features/instantiate/instantiation/instantiationSlice';
 import { setupStore } from 'src/store';
+import { renderWithProviders } from 'src/testUtils';
+import { AltinnAppTheme } from 'src/theme';
 import { HttpStatusCodes } from 'src/utils/network/networking';
 import type { IRuntimeState } from 'src/types';
-
-import { AltinnAppTheme } from 'src/theme';
 
 describe('InstantiateContainer', () => {
   function DefinedRoutes() {

--- a/src/features/instantiate/containers/InstantiateContainer.tsx
+++ b/src/features/instantiate/containers/InstantiateContainer.tsx
@@ -2,19 +2,18 @@ import * as React from 'react';
 import { Navigate, Outlet } from 'react-router-dom';
 
 import { useAppDispatch, useAppSelector, useInstanceIdParams } from 'src/common/hooks';
+import { AltinnContentIconFormData, AltinnContentLoader } from 'src/components/shared';
 import InstantiateValidationError from 'src/features/instantiate/containers/InstantiateValidationError';
 import MissingRolesError from 'src/features/instantiate/containers/MissingRolesError';
 import UnknownError from 'src/features/instantiate/containers/UnknownError';
 import { InstantiationActions } from 'src/features/instantiate/instantiation/instantiationSlice';
 import Presentation from 'src/shared/containers/Presentation';
+import { AltinnAppTheme } from 'src/theme';
 import { ProcessTaskType } from 'src/types';
 import { changeBodyBackground } from 'src/utils/bodyStyling';
 import { HttpStatusCodes } from 'src/utils/network/networking';
-import { getTextFromAppOrDefault } from 'src/utils/textResource';
-
-import { AltinnContentIconFormData, AltinnContentLoader } from 'src/components/shared';
-import { AltinnAppTheme } from 'src/theme';
 import { isAxiosError } from 'src/utils/sharedUtils';
+import { getTextFromAppOrDefault } from 'src/utils/textResource';
 
 const titleKey = 'instantiate.starting';
 

--- a/src/features/instantiate/containers/InstantiateValidationError.tsx
+++ b/src/features/instantiate/containers/InstantiateValidationError.tsx
@@ -2,9 +2,8 @@ import * as React from 'react';
 
 import { useAppSelector } from 'src/common/hooks';
 import InstantiationErrorPage from 'src/features/instantiate/containers/InstantiationErrorPage';
-import { getTextFromAppOrDefault } from 'src/utils/textResource';
-
 import { getLanguageFromKey, getParsedLanguageFromKey } from 'src/utils/sharedUtils';
+import { getTextFromAppOrDefault } from 'src/utils/textResource';
 
 function InstantiateValidationError(props: { message: string }) {
   const language = useAppSelector((state) => state.language.language);

--- a/src/features/instantiate/containers/InstantiationContainer.tsx
+++ b/src/features/instantiate/containers/InstantiationContainer.tsx
@@ -5,9 +5,8 @@ import { Grid, makeStyles } from '@material-ui/core';
 import { useAppSelector } from 'src/common/hooks';
 import Header from 'src/shared/components/altinnAppHeader';
 import { ReadyForPrint } from 'src/shared/components/ReadyForPrint';
-import { changeBodyBackground } from 'src/utils/bodyStyling';
-
 import { AltinnAppTheme } from 'src/theme';
+import { changeBodyBackground } from 'src/utils/bodyStyling';
 
 const useStyles = makeStyles((theme) => ({
   instantiatePage: {

--- a/src/features/instantiate/containers/MissingRolesError.tsx
+++ b/src/features/instantiate/containers/MissingRolesError.tsx
@@ -3,9 +3,8 @@ import { Link } from 'react-router-dom';
 
 import { useAppSelector } from 'src/common/hooks';
 import InstantiationErrorPage from 'src/features/instantiate/containers/InstantiationErrorPage';
-import { getHostname } from 'src/utils/urls/appUrlHelper';
-
 import { getLanguageFromKey, getParsedLanguageFromKey, getParsedLanguageFromText } from 'src/utils/sharedUtils';
+import { getHostname } from 'src/utils/urls/appUrlHelper';
 
 function MissingRolesError() {
   const language = useAppSelector((state) => state.language.language);

--- a/src/features/instantiate/containers/NoValidPartiesError.tsx
+++ b/src/features/instantiate/containers/NoValidPartiesError.tsx
@@ -2,9 +2,8 @@ import * as React from 'react';
 
 import { useAppSelector } from 'src/common/hooks';
 import InstantiationErrorPage from 'src/features/instantiate/containers/InstantiationErrorPage';
-import { getHostname } from 'src/utils/urls/appUrlHelper';
-
 import { getLanguageFromKey, getParsedLanguageFromKey } from 'src/utils/sharedUtils';
+import { getHostname } from 'src/utils/urls/appUrlHelper';
 
 function NoValidPartiesError() {
   const language = useAppSelector((state) => state.language.language);

--- a/src/features/instantiate/containers/PartySelection.tsx
+++ b/src/features/instantiate/containers/PartySelection.tsx
@@ -5,19 +5,18 @@ import { Grid, makeStyles, Typography } from '@material-ui/core';
 import AddIcon from '@material-ui/icons/Add';
 
 import { useAppDispatch, useAppSelector } from 'src/common/hooks';
+import { AltinnCheckBox } from 'src/components/shared';
 import { InstantiationContainer } from 'src/features/instantiate/containers';
 import NoValidPartiesError from 'src/features/instantiate/containers/NoValidPartiesError';
 import { InstantiationActions } from 'src/features/instantiate/instantiation/instantiationSlice';
 import AltinnParty from 'src/shared/components/altinnParty';
 import AltinnPartySearch from 'src/shared/components/altinnPartySearch';
 import { PartyActions } from 'src/shared/resources/party/partySlice';
+import { AltinnAppTheme } from 'src/theme';
 import { changeBodyBackground } from 'src/utils/bodyStyling';
 import { HttpStatusCodes } from 'src/utils/network/networking';
-import { capitalizeName } from 'src/utils/stringHelper';
-
-import { AltinnCheckBox } from 'src/components/shared';
-import { AltinnAppTheme } from 'src/theme';
 import { getLanguageFromKey } from 'src/utils/sharedUtils';
+import { capitalizeName } from 'src/utils/stringHelper';
 import type { IParty } from 'src/types/shared';
 
 const useStyles = makeStyles((theme) => ({

--- a/src/features/instantiate/containers/UnknownError.tsx
+++ b/src/features/instantiate/containers/UnknownError.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 
 import { useAppSelector } from 'src/common/hooks';
 import InstantiationErrorPage from 'src/features/instantiate/containers/InstantiationErrorPage';
-
 import { getLanguageFromKey, getParsedLanguageFromKey } from 'src/utils/sharedUtils';
 
 function UnknownError() {

--- a/src/features/instantiate/instantiation/sagas/instantiate/index.ts
+++ b/src/features/instantiate/instantiation/sagas/instantiate/index.ts
@@ -4,10 +4,9 @@ import type { SagaIterator } from 'redux-saga';
 
 import { InstantiationActions } from 'src/features/instantiate/instantiation/instantiationSlice';
 import { InstanceDataActions } from 'src/shared/resources/instanceData/instanceDataSlice';
-import { getCreateInstancesUrl, invalidateCookieUrl, redirectToUpgrade } from 'src/utils/urls/appUrlHelper';
 import { post, putWithoutConfig } from 'src/utils/network/networking';
+import { getCreateInstancesUrl, invalidateCookieUrl, redirectToUpgrade } from 'src/utils/urls/appUrlHelper';
 import type { IRuntimeState } from 'src/types';
-
 import type { IParty } from 'src/types/shared';
 
 const SelectedPartySelector = (state: IRuntimeState) => state.party.selectedParty;

--- a/src/features/receipt/containers/ReceiptContainer.test.tsx
+++ b/src/features/receipt/containers/ReceiptContainer.test.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { Route, useLocation } from 'react-router-dom';
 
-import { dataTypes, instanceOwner, partyMember, partyTypesAllowed, userProfile } from '__mocks__/constants';
 import { screen } from '@testing-library/react';
-import { MemoryRouterWithRedirectingRoot, renderWithProviders } from 'testUtils';
 
+import { dataTypes, instanceOwner, partyMember, partyTypesAllowed, userProfile } from 'src/__mocks__/constants';
 import ReceiptContainer, { returnInstanceMetaDataObject } from 'src/features/receipt/containers/ReceiptContainer';
+import { MemoryRouterWithRedirectingRoot, renderWithProviders } from 'src/testUtils';
 
 interface IRender {
   populateStore?: boolean;

--- a/src/features/receipt/containers/ReceiptContainer.tsx
+++ b/src/features/receipt/containers/ReceiptContainer.tsx
@@ -3,19 +3,18 @@ import React, { useEffect, useState } from 'react';
 import moment from 'moment';
 
 import { useAppDispatch, useAppSelector, useInstanceIdParams } from 'src/common/hooks';
-import { selectAppName } from 'src/selectors/language';
-import { ReadyForPrint } from 'src/shared/components/ReadyForPrint';
-import { InstanceDataActions } from 'src/shared/resources/instanceData/instanceDataSlice';
-import { getTextFromAppOrDefault } from 'src/utils/textResource';
-
 import {
   AltinnContentIconReceipt,
   AltinnContentLoader,
   AltinnReceipt,
   AltinnReceiptSimple,
 } from 'src/components/shared';
-import { getLanguageFromKey, mapInstanceAttachments, returnUrlToArchive } from 'src/utils/sharedUtils';
+import { selectAppName } from 'src/selectors/language';
+import { ReadyForPrint } from 'src/shared/components/ReadyForPrint';
+import { InstanceDataActions } from 'src/shared/resources/instanceData/instanceDataSlice';
 import { getAttachmentGroupings, getInstancePdf } from 'src/utils/attachmentsUtils';
+import { getLanguageFromKey, mapInstanceAttachments, returnUrlToArchive } from 'src/utils/sharedUtils';
+import { getTextFromAppOrDefault } from 'src/utils/textResource';
 import type { IAttachment, IParty } from 'src/types/shared';
 
 export const returnInstanceMetaDataObject = (

--- a/src/language/languages.ts
+++ b/src/language/languages.ts
@@ -1,6 +1,6 @@
-import { nb } from './texts/nb';
-import { en } from './texts/en';
-import { nn } from './texts/nn';
+import { en } from 'src/language/texts/en';
+import { nb } from 'src/language/texts/nb';
+import { nn } from 'src/language/texts/nn';
 
 export function getLanguageFromCode(languageCode: string) {
   switch (languageCode) {

--- a/src/language/sharedLanguage.test.ts
+++ b/src/language/sharedLanguage.test.ts
@@ -1,20 +1,20 @@
-import type {
-  ITextResource,
-  IDataSources,
-  IDataSource,
-  IApplicationSettings,
-  IInstanceContext,
-  IAltinnOrg,
-  IAltinnOrgs,
-  IApplication,
-} from 'src/types/shared';
 import {
   getAppName,
   getAppOwner,
   getParsedLanguageFromText,
   getTextResourceByKey,
   replaceTextResourceParams,
-} from './sharedLanguage';
+} from 'src/language/sharedLanguage';
+import type {
+  IAltinnOrg,
+  IAltinnOrgs,
+  IApplication,
+  IApplicationSettings,
+  IDataSource,
+  IDataSources,
+  IInstanceContext,
+  ITextResource,
+} from 'src/types/shared';
 
 describe('language.ts', () => {
   const adjectiveValue = 'awesome';

--- a/src/language/sharedLanguage.ts
+++ b/src/language/sharedLanguage.ts
@@ -1,9 +1,9 @@
 import DOMPurify from 'dompurify';
-import type { HTMLReactParserOptions } from 'html-react-parser';
 import parseHtmlToReact from 'html-react-parser';
 import { marked } from 'marked';
+import type { HTMLReactParserOptions } from 'html-react-parser';
 
-import type { ITextResource, IDataSources, ILanguage, IApplication, IAltinnOrgs } from 'src/types/shared';
+import type { IAltinnOrgs, IApplication, IDataSources, ILanguage, ITextResource } from 'src/types/shared';
 
 DOMPurify.addHook('afterSanitizeAttributes', (node) => {
   if (node.tagName === 'A') {

--- a/src/selectors/appLanguageStateSelector.test.ts
+++ b/src/selectors/appLanguageStateSelector.test.ts
@@ -1,6 +1,5 @@
-import { getProfileStateMock } from '__mocks__/profileStateMock';
-import { statelessAndAllowAnonymousMock } from '__mocks__/statelessAndAllowAnonymousMock';
-
+import { getProfileStateMock } from 'src/__mocks__/profileStateMock';
+import { statelessAndAllowAnonymousMock } from 'src/__mocks__/statelessAndAllowAnonymousMock';
 import { appLanguageStateSelector } from 'src/selectors/appLanguageStateSelector';
 
 describe('appLanguageStateSelector', () => {

--- a/src/selectors/appLanguageStateSelector.ts
+++ b/src/selectors/appLanguageStateSelector.ts
@@ -1,7 +1,6 @@
 import { makeGetAllowAnonymousSelector } from 'src/selectors/getAllowAnonymous';
 import { profileStateSelector } from 'src/selectors/simpleSelectors';
 import type { IRuntimeState } from 'src/types';
-
 import type { IProfile } from 'src/types/shared';
 
 const selectedAppLanguageStateSelector = (state: IRuntimeState) => state.language.selectedAppLanguage;

--- a/src/selectors/getAllowAnonymous.test.ts
+++ b/src/selectors/getAllowAnonymous.test.ts
@@ -1,6 +1,5 @@
-import { getInitialStateMock } from '__mocks__/initialStateMock';
-import { statelessAndAllowAnonymousMock } from '__mocks__/statelessAndAllowAnonymousMock';
-
+import { getInitialStateMock } from 'src/__mocks__/initialStateMock';
+import { statelessAndAllowAnonymousMock } from 'src/__mocks__/statelessAndAllowAnonymousMock';
 import { makeGetAllowAnonymousSelector } from 'src/selectors/getAllowAnonymous';
 import type { IRuntimeState } from 'src/types';
 

--- a/src/selectors/getErrors.test.ts
+++ b/src/selectors/getErrors.test.ts
@@ -1,5 +1,4 @@
-import { getInitialStateMock } from '__mocks__/initialStateMock';
-
+import { getInitialStateMock } from 'src/__mocks__/initialStateMock';
 import { makeGetHasErrorsSelector } from 'src/selectors/getErrors';
 import type { IFormDataState } from 'src/features/form/data';
 import type { IFormDynamicState } from 'src/features/form/dynamics';

--- a/src/selectors/language.test.ts
+++ b/src/selectors/language.test.ts
@@ -1,5 +1,4 @@
-import { getInitialStateMock } from '__mocks__/initialStateMock';
-
+import { getInitialStateMock } from 'src/__mocks__/initialStateMock';
 import { selectAppName, selectAppOwner } from 'src/selectors/language';
 
 describe('src > selectors > language', () => {

--- a/src/selectors/language.ts
+++ b/src/selectors/language.ts
@@ -1,8 +1,7 @@
 import { createSelector } from 'reselect';
 
-import type { IRuntimeState } from 'src/types';
-
 import { getAppName, getAppOwner } from 'src/utils/sharedUtils';
+import type { IRuntimeState } from 'src/types';
 
 const selectTextResources = (state: IRuntimeState) => state.textResources.resources;
 const selectApplicationMetadata = (state: IRuntimeState) => state.applicationMetadata.applicationMetadata;

--- a/src/selectors/simpleSelectors.test.ts
+++ b/src/selectors/simpleSelectors.test.ts
@@ -1,6 +1,5 @@
-import { getFormLayoutStateMock } from '__mocks__/formLayoutStateMock';
-import { getInitialStateMock } from '__mocks__/initialStateMock';
-
+import { getFormLayoutStateMock } from 'src/__mocks__/formLayoutStateMock';
+import { getInitialStateMock } from 'src/__mocks__/initialStateMock';
 import {
   appMetaDataSelector,
   currentSelectedPartyIdSelector,

--- a/src/services/InstancesApi.tsx
+++ b/src/services/InstancesApi.tsx
@@ -1,5 +1,4 @@
 import { appApi } from 'src/services/AppApi';
-
 import type { IInstance } from 'src/types/shared';
 
 export interface Prefill {

--- a/src/services/LanguageApi.tsx
+++ b/src/services/LanguageApi.tsx
@@ -1,5 +1,4 @@
 import { appApi } from 'src/services/AppApi';
-
 import type { IAppLanguage } from 'src/types/shared';
 
 export const languageApi = appApi.injectEndpoints({

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,6 +1,7 @@
 import 'jest';
 import '@testing-library/jest-dom/extend-expect';
-import { TextEncoder, TextDecoder } from 'util';
+
+import { TextDecoder, TextEncoder } from 'util';
 
 import type { IAltinnWindow } from 'src/types';
 

--- a/src/shared/components/altinnAppHeader.test.tsx
+++ b/src/shared/components/altinnAppHeader.test.tsx
@@ -1,14 +1,13 @@
 import React from 'react';
 
-import { organisationMock } from '__mocks__/organisationMock';
-import { getProfileStateMock } from '__mocks__/profileStateMock';
 import { screen } from '@testing-library/react';
-import { renderWithProviders } from 'testUtils';
 
-import Header from 'src/shared/components/altinnAppHeader';
-import type { IHeaderProps } from 'src/shared/components/altinnAppHeader';
-
+import { organisationMock } from 'src/__mocks__/organisationMock';
+import { getProfileStateMock } from 'src/__mocks__/profileStateMock';
 import { getLanguageFromCode } from 'src/language/languages';
+import Header from 'src/shared/components/altinnAppHeader';
+import { renderWithProviders } from 'src/testUtils';
+import type { IHeaderProps } from 'src/shared/components/altinnAppHeader';
 
 describe('AltinnAppHeader', () => {
   it('should show organisation name when profile has party, and party has organisation with name, and "type" is not set', () => {

--- a/src/shared/components/altinnAppHeader.tsx
+++ b/src/shared/components/altinnAppHeader.tsx
@@ -3,10 +3,9 @@ import React from 'react';
 import { AppBar, Grid, Toolbar } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 
-import { renderParty } from 'src/shared/resources/utils/party';
-
-import { AltinnLogo } from 'src/components/shared';
 import { LandmarkShortcuts } from 'src/components/LandmarkShortcuts';
+import { AltinnLogo } from 'src/components/shared';
+import { renderParty } from 'src/shared/resources/utils/party';
 import { AltinnAppTheme } from 'src/theme';
 import { getLanguageFromKey, returnUrlToMessagebox } from 'src/utils/sharedUtils';
 import { returnUrlToAllSchemas, returnUrlToProfile } from 'src/utils/urls/urlHelper';

--- a/src/shared/components/altinnParty.test.tsx
+++ b/src/shared/components/altinnParty.test.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
-import { getInitialStateMock } from '__mocks__/mocks';
-import { partyMock } from '__mocks__/partyMock';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { renderWithProviders } from 'testUtils';
 
+import { getInitialStateMock } from 'src/__mocks__/mocks';
+import { partyMock } from 'src/__mocks__/partyMock';
 import AltinnParty from 'src/shared/components/altinnParty';
+import { renderWithProviders } from 'src/testUtils';
 import type { IAltinnPartyProps } from 'src/shared/components/altinnParty';
 
 const user = userEvent.setup();

--- a/src/shared/components/altinnParty.tsx
+++ b/src/shared/components/altinnParty.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { Grid, makeStyles, Paper, Typography } from '@material-ui/core';
 
 import { useAppSelector } from 'src/common/hooks';
-
 import { AltinnCollapsableList } from 'src/components/shared';
 import { getLanguageFromKey } from 'src/utils/sharedUtils';
 import type { IParty } from 'src/types/shared';

--- a/src/shared/components/altinnPartySearch.test.tsx
+++ b/src/shared/components/altinnPartySearch.test.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 
-import { getInitialStateMock } from '__mocks__/initialStateMock';
-import { screen, act } from '@testing-library/react';
+import { act, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { renderWithProviders } from 'testUtils';
 
+import { getInitialStateMock } from 'src/__mocks__/initialStateMock';
 import AltinnPartySearch from 'src/shared/components/altinnPartySearch';
+import { renderWithProviders } from 'src/testUtils';
 import type { IAltinnPartySearchProps } from 'src/shared/components/altinnPartySearch';
 
 const user = userEvent.setup();

--- a/src/shared/components/altinnPartySearch.tsx
+++ b/src/shared/components/altinnPartySearch.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { Grid, makeStyles } from '@material-ui/core';
 
 import { useAppSelector } from 'src/common/hooks';
-
 import { AltinnInput } from 'src/components/shared';
 import { getLanguageFromKey } from 'src/utils/sharedUtils';
 

--- a/src/shared/containers/Presentation.test.tsx
+++ b/src/shared/containers/Presentation.test.tsx
@@ -1,18 +1,18 @@
 import React from 'react';
 
-import { getInitialStateMock } from '__mocks__/mocks';
-import { partyMock } from '__mocks__/partyMock';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import axios from 'axios';
-import { renderWithProviders } from 'testUtils';
 
+import { getInitialStateMock } from 'src/__mocks__/mocks';
+import { partyMock } from 'src/__mocks__/partyMock';
 import Presentation from 'src/shared/containers/Presentation';
+import { renderWithProviders } from 'src/testUtils';
+import { AltinnAppTheme } from 'src/theme';
 import { ProcessTaskType } from 'src/types';
 import { HttpStatusCodes } from 'src/utils/network/networking';
-import type { IPresentationProvidedProps } from 'src/shared/containers/Presentation';
 import { returnUrlToMessagebox } from 'src/utils/urls/urlHelper';
-import { AltinnAppTheme } from 'src/theme';
+import type { IPresentationProvidedProps } from 'src/shared/containers/Presentation';
 
 jest.mock('axios');
 

--- a/src/shared/containers/Presentation.tsx
+++ b/src/shared/containers/Presentation.tsx
@@ -3,16 +3,15 @@ import * as React from 'react';
 import { useAppDispatch, useAppSelector } from 'src/common/hooks';
 import Header from 'src/components/presentation/Header';
 import NavBar from 'src/components/presentation/NavBar';
+import { AltinnAppHeader, AltinnSubstatusPaper } from 'src/components/shared';
 import { FormLayoutActions } from 'src/features/form/layout/formLayoutSlice';
 import { getLayoutOrderFromTracks } from 'src/selectors/getLayoutOrder';
+import { AltinnAppTheme } from 'src/theme';
 import { PresentationType, ProcessTaskType } from 'src/types';
-import { getRedirectUrl } from 'src/utils/urls/appUrlHelper';
 import { getNextView } from 'src/utils/formLayout';
 import { get } from 'src/utils/network/networking';
-
-import { AltinnAppHeader, AltinnSubstatusPaper } from 'src/components/shared';
-import { AltinnAppTheme } from 'src/theme';
 import { getTextResourceByKey, returnUrlFromQueryParameter, returnUrlToMessagebox } from 'src/utils/sharedUtils';
+import { getRedirectUrl } from 'src/utils/urls/appUrlHelper';
 
 export interface IPresentationProvidedProps {
   header?: string | JSX.Element | JSX.Element[];

--- a/src/shared/containers/ProcessWrapper.tsx
+++ b/src/shared/containers/ProcessWrapper.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { useAppSelector, useInstanceIdParams, useProcess } from 'src/common/hooks';
 import { useApiErrorCheck } from 'src/common/hooks/useApiErrorCheck';
+import { AltinnContentIconFormData, AltinnContentLoader } from 'src/components/shared';
 import { Confirm } from 'src/features/confirm/containers/Confirm';
 import Feedback from 'src/features/feedback/Feedback';
 import { Form } from 'src/features/form/containers/Form';
@@ -11,8 +12,6 @@ import Presentation from 'src/shared/containers/Presentation';
 import { InstanceDataActions } from 'src/shared/resources/instanceData/instanceDataSlice';
 import { ProcessTaskType } from 'src/types';
 import { behavesLikeDataTask } from 'src/utils/formLayout';
-
-import { AltinnContentIconFormData, AltinnContentLoader } from 'src/components/shared';
 
 const ProcessWrapper = () => {
   const instantiating = useAppSelector((state) => state.instantiation.instantiating);

--- a/src/shared/resources/applicationMetadata/sagas/get/index.ts
+++ b/src/shared/resources/applicationMetadata/sagas/get/index.ts
@@ -4,8 +4,8 @@ import type { SagaIterator } from 'redux-saga';
 import { ApplicationMetadataActions } from 'src/shared/resources/applicationMetadata/applicationMetadataSlice';
 import { LanguageActions } from 'src/shared/resources/language/languageSlice';
 import { QueueActions } from 'src/shared/resources/queue/queueSlice';
-import { applicationMetadataApiUrl } from 'src/utils/urls/appUrlHelper';
 import { get } from 'src/utils/network/networking';
+import { applicationMetadataApiUrl } from 'src/utils/urls/appUrlHelper';
 
 export function* getApplicationMetadata(): SagaIterator {
   try {

--- a/src/shared/resources/applicationSettings/applicationSettingsSlice.ts
+++ b/src/shared/resources/applicationSettings/applicationSettingsSlice.ts
@@ -5,7 +5,6 @@ import type {
   IFetchApplicationSettingsRejected,
 } from 'src/shared/resources/applicationSettings/applicationSettingsTypes';
 import type { MkActionType } from 'src/shared/resources/utils/sagaSlice';
-
 import type { IApplicationSettings } from 'src/types/shared';
 
 export interface IApplicationSettingsState {

--- a/src/shared/resources/applicationSettings/fetch/fetchApplicationSettingsSaga.test.ts
+++ b/src/shared/resources/applicationSettings/fetch/fetchApplicationSettingsSaga.test.ts
@@ -2,8 +2,8 @@ import { expectSaga } from 'redux-saga-test-plan';
 
 import { ApplicationSettingsActions } from 'src/shared/resources/applicationSettings/applicationSettingsSlice';
 import { getApplicationSettings } from 'src/shared/resources/applicationSettings/fetch/fetchApplicationSettingsSaga';
-import { applicationSettingsApiUrl } from 'src/utils/urls/appUrlHelper';
 import * as networking from 'src/utils/network/networking';
+import { applicationSettingsApiUrl } from 'src/utils/urls/appUrlHelper';
 
 describe('fetchApplicationSettingsSaga', () => {
   it('should set state with result if get is successful ', () => {

--- a/src/shared/resources/applicationSettings/fetch/fetchApplicationSettingsSaga.ts
+++ b/src/shared/resources/applicationSettings/fetch/fetchApplicationSettingsSaga.ts
@@ -2,8 +2,8 @@ import { call, put } from 'redux-saga/effects';
 import type { SagaIterator } from 'redux-saga';
 
 import { ApplicationSettingsActions as Actions } from 'src/shared/resources/applicationSettings/applicationSettingsSlice';
-import { applicationSettingsApiUrl } from 'src/utils/urls/appUrlHelper';
 import { get } from 'src/utils/network/networking';
+import { applicationSettingsApiUrl } from 'src/utils/urls/appUrlHelper';
 
 export function* getApplicationSettings(): SagaIterator {
   try {

--- a/src/shared/resources/attachments/delete/deleteAttachmentSagas.ts
+++ b/src/shared/resources/attachments/delete/deleteAttachmentSagas.ts
@@ -6,9 +6,9 @@ import type { SagaIterator } from 'redux-saga';
 import { FormDataActions } from 'src/features/form/data/formDataSlice';
 import { ValidationActions } from 'src/features/form/validation/validationSlice';
 import { AttachmentActions } from 'src/shared/resources/attachments/attachmentSlice';
-import { dataElementUrl } from 'src/utils/urls/appUrlHelper';
 import { getFileUploadComponentValidations } from 'src/utils/formComponentUtils';
 import { httpDelete } from 'src/utils/network/networking';
+import { dataElementUrl } from 'src/utils/urls/appUrlHelper';
 import type { IDeleteAttachmentAction } from 'src/shared/resources/attachments/delete/deleteAttachmentActions';
 import type { IRuntimeState } from 'src/types';
 

--- a/src/shared/resources/attachments/map/mapAttachmentsSagas.test.ts
+++ b/src/shared/resources/attachments/map/mapAttachmentsSagas.test.ts
@@ -1,7 +1,7 @@
-import { getInitialStateMock } from '__mocks__/mocks';
 import { select } from 'redux-saga/effects';
 import { expectSaga } from 'redux-saga-test-plan';
 
+import { getInitialStateMock } from 'src/__mocks__/mocks';
 import { selectFormLayouts } from 'src/features/form/layout/update/updateFormLayoutSagas';
 import { AttachmentActions } from 'src/shared/resources/attachments/attachmentSlice';
 import {

--- a/src/shared/resources/attachments/map/mapAttachmentsSagas.ts
+++ b/src/shared/resources/attachments/map/mapAttachmentsSagas.ts
@@ -13,7 +13,6 @@ import type { ILayouts } from 'src/features/form/layout';
 import type { IApplicationMetadata } from 'src/shared/resources/applicationMetadata';
 import type { IAttachments } from 'src/shared/resources/attachments';
 import type { ILayoutSets, IRuntimeState } from 'src/types';
-
 import type { IData, IInstance } from 'src/types/shared';
 
 export function* watchMapAttachmentsSaga(): SagaIterator {

--- a/src/shared/resources/attachments/update/updateAttachmentSagas.ts
+++ b/src/shared/resources/attachments/update/updateAttachmentSagas.ts
@@ -5,14 +5,13 @@ import type { SagaIterator } from 'redux-saga';
 
 import { ValidationActions } from 'src/features/form/validation/validationSlice';
 import { AttachmentActions } from 'src/shared/resources/attachments/attachmentSlice';
-import { fileTagUrl } from 'src/utils/urls/appUrlHelper';
 import { getFileUploadComponentValidations } from 'src/utils/formComponentUtils';
 import { httpDelete, post } from 'src/utils/network/networking';
 import { selectNotNull } from 'src/utils/sagas';
+import { fileTagUrl } from 'src/utils/urls/appUrlHelper';
 import type { IAttachment } from 'src/shared/resources/attachments';
 import type { IUpdateAttachmentAction } from 'src/shared/resources/attachments/update/updateAttachmentActions';
 import type { IRuntimeState } from 'src/types';
-
 import type { ILanguage } from 'src/types/shared';
 
 export function* updateAttachmentSaga({

--- a/src/shared/resources/attachments/upload/uploadAttachmentSagas.ts
+++ b/src/shared/resources/attachments/upload/uploadAttachmentSagas.ts
@@ -6,14 +6,13 @@ import type { SagaIterator } from 'redux-saga';
 import { FormDataActions } from 'src/features/form/data/formDataSlice';
 import { ValidationActions } from 'src/features/form/validation/validationSlice';
 import { AttachmentActions } from 'src/shared/resources/attachments/attachmentSlice';
-import { fileUploadUrl } from 'src/utils/urls/appUrlHelper';
 import { getFileUploadComponentValidations } from 'src/utils/formComponentUtils';
 import { post } from 'src/utils/network/networking';
+import { customEncodeURI } from 'src/utils/sharedUtils';
+import { fileUploadUrl } from 'src/utils/urls/appUrlHelper';
 import type { IAttachment } from 'src/shared/resources/attachments';
 import type { IUploadAttachmentAction } from 'src/shared/resources/attachments/upload/uploadAttachmentActions';
 import type { IRuntimeState } from 'src/types';
-
-import { customEncodeURI } from 'src/utils/sharedUtils';
 import type { ILanguage } from 'src/types/shared';
 
 export function* uploadAttachmentSaga({

--- a/src/shared/resources/dataLists/fetchDataListsSaga.ts
+++ b/src/shared/resources/dataLists/fetchDataListsSaga.ts
@@ -5,9 +5,10 @@ import type { SagaIterator } from 'redux-saga';
 import { appLanguageStateSelector } from 'src/selectors/appLanguageStateSelector';
 import { listStateSelector } from 'src/selectors/dataListStateSelector';
 import { DataListsActions } from 'src/shared/resources/dataLists/dataListsSlice';
-import { getDataListsUrl } from 'src/utils/urls/appUrlHelper';
 import { getDataListLookupKey, getDataListLookupKeys } from 'src/utils/dataList';
 import { selectNotNull } from 'src/utils/sagas';
+import { get } from 'src/utils/sharedUtils';
+import { getDataListsUrl } from 'src/utils/urls/appUrlHelper';
 import type { IFormData } from 'src/features/form/data';
 import type { ILayouts } from 'src/features/form/layout';
 import type {
@@ -17,8 +18,6 @@ import type {
   IFetchSpecificDataListSaga,
 } from 'src/shared/resources/dataLists/index';
 import type { IRepeatingGroups, IRuntimeState } from 'src/types';
-
-import { get } from 'src/utils/sharedUtils';
 
 export const formLayoutSelector = (state: IRuntimeState): ILayouts | null => state.formLayout?.layouts;
 export const formDataSelector = (state: IRuntimeState) => state.formData.formData;

--- a/src/shared/resources/instanceData/get/getInstanceDataSagas.ts
+++ b/src/shared/resources/instanceData/get/getInstanceDataSagas.ts
@@ -3,8 +3,8 @@ import type { PayloadAction } from '@reduxjs/toolkit';
 import type { SagaIterator } from 'redux-saga';
 
 import { InstanceDataActions } from 'src/shared/resources/instanceData/instanceDataSlice';
-import { instancesControllerUrl, invalidateCookieUrl, redirectToUpgrade } from 'src/utils/urls/appUrlHelper';
 import { get, putWithoutConfig } from 'src/utils/network/networking';
+import { instancesControllerUrl, invalidateCookieUrl, redirectToUpgrade } from 'src/utils/urls/appUrlHelper';
 import type { IGetInstanceData } from 'src/shared/resources/instanceData';
 
 export function* getInstanceDataSaga({ payload: { instanceId } }: PayloadAction<IGetInstanceData>): SagaIterator {

--- a/src/shared/resources/language/fetch/fetchLanguageSagas.test.ts
+++ b/src/shared/resources/language/fetch/fetchLanguageSagas.test.ts
@@ -2,14 +2,13 @@ import { all, call, select, take, takeLatest } from 'redux-saga/effects';
 import { expectSaga } from 'redux-saga-test-plan';
 
 import { FormLayoutActions } from 'src/features/form/layout/formLayoutSlice';
+import { getLanguageFromCode } from 'src/language/languages';
 import { appLanguageStateSelector } from 'src/selectors/appLanguageStateSelector';
 import { makeGetAllowAnonymousSelector } from 'src/selectors/getAllowAnonymous';
 import { ApplicationMetadataActions } from 'src/shared/resources/applicationMetadata/applicationMetadataSlice';
 import { fetchLanguageSaga, watchFetchLanguageSaga } from 'src/shared/resources/language/fetch/fetchLanguageSagas';
 import { LanguageActions } from 'src/shared/resources/language/languageSlice';
 import { waitFor } from 'src/utils/sagas';
-
-import { getLanguageFromCode } from 'src/language/languages';
 
 describe('languageActions', () => {
   it('should create an action with correct type: FETCH_LANGUAGE', () => {

--- a/src/shared/resources/language/fetch/fetchLanguageSagas.ts
+++ b/src/shared/resources/language/fetch/fetchLanguageSagas.ts
@@ -2,14 +2,13 @@ import { all, call, put, select, take, takeLatest } from 'redux-saga/effects';
 import type { SagaIterator } from 'redux-saga';
 
 import { FormLayoutActions } from 'src/features/form/layout/formLayoutSlice';
+import { getLanguageFromCode } from 'src/language/languages';
 import { appLanguageStateSelector } from 'src/selectors/appLanguageStateSelector';
 import { makeGetAllowAnonymousSelector } from 'src/selectors/getAllowAnonymous';
 import { ApplicationMetadataActions } from 'src/shared/resources/applicationMetadata/applicationMetadataSlice';
 import { LanguageActions } from 'src/shared/resources/language/languageSlice';
 import { QueueActions } from 'src/shared/resources/queue/queueSlice';
 import { waitFor } from 'src/utils/sagas';
-
-import { getLanguageFromCode } from 'src/language/languages';
 
 export function* fetchLanguageSaga(defaultLanguage = false): SagaIterator {
   try {

--- a/src/shared/resources/language/languageSlice.ts
+++ b/src/shared/resources/language/languageSlice.ts
@@ -6,7 +6,6 @@ import { OptionsActions } from 'src/shared/resources/options/optionsSlice';
 import { createSagaSlice } from 'src/shared/resources/utils/sagaSlice';
 import type { MkActionType } from 'src/shared/resources/utils/sagaSlice';
 import type { IAltinnWindow } from 'src/types';
-
 import type { ILanguage } from 'src/types/shared';
 
 export interface IFetchLanguageFulfilled {

--- a/src/shared/resources/options/fetch/fetchOptionsSagas.test.ts
+++ b/src/shared/resources/options/fetch/fetchOptionsSagas.test.ts
@@ -13,11 +13,10 @@ import {
   optionsWithIndexIndicatorsSelector,
   repeatingGroupsSelector,
 } from 'src/shared/resources/options/fetch/fetchOptionsSagas';
+import * as networking from 'src/utils/network/sharedNetworking';
 import { selectNotNull } from 'src/utils/sagas';
 import type { ILayouts, ISelectionComponentProps } from 'src/features/form/layout';
 import type { IOptions, IRuntimeState } from 'src/types';
-
-import * as networking from 'src/utils/network/sharedNetworking';
 import type { IInstance } from 'src/types/shared';
 
 describe('fetchOptionsSagas', () => {

--- a/src/shared/resources/options/fetch/fetchOptionsSagas.ts
+++ b/src/shared/resources/options/fetch/fetchOptionsSagas.ts
@@ -4,7 +4,6 @@ import type { SagaIterator } from 'redux-saga';
 
 import { appLanguageStateSelector } from 'src/selectors/appLanguageStateSelector';
 import { OptionsActions } from 'src/shared/resources/options/optionsSlice';
-import { getOptionsUrl } from 'src/utils/urls/appUrlHelper';
 import {
   getKeyIndex,
   getKeyWithoutIndex,
@@ -13,6 +12,8 @@ import {
 } from 'src/utils/databindings';
 import { getOptionLookupKey, getOptionLookupKeys } from 'src/utils/options';
 import { selectNotNull } from 'src/utils/sagas';
+import { get } from 'src/utils/sharedUtils';
+import { getOptionsUrl } from 'src/utils/urls/appUrlHelper';
 import type { IFormData } from 'src/features/form/data';
 import type { IUpdateFormDataFulfilled } from 'src/features/form/data/formDataTypes';
 import type { ILayouts, ISelectionComponentProps } from 'src/features/form/layout';
@@ -24,8 +25,6 @@ import type {
   IRepeatingGroups,
   IRuntimeState,
 } from 'src/types';
-
-import { get } from 'src/utils/sharedUtils';
 
 export const formLayoutSelector = (state: IRuntimeState): ILayouts | null => state.formLayout?.layouts;
 export const formDataSelector = (state: IRuntimeState) => state.formData.formData;

--- a/src/shared/resources/orgs/fetch/fetchOrgsSagas.ts
+++ b/src/shared/resources/orgs/fetch/fetchOrgsSagas.ts
@@ -3,7 +3,6 @@ import { call, put } from 'redux-saga/effects';
 import type { SagaIterator } from 'redux-saga';
 
 import { OrgsActions } from 'src/shared/resources/orgs/orgsSlice';
-
 import { orgsListUrl } from 'src/utils/sharedUtils';
 
 export function* fetchOrgsSaga(): SagaIterator {

--- a/src/shared/resources/party/getParties/getPartiesSagas.ts
+++ b/src/shared/resources/party/getParties/getPartiesSagas.ts
@@ -3,10 +3,9 @@ import type { SagaIterator } from 'redux-saga';
 
 import { PartyActions } from 'src/shared/resources/party/partySlice';
 import { QueueActions } from 'src/shared/resources/queue/queueSlice';
-import { currentPartyUrl, validPartiesUrl } from 'src/utils/urls/appUrlHelper';
 import { get } from 'src/utils/network/networking';
+import { currentPartyUrl, validPartiesUrl } from 'src/utils/urls/appUrlHelper';
 import type { IRuntimeState } from 'src/types';
-
 import type { IParty } from 'src/types/shared';
 
 const PartiesSelector = (state: IRuntimeState) => state.party.parties;

--- a/src/shared/resources/party/selectParty/selectPartySagas.ts
+++ b/src/shared/resources/party/selectParty/selectPartySagas.ts
@@ -3,8 +3,8 @@ import type { PayloadAction } from '@reduxjs/toolkit';
 import type { SagaIterator } from 'redux-saga';
 
 import { PartyActions } from 'src/shared/resources/party/partySlice';
-import { updateCookieUrl } from 'src/utils/urls/appUrlHelper';
 import { putWithoutConfig } from 'src/utils/network/networking';
+import { updateCookieUrl } from 'src/utils/urls/appUrlHelper';
 import type { ISelectParty } from 'src/shared/resources/party';
 import type { IAltinnWindow } from 'src/types';
 

--- a/src/shared/resources/process/checkProcessUpdated/checkProcessUpdatedSagas.ts
+++ b/src/shared/resources/process/checkProcessUpdated/checkProcessUpdatedSagas.ts
@@ -3,11 +3,10 @@ import type { SagaIterator } from 'redux-saga';
 
 import { ProcessActions } from 'src/shared/resources/process/processSlice';
 import { ProcessTaskType } from 'src/types';
+import { get } from 'src/utils/sharedUtils';
 import { getProcessStateUrl } from 'src/utils/urls/appUrlHelper';
 import type { IProcessState } from 'src/shared/resources/process';
 import type { IRuntimeState } from 'src/types';
-
-import { get } from 'src/utils/sharedUtils';
 import type { IProcess } from 'src/types/shared';
 
 const processSelector = (state: IRuntimeState): IProcessState => state.process;

--- a/src/shared/resources/process/completeProcess/completeProcessSagas.ts
+++ b/src/shared/resources/process/completeProcess/completeProcessSagas.ts
@@ -7,13 +7,12 @@ import { InstanceDataActions } from 'src/shared/resources/instanceData/instanceD
 import { IsLoadingActions } from 'src/shared/resources/isLoading/isLoadingSlice';
 import { ProcessActions } from 'src/shared/resources/process/processSlice';
 import { ProcessTaskType } from 'src/types';
-import { getProcessNextUrl } from 'src/utils/urls/appUrlHelper';
 import { behavesLikeDataTask } from 'src/utils/formLayout';
+import { put as httpPut } from 'src/utils/sharedUtils';
+import { getProcessNextUrl } from 'src/utils/urls/appUrlHelper';
 import type { IInstanceDataState } from 'src/shared/resources/instanceData';
 import type { ICompleteProcessFulfilled } from 'src/shared/resources/process';
 import type { IRuntimeState } from 'src/types';
-
-import { put as httpPut } from 'src/utils/sharedUtils';
 import type { IProcess } from 'src/types/shared';
 
 const instanceDataSelector = (state: IRuntimeState) => state.instanceData;

--- a/src/shared/resources/process/getProcessState/getProcessStateSagas.ts
+++ b/src/shared/resources/process/getProcessState/getProcessStateSagas.ts
@@ -3,9 +3,8 @@ import type { SagaIterator } from 'redux-saga';
 
 import { ProcessActions } from 'src/shared/resources/process/processSlice';
 import { ProcessTaskType } from 'src/types';
-import { getProcessStateUrl } from 'src/utils/urls/appUrlHelper';
-
 import { get } from 'src/utils/sharedUtils';
+import { getProcessStateUrl } from 'src/utils/urls/appUrlHelper';
 import type { IProcess } from 'src/types/shared';
 
 export function* getProcessStateSaga(): SagaIterator {

--- a/src/shared/resources/process/getTasks/getTasksSagas.ts
+++ b/src/shared/resources/process/getTasks/getTasksSagas.ts
@@ -4,10 +4,9 @@ import type { SagaIterator } from 'redux-saga';
 
 import { ProcessActions } from 'src/shared/resources/process/processSlice';
 import { ProcessTaskType } from 'src/types';
+import { get } from 'src/utils/sharedUtils';
 import { getProcessNextUrl } from 'src/utils/urls/appUrlHelper';
 import type { IGetTasksFulfilled } from 'src/shared/resources/process';
-
-import { get } from 'src/utils/sharedUtils';
 import type { IProcess } from 'src/types/shared';
 
 export function* getTasksSaga({ payload: { processStep } }: PayloadAction<IGetTasksFulfilled>): SagaIterator {

--- a/src/shared/resources/profile/fetch/fetchProfileSagas.ts
+++ b/src/shared/resources/profile/fetch/fetchProfileSagas.ts
@@ -6,7 +6,6 @@ import { ProfileActions } from 'src/shared/resources/profile/profileSlice';
 import { QueueActions } from 'src/shared/resources/queue/queueSlice';
 import { get } from 'src/utils/network/networking';
 import type { IFetchProfile } from 'src/shared/resources/profile';
-
 import type { IProfile } from 'src/types/shared';
 
 export function* fetchProfileSaga({ payload: { url } }: PayloadAction<IFetchProfile>): SagaIterator {

--- a/src/shared/resources/profile/profileSlice.ts
+++ b/src/shared/resources/profile/profileSlice.ts
@@ -7,7 +7,6 @@ import type {
   IProfileState,
 } from 'src/shared/resources/profile';
 import type { MkActionType } from 'src/shared/resources/utils/sagaSlice';
-
 import type { IProfile } from 'src/types/shared';
 
 const initialState: IProfileState = {

--- a/src/shared/resources/queue/infoTask/infoTaskQueueSaga.test.ts
+++ b/src/shared/resources/queue/infoTask/infoTaskQueueSaga.test.ts
@@ -1,8 +1,8 @@
-import { applicationMetadataMock } from '__mocks__/applicationMetadataMock';
-import { getInstanceDataStateMock } from '__mocks__/instanceDataStateMock';
 import { select } from 'redux-saga/effects';
 import { expectSaga } from 'redux-saga-test-plan';
 
+import { applicationMetadataMock } from 'src/__mocks__/applicationMetadataMock';
+import { getInstanceDataStateMock } from 'src/__mocks__/instanceDataStateMock';
 import { FormDataActions } from 'src/features/form/data/formDataSlice';
 import { IsLoadingActions } from 'src/shared/resources/isLoading/isLoadingSlice';
 import {

--- a/src/shared/resources/queue/infoTask/infoTaskQueueSaga.ts
+++ b/src/shared/resources/queue/infoTask/infoTaskQueueSaga.ts
@@ -6,12 +6,11 @@ import { InstanceDataActions } from 'src/shared/resources/instanceData/instanceD
 import { IsLoadingActions } from 'src/shared/resources/isLoading/isLoadingSlice';
 import { QueueActions } from 'src/shared/resources/queue/queueSlice';
 import { TextResourcesActions } from 'src/shared/resources/textResources/textResourcesSlice';
-import { getFetchFormDataUrl } from 'src/utils/urls/appUrlHelper';
 import { convertModelToDataBinding } from 'src/utils/databindings';
+import { get } from 'src/utils/sharedUtils';
+import { getFetchFormDataUrl } from 'src/utils/urls/appUrlHelper';
 import type { IApplicationMetadata } from 'src/shared/resources/applicationMetadata';
 import type { IRuntimeState, ITextResource } from 'src/types';
-
-import { get } from 'src/utils/sharedUtils';
 import type { IInstance } from 'src/types/shared';
 
 export const ApplicationMetadataSelector = (state: IRuntimeState) => state.applicationMetadata.applicationMetadata;

--- a/src/shared/resources/textResources/fetch/fetchTextResourcesSagas.test.ts
+++ b/src/shared/resources/textResources/fetch/fetchTextResourcesSagas.test.ts
@@ -12,10 +12,9 @@ import {
   watchFetchTextResourcesSaga,
 } from 'src/shared/resources/textResources/fetch/fetchTextResourcesSagas';
 import { TextResourcesActions } from 'src/shared/resources/textResources/textResourcesSlice';
-import { textResourcesUrl } from 'src/utils/urls/appUrlHelper';
 import { get } from 'src/utils/network/networking';
 import { waitFor } from 'src/utils/sagas';
-
+import { textResourcesUrl } from 'src/utils/urls/appUrlHelper';
 import type { IProfile } from 'src/types/shared';
 
 describe('fetchTextResourcesSagas', () => {

--- a/src/shared/resources/textResources/fetch/fetchTextResourcesSagas.ts
+++ b/src/shared/resources/textResources/fetch/fetchTextResourcesSagas.ts
@@ -8,9 +8,9 @@ import { ApplicationMetadataActions } from 'src/shared/resources/applicationMeta
 import { LanguageActions } from 'src/shared/resources/language/languageSlice';
 import { QueueActions } from 'src/shared/resources/queue/queueSlice';
 import { TextResourcesActions } from 'src/shared/resources/textResources/textResourcesSlice';
-import { oldTextResourcesUrl, textResourcesUrl } from 'src/utils/urls/appUrlHelper';
 import { get } from 'src/utils/network/networking';
 import { waitFor } from 'src/utils/sagas';
+import { oldTextResourcesUrl, textResourcesUrl } from 'src/utils/urls/appUrlHelper';
 
 export function* fetchTextResources(): SagaIterator {
   try {

--- a/src/shared/resources/textResources/replace/replaceTextResourcesSagas.ts
+++ b/src/shared/resources/textResources/replace/replaceTextResourcesSagas.ts
@@ -3,13 +3,12 @@ import type { SagaIterator } from 'redux-saga';
 
 import { FormDataActions } from 'src/features/form/data/formDataSlice';
 import { FormLayoutActions } from 'src/features/form/layout/formLayoutSlice';
+import { replaceTextResourceParams } from 'src/language/sharedLanguage';
 import { TextResourcesActions } from 'src/shared/resources/textResources/textResourcesSlice';
 import { buildInstanceContext } from 'src/utils/instanceContext';
 import type { IFormData } from 'src/features/form/data';
 import type { ITextResourcesState } from 'src/shared/resources/textResources';
 import type { IRepeatingGroups, IRuntimeState } from 'src/types';
-
-import { replaceTextResourceParams } from 'src/language/sharedLanguage';
 import type { IApplicationSettings, IDataSources, IInstance, IInstanceContext, ITextResource } from 'src/types/shared';
 
 export const InstanceSelector: (state: IRuntimeState) => IInstance | null = (state) => state.instanceData?.instance;

--- a/src/testUtils.tsx
+++ b/src/testUtils.tsx
@@ -1,16 +1,16 @@
 import React from 'react';
-import { createTheme, MuiThemeProvider } from '@material-ui/core';
 import { Provider } from 'react-redux';
+import { MemoryRouter, Navigate, Route, Routes } from 'react-router-dom';
+
+import { createTheme, MuiThemeProvider } from '@material-ui/core';
 import { render as rtlRender } from '@testing-library/react';
 import type { RenderOptions } from '@testing-library/react';
 import type { PreloadedState } from 'redux';
 
-import type { RootState, AppStore } from 'src/store';
 import { setupStore } from 'src/store';
 import { AltinnAppTheme } from 'src/theme';
-
-import { MemoryRouter, Navigate, Route, Routes } from 'react-router-dom';
 import type { IComponentProps } from 'src/components';
+import type { AppStore, RootState } from 'src/store';
 
 interface ExtendedRenderOptions extends Omit<RenderOptions, 'queries'> {
   preloadedState?: PreloadedState<RootState>;

--- a/src/theme/altinnAppTheme.tsx
+++ b/src/theme/altinnAppTheme.tsx
@@ -1,4 +1,4 @@
-import { commonTheme } from './commonTheme';
+import { commonTheme } from 'src/theme/commonTheme';
 
 const AltinnAppTheme = {
   ...commonTheme,

--- a/src/theme/altinnReceiptTheme.tsx
+++ b/src/theme/altinnReceiptTheme.tsx
@@ -1,4 +1,4 @@
-import { commonTheme } from './commonTheme';
+import { commonTheme } from 'src/theme/commonTheme';
 
 const AltinnReceiptTheme = {
   ...commonTheme,

--- a/src/theme/altinnStudioTheme.tsx
+++ b/src/theme/altinnStudioTheme.tsx
@@ -1,4 +1,4 @@
-import { commonTheme } from './commonTheme';
+import { commonTheme } from 'src/theme/commonTheme';
 
 const theme = {
   ...commonTheme,

--- a/src/utils/appMetadata.test.ts
+++ b/src/utils/appMetadata.test.ts
@@ -1,5 +1,4 @@
-import { instanceOwner, partyTypesAllowed } from '__mocks__/constants';
-
+import { instanceOwner, partyTypesAllowed } from 'src/__mocks__/constants';
 import {
   getCurrentDataTypeForApplication,
   getCurrentDataTypeId,
@@ -9,7 +8,6 @@ import {
   isStatelessApp,
 } from 'src/utils/appMetadata';
 import type { ILayoutSets } from 'src/types';
-
 import type { IApplication, IData, IInstance, ITask } from 'src/types/shared';
 
 describe('appMetadata.ts', () => {

--- a/src/utils/appMetadata.ts
+++ b/src/utils/appMetadata.ts
@@ -1,7 +1,6 @@
 import { getInstanceIdRegExp } from 'src/utils';
 import { getLayoutsetForDataElement } from 'src/utils/layout';
 import type { ILayoutSets } from 'src/types';
-
 import type { IApplication, IInstance } from 'src/types/shared';
 
 export function getDataTypeByLayoutSetId(layoutSetId: string | undefined, layoutSets: ILayoutSets | undefined | null) {

--- a/src/utils/attachment.ts
+++ b/src/utils/attachment.ts
@@ -3,7 +3,6 @@ import { splitDashedKey } from 'src/utils/formLayout';
 import type { IFormData } from 'src/features/form/data';
 import type { ILayoutComponent, ILayouts } from 'src/features/form/layout';
 import type { IAttachments } from 'src/shared/resources/attachments';
-
 import type { IData } from 'src/types/shared';
 
 export function mapAttachmentListToAttachments(

--- a/src/utils/attachmentsUtils.test.ts
+++ b/src/utils/attachmentsUtils.test.ts
@@ -1,5 +1,5 @@
+import { getInstancePdf, mapInstanceAttachments } from 'src/utils/attachmentsUtils';
 import type { IData } from 'src/types/shared';
-import { getInstancePdf, mapInstanceAttachments } from './attachmentsUtils';
 
 test('mapInstanceAttachments() returns correct attachment array', () => {
   const instance = {

--- a/src/utils/attachmentsUtils.ts
+++ b/src/utils/attachmentsUtils.ts
@@ -1,5 +1,5 @@
-import type { IAttachment, IData, ITextResource, IAttachmentGrouping, IDataType, IApplication } from 'src/types/shared';
 import { getTextResourceByKey } from 'src/language/sharedLanguage';
+import type { IApplication, IAttachment, IAttachmentGrouping, IData, IDataType, ITextResource } from 'src/types/shared';
 
 export const mapInstanceAttachments = (
   data: IData[] | undefined,

--- a/src/utils/formComponentUtils.test.ts
+++ b/src/utils/formComponentUtils.test.ts
@@ -1,5 +1,6 @@
 import parseHtmlToReact from 'html-react-parser';
 
+import { parseOptions } from 'src/language/sharedLanguage';
 import { AsciiUnitSeparator } from 'src/utils/attachment';
 import {
   atleastOneTagExists,
@@ -27,8 +28,6 @@ import type {
   IRepeatingGroups,
   ITextResource,
 } from 'src/types';
-
-import { parseOptions } from 'src/language/sharedLanguage';
 
 describe('formComponentUtils', () => {
   const mockFormData: IFormData = {

--- a/src/utils/formComponentUtils.ts
+++ b/src/utils/formComponentUtils.ts
@@ -6,6 +6,12 @@ import { AsciiUnitSeparator } from 'src/utils/attachment';
 import { getDateFormat } from 'src/utils/dateHelpers';
 import { setMappingForRepeatingGroupComponent } from 'src/utils/formLayout';
 import { getOptionLookupKey, getRelevantFormDataForOptionSource, setupSourceOptions } from 'src/utils/options';
+import {
+  formatISOString,
+  getLanguageFromKey,
+  getParsedLanguageFromText,
+  getTextResourceByKey,
+} from 'src/utils/sharedUtils';
 import { getTextFromAppOrDefault } from 'src/utils/textResource';
 import type { IFormData } from 'src/features/form/data';
 import type {
@@ -26,13 +32,6 @@ import type {
   ITextResourceBindings,
   IValidations,
 } from 'src/types';
-
-import {
-  formatISOString,
-  getLanguageFromKey,
-  getParsedLanguageFromText,
-  getTextResourceByKey,
-} from 'src/utils/sharedUtils';
 import type { ILanguage } from 'src/types/shared';
 
 export const componentValidationsHandledByGenericComponent = (

--- a/src/utils/formLayout.ts
+++ b/src/utils/formLayout.ts
@@ -18,7 +18,6 @@ import type {
   IRepeatingGroups,
   ITextResourceBindings,
 } from 'src/types';
-
 import type { ITextResource } from 'src/types/shared';
 
 interface SplitKey {

--- a/src/utils/formatDate.test.tsx
+++ b/src/utils/formatDate.test.tsx
@@ -1,4 +1,4 @@
-import { formatNameAndDate, returnDatestringFromDate } from './formatDate';
+import { formatNameAndDate, returnDatestringFromDate } from 'src/utils/formatDate';
 
 describe('formatNameAndDate', () => {
   it('should return positive result with date and name', () => {

--- a/src/utils/instanceContext.test.ts
+++ b/src/utils/instanceContext.test.ts
@@ -1,5 +1,4 @@
 import { buildInstanceContext } from 'src/utils/instanceContext';
-
 import type { IInstance, IInstanceContext } from 'src/types/shared';
 
 describe('instanceContext', () => {

--- a/src/utils/instanceContext.ts
+++ b/src/utils/instanceContext.ts
@@ -1,7 +1,6 @@
 import { createSelector } from 'reselect';
 
 import type { IRuntimeState } from 'src/types';
-
 import type { IInstance, IInstanceContext } from 'src/types/shared';
 
 const getInstance = (state: IRuntimeState) => state.instanceData.instance;

--- a/src/utils/instanceIdRegExp.test.ts
+++ b/src/utils/instanceIdRegExp.test.ts
@@ -1,5 +1,4 @@
-import { instanceIdExample } from '__mocks__/mocks';
-
+import { instanceIdExample } from 'src/__mocks__/mocks';
 import { getInstanceIdRegExp } from 'src/utils/instanceIdRegExp';
 
 describe('instanceIdRegExp', () => {

--- a/src/utils/layout/hierarchy.test.ts
+++ b/src/utils/layout/hierarchy.test.ts
@@ -1,5 +1,4 @@
-import { getInitialStateMock } from '__mocks__/mocks';
-
+import { getInitialStateMock } from 'src/__mocks__/mocks';
 import { getRepeatingGroups } from 'src/utils/formLayout';
 import {
   layoutAsHierarchy,

--- a/src/utils/layout/index.tsx
+++ b/src/utils/layout/index.tsx
@@ -13,7 +13,6 @@ import type {
   ILayouts,
 } from 'src/features/form/layout';
 import type { ILayoutSet, ILayoutSets } from 'src/types';
-
 import type { IInstance } from 'src/types/shared';
 
 export function getLayoutComponentById(id: string, layouts: ILayouts | null): ILayoutComponentOrGroup | undefined {

--- a/src/utils/layout/useLayoutsAsNodes.test.tsx
+++ b/src/utils/layout/useLayoutsAsNodes.test.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 
-import { getInitialStateMock } from '__mocks__/mocks';
 import { renderHook } from '@testing-library/react';
 
+import { getInitialStateMock } from 'src/__mocks__/mocks';
 import { setupStore } from 'src/store';
 import { useLayoutsAsNodes } from 'src/utils/layout/useLayoutsAsNodes';
 import type { ContextDataSources } from 'src/features/expressions/ExprContext';

--- a/src/utils/network/sharedNetworking.ts
+++ b/src/utils/network/sharedNetworking.ts
@@ -1,5 +1,5 @@
-import type { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios';
 import axios from 'axios';
+import type { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios';
 
 export async function get(url: string, options?: AxiosRequestConfig): Promise<any> {
   const response: AxiosResponse = await axios.get(url, {

--- a/src/utils/options.test.ts
+++ b/src/utils/options.test.ts
@@ -7,7 +7,6 @@ import {
 import type { IFormData } from 'src/features/form/data';
 import type { ILayout } from 'src/features/form/layout';
 import type { IMapping, IOptions, IOptionSource, IRepeatingGroups } from 'src/types';
-
 import type { IDataSources, ITextResource } from 'src/types/shared';
 
 describe('utils > options', () => {

--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -5,6 +5,7 @@ import {
   keyHasIndexIndicators,
   replaceIndexIndicatorsWithIndexes,
 } from 'src/utils/databindings';
+import { replaceTextResourceParams } from 'src/utils/sharedUtils';
 import type { IFormData } from 'src/features/form/data';
 import type { ILayout } from 'src/features/form/layout';
 import type {
@@ -16,8 +17,6 @@ import type {
   IRepeatingGroups,
   ITextResource,
 } from 'src/types';
-
-import { replaceTextResourceParams } from 'src/utils/sharedUtils';
 import type { IDataSources } from 'src/types/shared';
 
 export function getOptionLookupKey({ id, mapping }: IOptionsMetaData) {

--- a/src/utils/render.tsx
+++ b/src/utils/render.tsx
@@ -3,9 +3,8 @@ import * as React from 'react';
 import { ErrorMessage } from '@altinn/altinn-design-system';
 
 import { SoftValidations } from 'src/features/form/components/SoftValidations';
-import type { IComponentBindingValidation } from 'src/types';
-
 import { getParsedLanguageFromText } from 'src/utils/sharedUtils';
+import type { IComponentBindingValidation } from 'src/types';
 
 export function renderValidationMessagesForComponent(
   validationMessages: IComponentBindingValidation | undefined | null,

--- a/src/utils/textResource.ts
+++ b/src/utils/textResource.ts
@@ -1,6 +1,5 @@
-import type { ITextResource } from 'src/types';
-
 import { getParsedLanguageFromKey, getParsedLanguageFromText, getTextResourceByKey } from 'src/utils/sharedUtils';
+import type { ITextResource } from 'src/types';
 import type { ILanguage } from 'src/types/shared';
 
 export function getTextFromAppOrDefault(

--- a/src/utils/urls/urlHelper.test.ts
+++ b/src/utils/urls/urlHelper.test.ts
@@ -1,12 +1,12 @@
 import {
-  returnUrlToMessagebox,
-  returnUrlToProfile,
-  returnUrlToAllSchemas,
-  returnBaseUrlToAltinn,
   customEncodeURI,
   logoutUrlAltinn,
   makeUrlRelativeIfSameDomain,
-} from './urlHelper';
+  returnBaseUrlToAltinn,
+  returnUrlToAllSchemas,
+  returnUrlToMessagebox,
+  returnUrlToProfile,
+} from 'src/utils/urls/urlHelper';
 
 describe('Shared urlHelper.ts', () => {
   test('returnUrlToMessagebox() returning production messagebox', () => {

--- a/src/utils/validation/validation.test.ts
+++ b/src/utils/validation/validation.test.ts
@@ -1,13 +1,14 @@
-import { getInitialStateMock } from '__mocks__/initialStateMock';
-import * as complexSchema from '__mocks__/json-schema/complex.json';
-import * as oneOfOnRootSchema from '__mocks__/json-schema/one-of-on-root.json';
-import * as refOnRootSchema from '__mocks__/json-schema/ref-on-root.json';
-import { getMockValidationState } from '__mocks__/validationStateMock';
 import Ajv from 'ajv';
 import Ajv2020 from 'ajv/dist/2020';
 import dot from 'dot-object';
 import type { ErrorObject } from 'ajv';
 
+import { getInitialStateMock } from 'src/__mocks__/initialStateMock';
+import * as complexSchema from 'src/__mocks__/json-schema/complex.json';
+import * as oneOfOnRootSchema from 'src/__mocks__/json-schema/one-of-on-root.json';
+import * as refOnRootSchema from 'src/__mocks__/json-schema/ref-on-root.json';
+import { getMockValidationState } from 'src/__mocks__/validationStateMock';
+import { getParsedLanguageFromKey, getTextResourceByKey } from 'src/language/sharedLanguage';
 import { Severity } from 'src/types';
 import { createRepeatingGroupComponents, getRepeatingGroups } from 'src/utils/formLayout';
 import { nodesInLayouts } from 'src/utils/layout/hierarchy';
@@ -24,8 +25,6 @@ import type {
   IValidations,
 } from 'src/types';
 import type { LayoutRootNodeCollection } from 'src/utils/layout/hierarchy';
-
-import { getParsedLanguageFromKey, getTextResourceByKey } from 'src/language/sharedLanguage';
 
 function toCollection(mockLayouts: ILayouts, repeatingGroups: IRepeatingGroups = {}) {
   return nodesInLayouts(

--- a/src/utils/validation/validation.ts
+++ b/src/utils/validation/validation.ts
@@ -17,6 +17,7 @@ import { createRepeatingGroupComponents, getVariableTextKeysForRepeatingGroupCom
 import { buildInstanceContext } from 'src/utils/instanceContext';
 import { matchLayoutComponent, setupGroupComponents } from 'src/utils/layout';
 import { nodesInLayout, resolvedNodesInLayouts } from 'src/utils/layout/hierarchy';
+import { getLanguageFromKey, getParsedLanguageFromKey, getTextResourceByKey } from 'src/utils/sharedUtils';
 import type { IFormData } from 'src/features/form/data';
 import type { ILayout, ILayoutComponent, ILayoutGroup, ILayouts } from 'src/features/form/layout';
 import type { ILayoutCompDatePicker } from 'src/features/form/layout/index';
@@ -34,10 +35,8 @@ import type {
   IValidationResult,
   IValidations,
 } from 'src/types';
-import type { LayoutNode, LayoutObject, LayoutRootNode, LayoutRootNodeCollection } from 'src/utils/layout/hierarchy';
-
-import { getLanguageFromKey, getParsedLanguageFromKey, getTextResourceByKey } from 'src/utils/sharedUtils';
 import type { ILanguage } from 'src/types/shared';
+import type { LayoutNode, LayoutObject, LayoutRootNode, LayoutRootNodeCollection } from 'src/utils/layout/hierarchy';
 
 export interface ISchemaValidators {
   [id: string]: ISchemaValidator;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,11 +18,9 @@
     "esModuleInterop": true,
     "baseUrl": ".",
     "paths": {
-      "src/*": ["src/*"],
-      "__mocks__/*": ["src/__mocks__/*"],
-      "testUtils": ["src/testUtils.tsx"]
+      "src/*": ["src/*"]
     }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
-  "exclude": ["node_modules", "cypress"],
+  "exclude": ["node_modules", "cypress"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5256,6 +5256,7 @@ __metadata:
     eslint-plugin-import: 2.26.0
     eslint-plugin-jsx-a11y: 6.6.1
     eslint-plugin-no-relative-import-paths: 1.5.0
+    eslint-plugin-preferred-import-path: ^1.1.0
     eslint-plugin-prettier: 4.2.1
     eslint-plugin-react: 7.31.11
     eslint-plugin-react-hooks: 4.6.0
@@ -7815,6 +7816,13 @@ __metadata:
   version: 1.5.0
   resolution: "eslint-plugin-no-relative-import-paths@npm:1.5.0"
   checksum: 812fb801b4bfe4bd93199cd9eae572ae356009cf2421f4553902421167f31ed47527eee2482ab350241fcef9256f3ecc717ac0cdf709347e7893107285727d2a
+  languageName: node
+  linkType: hard
+
+"eslint-plugin-preferred-import-path@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "eslint-plugin-preferred-import-path@npm:1.1.0"
+  checksum: e15bd32ea0dc2e00b7deb24e18630c72fedb3f9a1bf0fa60f22874de49abdeb804ae50b22807887952acb008297ab920359ce005f07800d5159e3e0a873d05cb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description
Some eslint rules fell out after #724. Running a re-sorting on imports now that source folders have been merged casues _a few_ changes. The nice part is that these are all automated changes, so any merge conflicts from this change can be steam-rolled forward (and eslint will sort your imports again for you).

## Related Issue(s)
- #724

## Verification
- Manual testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing
  - [x] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added
  - [ ] Cypress E2E test(s) have been added
  - [x] No automatic tests are needed here
  - [ ] I want someone to help me make some tests
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been updated
   <!--- insert link to PR here -->
  - [x] No changes/updates needed
- Changes/additions to component properties
  - [ ] Changes are reflected in both `layout/index.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
   <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board <!--- If you don't have permissions for this, someone else will do it for you -->
