### PR TITLE
Adding test for hidden components in group summary + bugfix

### DIFF
--- a/src/features/form/layout/formLayoutSlice.ts
+++ b/src/features/form/layout/formLayoutSlice.ts
@@ -1,5 +1,7 @@
-import { put } from 'redux-saga/effects';
+import { put, takeLatest } from 'redux-saga/effects';
+import type { SagaIterator } from 'redux-saga';
 
+import { FormDataActions } from 'src/features/form/data/formDataSlice';
 import {
   fetchLayoutSetsSaga,
   watchFetchFormLayoutSaga,
@@ -8,13 +10,13 @@ import {
 import {
   calculatePageOrderAndMoveToNextPageSaga,
   findAndMoveToNextVisibleLayout,
+  initRepeatingGroupsSaga,
   updateCurrentViewSaga,
   updateFileUploaderWithTagChosenOptionsSaga,
   updateFileUploaderWithTagEditIndexSaga,
   updateRepeatingGroupEditIndexSaga,
   updateRepeatingGroupsSaga,
   watchInitialCalculatePageOrderAndMoveToNextPageSaga,
-  watchInitRepeatingGroupsSaga,
   watchMapFileUploaderWithTagSaga,
 } from 'src/features/form/layout/update/updateFormLayoutSagas';
 import { DataListsActions } from 'src/shared/resources/dataLists/dataListsSlice';
@@ -322,7 +324,14 @@ const formLayoutSlice = createSagaSlice((mkAction: MkActionType<ILayoutState>) =
       },
     }),
     initRepeatingGroups: mkAction<void>({
-      saga: () => watchInitRepeatingGroupsSaga,
+      takeEvery: initRepeatingGroupsSaga,
+      saga: () =>
+        function* (): SagaIterator {
+          yield takeLatest(
+            [FormDataActions.fetchFulfilled, FormLayoutActions.initRepeatingGroups, FormLayoutActions.fetchFulfilled],
+            initRepeatingGroupsSaga,
+          );
+        },
     }),
     clearKeepScrollPos: mkAction<void>({
       reducer: (state) => {

--- a/src/features/form/layout/update/updateFormLayoutSagas.test.ts
+++ b/src/features/form/layout/update/updateFormLayoutSagas.test.ts
@@ -1,6 +1,6 @@
 import mockAxios from 'jest-mock-axios';
 import { select, take } from 'redux-saga/effects';
-import { expectSaga, testSaga } from 'redux-saga-test-plan';
+import { expectSaga } from 'redux-saga-test-plan';
 import type { PayloadAction } from '@reduxjs/toolkit';
 
 import { getInitialStateMock } from 'src/__mocks__/initialStateMock';
@@ -10,7 +10,6 @@ import { FormLayoutActions } from 'src/features/form/layout/formLayoutSlice';
 import {
   calculatePageOrderAndMoveToNextPageSaga,
   findAndMoveToNextVisibleLayout,
-  initRepeatingGroupsSaga,
   selectAllLayouts,
   selectAttachmentState,
   selectCurrentLayout,
@@ -19,7 +18,6 @@ import {
   selectOptions,
   selectValidations,
   updateRepeatingGroupsSaga,
-  watchInitRepeatingGroupsSaga,
 } from 'src/features/form/layout/update/updateFormLayoutSagas';
 import { ValidationActions } from 'src/features/form/validation/validationSlice';
 import { selectLayoutOrder } from 'src/selectors/getLayoutOrder';
@@ -38,24 +36,6 @@ import type { IRuntimeState } from 'src/types';
 describe('updateLayoutSagas', () => {
   beforeEach(() => {
     mockAxios.reset();
-  });
-
-  describe('watchInitRepeatingGroupsSaga', () => {
-    it('should wait for layout, then wait trigger on relevant actions', () => {
-      const saga = testSaga(watchInitRepeatingGroupsSaga);
-      saga
-        .next()
-        .take(FormLayoutActions.fetchFulfilled)
-        .next()
-        .call(initRepeatingGroupsSaga)
-        .next()
-        .takeLatest(
-          [FormDataActions.fetchFulfilled, FormLayoutActions.initRepeatingGroups, FormLayoutActions.fetchFulfilled],
-          initRepeatingGroupsSaga,
-        )
-        .next()
-        .isDone();
-    });
   });
 
   describe('updateRepeatingGroupsSaga', () => {

--- a/src/features/form/layout/update/updateFormLayoutSagas.ts
+++ b/src/features/form/layout/update/updateFormLayoutSagas.ts
@@ -30,7 +30,7 @@ import {
 } from 'src/utils/formLayout';
 import { getLayoutsetForDataElement } from 'src/utils/layout';
 import { getOptionLookupKey, removeGroupOptionsByIndex } from 'src/utils/options';
-import { waitFor } from 'src/utils/sagas';
+import { selectNotNull, waitFor } from 'src/utils/sagas';
 import { get, post } from 'src/utils/sharedUtils';
 import { getCalculatePageOrderUrl, getDataValidationUrl } from 'src/utils/urls/appUrlHelper';
 import {
@@ -656,10 +656,10 @@ export function* updateRepeatingGroupEditIndexSaga({
 }
 
 export function* initRepeatingGroupsSaga(): SagaIterator {
+  const layouts = yield selectNotNull(selectFormLayouts);
   const formDataState: IFormDataState = yield select(selectFormData);
   const state: IRuntimeState = yield select();
   const currentGroups = state.formLayout.uiConfig.repeatingGroups || {};
-  const layouts = yield select(selectFormLayouts);
   let newGroups: IRepeatingGroups = {};
   Object.keys(layouts).forEach((layoutKey: string) => {
     newGroups = {
@@ -728,15 +728,7 @@ export function* initRepeatingGroupsSaga(): SagaIterator {
       repeatingGroups: newGroups,
     }),
   );
-}
-
-export function* watchInitRepeatingGroupsSaga(): SagaIterator {
-  yield take(FormLayoutActions.fetchFulfilled);
-  yield call(initRepeatingGroupsSaga);
-  yield takeLatest(
-    [FormDataActions.fetchFulfilled, FormLayoutActions.initRepeatingGroups, FormLayoutActions.fetchFulfilled],
-    initRepeatingGroupsSaga,
-  );
+  yield put(FormDynamicsActions.checkIfConditionalRulesShouldRun({}));
 }
 
 export function* updateFileUploaderWithTagEditIndexSaga({

--- a/test/e2e/integration/app-frontend/summary.ts
+++ b/test/e2e/integration/app-frontend/summary.ts
@@ -195,6 +195,52 @@ describe('Summary', () => {
         cy.wrap(item).eq(5).should('contain.text', `${texts.nestedOption2}, ${texts.nestedOption3}`);
       });
 
+    cy.get(appFrontend.navMenu).find('li > button').first().click();
+    cy.get(appFrontend.group.prefill.liten).click().blur();
+    cy.get(appFrontend.group.prefill.middels).click().blur();
+    cy.get(appFrontend.group.prefill.svaer).click().blur();
+    cy.get(appFrontend.navMenu).find('li > button').last().click();
+
+    function assertSummaryItem(groupRow: number, items: { [key: string]: boolean }) {
+      cy.get(appFrontend.group.mainGroupSummary)
+        .eq(groupRow)
+        .then((row) => {
+          for (const item of Object.keys(items)) {
+            const shouldExist = items[item];
+            cy.wrap(row)
+              .find(`[data-testid="summary-${item}"]`)
+              .should(shouldExist ? 'be.visible' : 'not.exist');
+          }
+        });
+    }
+
+    const regularRow = {
+      'currentValue-summary': true,
+      'newValue-summary': true,
+      'mainUploaderSingle-summary': true,
+      'mainUploaderMulti-summary': true,
+      'subGroup-summary-group': true,
+    };
+
+    // Rows that come from prefill have their uploaders removed, so these should be hidden
+    const prefillRow = {
+      ...regularRow,
+      'mainUploaderSingle-summary': false,
+      'mainUploaderMulti-summary': false,
+    };
+
+    // Rows that come from prefill AND have a 'currentValue' above 100 have their subGroup removed
+    const prefillRowAbove100 = {
+      ...prefillRow,
+      'subGroup-summary-group': false,
+    };
+
+    cy.get(appFrontend.group.mainGroupSummary).should('have.length', 4);
+    assertSummaryItem(0, regularRow);
+    assertSummaryItem(1, prefillRow);
+    assertSummaryItem(2, prefillRowAbove100);
+    assertSummaryItem(3, prefillRowAbove100);
+
     // Hiding the group should hide the group summary as well
     cy.get('[data-testid=summary-summary-1]').should('be.visible');
     cy.get(appFrontend.navMenu).find('li > button').eq(1).click();


### PR DESCRIPTION
## Description
Adding a test for the functionality described in #503. When adding this test, I found a bug where my prefill-checkboxes (which uses server-side code to add rows to the repeating group) did not correctly re-calculate hidden fields (because it did not call `checkIfConditionalRulesShouldRun` after re-calculating repeating groups). Fixing that as well. 

## Related Issue(s)
- closes #503

## Verification
- Manual testing
  - [x] I have tested these changes manually
  - [x] Creator of the original issue (or service owner) has been contacted for manual testing
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added
  - [x] Cypress E2E test(s) have been added
  - [ ] No automatic tests are needed here
  - [ ] I want someone to help me make some tests
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been updated
  <!--- insert link to PR here -->
  - [x] No changes/updates needed
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board <!--- If you don't have permissions for this, someone else will do it for you -->
