### PR TITLE
Fix *FIXED* bug

### DIFF
--- a/src/utils/validation/validation.test.ts
+++ b/src/utils/validation/validation.test.ts
@@ -1240,6 +1240,14 @@ describe('utils > validation', () => {
           code: '',
         },
         {
+          field: 'dataModelField_1',
+          severity: Severity.Fixed,
+          scope: null,
+          targetId: '',
+          description: 'Another error message',
+          code: '',
+        },
+        {
           field: 'dataModelField_2',
           severity: Severity.Success,
           scope: null,
@@ -1263,6 +1271,7 @@ describe('utils > validation', () => {
             simpleBinding: {
               errors: [getTextResourceByKey('Error message', [])],
               info: [getTextResourceByKey('Info message', [])],
+              fixed: [getTextResourceByKey('Another error message', [])],
             },
           },
           componentId_2: {
@@ -2523,6 +2532,21 @@ describe('utils > validation', () => {
       expect(merged.warnings).toEqual(['warning1', 'warning2', 'warning3']);
       expect(merged.info).toEqual(['info1', 'info2', 'info3']);
       expect(merged.success).toEqual(['success1', 'success2', 'success3']);
+    });
+
+    it('should remove fixed validation errors', () => {
+      const original: IComponentBindingValidation = {
+        errors: ['error1', 'error2'],
+      };
+      const newValidations: IComponentBindingValidation = {
+        errors: ['error3'],
+        fixed: ['error1'],
+      };
+
+      const merged = validation.mergeComponentBindingValidations(original, newValidations);
+
+      expect(merged.errors).toEqual(['error2', 'error3']);
+      expect(merged.fixed).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the Title above
  Describe your change(s) in detail here

  Also add the relevant label in the column on the right:
    Breaking changes: kind/breaking-change
    New features:     kind/product-feature
    Bug fixes:        kind/bug
    Dependencies:     kind/dependencies
    Other changes:    kind/other
-->

The problem seems to be that when the validations are mapped to the redux store format using `mapDataElementValidationToRedux`, it will sometimes call `mergeComponentValidations` as part of this process. This strips away the *FIXED* validations by trying to remove the errors that are supposed to be fixed. However, in this step of the process we are not yet looking at existing validation errors, so it will simply strip away the *FIXED* validations before we actually merge with the existing validations. I therefore added a `fixValidations` option (`default=true`) to the merge-functions so that it is possible to merge without applying fixed validations and simply keeping them around. This option is then set to `false` in `mapDataElementValidationToRedux`.

This seems to fix the issue in `brg/rrh-innrapportering`, but because the actual app uses some secrets to look up info on personnummer, I only tested by hacking the validation code.

## Related Issue(s)

- closes #764 

## Verification

- Manual testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added
  - [ ] Cypress E2E test(s) have been added
  - [ ] No automatic tests are needed here
  - [ ] I want someone to help me make some tests
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been updated
  <!--- insert link to PR here -->
  - [x] No changes/updates needed
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board <!--- If you don't have permissions for this, someone else will do it for you -->
