### PR TITLE
Add customreceipt as alternative to simplereceipt

### DIFF
--- a/src/features/receipt/containers/ReceiptContainer.tsx
+++ b/src/features/receipt/containers/ReceiptContainer.tsx
@@ -146,12 +146,15 @@ const ReceiptContainer = () => {
                 pdf={pdf || undefined}
               />
             ))}
-          {applicationMetadata.autoDeleteOnProcessEnd && (
-            <AltinnReceiptSimple
-              body={getTextFromAppOrDefault('receipt.body_simple', textResources, language, undefined, false)}
-              title={getTextFromAppOrDefault('receipt.title', textResources, language)}
-            />
-          )}
+          {applicationMetadata.autoDeleteOnProcessEnd &&
+            (receiptLayoutName && layouts.includes(receiptLayoutName) ? (
+              <CustomReceipt />
+            ) : (
+              <AltinnReceiptSimple
+                body={getTextFromAppOrDefault('receipt.body_simple', textResources, language, undefined, false)}
+                title={getTextFromAppOrDefault('receipt.title', textResources, language)}
+              />
+            ))}
           <ReadyForPrint />
         </>
       ) : (


### PR DESCRIPTION
## Description
Add customReceipt component as an alternative to simpleReceipt when `autodeleteonprocessend` is enabled. 

## Related Issue(s)

- closes [#9548](https://github.com/Altinn/altinn-studio/issues/9548)

## Verification

- Manual testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added
  - [ ] Cypress E2E test(s) have been added
  - [ ] No automatic tests are needed here
  - [ ] I want someone to help me make some tests
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been updated
  <!--- insert link to PR here -->
  - [ ] No changes/updates needed
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [ ] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board <!--- If you don't have permissions for this, someone else will do it for you -->
