### PR TITLE
Fixing multiple minor bugs in repeating groups + expressions

### DIFF
--- a/src/features/expressions/index.ts
+++ b/src/features/expressions/index.ts
@@ -59,7 +59,7 @@ export function evalExprInObj<T>(args: EvalExprInObjArgs<T>): ExprResolved<T> {
 
 function getDefaultValueFor(path: string[], defaults: any) {
   const pathString = path.join('.');
-  const pathStringAnyDefault = [...path.slice(0, path.length - 2), DEFAULT_FOR_ALL_VALUES_IN_OBJ].join('.');
+  const pathStringAnyDefault = [...path.slice(0, path.length - 1), DEFAULT_FOR_ALL_VALUES_IN_OBJ].join('.');
   const defaultValueSpecific = dot.pick(pathString, defaults);
   const defaultValueGeneric = dot.pick(pathStringAnyDefault, defaults);
 
@@ -144,6 +144,10 @@ export function evalExpr(
     const result = innerEvalExpr(ctx);
     if ((result === null || result === undefined) && options && 'defaultValue' in options) {
       return options.defaultValue;
+    }
+
+    if (options && 'defaultValue' in options && typeof options.defaultValue !== typeof result) {
+      return castValue(result, typeof options.defaultValue as BaseValue, ctx);
     }
 
     return result;
@@ -576,8 +580,5 @@ export const ExprDefaultsForGroup: ExprDefaultValues<ILayoutGroup> = {
     saveButton: true,
     alertOnDelete: false,
     saveAndNextButton: false,
-  },
-  textResourceBindings: {
-    [DEFAULT_FOR_ALL_VALUES_IN_OBJ]: '',
   },
 };

--- a/src/features/expressions/useExpressions.ts
+++ b/src/features/expressions/useExpressions.ts
@@ -110,10 +110,12 @@ function getComponentDefaults(): any {
 
 export function useExpressionsForComponent<T extends ILayoutComponentOrGroup | undefined | null>(
   input: T,
+  options?: Omit<UseExpressionsOptions<T>, 'forComponentId' | 'defaults'>,
 ): ExprResolved<T> {
   const defaults = getComponentDefaults();
   return useExpressions(input, {
     forComponentId: (typeof input === 'object' && input !== null && input.id) || undefined,
     defaults,
+    ...options,
   });
 }

--- a/src/features/form/containers/GroupContainer.tsx
+++ b/src/features/form/containers/GroupContainer.tsx
@@ -252,10 +252,8 @@ export function GroupContainer({ id, container, components }: IGroupProps): JSX.
           textResources={textResources}
           layout={layout}
           repeatingGroupDeepCopyComponents={repeatingGroupDeepCopyComponents}
-          hideSaveButton={edit?.saveButton === false}
           multiPageIndex={multiPageIndex}
           setMultiPageIndex={setMultiPageIndex}
-          showSaveAndNextButton={edit?.saveAndNextButton === true}
           filteredIndexes={filteredIndexList}
         />
       )}
@@ -282,8 +280,7 @@ export function GroupContainer({ id, container, components }: IGroupProps): JSX.
                 setEditIndex={setEditIndex}
                 onClickRemove={onClickRemove}
                 repeatingGroupDeepCopyComponents={repeatingGroupDeepCopyComponents}
-                hideSaveButton={true}
-                hideDeleteButton={edit?.deleteButton === false}
+                forceHideSaveButton={true}
               />
             );
           })}

--- a/src/features/form/containers/RepeatingGroupTable.tsx
+++ b/src/features/form/containers/RepeatingGroupTable.tsx
@@ -304,10 +304,8 @@ export function RepeatingGroupTable({
           textResources={textResources}
           layout={layout}
           repeatingGroupDeepCopyComponents={repeatingGroupDeepCopyComponents}
-          hideSaveButton={edit?.saveButton === false}
           multiPageIndex={multiPageIndex}
           setMultiPageIndex={setMultiPageIndex}
-          showSaveAndNextButton={edit?.saveAndNextButton === true}
           filteredIndexes={filteredIndexes}
         />
       )

--- a/src/features/form/containers/RepeatingGroupsEditContainer.test.tsx
+++ b/src/features/form/containers/RepeatingGroupsEditContainer.test.tsx
@@ -111,8 +111,6 @@ describe('RepeatingGroupsEditContainer', () => {
       repeatingGroupIndex: repeatingGroupIndex,
       setEditIndex: jest.fn(),
       onClickRemove: jest.fn(),
-      hideDeleteButton: false,
-      showSaveAndNextButton: multiPageGroup.edit?.saveAndNextButton === true,
       ...props,
     };
 

--- a/src/features/form/containers/RepeatingGroupsEditContainer.tsx
+++ b/src/features/form/containers/RepeatingGroupsEditContainer.tsx
@@ -6,8 +6,7 @@ import { Delete as DeleteIcon } from '@navikt/ds-icons';
 import cn from 'classnames';
 
 import { AltinnButton } from 'src/components/shared';
-import { ExprDefaultsForGroup } from 'src/features/expressions';
-import { useExpressions } from 'src/features/expressions/useExpressions';
+import { useExpressionsForComponent } from 'src/features/expressions/useExpressions';
 import theme from 'src/theme/altinnStudioTheme';
 import { renderGenericComponent } from 'src/utils/layout';
 import { getLanguageFromKey, getTextResourceByKey } from 'src/utils/sharedUtils';
@@ -29,11 +28,9 @@ export interface IRepeatingGroupsEditContainer {
   setEditIndex: (index: number, forceValidation?: boolean) => void;
   repeatingGroupIndex: number;
   onClickRemove?: (groupIndex: number) => void;
-  hideSaveButton?: boolean;
-  hideDeleteButton?: boolean;
+  forceHideSaveButton?: boolean;
   multiPageIndex?: number;
   setMultiPageIndex?: (index: number) => void;
-  showSaveAndNextButton?: boolean;
   filteredIndexes?: number[] | null;
 }
 
@@ -83,19 +80,18 @@ export function RepeatingGroupsEditContainer({
   setEditIndex,
   repeatingGroupIndex,
   onClickRemove,
-  hideSaveButton,
-  hideDeleteButton,
+  forceHideSaveButton,
   multiPageIndex,
   setMultiPageIndex,
-  showSaveAndNextButton,
   filteredIndexes,
 }: IRepeatingGroupsEditContainer): JSX.Element {
   const classes = useStyles();
 
-  const textResourceBindings = useExpressions(container.textResourceBindings, {
-    forComponentId: container.id,
-    defaults: ExprDefaultsForGroup.textResourceBindings,
+  const group = useExpressionsForComponent(container, {
+    rowIndex: editIndex,
   });
+
+  const hideSaveButton = forceHideSaveButton || group.edit?.saveButton === false;
 
   let nextIndex: number | null = null;
   if (filteredIndexes) {
@@ -112,7 +108,7 @@ export function RepeatingGroupsEditContainer({
   const nextClicked = () => {
     if (nextIndex !== null) {
       setEditIndex && setEditIndex(nextIndex, true);
-      if (container.edit?.multiPage) {
+      if (group.edit?.multiPage) {
         setMultiPageIndex && setMultiPageIndex(0);
       }
     }
@@ -120,18 +116,18 @@ export function RepeatingGroupsEditContainer({
 
   const removeClicked = () => {
     onClickRemove && onClickRemove(editIndex);
-    if (container.edit?.multiPage) {
+    if (group.edit?.multiPage) {
       setMultiPageIndex && setMultiPageIndex(0);
     }
   };
 
-  const isNested = typeof container.baseComponentId === 'string';
+  const isNested = typeof group.baseComponentId === 'string';
 
   return (
     <div
       className={cn(
         isNested ? classes.nestedEditContainer : classes.editContainer,
-        { [classes.showAll]: container.edit?.mode === 'showAll' },
+        { [classes.showAll]: group.edit?.mode === 'showAll' },
         className,
       )}
       data-testid='group-edit-container'
@@ -142,7 +138,7 @@ export function RepeatingGroupsEditContainer({
         direction='row'
         spacing={3}
       >
-        {!hideDeleteButton && container.edit?.mode === 'showAll' && (
+        {group.edit?.deleteButton !== false && group.edit?.mode === 'showAll' && (
           <Grid
             item={true}
             container={true}
@@ -174,12 +170,10 @@ export function RepeatingGroupsEditContainer({
         >
           {repeatingGroupDeepCopyComponents[editIndex]?.map((component: ILayoutComponent) => {
             if (
-              container.edit?.multiPage &&
+              group.edit?.multiPage &&
               typeof multiPageIndex === 'number' &&
               multiPageIndex > -1 &&
-              !container.children.includes(
-                `${multiPageIndex}:${component.id.substring(0, component.id.lastIndexOf('-'))}`,
-              )
+              !group.children.includes(`${multiPageIndex}:${component.id.substring(0, component.id.lastIndexOf('-'))}`)
             ) {
               return null;
             }
@@ -191,11 +185,11 @@ export function RepeatingGroupsEditContainer({
           })}
         </Grid>
         <Grid item={true}>
-          {container.edit?.multiPage && (
+          {group.edit?.multiPage && (
             <div style={style}>
               {typeof multiPageIndex === 'number' &&
                 multiPageIndex > -1 &&
-                container.children.find((childId) => childId.startsWith(`${multiPageIndex + 1}:`)) && (
+                group.children.find((childId) => childId.startsWith(`${multiPageIndex + 1}:`)) && (
                   <AltinnButton
                     btnText={getLanguageFromKey('general.next', language)}
                     secondaryButton={true}
@@ -204,7 +198,7 @@ export function RepeatingGroupsEditContainer({
                 )}
               {typeof multiPageIndex === 'number' &&
                 multiPageIndex > 0 &&
-                container.children.find((childId) => childId.startsWith(`${multiPageIndex - 1}:`)) && (
+                group.children.find((childId) => childId.startsWith(`${multiPageIndex - 1}:`)) && (
                   <AltinnButton
                     btnText={getLanguageFromKey('general.back', language)}
                     secondaryButton={true}
@@ -218,7 +212,7 @@ export function RepeatingGroupsEditContainer({
             direction='row'
             spacing={2}
           >
-            {showSaveAndNextButton && nextIndex !== null && (
+            {group.edit?.saveAndNextButton === true && nextIndex !== null && (
               <Grid item={true}>
                 <Button
                   id={`next-button-grp-${id}`}
@@ -226,13 +220,13 @@ export function RepeatingGroupsEditContainer({
                   variant={ButtonVariant.Filled}
                   color={ButtonColor.Primary}
                 >
-                  {textResourceBindings?.save_and_next_button
-                    ? getTextResourceByKey(textResourceBindings.save_and_next_button, textResources)
+                  {group.textResourceBindings?.save_and_next_button
+                    ? getTextResourceByKey(group.textResourceBindings.save_and_next_button, textResources)
                     : getLanguageFromKey('general.save_and_next', language)}
                 </Button>
               </Grid>
             )}
-            {(!hideSaveButton || (showSaveAndNextButton && nextIndex === null)) && (
+            {(!hideSaveButton || (group.edit?.saveAndNextButton === true && nextIndex === null)) && (
               <Grid item={true}>
                 <Button
                   id={`add-button-grp-${id}`}
@@ -240,8 +234,8 @@ export function RepeatingGroupsEditContainer({
                   variant={ButtonVariant.Outline}
                   color={ButtonColor.Primary}
                 >
-                  {textResourceBindings?.save_button
-                    ? getTextResourceByKey(textResourceBindings.save_button, textResources)
+                  {group.textResourceBindings?.save_button
+                    ? getTextResourceByKey(group.textResourceBindings.save_button, textResources)
                     : getLanguageFromKey('general.save_and_close', language)}
                 </Button>
               </Grid>

--- a/test/e2e/integration/app-frontend/attachments-in-group.ts
+++ b/test/e2e/integration/app-frontend/attachments-in-group.ts
@@ -171,28 +171,28 @@ describe('Repeating group attachments', () => {
     ];
 
     uploadFile({
-      item: appFrontend.group.rows[0].uploadSingle,
+      item: appFrontend.group.row(0).uploadSingle,
       idx: 0,
       fileName: filenames[0].single,
       verifyTableRow: true,
-      tableRow: appFrontend.group.rows[0],
+      tableRow: appFrontend.group.row(0),
       secondPage: true,
     });
     getState().should('deep.equal', {
-      [appFrontend.group.rows[0].uploadSingle.stateKey]: [filenames[0].single],
+      [appFrontend.group.row(0).uploadSingle.stateKey]: [filenames[0].single],
     });
 
     filenames[0].multi.forEach((fileName, idx) => {
       uploadFile({
-        item: appFrontend.group.rows[0].uploadMulti,
+        item: appFrontend.group.row(0).uploadMulti,
         idx,
         fileName,
         verifyTableRow: true,
-        tableRow: appFrontend.group.rows[0],
+        tableRow: appFrontend.group.row(0),
         secondPage: true,
       });
       if (idx !== filenames[0].multi.length - 1) {
-        cy.get(appFrontend.group.rows[0].uploadMulti.addMoreBtn).click();
+        cy.get(appFrontend.group.row(0).uploadMulti.addMoreBtn).click();
       }
     });
 
@@ -202,47 +202,47 @@ describe('Repeating group attachments', () => {
     gotoSecondPage();
 
     uploadFile({
-      item: appFrontend.group.rows[1].uploadSingle,
+      item: appFrontend.group.row(1).uploadSingle,
       idx: 0,
       fileName: filenames[1].single,
       verifyTableRow: true,
-      tableRow: appFrontend.group.rows[1],
+      tableRow: appFrontend.group.row(1),
       secondPage: true,
     });
     filenames[1].multi.forEach((fileName, idx) => {
       uploadFile({
-        item: appFrontend.group.rows[1].uploadMulti,
+        item: appFrontend.group.row(1).uploadMulti,
         idx,
         fileName,
         verifyTableRow: true,
-        tableRow: appFrontend.group.rows[1],
+        tableRow: appFrontend.group.row(1),
         secondPage: true,
       });
       if (idx !== filenames[1].multi.length - 1) {
-        cy.get(appFrontend.group.rows[1].uploadMulti.addMoreBtn).click();
+        cy.get(appFrontend.group.row(1).uploadMulti.addMoreBtn).click();
       }
     });
     cy.get(appFrontend.group.saveMainGroup).click();
     cy.get(appFrontend.group.saveMainGroup).should('not.exist');
 
     [0, 1].forEach((row) => {
-      cy.get(appFrontend.group.rows[row].editBtn).click();
+      cy.get(appFrontend.group.row[row].editBtn).click();
       gotoSecondPage();
       filenames[row].nested.forEach((nestedRow, nestedRowIdx) => {
         nestedRow.forEach((fileName, idx) => {
           uploadFile({
-            item: appFrontend.group.rows[row].nestedGroup.rows[nestedRowIdx].uploadTagMulti,
+            item: appFrontend.group.row(row).nestedGroup.row(nestedRowIdx).uploadTagMulti,
             idx,
             fileName,
             verifyTableRow: true,
             isTaggedUploader: true,
-            tableRow: appFrontend.group.rows[row].nestedGroup.rows[nestedRowIdx],
+            tableRow: appFrontend.group.row(row).nestedGroup.row(nestedRowIdx),
           });
         });
-        cy.get(appFrontend.group.rows[row].nestedGroup.saveBtn).click();
-        cy.get(appFrontend.group.rows[row].nestedGroup.saveBtn).should('not.exist');
+        cy.get(appFrontend.group.row(row).nestedGroup.saveBtn).click();
+        cy.get(appFrontend.group.row(row).nestedGroup.saveBtn).should('not.exist');
         if (nestedRowIdx === 0) {
-          cy.get(appFrontend.group.rows[row].nestedGroup.groupContainer)
+          cy.get(appFrontend.group.row(row).nestedGroup.groupContainer)
             .parent()
             .find(appFrontend.group.addNewItemSubGroup)
             .click();
@@ -253,87 +253,87 @@ describe('Repeating group attachments', () => {
     });
 
     getState().should('deep.equal', {
-      [appFrontend.group.rows[0].uploadSingle.stateKey]: [filenames[0].single],
-      [appFrontend.group.rows[0].uploadMulti.stateKey]: filenames[0].multi,
-      [appFrontend.group.rows[1].uploadSingle.stateKey]: [filenames[1].single],
-      [appFrontend.group.rows[1].uploadMulti.stateKey]: filenames[1].multi,
-      [appFrontend.group.rows[0].nestedGroup.rows[0].uploadTagMulti.stateKey]: filenames[0].nested[0],
-      [appFrontend.group.rows[0].nestedGroup.rows[1].uploadTagMulti.stateKey]: filenames[0].nested[1],
-      [appFrontend.group.rows[1].nestedGroup.rows[0].uploadTagMulti.stateKey]: filenames[1].nested[0],
-      [appFrontend.group.rows[1].nestedGroup.rows[1].uploadTagMulti.stateKey]: filenames[1].nested[1],
+      [appFrontend.group.row(0).uploadSingle.stateKey]: [filenames[0].single],
+      [appFrontend.group.row(0).uploadMulti.stateKey]: filenames[0].multi,
+      [appFrontend.group.row(1).uploadSingle.stateKey]: [filenames[1].single],
+      [appFrontend.group.row(1).uploadMulti.stateKey]: filenames[1].multi,
+      [appFrontend.group.row(0).nestedGroup.row(0).uploadTagMulti.stateKey]: filenames[0].nested[0],
+      [appFrontend.group.row(0).nestedGroup.row(1).uploadTagMulti.stateKey]: filenames[0].nested[1],
+      [appFrontend.group.row(1).nestedGroup.row(0).uploadTagMulti.stateKey]: filenames[1].nested[0],
+      [appFrontend.group.row(1).nestedGroup.row(1).uploadTagMulti.stateKey]: filenames[1].nested[1],
     });
 
     const deletedAttachmentNames: string[] = [];
     const verifyPreview = (firstRowDeleted = false) => {
       let idx = 0;
       if (!firstRowDeleted) {
-        verifyTableRowPreview(appFrontend.group.rows[idx].uploadSingle, filenames[0].single, deletedAttachmentNames);
-        verifyTableRowPreview(appFrontend.group.rows[idx].uploadMulti, filenames[0].multi[0], deletedAttachmentNames);
-        verifyTableRowPreview(appFrontend.group.rows[idx].uploadMulti, filenames[0].multi[1], deletedAttachmentNames);
-        verifyTableRowPreview(appFrontend.group.rows[idx].uploadMulti, filenames[0].multi[2], deletedAttachmentNames);
+        verifyTableRowPreview(appFrontend.group.row(idx).uploadSingle, filenames[0].single, deletedAttachmentNames);
+        verifyTableRowPreview(appFrontend.group.row(idx).uploadMulti, filenames[0].multi[0], deletedAttachmentNames);
+        verifyTableRowPreview(appFrontend.group.row(idx).uploadMulti, filenames[0].multi[1], deletedAttachmentNames);
+        verifyTableRowPreview(appFrontend.group.row(idx).uploadMulti, filenames[0].multi[2], deletedAttachmentNames);
         idx++;
       }
 
-      verifyTableRowPreview(appFrontend.group.rows[idx].uploadSingle, filenames[1].single, deletedAttachmentNames);
-      verifyTableRowPreview(appFrontend.group.rows[idx].uploadMulti, filenames[1].multi[0], deletedAttachmentNames);
-      verifyTableRowPreview(appFrontend.group.rows[idx].uploadMulti, filenames[1].multi[1], deletedAttachmentNames);
-      verifyTableRowPreview(appFrontend.group.rows[idx].uploadMulti, filenames[1].multi[2], deletedAttachmentNames);
-      verifyTableRowPreview(appFrontend.group.rows[idx].uploadMulti, filenames[1].multi[3], deletedAttachmentNames);
+      verifyTableRowPreview(appFrontend.group.row(idx).uploadSingle, filenames[1].single, deletedAttachmentNames);
+      verifyTableRowPreview(appFrontend.group.row(idx).uploadMulti, filenames[1].multi[0], deletedAttachmentNames);
+      verifyTableRowPreview(appFrontend.group.row(idx).uploadMulti, filenames[1].multi[1], deletedAttachmentNames);
+      verifyTableRowPreview(appFrontend.group.row(idx).uploadMulti, filenames[1].multi[2], deletedAttachmentNames);
+      verifyTableRowPreview(appFrontend.group.row(idx).uploadMulti, filenames[1].multi[3], deletedAttachmentNames);
     };
 
     verifyPreview();
 
-    cy.get(appFrontend.group.rows[0].editBtn).click();
+    cy.get(appFrontend.group.row(0).editBtn).click();
     gotoSecondPage();
 
     interceptFormDataSave();
 
     // Now that all attachments described above have been uploaded and verified, start deleting the middle attachment
     // of the first-row multi-uploader to verify that the next attachment is shifted upwards.
-    cy.get(appFrontend.group.rows[0].uploadMulti.attachments[1].deleteBtn).click();
+    cy.get(appFrontend.group.row(0).uploadMulti.attachments(1).deleteBtn).click();
     deletedAttachmentNames.push(filenames[0].multi[1]);
     waitForFormDataSave();
 
     // The next attachment filename should now replace the deleted one:
-    cy.get(appFrontend.group.rows[0].uploadMulti.attachments[1].name)
+    cy.get(appFrontend.group.row(0).uploadMulti.attachments(1).name)
       .should('be.visible')
       .should('contain.text', filenames[0].multi[2]);
 
     // This verifies that the deleted filename is no longer part of the table header preview:
-    cy.get(appFrontend.group.rows[0].editBtn).click();
+    cy.get(appFrontend.group.row(0).editBtn).click();
     verifyPreview();
 
     // Let's also delete one of the nested attachments to verify the same thing happens there.
-    cy.get(appFrontend.group.rows[0].editBtn).click();
+    cy.get(appFrontend.group.row(0).editBtn).click();
     cy.get(appFrontend.group.saveMainGroup).click();
     cy.get(appFrontend.group.saveMainGroup).should('not.exist');
-    cy.get(appFrontend.group.rows[1].editBtn).click();
+    cy.get(appFrontend.group.row(1).editBtn).click();
     gotoSecondPage();
-    cy.get(appFrontend.group.rows[1].nestedGroup.rows[1].editBtn).click();
-    cy.get(appFrontend.group.rows[1].nestedGroup.rows[1].uploadTagMulti.attachments[1].editBtn || '').click();
+    cy.get(appFrontend.group.row(1).nestedGroup.row(1).editBtn).click();
+    cy.get(appFrontend.group.row(1).nestedGroup.row(1).uploadTagMulti.attachments(1).editBtn || '').click();
 
-    cy.get(appFrontend.group.rows[1].nestedGroup.rows[1].uploadTagMulti.attachments[1].deleteBtn).click();
+    cy.get(appFrontend.group.row(1).nestedGroup.row(1).uploadTagMulti.attachments(1).deleteBtn).click();
     deletedAttachmentNames.push(filenames[1].nested[1][1]);
     waitForFormDataSave();
 
     // The next filename should have replaced it:
-    cy.get(appFrontend.group.rows[1].nestedGroup.rows[1].uploadTagMulti.attachments[1].name)
+    cy.get(appFrontend.group.row(1).nestedGroup.row(1).uploadTagMulti.attachments(1).name)
       .should('be.visible')
       .should('contain.text', filenames[1].nested[1][2]);
 
-    cy.get(appFrontend.group.rows[1].editBtn).click();
+    cy.get(appFrontend.group.row(1).editBtn).click();
     verifyPreview();
-    cy.get(appFrontend.group.rows[1].editBtn).click();
+    cy.get(appFrontend.group.row(1).editBtn).click();
 
     const expectedAttachmentState = {
-      [appFrontend.group.rows[0].uploadSingle.stateKey]: [filenames[0].single],
-      [appFrontend.group.rows[0].uploadMulti.stateKey]: [filenames[0].multi[0], filenames[0].multi[2]],
-      [appFrontend.group.rows[1].uploadSingle.stateKey]: [filenames[1].single],
-      [appFrontend.group.rows[1].uploadMulti.stateKey]: filenames[1].multi,
-      [appFrontend.group.rows[0].nestedGroup.rows[0].uploadTagMulti.stateKey]: filenames[0].nested[0],
-      [appFrontend.group.rows[0].nestedGroup.rows[1].uploadTagMulti.stateKey]: filenames[0].nested[1],
-      [appFrontend.group.rows[1].nestedGroup.rows[0].uploadTagMulti.stateKey]: filenames[1].nested[0],
-      [appFrontend.group.rows[1].nestedGroup.rows[1].uploadTagMulti.stateKey]: [
+      [appFrontend.group.row(0).uploadSingle.stateKey]: [filenames[0].single],
+      [appFrontend.group.row(0).uploadMulti.stateKey]: [filenames[0].multi[0], filenames[0].multi[2]],
+      [appFrontend.group.row(1).uploadSingle.stateKey]: [filenames[1].single],
+      [appFrontend.group.row(1).uploadMulti.stateKey]: filenames[1].multi,
+      [appFrontend.group.row(0).nestedGroup.row(0).uploadTagMulti.stateKey]: filenames[0].nested[0],
+      [appFrontend.group.row(0).nestedGroup.row(1).uploadTagMulti.stateKey]: filenames[0].nested[1],
+      [appFrontend.group.row(1).nestedGroup.row(0).uploadTagMulti.stateKey]: filenames[1].nested[0],
+      [appFrontend.group.row(1).nestedGroup.row(1).uploadTagMulti.stateKey]: [
         filenames[1].nested[1][0],
         filenames[1].nested[1][2],
       ],
@@ -384,20 +384,20 @@ describe('Repeating group attachments', () => {
 
     // Delete the first row of the nested repeating group. This should make the second row in that nested group shift
     // the attachments upwards.
-    cy.get(appFrontend.group.rows[0].editBtn).click();
+    cy.get(appFrontend.group.row(0).editBtn).click();
     gotoSecondPage();
-    cy.get(appFrontend.group.rows[0].nestedGroup.rows[0].deleteBtn).click();
+    cy.get(appFrontend.group.row(0).nestedGroup.row(0).deleteBtn).click();
 
     waitForFormDataSave();
 
     const expectedAttachmentStateAfterDeletingFirstNestedRow = {
-      [appFrontend.group.rows[0].uploadSingle.stateKey]: [filenames[0].single],
-      [appFrontend.group.rows[0].uploadMulti.stateKey]: [filenames[0].multi[0], filenames[0].multi[2]],
-      [appFrontend.group.rows[1].uploadSingle.stateKey]: [filenames[1].single],
-      [appFrontend.group.rows[1].uploadMulti.stateKey]: filenames[1].multi,
-      [appFrontend.group.rows[0].nestedGroup.rows[0].uploadTagMulti.stateKey]: filenames[0].nested[1],
-      [appFrontend.group.rows[1].nestedGroup.rows[0].uploadTagMulti.stateKey]: filenames[1].nested[0],
-      [appFrontend.group.rows[1].nestedGroup.rows[1].uploadTagMulti.stateKey]: [
+      [appFrontend.group.row(0).uploadSingle.stateKey]: [filenames[0].single],
+      [appFrontend.group.row(0).uploadMulti.stateKey]: [filenames[0].multi[0], filenames[0].multi[2]],
+      [appFrontend.group.row(1).uploadSingle.stateKey]: [filenames[1].single],
+      [appFrontend.group.row(1).uploadMulti.stateKey]: filenames[1].multi,
+      [appFrontend.group.row(0).nestedGroup.row(0).uploadTagMulti.stateKey]: filenames[0].nested[1],
+      [appFrontend.group.row(1).nestedGroup.row(0).uploadTagMulti.stateKey]: filenames[1].nested[0],
+      [appFrontend.group.row(1).nestedGroup.row(1).uploadTagMulti.stateKey]: [
         filenames[1].nested[1][0],
         filenames[1].nested[1][2],
       ],
@@ -428,11 +428,11 @@ describe('Repeating group attachments', () => {
 
     // Verify that one of the attachments in the next nested row is visible in the table header. This is also a trick
     // to ensure we wait until the deletion is done before we fetch the redux state.
-    cy.get(appFrontend.group.rows[0].nestedGroup.rows[0].uploadTagMulti.tableRowPreview).should(
+    cy.get(appFrontend.group.row(0).nestedGroup.row(0).uploadTagMulti.tableRowPreview).should(
       'contain.text',
       filenames[0].nested[1][2],
     );
-    cy.get(appFrontend.group.rows[0].nestedGroup.rows[0].editBtn).click();
+    cy.get(appFrontend.group.row(0).nestedGroup.row(0).editBtn).click();
 
     cy.getReduxState(simplifyFormData).should('deep.equal', expectedFormDataAfterDeletingFirstNestedRow);
     getState().should('deep.equal', expectedAttachmentStateAfterDeletingFirstNestedRow);
@@ -441,16 +441,16 @@ describe('Repeating group attachments', () => {
     // nested rows.
     cy.get(appFrontend.group.saveMainGroup).click();
     cy.get(appFrontend.group.saveMainGroup).should('not.exist');
-    cy.get(appFrontend.group.rows[0].deleteBtn).click();
+    cy.get(appFrontend.group.row(0).deleteBtn).click();
 
     verifyPreview(true);
     waitForFormDataSave();
 
     const expectedAttachmentStateAfterDeletingFirstRow = {
-      [appFrontend.group.rows[0].uploadSingle.stateKey]: [filenames[1].single],
-      [appFrontend.group.rows[0].uploadMulti.stateKey]: filenames[1].multi,
-      [appFrontend.group.rows[0].nestedGroup.rows[0].uploadTagMulti.stateKey]: filenames[1].nested[0],
-      [appFrontend.group.rows[0].nestedGroup.rows[1].uploadTagMulti.stateKey]: [
+      [appFrontend.group.row(0).uploadSingle.stateKey]: [filenames[1].single],
+      [appFrontend.group.row(0).uploadMulti.stateKey]: filenames[1].multi,
+      [appFrontend.group.row(0).nestedGroup.row(0).uploadTagMulti.stateKey]: filenames[1].nested[0],
+      [appFrontend.group.row(0).nestedGroup.row(1).uploadTagMulti.stateKey]: [
         filenames[1].nested[1][0],
         filenames[1].nested[1][2],
       ],

--- a/test/e2e/integration/app-frontend/calculate-page-order.ts
+++ b/test/e2e/integration/app-frontend/calculate-page-order.ts
@@ -47,7 +47,7 @@ describe('Calculate Page Order', () => {
     cy.get(appFrontend.navMenuCurrent).should('have.text', '3. summary');
 
     cy.get(appFrontend.navMenu).find('li > button').eq(1).click();
-    cy.get(appFrontend.group.rows[0].editBtn).click();
+    cy.get(appFrontend.group.row(0).editBtn).click();
     cy.get(appFrontend.group.newValue).clear().type('2');
 
     cy.get(appFrontend.navButtons).contains(mui.button, texts.next).click();

--- a/test/e2e/integration/app-frontend/group.ts
+++ b/test/e2e/integration/app-frontend/group.ts
@@ -150,7 +150,7 @@ describe('Group', () => {
       cy.get(appFrontend.group.addNewItem).should('exist').and('be.visible').focus().click();
       cy.get(appFrontend.group.currentValue).should('be.visible').type('123').blur();
 
-      cy.get(appFrontend.group.rows[0].editBtn).should('exist').and('be.visible').focus().click();
+      cy.get(appFrontend.group.row(0).editBtn).should('exist').and('be.visible').focus().click();
       cy.get(appFrontend.group.saveMainGroup).focus().should('be.visible').click();
 
       cy.wait('@validate');
@@ -165,7 +165,7 @@ describe('Group', () => {
         cy.get(appFrontend.errorReport).should('not.exist');
       }
 
-      cy.get(appFrontend.group.rows[0].editBtn).should('exist').and('be.visible').focus().click();
+      cy.get(appFrontend.group.row(0).editBtn).should('exist').and('be.visible').focus().click();
       cy.get(appFrontend.group.currentValue).should('be.visible').clear().blur();
       cy.get(appFrontend.group.saveMainGroup).focus().should('be.visible').click();
 
@@ -222,51 +222,39 @@ describe('Group', () => {
     cy.get(appFrontend.group.showGroupToContinue).find('input').check();
     expectRows();
 
-    cy.contains(mui.button, texts.prev).click();
-    cy.get(appFrontend.group.prefill.liten).click();
-    cy.contains(mui.button, texts.next).click();
+    function clickOnPrefills(...items: (keyof typeof appFrontend.group.prefill)[]) {
+      cy.contains(mui.button, texts.prev).click();
+      for (const item of items) {
+        cy.get(appFrontend.group.prefill[item]).click().blur();
+      }
+      cy.contains(mui.button, texts.next).click();
+    }
+
+    clickOnPrefills('liten');
     expectRows(['NOK 1', 'NOK 5']);
 
-    cy.contains(mui.button, texts.prev).click();
-    cy.get(appFrontend.group.prefill.middels).click();
-    cy.get(appFrontend.group.prefill.svaer).click();
-    cy.contains(mui.button, texts.next).click();
+    clickOnPrefills('middels', 'svaer');
     expectRows(['NOK 1', 'NOK 5'], ['NOK 120', 'NOK 350'], ['NOK 80 323', 'NOK 123 455']);
 
-    cy.contains(mui.button, texts.prev).click();
-    cy.get(appFrontend.group.prefill.middels).click();
-    cy.get(appFrontend.group.prefill.svaer).click();
-    cy.contains(mui.button, texts.next).click();
+    clickOnPrefills('middels', 'svaer');
     expectRows(['NOK 1', 'NOK 5']);
 
-    cy.contains(mui.button, texts.prev).click();
-    cy.get(appFrontend.group.prefill.enorm).click();
-    cy.get(appFrontend.group.prefill.liten).click();
-    cy.contains(mui.button, texts.next).click();
+    clickOnPrefills('enorm', 'liten');
     expectRows(['NOK 9 872 345', 'NOK 18 872 345']);
 
-    cy.contains(mui.button, texts.prev).click();
-    cy.get(appFrontend.group.prefill.marked).click();
-    cy.contains(mui.button, texts.next).click();
-    expectRows(['NOK 9 872 345', 'NOK 18 872 345'], ['NOK 1 234', 'NOK 4 321']);
-    cy.get(appFrontend.group.mainGroup)
-      .find(mui.tableBody)
-      .then((table) => {
-        cy.wrap(table).children().eq(0).find(appFrontend.group.delete).should('be.visible');
-        cy.wrap(table)
-          .children()
-          .eq(0)
-          .find(appFrontend.group.edit)
-          .should('be.visible')
-          .should('have.text', texts.edit);
-        cy.wrap(table).children().eq(1).find(appFrontend.group.delete).should('not.exist');
-        cy.wrap(table)
-          .children()
-          .eq(1)
-          .find(appFrontend.group.edit)
-          .should('be.visible')
-          .should('have.text', texts.view);
-      });
+    clickOnPrefills('liten');
+    expectRows(['NOK 9 872 345', 'NOK 18 872 345'], ['NOK 1', 'NOK 5']);
+
+    cy.get(appFrontend.group.row(0).editBtn).should('have.text', 'Se innhold');
+    cy.get(appFrontend.group.row(0).deleteBtn).should('not.exist');
+    cy.get(appFrontend.group.row(0).editBtn).click().should('have.text', 'Lukk');
+    cy.get(appFrontend.group.saveMainGroup).should('have.text', 'Lukk').click().should('not.exist');
+
+    // The 'liten' row differs, as it should not have a save button on the bottom
+    cy.get(appFrontend.group.row(1).editBtn).should('have.text', 'Se innhold');
+    cy.get(appFrontend.group.row(1).deleteBtn).should('not.exist');
+    cy.get(appFrontend.group.row(1).editBtn).click().should('have.text', 'Lukk');
+    cy.get(appFrontend.group.saveMainGroup).should('not.exist');
   });
 
   it('Delete group row after validation', () => {

--- a/test/e2e/integration/app-frontend/summary.ts
+++ b/test/e2e/integration/app-frontend/summary.ts
@@ -161,9 +161,9 @@ describe('Summary', () => {
       });
 
     // Check to show a couple of nested options, then go back to the summary
-    cy.get(appFrontend.group.rows[0].editBtn).click();
+    cy.get(appFrontend.group.row(0).editBtn).click();
     cy.get(appFrontend.group.mainGroup).find(appFrontend.group.editContainer).find(appFrontend.group.next).click();
-    cy.get(appFrontend.group.rows[0].nestedGroup.rows[0].nestedDynamics).click();
+    cy.get(appFrontend.group.row(0).nestedGroup.row(0).nestedDynamics).click();
 
     const workAroundSlowSave = JSON.parse('true');
     if (workAroundSlowSave) {
@@ -172,14 +172,14 @@ describe('Summary', () => {
       // and in the future we should fix this properly by simplifying to save data immediately in the redux state
       // but delay the PUT request instead.
       // See https://github.com/Altinn/app-frontend-react/issues/339#issuecomment-1321920974
-      cy.get(appFrontend.group.rows[0].nestedGroup.rows[0].nestedOptions[1]).check().blur();
-      cy.get(appFrontend.group.rows[0].nestedGroup.rows[0].nestedOptions[2]).check().blur();
+      cy.get(appFrontend.group.row(0).nestedGroup.row(0).nestedOptions[1]).check().blur();
+      cy.get(appFrontend.group.row(0).nestedGroup.row(0).nestedOptions[2]).check().blur();
     } else {
-      cy.get(appFrontend.group.rows[0].nestedGroup.rows[0].nestedOptions[1]).check();
-      cy.get(appFrontend.group.rows[0].nestedGroup.rows[0].nestedOptions[2]).check();
+      cy.get(appFrontend.group.row(0).nestedGroup.row(0).nestedOptions[1]).check();
+      cy.get(appFrontend.group.row(0).nestedGroup.row(0).nestedOptions[2]).check();
     }
 
-    cy.get(appFrontend.group.rows[0].nestedGroup.saveBtn).click();
+    cy.get(appFrontend.group.row(0).nestedGroup.saveBtn).click();
     cy.get(appFrontend.group.saveMainGroup).click();
     cy.contains(mui.button, texts.backToSummary).click();
 

--- a/test/e2e/pageobjects/app-frontend.ts
+++ b/test/e2e/pageobjects/app-frontend.ts
@@ -122,7 +122,6 @@ export default class AppFrontend {
       stor: 'input[name=stor]',
       svaer: 'input[name=svaer]',
       enorm: 'input[name=enorm]',
-      marked: 'input[name=prefill]',
     },
     showGroupToContinue: '#showGroupToContinue',
     mainGroup: '#group-mainGroup',
@@ -157,13 +156,13 @@ export default class AppFrontend {
     popOverCancelButton: '[data-testid="warning-popover-cancel-button"]',
     edit: '[data-testid=edit-button]',
     delete: '[data-testid=delete-button]',
-    rows: [0, 1].map((idx) => ({
+    row: (idx: number) => ({
       uploadSingle: makeUploaderSelectors('mainUploaderSingle', idx, 3),
       uploadMulti: makeUploaderSelectors('mainUploaderMulti', idx, 4),
-      editBtn: `#group-mainGroup-table-body > tr:nth-child(${idx + 1}) > td:nth-last-of-type(2n) button`,
-      deleteBtn: `#group-mainGroup-table-body > tr:nth-child(${idx + 1}) > td:last-of-type button`,
+      editBtn: `#group-mainGroup-table-body > tr:nth-child(${idx + 1}) [data-testid=edit-button]`,
+      deleteBtn: `#group-mainGroup-table-body > tr:nth-child(${idx + 1}) [data-testid=delete-button]`,
       nestedGroup: {
-        rows: [0, 1].map((subIdx) => ({
+        row: (subIdx: number) => ({
           uploadTagMulti: makeUploaderSelectors('subUploader', `${idx}-${subIdx}`, 2, true),
           nestedDynamics: `#nestedDynamics-${idx}-${subIdx} input[type=checkbox]`,
           nestedOptions: [
@@ -173,11 +172,11 @@ export default class AppFrontend {
           ],
           editBtn: `#group-subGroup-${idx}-table-body > tr:nth-child(${subIdx + 1}) > td:nth-last-of-type(2n) button`,
           deleteBtn: `#group-subGroup-${idx}-table-body > tr:nth-child(${subIdx + 1}) > td:last-of-type button`,
-        })),
+        }),
         groupContainer: `#group-subGroup-${idx}`,
         saveBtn: `#add-button-grp-subGroup-${idx}`,
       },
-    })),
+    }),
   };
 
   //Stateless-app
@@ -224,7 +223,7 @@ export const makeUploaderSelectors = (
     stateKey: `${id}-${row}`,
     dropZoneContainer: `#altinn-drop-zone-${id}-${row}`,
     dropZone: `#altinn-drop-zone-${id}-${row} input[type=file]`,
-    attachments: [...Array(5)].map((_, idx) => ({
+    attachments: (idx) => ({
       name: `${tableSelector} > tbody > tr:nth-child(${idx + 1}) > td:nth-child(1)`,
       status: `${tableSelector} > tbody > tr:nth-child(${idx + 1}) > td:nth-child(${statusIdx})`,
       deleteBtn: `${tableSelector} > tbody > tr:nth-child(${idx + 1}) div[role=button]`,
@@ -238,7 +237,7 @@ export const makeUploaderSelectors = (
             deleteBtn: `${tableSelector} > tbody > tr:nth-child(${idx + 1}) button[class*=deleteButton]`,
           }
         : {}),
-    })),
+    }),
     addMoreBtn: `#altinn-fileuploader-${id}-${row} > button`,
     tableRowPreview:
       typeof row === 'number'

--- a/test/e2e/support/navigation.ts
+++ b/test/e2e/support/navigation.ts
@@ -144,28 +144,28 @@ const completeFormSlow: { [key in FrontendTestTask]: () => void } = {
       cy.wrap(checkbox).should('be.visible').find('input').check();
     });
     cy.addItemToGroup(1, 2, 'automation');
-    cy.get(appFrontend.group.rows[0].editBtn).click();
+    cy.get(appFrontend.group.row(0).editBtn).click();
     cy.get(appFrontend.group.editContainer).find(appFrontend.group.next).click();
-    cy.get(appFrontend.group.rows[0].uploadSingle.dropZone).selectFile(mkFile('attachment-in-single.pdf'), {
+    cy.get(appFrontend.group.row(0).uploadSingle.dropZone).selectFile(mkFile('attachment-in-single.pdf'), {
       force: true,
     });
-    cy.get(appFrontend.group.rows[0].uploadMulti.dropZone).selectFile(mkFile('attachment-in-multi1.pdf'), {
+    cy.get(appFrontend.group.row(0).uploadMulti.dropZone).selectFile(mkFile('attachment-in-multi1.pdf'), {
       force: true,
     });
-    cy.get(appFrontend.group.rows[0].uploadMulti.addMoreBtn).click();
-    cy.get(appFrontend.group.rows[0].uploadMulti.dropZone).selectFile(mkFile('attachment-in-multi2.pdf'), {
+    cy.get(appFrontend.group.row(0).uploadMulti.addMoreBtn).click();
+    cy.get(appFrontend.group.row(0).uploadMulti.dropZone).selectFile(mkFile('attachment-in-multi2.pdf'), {
       force: true,
     });
-    cy.get(appFrontend.group.rows[0].nestedGroup.rows[0].editBtn).click();
-    cy.get(appFrontend.group.rows[0].nestedGroup.rows[0].uploadTagMulti.dropZone).selectFile(
+    cy.get(appFrontend.group.row(0).nestedGroup.row(0).editBtn).click();
+    cy.get(appFrontend.group.row(0).nestedGroup.row(0).uploadTagMulti.dropZone).selectFile(
       mkFile('attachment-in-nested.pdf'),
       { force: true },
     );
-    cy.get(appFrontend.group.rows[0].nestedGroup.rows[0].uploadTagMulti.attachments[0].tagSelector || 'nothing')
+    cy.get(appFrontend.group.row(0).nestedGroup.row(0).uploadTagMulti.attachments[0].tagSelector || 'nothing')
       .should('be.visible')
       .select('altinn');
-    cy.get(appFrontend.group.rows[0].nestedGroup.rows[0].uploadTagMulti.attachments[0].tagSave || 'nothing').click();
-    cy.get(appFrontend.group.rows[0].nestedGroup.rows[0].uploadTagMulti.attachments[0].tagSelector || 'nothing').should(
+    cy.get(appFrontend.group.row(0).nestedGroup.row(0).uploadTagMulti.attachments[0].tagSave || 'nothing').click();
+    cy.get(appFrontend.group.row(0).nestedGroup.row(0).uploadTagMulti.attachments[0].tagSelector || 'nothing').should(
       'not.exist',
     );
 


### PR DESCRIPTION
## Description
1. The `saveButton` and `saveAndNextButton` properties can have expressions on them, and should be evaluated per-row.
2. When overriding text resource bindings using expressions for a group, they should also be evaluated per-row if possible.
3. Updated the group cypress test (especially the prefill one) to properly handle all prefilled rows, not just the special 'marked' one.
4. The DEFAULT_FOR_ALL_VALUES_IN_OBJ functionality in expressions did not work properly when evaluating deeper inside an object
5. When evaluating an expression, it's perfectly fine to do a "hidden": ["dataModel", "something"] if your data model contains a boolean, but that boolean was not converted/cast at the end, because the `dataModel` function returns the value cast to a string, and the boolean is a string in the data model anyway. However, we can fix this by casting to the same type as the default type (which is always the same as the expected return type, thanks to the deep resolving typescript magic).

Also: Converting the weird 'rows' with fixed lengths to be functions instead.

**NOTE:** There are accompanying changes to `frontend-test` for this as well, finally fixing the brokenness when having selected prefills for repeating groups. All other PR tests will fail until this is merged, and their branches merge/rebase from main.

## Related Issue(s)

- closes #620

## Verification

- Manual testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added
  - [x] Cypress E2E test(s) have been added
  - [ ] No automatic tests are needed here
  - [ ] I want someone to help me make some tests
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been updated
  <!--- insert link to PR here -->
  - [x] No changes/updates needed
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board <!--- If you don't have permissions for this, someone else will do it for you -->
