### PR TITLE
Fixing `validatePage` on stateless apps

### DIFF
--- a/src/utils/appMetadata.ts
+++ b/src/utils/appMetadata.ts
@@ -94,6 +94,10 @@ export const getCurrentTaskData = (appMetaData: IApplication, instance: IInstanc
   return instance.data.find((element) => element.dataType === currentDataTypeId);
 };
 
+/**
+ * @deprecated Prefer getCurrentDataTypeForApplication() instead, as this function should be unexported - it does
+ * not account for stateless apps.
+ */
 export const getCurrentDataTypeId = (
   appMetaData: IApplication | null,
   instance?: IInstance | null,

--- a/src/utils/validation/runClientSideValidation.ts
+++ b/src/utils/validation/runClientSideValidation.ts
@@ -1,5 +1,5 @@
 import { getLayoutOrderFromTracks } from 'src/selectors/getLayoutOrder';
-import { getCurrentDataTypeId } from 'src/utils/appMetadata';
+import { getCurrentDataTypeForApplication } from 'src/utils/appMetadata';
 import { convertDataBindingToModel } from 'src/utils/databindings';
 import { resolvedLayoutsFromState } from 'src/utils/layout/hierarchy';
 import {
@@ -36,11 +36,11 @@ export function runClientSideValidation(state: IRuntimeState): ValidationResult 
     return out;
   }
 
-  const currentDataTaskDataTypeId = getCurrentDataTypeId(
-    state.applicationMetadata.applicationMetadata,
-    state.instanceData.instance,
-    state.formLayout.layoutsets,
-  );
+  const currentDataTaskDataTypeId = getCurrentDataTypeForApplication({
+    application: state.applicationMetadata.applicationMetadata,
+    instance: state.instanceData.instance,
+    layoutSets: state.formLayout.layoutsets,
+  });
   out.model = convertDataBindingToModel(state.formData.formData);
   const validator = getValidator(currentDataTaskDataTypeId, state.formDataModel.schemas);
 

--- a/src/utils/validation/validation.ts
+++ b/src/utils/validation/validation.ts
@@ -8,7 +8,7 @@ import type { Options } from 'ajv';
 import type * as AjvCore from 'ajv/dist/core';
 
 import { Severity } from 'src/types';
-import { getCurrentDataTypeId } from 'src/utils/appMetadata';
+import { getCurrentDataTypeForApplication } from 'src/utils/appMetadata';
 import { AsciiUnitSeparator } from 'src/utils/attachment';
 import { convertDataBindingToModel, getFormDataFromFieldKey, getKeyWithoutIndex } from 'src/utils/databindings';
 import { getDateConstraint, getDateFormat } from 'src/utils/dateHelpers';
@@ -1327,11 +1327,11 @@ export function validateGroup(groupId: string, state: IRuntimeState, onlyInRowIn
     return {};
   }
 
-  const currentDataTaskDataTypeId = getCurrentDataTypeId(
-    state.applicationMetadata.applicationMetadata,
-    state.instanceData.instance,
-    state.formLayout.layoutsets,
-  );
+  const currentDataTaskDataTypeId = getCurrentDataTypeForApplication({
+    application: state.applicationMetadata.applicationMetadata,
+    instance: state.instanceData.instance,
+    layoutSets: state.formLayout.layoutsets,
+  });
   const validator = getValidator(currentDataTaskDataTypeId, state.formDataModel.schemas);
   const emptyFieldsValidations = validateEmptyFieldsForNodes(
     formData,

--- a/test/e2e/fixtures/texts.json
+++ b/test/e2e/fixtures/texts.json
@@ -15,6 +15,7 @@
   "prev": "Forrige",
   "next": "Neste",
   "requiredField": "Feltet er påkrevd",
+  "requiredFieldName": "Du må fylle ut navn",
   "requiredFieldLastName": "Du må fylle ut nytt etternavn",
   "requiredFieldDateFrom": "Du må fylle ut dato for navneendring",
   "requiredFieldFromValue": "Du må fylle ut 1. endre fra",

--- a/test/e2e/integration/app-stateless-anonymous/validation.ts
+++ b/test/e2e/integration/app-stateless-anonymous/validation.ts
@@ -1,0 +1,35 @@
+import * as texts from 'test/e2e/fixtures/texts.json';
+import AppFrontend from 'test/e2e/pageobjects/app-frontend';
+import Common from 'test/e2e/pageobjects/common';
+
+const appFrontend = new AppFrontend();
+const mui = new Common();
+
+describe('Validation in anonymous stateless app', () => {
+  beforeEach(() => {
+    cy.startAppInstance(appFrontend.apps.anonymousStateless, true);
+    cy.get(appFrontend.stateless.name).should('exist').and('be.visible');
+  });
+
+  it('Should show validation message for missing name', () => {
+    cy.get(appFrontend.stateless.name).invoke('val').should('be.empty');
+    cy.get(appFrontend.navButtons).contains(mui.button, 'next').click();
+
+    const nameError = appFrontend.fieldValidationError.replace('field', appFrontend.stateless.name.substring(1));
+
+    cy.get(appFrontend.stateless.name).should('be.visible');
+    cy.get(nameError).should('be.visible').should('have.text', texts.requiredFieldName);
+    cy.get(appFrontend.errorReport)
+      .should('be.visible')
+      .should('be.inViewport')
+      .should('contain.text', texts.errorReport)
+      .should('contain.text', texts.requiredFieldName);
+
+    cy.get(appFrontend.stateless.name).type('Hello world');
+    cy.get(nameError).should('not.exist');
+    cy.get(appFrontend.errorReport).should('not.exist');
+
+    cy.get(appFrontend.navButtons).contains(mui.button, 'next').click();
+    cy.get(appFrontend.navButtons).should('not.exist');
+  });
+});

--- a/test/e2e/support/start-app-instance.ts
+++ b/test/e2e/support/start-app-instance.ts
@@ -40,12 +40,11 @@ Cypress.Commands.add('startAppInstance', (appName, anonymous = false) => {
     }
   }).as('frontend');
 
-  cy.visit('/', visitOptions);
-
   if (Cypress.env('environment') === 'local') {
     if (anonymous) {
       cy.visit(`${Cypress.config('baseUrl')}/ttd/${appName}/`, visitOptions);
     } else {
+      cy.visit('/', visitOptions);
       cy.get(appFrontend.appSelection).select(appName);
       cy.get(appFrontend.startButton).click();
     }


### PR DESCRIPTION
## Description
The validation logic did not fetch the correct data type, and caused the JsonSchema to be undefined, crashing when triggering `validatePage`.

## Related Issue(s)
- closes #776

## Verification
- Manual testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added
  - [x] Cypress E2E test(s) have been added
  - [ ] No automatic tests are needed here
  - [ ] I want someone to help me make some tests
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been updated
  <!--- insert link to PR here -->
  - [x] No changes/updates needed
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board <!--- If you don't have permissions for this, someone else will do it for you -->
