### PR TITLE
Hiding components in hidden groups/repeating groups

### DIFF
--- a/src/features/expressions/shared-tests/functions/component/hidden-in-non-repeating-group.json
+++ b/src/features/expressions/shared-tests/functions/component/hidden-in-non-repeating-group.json
@@ -1,0 +1,50 @@
+{
+  "name": "Lookup for component inside hidden non-repeating group",
+  "expression": ["component", "dagligLederNavn"],
+  "expects": null,
+  "layouts": {
+    "Page1": {
+      "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+      "data": {
+        "layout": [
+          {
+            "id": "bedrift",
+            "type": "Group",
+            "dataModelBindings": {
+              "group": "Bedrift"
+            },
+            "children": ["bedriftsNavn", "dagligLederNavn"],
+            "hidden": ["greaterThan", ["dataModel", "Bedrift.DagligLeder.Alder"], 18]
+          },
+          {
+            "id": "bedriftsNavn",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "Bedrift.Navn"
+            }
+          },
+          {
+            "id": "dagligLederNavn",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "Bedrift.DagligLeder.Navn"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "dataModel": {
+    "Bedrift": {
+      "Navn": "Hell og lykke AS",
+      "DagligLeder": {
+        "Navn": "Kaare",
+        "Alder": 24
+      }
+    }
+  },
+  "context": {
+    "component": "bedriftsNavn",
+    "currentLayout": "Page1"
+  }
+}

--- a/src/features/expressions/shared-tests/functions/component/visible-in-non-repeating-group.json
+++ b/src/features/expressions/shared-tests/functions/component/visible-in-non-repeating-group.json
@@ -1,0 +1,50 @@
+{
+  "name": "Lookup for component inside visible non-repeating group",
+  "expression": ["component", "dagligLederNavn"],
+  "expects": "Kaare",
+  "layouts": {
+    "Page1": {
+      "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+      "data": {
+        "layout": [
+          {
+            "id": "bedrift",
+            "type": "Group",
+            "dataModelBindings": {
+              "group": "Bedrift"
+            },
+            "children": ["bedriftsNavn", "dagligLederNavn"],
+            "hidden": ["greaterThan", ["dataModel", "Bedrift.DagligLeder.Alder"], 35]
+          },
+          {
+            "id": "bedriftsNavn",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "Bedrift.Navn"
+            }
+          },
+          {
+            "id": "dagligLederNavn",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "Bedrift.DagligLeder.Navn"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "dataModel": {
+    "Bedrift": {
+      "Navn": "Hell og lykke AS",
+      "DagligLeder": {
+        "Navn": "Kaare",
+        "Alder": 24
+      }
+    }
+  },
+  "context": {
+    "component": "bedriftsNavn",
+    "currentLayout": "Page1"
+  }
+}

--- a/src/features/form/dynamics/conditionalRendering/conditionalRenderingSagas.ts
+++ b/src/features/form/dynamics/conditionalRendering/conditionalRenderingSagas.ts
@@ -128,8 +128,11 @@ export function* checkIfConditionalRulesShouldRunSaga({
 function runExpressionRules(layouts: LayoutRootNodeCollection<'resolved'>, present: Set<string>, future: Set<string>) {
   for (const layout of Object.values(layouts.all())) {
     for (const node of layout.flat(true)) {
-      if (node.item.hidden === true) {
+      if (node.item.hidden === true || future.has(node.item.id)) {
         future.add(node.item.id);
+        for (const childNode of node.children().flat()) {
+          future.add(childNode.item.id);
+        }
       }
     }
   }


### PR DESCRIPTION
## Description
As discussed in #503, summaries for components in non-repeating groups that are hidden, should _also_ be hidden. I started to implement this, but it turned out possibly way easier than I anticipated. Opening a PR to see if the tests pass. Needed parts (especially cypress tests for the summary components) are stil. missing.

## Related Issue(s)
- closes #503

## Verification
- Manual testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added
  - [ ] Cypress E2E test(s) have been added **NEEDED**
  - [ ] No automatic tests are needed here
  - [ ] I want someone to help me make some tests
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been updated
   <!--- insert link to PR here -->
  - [x] No changes/updates needed
- Changes/additions to component properties
  - [ ] Changes are reflected in both `layout/index.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
   <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board <!--- If you don't have permissions for this, someone else will do it for you -->
