### PR TITLE
Showing validation error in vscode when using invalid IDs for components

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -47,7 +47,8 @@
     "coverage",
     "dist",
     "**/*.snap",
-    "src/features/expressions/shared-tests/**/*.json"
+    "src/features/expressions/shared-tests/**/*.json",
+    "schemas/**/*.json"
   ],
   "rules": {
     "no-console": [

--- a/schemas/json/layout/layout.schema.v1.json
+++ b/schemas/json/layout/layout.schema.v1.json
@@ -35,8 +35,8 @@
         "id": {
           "type": "string",
           "title": "id",
-          "pattern": "^[0-9a-zA-Z][0-9a-zA-Z-]*[0-9a-zA-Z]$",
-          "description": "The component ID. Must be unique within a given layout."
+          "pattern": "^[0-9a-zA-Z][0-9a-zA-Z-]*(-?[a-zA-Z]+|[a-zA-Z][0-9])$",
+          "description": "The component ID. Must be unique within all layouts/pages in a layout-set. Cannot end with <dash><number>."
         },
         "type": {
           "type": "string",

--- a/schemas/json/layout/layout.schema.v1.json
+++ b/schemas/json/layout/layout.schema.v1.json
@@ -35,40 +35,14 @@
         "id": {
           "type": "string",
           "title": "id",
-          "pattern": "^[0-9a-zA-Z][0-9a-zA-Z-]*(-?[a-zA-Z]+|[a-zA-Z][0-9])$",
-          "description": "The component ID. Must be unique within all layouts/pages in a layout-set. Cannot end with <dash><number>."
+          "pattern": "^[0-9a-zA-Z][0-9a-zA-Z-]*[0-9a-zA-Z]$",
+          "description": "The component ID. Must be unique within a given layout."
         },
         "type": {
           "type": "string",
           "title": "Type",
           "description": "The component type.",
-          "enum": [
-            "AddressComponent",
-            "AttachmentList",
-            "Button",
-            "Checkboxes",
-            "Custom",
-            "Datepicker",
-            "Dropdown",
-            "FileUpload",
-            "FileUploadWithTag",
-            "Group",
-            "Header",
-            "Image",
-            "Input",
-            "InstantiationButton",
-            "Likert",
-            "List",
-            "MultipleSelect",
-            "NavigationButtons",
-            "NavigationBar",
-            "Panel",
-            "Paragraph",
-            "PrintButton",
-            "RadioButtons",
-            "Summary",
-            "TextArea"
-          ]
+          "enum": ["AddressComponent", "AttachmentList", "Button", "Checkboxes", "Custom", "Datepicker", "Dropdown", "FileUpload", "FileUploadWithTag", "Group", "Header", "Image", "Input", "InstantiationButton", "Likert","List", "MultipleSelect", "NavigationButtons", "NavigationBar", "Panel", "Paragraph", "PrintButton", "RadioButtons", "Summary", "TextArea"]
         },
         "required": {
           "title": "Required",
@@ -145,87 +119,27 @@
       },
       "required": ["id", "type"],
       "allOf": [
-        {
-          "if": { "properties": { "type": { "const": "AddressComponent" } } },
-          "then": { "$ref": "#/definitions/addressComponent" }
-        },
-        {
-          "if": { "properties": { "type": { "const": "AttachmentList" } } },
-          "then": { "$ref": "#/definitions/attachmentListComponent" }
-        },
-        {
-          "if": { "properties": { "type": { "const": "Checkboxes" } } },
-          "then": { "$ref": "#/definitions/radioAndCheckboxComponents" }
-        },
-        {
-          "if": { "properties": { "type": { "const": "Custom" } } },
-          "then": { "$ref": "#/definitions/customComponent" }
-        },
-        {
-          "if": { "properties": { "type": { "const": "Datepicker" } } },
-          "then": { "$ref": "#/definitions/datepickerComponent" }
-        },
-        {
-          "if": { "properties": { "type": { "const": "Dropdown" } } },
-          "then": { "$ref": "#/definitions/selectionComponents" }
-        },
-        {
-          "if": { "properties": { "type": { "const": "FileUpload" } } },
-          "then": { "$ref": "#/definitions/fileUploadComponent" }
-        },
-        {
-          "if": { "properties": { "type": { "const": "FileUploadWithTag" } } },
-          "then": { "$ref": "#/definitions/fileUploadWithTagComponent" }
-        },
-        {
-          "if": { "properties": { "type": { "const": "Group" } } },
-          "then": { "$ref": "#/definitions/groupComponent" }
-        },
-        {
-          "if": { "properties": { "type": { "const": "Image" } } },
-          "then": { "$ref": "#/definitions/imageComponent" }
-        },
-        {
-          "if": { "properties": { "type": { "const": "Input" } } },
-          "then": { "$ref": "#/definitions/inputComponent" }
-        },
-        {
-          "if": { "properties": { "type": { "const": "TextArea" } } },
-          "then": { "$ref": "#/definitions/textAreaComponent" }
-        },
-        {
-          "if": { "properties": { "type": { "const": "InstantiationButton" } } },
-          "then": { "$ref": "#/definitions/instantiationButtonComponent" }
-        },
-        {
-          "if": { "properties": { "type": { "const": "Likert" } } },
-          "then": { "$ref": "#/definitions/radioAndCheckboxComponents" }
-        },
-        {
-          "if": { "properties": { "type": { "const": "MultipleSelect" } } },
-          "then": { "$ref": "#/definitions/selectionComponents" }
-        },
-        {
-          "if": { "properties": { "type": { "const": "NavigationButtons" } } },
-          "then": { "$ref": "#/definitions/navigationButtonsComponent" }
-        },
-        {
-          "if": { "properties": { "type": { "const": "RadioButtons" } } },
-          "then": { "$ref": "#/definitions/radioAndCheckboxComponents" }
-        },
-        {
-          "if": { "properties": { "type": { "const": "Summary" } } },
-          "then": { "$ref": "#/definitions/summaryComponent" }
-        },
-        {
-          "if": { "properties": { "type": { "const": "Header" } } },
-          "then": { "$ref": "#/definitions/headerComponent" }
-        },
-        {
-          "if": { "properties": { "type": { "const": "Panel" } } },
-          "then": { "$ref": "#/definitions/panelComponent" }
-        },
-        { "if": { "properties": { "type": { "const": "List" } } }, "then": { "$ref": "#/definitions/listComponent" } }
+        { "if": {"properties": {"type": { "const": "AddressComponent"}}}, "then": { "$ref": "#/definitions/addressComponent"}},
+        { "if": {"properties": {"type": { "const": "AttachmentList"}}}, "then": { "$ref": "#/definitions/attachmentListComponent"}},
+        { "if": {"properties": {"type": { "const": "Checkboxes"}}}, "then": { "$ref": "#/definitions/radioAndCheckboxComponents"}},
+        { "if": {"properties": {"type": { "const": "Custom"}}}, "then": { "$ref": "#/definitions/customComponent"}},
+        { "if": {"properties": {"type": { "const": "Datepicker"}}}, "then": { "$ref": "#/definitions/datepickerComponent"}},
+        { "if": {"properties": {"type": { "const": "Dropdown"}}}, "then": { "$ref": "#/definitions/selectionComponents"}},
+        { "if": {"properties": {"type": { "const": "FileUpload"}}}, "then": { "$ref": "#/definitions/fileUploadComponent"}},
+        { "if": {"properties": {"type": { "const": "FileUploadWithTag"}}}, "then": { "$ref": "#/definitions/fileUploadWithTagComponent"}},
+        { "if": {"properties": {"type": { "const": "Group"}}}, "then": { "$ref": "#/definitions/groupComponent"}},
+        { "if": {"properties": {"type": { "const": "Image"}}}, "then": { "$ref": "#/definitions/imageComponent"}},
+        { "if": {"properties": {"type": { "const": "Input"}}}, "then": { "$ref": "#/definitions/inputComponent"}},
+        { "if": {"properties": {"type": { "const": "TextArea"}}}, "then": { "$ref": "#/definitions/textAreaComponent"}},
+        { "if": {"properties": {"type": { "const": "InstantiationButton"}}}, "then": { "$ref": "#/definitions/instantiationButtonComponent"}},
+        { "if": {"properties": {"type": { "const": "Likert"}}}, "then": { "$ref": "#/definitions/radioAndCheckboxComponents"}},
+        { "if": {"properties": {"type": { "const": "MultipleSelect"}}}, "then": { "$ref": "#/definitions/selectionComponents"}},
+        { "if": {"properties": {"type": { "const": "NavigationButtons"}}}, "then": { "$ref": "#/definitions/navigationButtonsComponent"}},
+        { "if": {"properties": {"type": { "const": "RadioButtons"}}}, "then": { "$ref": "#/definitions/radioAndCheckboxComponents"}},
+        { "if": {"properties": {"type": { "const": "Summary"}}}, "then": {"$ref": "#/definitions/summaryComponent"}},
+        { "if": {"properties": {"type": { "const": "Header"}}}, "then": {"$ref": "#/definitions/headerComponent"}},
+        { "if": {"properties": {"type": { "const": "Panel"}}}, "then": {"$ref": "#/definitions/panelComponent"}},
+        { "if": {"properties": {"type": { "const": "List"}}}, "then": {"$ref": "#/definitions/listComponent"}}
       ]
     },
     "headerComponent": {
@@ -304,10 +218,12 @@
           ]
         }
       },
-      "required": ["displayMode", "maxFileSizeInMB", "maxNumberOfAttachments", "minNumberOfAttachments"]
+      "required": ["displayMode", "maxFileSizeInMB", "maxNumberOfAttachments", "minNumberOfAttachments" ]
     },
     "fileUploadWithTagComponent": {
-      "allOf": [{ "$ref": "#/definitions/fileUploadComponent" }],
+      "allOf": [
+        { "$ref": "#/definitions/fileUploadComponent" }
+      ],
       "properties": {
         "optionsId": {
           "type": "string",
@@ -372,7 +288,9 @@
       "type": "integer",
       "maximum": 12,
       "minimum": 1,
-      "examples": [12]
+      "examples": [
+        12
+      ]
     },
     "gridSettings": {
       "allOf": [
@@ -532,11 +450,9 @@
     },
     "groupPanelOptions": {
       "additionalProperties": false,
-      "allOf": [
-        {
-          "$ref": "#/definitions/panelComponent"
-        }
-      ],
+      "allOf": [{
+        "$ref": "#/definitions/panelComponent"
+      }],
       "properties": {
         "iconUrl": {
           "title": "Icon url",
@@ -554,7 +470,7 @@
           "description": "Reference to the group that is being displayed in the panel. Used for referencing another repeating group context.",
           "type": "object",
           "properties": {
-            "group": {
+            "group" : {
               "type": "string",
               "title": "Group",
               "description": "Group reference. Can be either the group id or the group data model binding.",
@@ -760,15 +676,15 @@
               "description": "",
               "type": "object",
               "properties": {
-                "nb": {
+                "nb" :{
                   "type": "string",
                   "title": "Bokmål"
                 },
-                "nn": {
+                "nn":{
                   "type": "string",
                   "title": "Nynorsk"
                 },
-                "en": {
+                "en":{
                   "type": "string",
                   "title": "English"
                 }
@@ -776,12 +692,12 @@
               "additionalProperties": true
             },
             "width": {
-              "type": "string",
+              "type":"string",
               "title": "Image width",
               "examples": ["100%"]
             },
             "align": {
-              "type": "string",
+              "type":"string",
               "title": "Align image",
               "enum": ["flex-start", "center", "flex-end", "space-between", "space-around", "space-evenly"]
             }
@@ -813,7 +729,10 @@
       "title": "Automatic saving while typing",
       "description": "Boolean or number. True = feature on (default), false = feature off (saves on focus blur), number = timeout in milliseconds (400 by default)",
       "default": true,
-      "oneOf": [{ "type": "boolean" }, { "type": "number" }]
+      "oneOf": [
+        { "type": "boolean" },
+        { "type": "number" }
+      ]
     },
     "inputFormatting": {
       "properties": {
@@ -824,7 +743,7 @@
           "type": "string",
           "title": "Align input",
           "description": "The alignment for Input field (eg. right aligning a series of numbers)",
-          "enum": ["left", "center", "right"]
+          "enum": [ "left", "center", "right"]
         }
       }
     },
@@ -880,7 +799,9 @@
           "description": "The value of this binding will be shown in the summary component for the list. This binding must be one of the specified bindings under dataModelBindings."
         }
       },
-      "required": ["dataListId"]
+      "required": [
+        "dataListId"
+      ]
     },
     "paginationProperties": {
       "type": "object",
@@ -899,7 +820,10 @@
           "description": "The pagination size that is set to default"
         }
       },
-      "required": ["alternatives", "default"]
+      "required": [
+        "alternatives",
+        "default"
+      ]
     }
   }
 }

--- a/schemas/json/layout/layout.schema.v1.json
+++ b/schemas/json/layout/layout.schema.v1.json
@@ -35,14 +35,40 @@
         "id": {
           "type": "string",
           "title": "id",
-          "pattern": "^[0-9a-zA-Z][0-9a-zA-Z-]*[0-9a-zA-Z]$",
-          "description": "The component ID. Must be unique within a given layout."
+          "pattern": "^[0-9a-zA-Z][0-9a-zA-Z-]*(-?[a-zA-Z]+|[a-zA-Z][0-9])$",
+          "description": "The component ID. Must be unique within all layouts/pages in a layout-set. Cannot end with <dash><number>."
         },
         "type": {
           "type": "string",
           "title": "Type",
           "description": "The component type.",
-          "enum": ["AddressComponent", "AttachmentList", "Button", "Checkboxes", "Custom", "Datepicker", "Dropdown", "FileUpload", "FileUploadWithTag", "Group", "Header", "Image", "Input", "InstantiationButton", "Likert","List", "MultipleSelect", "NavigationButtons", "NavigationBar", "Panel", "Paragraph", "PrintButton", "RadioButtons", "Summary", "TextArea"]
+          "enum": [
+            "AddressComponent",
+            "AttachmentList",
+            "Button",
+            "Checkboxes",
+            "Custom",
+            "Datepicker",
+            "Dropdown",
+            "FileUpload",
+            "FileUploadWithTag",
+            "Group",
+            "Header",
+            "Image",
+            "Input",
+            "InstantiationButton",
+            "Likert",
+            "List",
+            "MultipleSelect",
+            "NavigationButtons",
+            "NavigationBar",
+            "Panel",
+            "Paragraph",
+            "PrintButton",
+            "RadioButtons",
+            "Summary",
+            "TextArea"
+          ]
         },
         "required": {
           "title": "Required",
@@ -119,27 +145,87 @@
       },
       "required": ["id", "type"],
       "allOf": [
-        { "if": {"properties": {"type": { "const": "AddressComponent"}}}, "then": { "$ref": "#/definitions/addressComponent"}},
-        { "if": {"properties": {"type": { "const": "AttachmentList"}}}, "then": { "$ref": "#/definitions/attachmentListComponent"}},
-        { "if": {"properties": {"type": { "const": "Checkboxes"}}}, "then": { "$ref": "#/definitions/radioAndCheckboxComponents"}},
-        { "if": {"properties": {"type": { "const": "Custom"}}}, "then": { "$ref": "#/definitions/customComponent"}},
-        { "if": {"properties": {"type": { "const": "Datepicker"}}}, "then": { "$ref": "#/definitions/datepickerComponent"}},
-        { "if": {"properties": {"type": { "const": "Dropdown"}}}, "then": { "$ref": "#/definitions/selectionComponents"}},
-        { "if": {"properties": {"type": { "const": "FileUpload"}}}, "then": { "$ref": "#/definitions/fileUploadComponent"}},
-        { "if": {"properties": {"type": { "const": "FileUploadWithTag"}}}, "then": { "$ref": "#/definitions/fileUploadWithTagComponent"}},
-        { "if": {"properties": {"type": { "const": "Group"}}}, "then": { "$ref": "#/definitions/groupComponent"}},
-        { "if": {"properties": {"type": { "const": "Image"}}}, "then": { "$ref": "#/definitions/imageComponent"}},
-        { "if": {"properties": {"type": { "const": "Input"}}}, "then": { "$ref": "#/definitions/inputComponent"}},
-        { "if": {"properties": {"type": { "const": "TextArea"}}}, "then": { "$ref": "#/definitions/textAreaComponent"}},
-        { "if": {"properties": {"type": { "const": "InstantiationButton"}}}, "then": { "$ref": "#/definitions/instantiationButtonComponent"}},
-        { "if": {"properties": {"type": { "const": "Likert"}}}, "then": { "$ref": "#/definitions/radioAndCheckboxComponents"}},
-        { "if": {"properties": {"type": { "const": "MultipleSelect"}}}, "then": { "$ref": "#/definitions/selectionComponents"}},
-        { "if": {"properties": {"type": { "const": "NavigationButtons"}}}, "then": { "$ref": "#/definitions/navigationButtonsComponent"}},
-        { "if": {"properties": {"type": { "const": "RadioButtons"}}}, "then": { "$ref": "#/definitions/radioAndCheckboxComponents"}},
-        { "if": {"properties": {"type": { "const": "Summary"}}}, "then": {"$ref": "#/definitions/summaryComponent"}},
-        { "if": {"properties": {"type": { "const": "Header"}}}, "then": {"$ref": "#/definitions/headerComponent"}},
-        { "if": {"properties": {"type": { "const": "Panel"}}}, "then": {"$ref": "#/definitions/panelComponent"}},
-        { "if": {"properties": {"type": { "const": "List"}}}, "then": {"$ref": "#/definitions/listComponent"}}
+        {
+          "if": { "properties": { "type": { "const": "AddressComponent" } } },
+          "then": { "$ref": "#/definitions/addressComponent" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "AttachmentList" } } },
+          "then": { "$ref": "#/definitions/attachmentListComponent" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "Checkboxes" } } },
+          "then": { "$ref": "#/definitions/radioAndCheckboxComponents" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "Custom" } } },
+          "then": { "$ref": "#/definitions/customComponent" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "Datepicker" } } },
+          "then": { "$ref": "#/definitions/datepickerComponent" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "Dropdown" } } },
+          "then": { "$ref": "#/definitions/selectionComponents" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "FileUpload" } } },
+          "then": { "$ref": "#/definitions/fileUploadComponent" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "FileUploadWithTag" } } },
+          "then": { "$ref": "#/definitions/fileUploadWithTagComponent" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "Group" } } },
+          "then": { "$ref": "#/definitions/groupComponent" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "Image" } } },
+          "then": { "$ref": "#/definitions/imageComponent" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "Input" } } },
+          "then": { "$ref": "#/definitions/inputComponent" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "TextArea" } } },
+          "then": { "$ref": "#/definitions/textAreaComponent" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "InstantiationButton" } } },
+          "then": { "$ref": "#/definitions/instantiationButtonComponent" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "Likert" } } },
+          "then": { "$ref": "#/definitions/radioAndCheckboxComponents" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "MultipleSelect" } } },
+          "then": { "$ref": "#/definitions/selectionComponents" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "NavigationButtons" } } },
+          "then": { "$ref": "#/definitions/navigationButtonsComponent" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "RadioButtons" } } },
+          "then": { "$ref": "#/definitions/radioAndCheckboxComponents" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "Summary" } } },
+          "then": { "$ref": "#/definitions/summaryComponent" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "Header" } } },
+          "then": { "$ref": "#/definitions/headerComponent" }
+        },
+        {
+          "if": { "properties": { "type": { "const": "Panel" } } },
+          "then": { "$ref": "#/definitions/panelComponent" }
+        },
+        { "if": { "properties": { "type": { "const": "List" } } }, "then": { "$ref": "#/definitions/listComponent" } }
       ]
     },
     "headerComponent": {
@@ -218,12 +304,10 @@
           ]
         }
       },
-      "required": ["displayMode", "maxFileSizeInMB", "maxNumberOfAttachments", "minNumberOfAttachments" ]
+      "required": ["displayMode", "maxFileSizeInMB", "maxNumberOfAttachments", "minNumberOfAttachments"]
     },
     "fileUploadWithTagComponent": {
-      "allOf": [
-        { "$ref": "#/definitions/fileUploadComponent" }
-      ],
+      "allOf": [{ "$ref": "#/definitions/fileUploadComponent" }],
       "properties": {
         "optionsId": {
           "type": "string",
@@ -288,9 +372,7 @@
       "type": "integer",
       "maximum": 12,
       "minimum": 1,
-      "examples": [
-        12
-      ]
+      "examples": [12]
     },
     "gridSettings": {
       "allOf": [
@@ -450,9 +532,11 @@
     },
     "groupPanelOptions": {
       "additionalProperties": false,
-      "allOf": [{
-        "$ref": "#/definitions/panelComponent"
-      }],
+      "allOf": [
+        {
+          "$ref": "#/definitions/panelComponent"
+        }
+      ],
       "properties": {
         "iconUrl": {
           "title": "Icon url",
@@ -470,7 +554,7 @@
           "description": "Reference to the group that is being displayed in the panel. Used for referencing another repeating group context.",
           "type": "object",
           "properties": {
-            "group" : {
+            "group": {
               "type": "string",
               "title": "Group",
               "description": "Group reference. Can be either the group id or the group data model binding.",
@@ -676,15 +760,15 @@
               "description": "",
               "type": "object",
               "properties": {
-                "nb" :{
+                "nb": {
                   "type": "string",
                   "title": "Bokmål"
                 },
-                "nn":{
+                "nn": {
                   "type": "string",
                   "title": "Nynorsk"
                 },
-                "en":{
+                "en": {
                   "type": "string",
                   "title": "English"
                 }
@@ -692,12 +776,12 @@
               "additionalProperties": true
             },
             "width": {
-              "type":"string",
+              "type": "string",
               "title": "Image width",
               "examples": ["100%"]
             },
             "align": {
-              "type":"string",
+              "type": "string",
               "title": "Align image",
               "enum": ["flex-start", "center", "flex-end", "space-between", "space-around", "space-evenly"]
             }
@@ -729,10 +813,7 @@
       "title": "Automatic saving while typing",
       "description": "Boolean or number. True = feature on (default), false = feature off (saves on focus blur), number = timeout in milliseconds (400 by default)",
       "default": true,
-      "oneOf": [
-        { "type": "boolean" },
-        { "type": "number" }
-      ]
+      "oneOf": [{ "type": "boolean" }, { "type": "number" }]
     },
     "inputFormatting": {
       "properties": {
@@ -743,7 +824,7 @@
           "type": "string",
           "title": "Align input",
           "description": "The alignment for Input field (eg. right aligning a series of numbers)",
-          "enum": [ "left", "center", "right"]
+          "enum": ["left", "center", "right"]
         }
       }
     },
@@ -799,9 +880,7 @@
           "description": "The value of this binding will be shown in the summary component for the list. This binding must be one of the specified bindings under dataModelBindings."
         }
       },
-      "required": [
-        "dataListId"
-      ]
+      "required": ["dataListId"]
     },
     "paginationProperties": {
       "type": "object",
@@ -820,10 +899,7 @@
           "description": "The pagination size that is set to default"
         }
       },
-      "required": [
-        "alternatives",
-        "default"
-      ]
+      "required": ["alternatives", "default"]
     }
   }
 }


### PR DESCRIPTION
## Description
As proven in #734, ending a component ID with `-5` (or any `<dash><number>`) may cause trouble. Since we add state like that when components are used inside repeating groups, weird stuff will happen if you provide those kinds of IDs yourself. Since it's a very large undertaking to fix this problem in app-frontend right now, we should at least warn developers about this when they edit their layouts in vscode.

## Related Issue(s)
- closes #734

## Verification
- Manual testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added
  - [ ] Cypress E2E test(s) have been added
  - [x] No automatic tests are needed here
  - [ ] I want someone to help me make some tests
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been updated
   <!--- insert link to PR here -->
  - [x] No changes/updates needed
- Changes/additions to component properties
  - [x] Changes are reflected in both `layout/index.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [ ] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
   <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board <!--- If you don't have permissions for this, someone else will do it for you -->
