### PR TITLE
Fix race-condition in useDelayedSavedState

### DIFF
--- a/src/components/hooks/useDelayedSavedState.ts
+++ b/src/components/hooks/useDelayedSavedState.ts
@@ -14,9 +14,18 @@ export function useDelayedSavedState(
   formValue?: string,
   saveAfter?: number | boolean,
 ): DelayedSavedStateRetVal {
-  const [immediateState, setImmediateState] = React.useState(formValue);
+  const [immediateState, _setImmediateState] = React.useState(formValue);
+  const immediateStateRef = React.useRef(formValue);
   const [saveNextChangeImmediately, setSaveNextChangeImmediately] = React.useState(false);
   const [skipNextValidation, setSkipNextValidation] = React.useState(false);
+
+  const setImmediateState = React.useCallback(
+    (value: string | undefined) => {
+      immediateStateRef.current = value;
+      _setImmediateState(value);
+    },
+    [_setImmediateState],
+  );
 
   const updateFormData = React.useCallback(
     (value: string | undefined, skipValidation = false) => {
@@ -44,7 +53,7 @@ export function useDelayedSavedState(
 
   React.useEffect(() => {
     setImmediateState(formValue);
-  }, [formValue]);
+  }, [formValue, setImmediateState]);
 
   React.useEffect(() => {
     if (saveAfter === false) {
@@ -69,7 +78,7 @@ export function useDelayedSavedState(
       }
     },
     saveValue: () => {
-      updateFormData(immediateState);
+      updateFormData(immediateStateRef.current);
     },
     onPaste: () => {
       setSaveNextChangeImmediately(true);


### PR DESCRIPTION
## Description
<!---
  Provide a general summary of your changes in the Title above
  Describe your change(s) in detail here

  Also add the relevant label in the column on the right:
    Breaking changes: kind/breaking-change
    New features:     kind/product-feature
    Bug fixes:        kind/bug
    Dependencies:     kind/dependencies
    Other changes:    kind/other
-->
A race-condition can occur if a value is updated with `setValue` very quickly followed by `saveValue`. This fixes that issue by using a ref for immediateState so that `saveValue` will always save the most up-to-date value.

## Related Issue(s)
- https://altinn.slack.com/archives/C02EVE4RU82/p1670585968531819

## Verification
- Manual testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added
  - [ ] Cypress E2E test(s) have been added
  - [x] No automatic tests are needed here
  - [ ] I want someone to help me make some tests
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been updated
   <!--- insert link to PR here -->
  - [x] No changes/updates needed
- Changes/additions to component properties
  - [ ] Changes are reflected in both `layout/index.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
   <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board <!--- If you don't have permissions for this, someone else will do it for you -->
