### PR TITLE
Null check empty optionLabel from repeating group

### DIFF
--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -122,11 +122,13 @@ export function setupSourceOptions({
 
   const options: IOption[] = [];
   for (let i = 0; i <= repGroup.index; i++) {
-    const option: IOption = {
-      label: replacedOptionLabels[i + 1].value,
-      value: replaceOptionDataField(relevantFormData, source.value, i),
-    };
-    options.push(option);
+    if (typeof replacedOptionLabels[i + 1]?.value !== 'undefined') {
+      const option: IOption = {
+        label: replacedOptionLabels[i + 1].value,
+        value: replaceOptionDataField(relevantFormData, source.value, i),
+      };
+      options.push(option);
+    }
   }
   return options;
 }


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the Title above
  Describe your change(s) in detail here

  Also add the relevant label in the column on the right:
    Breaking changes: kind/breaking-change
    New features:     kind/product-feature
    Bug fixes:        kind/bug
    Dependencies:     kind/dependencies
    Other changes:    kind/other
-->
When using a repeating group as a source for options, there was a bug where adding a new element to the source repeating group would cause a crash because of a missing null check. This is because it would iterate over the length of the repeating group, and when a new element is added, the length (repeatingGroupIndex) is incremented before any new data is added. This caused a `cannot read properties of undefined` exception. Fixed by a simple null check on the option to be added.

Confirmed that the fix works in `ra0244-01`.

## Related Issue(s)

- https://altinn.slack.com/archives/C02EVE4RU82/p1672816833823229

## Verification

- Manual testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added
  - [ ] Cypress E2E test(s) have been added
  - [x] No automatic tests are needed here
  - [ ] I want someone to help me make some tests
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been updated
  <!--- insert link to PR here -->
  - [x] No changes/updates needed
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board <!--- If you don't have permissions for this, someone else will do it for you -->
