### PR TITLE
Fixing unintended line-break before help-text icon

### DIFF
--- a/src/features/form/components/HelpTextContainer.tsx
+++ b/src/features/form/components/HelpTextContainer.tsx
@@ -36,7 +36,7 @@ export function HelpTextContainer({ language, helpText }: IHelpTextContainerProp
   }
 
   return (
-    <div
+    <span
       tabIndex={-1}
       onBlur={onBlur}
     >
@@ -57,6 +57,6 @@ export function HelpTextContainer({ language, helpText }: IHelpTextContainerProp
         helpText={helpText}
         onClose={handlePopoverClose}
       />
-    </div>
+    </span>
   );
 }


### PR DESCRIPTION
## Description
In #708 a `div` element was introduced, which caused the icon to be a block-level element. Fine for those wrapping it in a `display: flex`, but caused a line-break everywhere else.

## Related Issue(s)
- https://altinn.slack.com/archives/C02EJ9HKQA3/p1671699864018289

## Verification
- Manual testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added
  - [ ] Cypress E2E test(s) have been added
  - [x] No automatic tests are needed here
  - [ ] I want someone to help me make some tests
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been updated
  <!--- insert link to PR here -->
  - [x] No changes/updates needed
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board <!--- If you don't have permissions for this, someone else will do it for you -->
