### PR TITLE
Adding missing `not` function to expresions JsonSchema

### DIFF
--- a/schemas/json/layout/expression.schema.v1.json
+++ b/schemas/json/layout/expression.schema.v1.json
@@ -54,7 +54,9 @@
       "oneOf": [
         { "type": "null", "title": "Null/missing value" },
         { "$ref": "#/definitions/strict-string" },
-        { "$ref": "#/definitions/func-if" }
+        { "$ref": "#/definitions/func-if" },
+        { "$ref": "#/definitions/strict-number", "description": "Numbers can be cast to strings" },
+        { "$ref": "#/definitions/strict-boolean", "description": "Booleans can be cast to strings" }
       ]
     },
     "strict-string": {
@@ -73,7 +75,9 @@
       "oneOf": [
         { "type": "null", "title": "Null/missing value" },
         { "$ref": "#/definitions/strict-boolean" },
-        { "$ref": "#/definitions/func-if" }
+        { "$ref": "#/definitions/func-if" },
+        { "$ref": "#/definitions/strict-string", "description": "Stringy true/false/0/1 can be cast to boolean" },
+        { "$ref": "#/definitions/strict-number", "description": "Numeric 0/1 can be cast to boolean" }
       ]
     },
     "strict-boolean": {
@@ -86,6 +90,7 @@
         { "$ref": "#/definitions/func-greaterThanEq" },
         { "$ref": "#/definitions/func-lessThan" },
         { "$ref": "#/definitions/func-lessThanEq" },
+        { "$ref": "#/definitions/func-not" },
         { "$ref": "#/definitions/func-and" },
         { "$ref": "#/definitions/func-or" }
       ]
@@ -95,7 +100,8 @@
       "oneOf": [
         { "type": "null", "title": "Null/missing value" },
         { "$ref": "#/definitions/strict-number" },
-        { "$ref": "#/definitions/func-if" }
+        { "$ref": "#/definitions/func-if" },
+        { "$ref": "#/definitions/strict-string", "description": "Numeric strings can be cast to numbers" }
       ]
     },
     "strict-number": {
@@ -207,6 +213,16 @@
         { "const":  "notEquals" },
         { "$ref": "#/definitions/any" },
         { "$ref": "#/definitions/any" }
+      ],
+      "additionalItems": false
+    },
+    "func-not": {
+      "title": "Not function",
+      "description": "This function inverts a boolean, returning true if given false, and vice versa.",
+      "type": "array",
+      "items": [
+        { "const":  "not" },
+        { "$ref": "#/definitions/boolean" }
       ],
       "additionalItems": false
     },


### PR DESCRIPTION
## Description
Also widening the types to allow for castable types.

## Related Issue(s)

- closes #{issue number}

## Verification

- Manual testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing
  - [x] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added
  - [ ] Cypress E2E test(s) have been added
  - [x] No automatic tests are needed here
  - [ ] I want someone to help me make some tests
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been updated
  <!--- insert link to PR here -->
  - [x] No changes/updates needed
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board <!--- If you don't have permissions for this, someone else will do it for you -->
