### PR TITLE
When a summary component sets display.hideBottomBorder we don't need space for a border

### DIFF
--- a/src/components/summary/SummaryComponent.tsx
+++ b/src/components/summary/SummaryComponent.tsx
@@ -27,11 +27,9 @@ export interface ISummaryComponent extends Omit<ILayoutCompSummary, 'type'> {
 }
 
 const useStyles = makeStyles({
-  row: {
+  border: {
     marginBottom: 10,
     paddingBottom: 10,
-  },
-  border: {
     borderBottom: '1px dashed #008FD6',
   },
   link: {
@@ -171,7 +169,7 @@ export function SummaryComponent({ id, grid, ...summaryProps }: ISummaryComponen
     >
       <Grid
         container={true}
-        className={cn(classes.row, {
+        className={cn({
           [classes.border]: !display?.hideBottomBorder,
         })}
       >


### PR DESCRIPTION
After giving `Header` components a custom look in https://github.com/Altinn/app-frontend-react/pull/725 I got new complaints about the blue line under the header.

![image](https://user-images.githubusercontent.com/131616/209765625-dee7a45c-5594-41b5-969a-5430f61a019f.png)

There is an existing config `display.hideBottomBorder` (introduced in https://github.com/Altinn/app-frontend-react/pull/489 without docs) that can be set on `Summary` components, to remove the line. Personally I think removing the line should be default for headers, but it's in a different component, so a `if(component.type == "Summary")` would be needed in another file, and I think we should find better solutions (eg. a `const hideBottomBorder = component.hideBottomBorder ?? component.componentTypeDefaults.summary.display.hideBottomBorder`).

This PR removes the extra spacing that is required for the blue dashed line when the blue dashed line is removed. I'm not sure if this extra spacing might be required in other instances, but it looks strange with header components.

![image](https://user-images.githubusercontent.com/131616/209767275-6596097c-53f0-4730-86ce-0098574cff93.png)


## Related Issue(s)
- https://github.com/Altinn/app-frontend-react/pull/725
- https://github.com/Altinn/app-frontend-react/pull/489

## Verification

- Manual testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added
  - [ ] Cypress E2E test(s) have been added
  - [x] No automatic tests are needed here
  - [ ] I want someone to help me make some tests
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been updated
  <!--- insert link to PR here -->
  - [x] No changes/updates needed
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board <!--- If you don't have permissions for this, someone else will do it for you -->
