### PR TITLE
Design system v0.25.13 with map component changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "webpack-dev-server": "4.11.1"
   },
   "dependencies": {
-    "@altinn/altinn-design-system": "0.25.11",
+    "@altinn/altinn-design-system": "0.25.13",
     "@babel/polyfill": "7.12.1",
     "@date-io/moment": "1.3.13",
     "@material-ui/core": "4.12.4",

--- a/src/layout/Map/MapComponent.tsx
+++ b/src/layout/Map/MapComponent.tsx
@@ -4,6 +4,7 @@ import { Map } from '@altinn/altinn-design-system';
 import { makeStyles, Typography } from '@material-ui/core';
 import type { Location } from '@altinn/altinn-design-system';
 
+import { markerIcon } from 'src/layout/Map/MapIcons';
 import { getLanguageFromKey, getParsedLanguageFromKey } from 'src/utils/sharedUtils';
 import type { PropsFromGenericComponent } from 'src/layout';
 
@@ -46,6 +47,7 @@ export function MapComponent({
         markerLocation={location}
         readOnly={readOnly}
         onClick={handleMapClicked}
+        markerIcon={markerIcon}
       />
       <Typography className={classes.footer}>{footerText}</Typography>
     </div>

--- a/src/layout/Map/MapComponentSummary.tsx
+++ b/src/layout/Map/MapComponentSummary.tsx
@@ -5,6 +5,7 @@ import { Typography } from '@material-ui/core';
 
 import { useAppSelector } from 'src/common/hooks';
 import { parseLocation, useStyles } from 'src/layout/Map/MapComponent';
+import { markerIcon } from 'src/layout/Map/MapIcons';
 import { getLanguageFromKey, getParsedLanguageFromKey } from 'src/utils/sharedUtils';
 import type { ILayoutCompMap } from 'src/layout/Map/types';
 
@@ -35,6 +36,7 @@ function MapComponentSummary({ component, formData }: IMapComponentSummary) {
           centerLocation={location}
           zoom={16}
           markerLocation={location}
+          markerIcon={markerIcon}
         />
       )}
       <Typography className={classes.footer}>{footerText}</Typography>

--- a/src/layout/Map/MapIcons.ts
+++ b/src/layout/Map/MapIcons.ts
@@ -1,0 +1,13 @@
+import Marker from 'leaflet/dist/images/marker-icon.png';
+import RetinaMarker from 'leaflet/dist/images/marker-icon-2x.png';
+import MarkerShadow from 'leaflet/dist/images/marker-shadow.png';
+import type { Map } from '@altinn/altinn-design-system';
+
+type MapProps = Parameters<typeof Map>[0];
+export const markerIcon: MapProps['markerIcon'] = {
+  iconUrl: Marker,
+  iconRetinaUrl: RetinaMarker,
+  shadowUrl: MarkerShadow,
+  iconSize: [25, 41],
+  iconAnchor: [12, 41],
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,9 +12,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@altinn/altinn-design-system@npm:0.25.11":
-  version: 0.25.11
-  resolution: "@altinn/altinn-design-system@npm:0.25.11"
+"@altinn/altinn-design-system@npm:0.25.13":
+  version: 0.25.13
+  resolution: "@altinn/altinn-design-system@npm:0.25.13"
   dependencies:
     "@altinn/figma-design-tokens": ^5.0.0
     "@navikt/ds-icons": ^2.0.0
@@ -25,7 +25,7 @@ __metadata:
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 97a9f2c4755ad6124d04150b594b49eb1255e95d5315f2d4e1158e99cd7ab7288cd512b898ce7790156caf2a2a914456218cf373431de280957ed40a2ab43b32
+  checksum: b86fca099112f208bfbd15a835eafefb7ce6b51f6073799746ab10bbcc56a919140501e2fdf6fdb00ab6ce721da1900db76775c9f816f27e4d4f5a7bc7a6a1ba
   languageName: node
   linkType: hard
 
@@ -5214,7 +5214,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "app-frontend-react@workspace:."
   dependencies:
-    "@altinn/altinn-design-system": 0.25.11
+    "@altinn/altinn-design-system": 0.25.13
     "@babel/core": 7.20.7
     "@babel/polyfill": 7.12.1
     "@babel/preset-env": 7.20.2


### PR DESCRIPTION
## Description
When upgrading the design system to v0.25.13, because of https://github.com/Altinn/altinn-design-system/pull/250, some changes are needed to the map component for it to still load images (such as the marker icon).

These changes are needed in order for the design system to be easier to use for others, such as OED (as they don't need the map component, and they don't want to have to support bundling `.png` image files in their webpack configuration just for that component which they don't need).

## Related Issue(s)
- https://github.com/Altinn/altinn-design-system/pull/215
- https://github.com/Altinn/altinn-design-system/pull/216
- https://github.com/Altinn/altinn-design-system/pull/250

## Verification
- Manual testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added
  - [ ] Cypress E2E test(s) have been added
  - [x] No automatic tests are needed here
  - [ ] I want someone to help me make some tests
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been updated
  <!--- insert link to PR here -->
  - [x] No changes/updates needed
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board <!--- If you don't have permissions for this, someone else will do it for you -->
