### PR TITLE
Fix `SummaryGroupComponent` showing non-existing validation errors

### DIFF
--- a/src/components/summary/SummaryGroupComponent.tsx
+++ b/src/components/summary/SummaryGroupComponent.tsx
@@ -14,6 +14,7 @@ import { renderLayoutComponent } from 'src/features/form/containers/Form';
 import appTheme from 'src/theme/altinnAppTheme';
 import { getDisplayFormDataForComponent, getFormDataForComponentInRepeatingGroup } from 'src/utils/formComponentUtils';
 import { getRepeatingGroupStartStopIndex, setMappingForRepeatingGroupComponent } from 'src/utils/formLayout';
+import { nodesInLayout } from 'src/utils/layout/hierarchy';
 import { getLanguageFromKey } from 'src/utils/sharedUtils';
 import { getTextFromAppOrDefault } from 'src/utils/textResource';
 import type { ComponentFromSummary } from 'src/features/form/containers/DisplayGroupContainer';
@@ -152,26 +153,21 @@ function SummaryGroupComponent({
   );
 
   React.useEffect(() => {
-    let groupErrors = false;
-    if (!largeGroup) {
-      for (let i = startIndex; i <= stopIndex; i++) {
-        if (groupErrors) {
-          break;
-        }
-
-        groupChildComponents.forEach((componentId: string) => {
-          const component = layout?.find((c: ILayoutComponent) => c.id === componentId);
-          const mainIndex = typeof index === 'number' && index >= 0 ? `-${index}` : '';
-          const componentIdWithIndex = component && `${component.id}${mainIndex}-${i}`;
-
-          if (pageRef && componentIdWithIndex && validations[pageRef] && validations[pageRef][componentIdWithIndex]) {
-            groupErrors = true;
-          }
-        });
+    if (!largeGroup && groupComponent && pageRef) {
+      const nodes = nodesInLayout(layout, repeatingGroups);
+      const groupNode = nodes.findById(groupComponent.id);
+      if (groupNode) {
+        const allChildren = groupNode.flat(true);
+        const hasGroupErrors = allChildren.some((child) =>
+          Object.keys(validations[pageRef]?.[child.item.id] || {}).some((bindingKey: string) => {
+            const length = validations[pageRef][child.item.id][bindingKey]?.errors?.length;
+            return length && length > 0;
+          }),
+        );
+        setGroupHasErrors(hasGroupErrors);
       }
-      setGroupHasErrors(groupErrors);
     }
-  }, [validations, largeGroup, pageRef, groupChildComponents, layout, index, stopIndex, startIndex]);
+  }, [groupComponent, largeGroup, layout, pageRef, repeatingGroups, validations]);
 
   const createRepeatingGroupSummaryComponents = () => {
     const componentArray: JSX.Element[] = [];


### PR DESCRIPTION
## Description
<!---
  Provide a general summary of your changes in the Title above
  Describe your change(s) in detail here

  Also add the relevant label in the column on the right:
    Breaking changes: kind/breaking-change
    New features:     kind/product-feature
    Bug fixes:        kind/bug
    Dependencies:     kind/dependencies
    Other changes:    kind/other
-->
Switched to using `nodesInLayout` to get all children of the group component to check against `formValidations`  properly. I'm not sure if tests are relevant here, as i do not know exactly what caused empty validation objects being left in `formValidations` (causing the old code to show errors), only that it happened quite a lot.

## Related Issue(s)
- closes #701

## Verification
- Manual testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added
  - [ ] Cypress E2E test(s) have been added
  - [ ] No automatic tests are needed here
  - [ ] I want someone to help me make some tests
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been updated
   <!--- insert link to PR here -->
  - [x] No changes/updates needed
- Changes/additions to component properties
  - [ ] Changes are reflected in both `layout/index.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
   <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board <!--- If you don't have permissions for this, someone else will do it for you -->
