### PR TITLE
`instanceOwnerPartyType` lookup in expressions

### DIFF
--- a/src/features/expressions/index.ts
+++ b/src/features/expressions/index.ts
@@ -256,6 +256,7 @@ const instanceContextKeys: { [key in keyof IInstanceContext]: true } = {
   instanceId: true,
   appId: true,
   instanceOwnerPartyId: true,
+  instanceOwnerPartyType: true,
 };
 
 /**

--- a/src/features/expressions/shared-tests/functions/instanceContext/only-dict.json
+++ b/src/features/expressions/shared-tests/functions/instanceContext/only-dict.json
@@ -2,7 +2,7 @@
   "name": "Only works on one level (as a dictionary)",
   "expression": ["equals", ["instanceContext", "deep.key"], null],
   "expectsFailure": "Unknown Instance context property deep.key",
-  "instanceContext": {
+  "instance": {
     "deep": {
       "key": "should not be found"
     }

--- a/src/features/expressions/shared-tests/functions/instanceContext/partyTypeOrg.json
+++ b/src/features/expressions/shared-tests/functions/instanceContext/partyTypeOrg.json
@@ -1,0 +1,13 @@
+{
+  "name": "PartyType is Org",
+  "expression": ["instanceContext", "instanceOwnerPartyType"],
+  "expects": "org",
+  "instance": {
+    "id": "d00ce51c-800b-416a-a906-ccab55f597e9",
+    "appId": "org/app-name",
+    "instanceOwner": {
+      "partyId": "12345",
+      "organisationNumber": "1234567"
+    }
+  }
+}

--- a/src/features/expressions/shared-tests/functions/instanceContext/partyTypePerson.json
+++ b/src/features/expressions/shared-tests/functions/instanceContext/partyTypePerson.json
@@ -1,0 +1,13 @@
+{
+  "name": "PartyType is Person",
+  "expression": ["instanceContext", "instanceOwnerPartyType"],
+  "expects": "person",
+  "instance": {
+    "id": "d00ce51c-800b-416a-a906-ccab55f597e9",
+    "appId": "org/app-name",
+    "instanceOwner": {
+      "partyId": "12345",
+      "personNumber": "1234567"
+    }
+  }
+}

--- a/src/features/expressions/shared-tests/functions/instanceContext/partyTypeSelfIdentified.json
+++ b/src/features/expressions/shared-tests/functions/instanceContext/partyTypeSelfIdentified.json
@@ -1,0 +1,13 @@
+{
+  "name": "PartyType is Self Identified",
+  "expression": ["instanceContext", "instanceOwnerPartyType"],
+  "expects": "selfIdentified",
+  "instance": {
+    "id": "d00ce51c-800b-416a-a906-ccab55f597e9",
+    "appId": "org/app-name",
+    "instanceOwner": {
+      "partyId": "12345",
+      "userName": "1234567"
+    }
+  }
+}

--- a/src/features/expressions/shared-tests/functions/instanceContext/partyTypeSelfIdentified.json
+++ b/src/features/expressions/shared-tests/functions/instanceContext/partyTypeSelfIdentified.json
@@ -7,7 +7,7 @@
     "appId": "org/app-name",
     "instanceOwner": {
       "partyId": "12345",
-      "userName": "1234567"
+      "username": "1234567"
     }
   }
 }

--- a/src/features/expressions/shared-tests/functions/instanceContext/partyTypeUnknown.json
+++ b/src/features/expressions/shared-tests/functions/instanceContext/partyTypeUnknown.json
@@ -1,7 +1,7 @@
 {
-  "name": "Looking up null",
-  "expression": ["instanceContext", null],
-  "expectsFailure": "Unknown Instance context property ",
+  "name": "Party type unknown",
+  "expression": ["instanceContext", "instanceOwnerPartyType"],
+  "expects": "unknown",
   "instance": {
     "id": "d00ce51c-800b-416a-a906-ccab55f597e9",
     "appId": "org/app-name",

--- a/src/features/expressions/shared-tests/functions/instanceContext/simple-lookup-equals.json
+++ b/src/features/expressions/shared-tests/functions/instanceContext/simple-lookup-equals.json
@@ -6,9 +6,11 @@
     ["instanceContext", "appId"]
   ],
   "expects": false,
-  "instanceContext": {
-    "instanceId": "d00ce51c-800b-416a-a906-ccab55f597e9",
+  "instance": {
+    "id": "d00ce51c-800b-416a-a906-ccab55f597e9",
     "appId": "org/app-name",
-    "instanceOwnerPartyId": "12345"
+    "instanceOwner": {
+      "partyId": "12345"
+    }
   }
 }

--- a/src/features/expressions/shared-tests/functions/instanceContext/simple-lookup-is-null.json
+++ b/src/features/expressions/shared-tests/functions/instanceContext/simple-lookup-is-null.json
@@ -2,9 +2,11 @@
   "name": "Simple lookup for non-existing key equals null",
   "expression": ["equals", ["instanceContext", "doesNotExist"], null],
   "expectsFailure": "Unknown Instance context property doesNotExist",
-  "instanceContext": {
-    "instanceId": "d00ce51c-800b-416a-a906-ccab55f597e9",
+  "instance": {
+    "id": "d00ce51c-800b-416a-a906-ccab55f597e9",
     "appId": "org/app-name",
-    "instanceOwnerPartyId": "12345"
+    "instanceOwner": {
+      "partyId": "12345"
+    }
   }
 }

--- a/src/features/expressions/shared-tests/functions/instanceContext/simple-lookup.json
+++ b/src/features/expressions/shared-tests/functions/instanceContext/simple-lookup.json
@@ -2,9 +2,11 @@
   "name": "Simple lookup",
   "expression": ["instanceContext", "appId"],
   "expects": "org/app-name",
-  "instanceContext": {
-    "instanceId": "d00ce51c-800b-416a-a906-ccab55f597e9",
+  "instance": {
+    "id": "d00ce51c-800b-416a-a906-ccab55f597e9",
     "appId": "org/app-name",
-    "instanceOwnerPartyId": "12345"
+    "instanceOwner": {
+      "partyId": "12345"
+    }
   }
 }

--- a/src/features/expressions/shared.test.ts
+++ b/src/features/expressions/shared.test.ts
@@ -5,12 +5,13 @@ import { NodeNotFoundWithoutContext } from 'src/features/expressions/errors';
 import { convertLayouts, getSharedTests } from 'src/features/expressions/shared';
 import { asExpression } from 'src/features/expressions/validation';
 import { getRepeatingGroups, splitDashedKey } from 'src/utils/formLayout';
+import { buildInstanceContext } from 'src/utils/instanceContext';
 import { nodesInLayouts, resolvedNodesInLayouts } from 'src/utils/layout/hierarchy';
 import type { ContextDataSources } from 'src/features/expressions/ExprContext';
 import type { FunctionTest, SharedTestContext, SharedTestContextList } from 'src/features/expressions/shared';
 import type { Expression } from 'src/features/expressions/types';
 import type { IRepeatingGroups } from 'src/types';
-import type { IApplicationSettings, IInstanceContext } from 'src/types/shared';
+import type { IApplicationSettings } from 'src/types/shared';
 import type { LayoutNode, LayoutRootNodeCollection } from 'src/utils/layout/hierarchy';
 
 function findComponent(context: FunctionTest['context'], collection: LayoutRootNodeCollection<any>) {
@@ -43,10 +44,10 @@ describe('Expressions shared function tests', () => {
   describe.each(sharedTests.content)('Function: $folderName', (folder) => {
     it.each(folder.content)(
       '$name',
-      ({ expression, expects, expectsFailure, context, layouts, dataModel, instanceContext, frontendSettings }) => {
+      ({ expression, expects, expectsFailure, context, layouts, dataModel, instance, frontendSettings }) => {
         const dataSources: ContextDataSources = {
           formData: dataModel ? dot.dot(dataModel) : {},
-          instanceContext: instanceContext || ({} as IInstanceContext),
+          instanceContext: buildInstanceContext(instance),
           applicationSettings: frontendSettings || ({} as IApplicationSettings),
           hiddenFields: new Set<string>(),
         };
@@ -129,10 +130,10 @@ describe('Expressions shared context tests', () => {
   }
 
   describe.each(sharedTests.content)('$folderName', (folder) => {
-    it.each(folder.content)('$name', ({ layouts, dataModel, instanceContext, frontendSettings, expectedContexts }) => {
+    it.each(folder.content)('$name', ({ layouts, dataModel, instance, frontendSettings, expectedContexts }) => {
       const dataSources: ContextDataSources = {
         formData: dataModel ? dot.dot(dataModel) : {},
-        instanceContext: instanceContext || ({} as IInstanceContext),
+        instanceContext: buildInstanceContext(instance),
         applicationSettings: frontendSettings || ({} as IApplicationSettings),
         hiddenFields: new Set(),
       };

--- a/src/features/expressions/shared.ts
+++ b/src/features/expressions/shared.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 
 import type { Expression } from 'src/features/expressions/types';
 import type { ILayout, ILayouts } from 'src/layout/layout';
-import type { IApplicationSettings, IInstanceContext } from 'src/types/shared';
+import type { IApplicationSettings, IInstance } from 'src/types/shared';
 
 export interface Layouts {
   [key: string]: {
@@ -18,7 +18,7 @@ export interface SharedTest {
   name: string;
   layouts?: Layouts;
   dataModel?: any;
-  instanceContext?: IInstanceContext;
+  instance?: IInstance;
   frontendSettings?: IApplicationSettings;
 }
 

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -110,6 +110,7 @@ export interface IInstanceOwner {
   partyId: string;
   personNumber?: string;
   organisationNumber?: string | null;
+  userName?: string;
 }
 
 export interface IInstanceState {
@@ -261,9 +262,12 @@ export interface IApplicationSettings {
   [source: string]: string;
 }
 
+export type InstanceOwnerPartyType = 'unknown' | 'org' | 'person' | 'selfIdentified';
+
 /** Describes an object with key values from current instance to be used in texts. */
 export interface IInstanceContext {
   instanceId: string;
   appId: string;
   instanceOwnerPartyId: string;
+  instanceOwnerPartyType: InstanceOwnerPartyType;
 }

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -110,7 +110,7 @@ export interface IInstanceOwner {
   partyId: string;
   personNumber?: string;
   organisationNumber?: string | null;
-  userName?: string;
+  username?: string;
 }
 
 export interface IInstanceState {

--- a/src/utils/instanceContext.test.ts
+++ b/src/utils/instanceContext.test.ts
@@ -18,6 +18,7 @@ describe('instanceContext', () => {
       appId: appId,
       instanceId: instaceId,
       instanceOwnerPartyId: partyId,
+      instanceOwnerPartyType: 'unknown',
     };
     const actual = buildInstanceContext(mockInstance);
 

--- a/src/utils/instanceContext.ts
+++ b/src/utils/instanceContext.ts
@@ -13,7 +13,7 @@ export function buildInstanceContext(instance?: IInstance | null): IInstanceCont
     ? 'org'
     : instance.instanceOwner.personNumber
     ? 'person'
-    : instance.instanceOwner.userName
+    : instance.instanceOwner.username
     ? 'selfIdentified'
     : 'unknown';
 

--- a/src/utils/instanceContext.ts
+++ b/src/utils/instanceContext.ts
@@ -9,11 +9,19 @@ export function buildInstanceContext(instance?: IInstance | null): IInstanceCont
   if (!instance) {
     return null;
   }
+  const instanceOwnerPartyType = instance.instanceOwner.organisationNumber
+    ? 'org'
+    : instance.instanceOwner.personNumber
+    ? 'person'
+    : instance.instanceOwner.userName
+    ? 'selfIdentified'
+    : 'unknown';
 
   return {
     appId: instance.appId,
     instanceId: instance.id,
     instanceOwnerPartyId: instance.instanceOwner.partyId,
+    instanceOwnerPartyType,
   };
 }
 

--- a/src/utils/instanceContext.ts
+++ b/src/utils/instanceContext.ts
@@ -6,7 +6,7 @@ import type { IInstance, IInstanceContext } from 'src/types/shared';
 const getInstance = (state: IRuntimeState) => state.instanceData.instance;
 
 export function buildInstanceContext(instance?: IInstance | null): IInstanceContext | null {
-  if (!instance) {
+  if (!instance || !instance.instanceOwner) {
     return null;
   }
   const instanceOwnerPartyType = instance.instanceOwner.organisationNumber
@@ -20,7 +20,7 @@ export function buildInstanceContext(instance?: IInstance | null): IInstanceCont
   return {
     appId: instance.appId,
     instanceId: instance.id,
-    instanceOwnerPartyId: instance.instanceOwner.partyId,
+    instanceOwnerPartyId: instance.instanceOwner?.partyId,
     instanceOwnerPartyType,
   };
 }

--- a/src/utils/layout/hierarchy.test.ts
+++ b/src/utils/layout/hierarchy.test.ts
@@ -519,6 +519,7 @@ describe('Hierarchical layout tools', () => {
         instanceId: 'test',
         instanceOwnerPartyId: 'test',
         appId: 'test',
+        instanceOwnerPartyType: 'unknown',
       },
       applicationSettings: {},
       hiddenFields: new Set(),


### PR DESCRIPTION
Add property `["instanceContext", "instanceOwnerPartyType"]` so that dynamic expression can reference the type of instance owner.

## Related Issue(s)

- closes https://github.com/Altinn/app-frontend-react/issues/794

## Remaining tasks (I think it should be possible approve the addition of functionality before I actually do all the work)
- [x] implement in backend app-lib-dotnet
- [x] Implement a few simple shared test to ensure that it works the same in frontend and backend
- [x] Add documentation
- [x] Ensure that this new enum is correct with how instanceOwner is intended to work. (consider adding an enum in the datamodel for InstanceOwner in backend as well)

## Verification

- Manual testing
  - [x] I have tested these changes manually
  - [x] Creator of the original issue (or service owner) has been contacted for manual testing
- Automated tests
  - [x] Unit test(s) have been added
  - [ ] Cypress E2E test(s) have been added
  - [ ] No automatic tests are needed here
  - [ ] I want someone to help me make some tests
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [x] Has been updated
  - https://github.com/Altinn/altinn-studio-docs/pull/790
- Changes/additions to component properties
  - [x] No changes made
- Support in Altinn Studio
  - [x] This change/feature does not require any changes to Altinn Studio (sadly, studio does not yet support expressions)
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board <!--- If you don't have permissions for this, someone else will do it for you -->
