### PR TITLE
Fetch PDF format from backend

### DIFF
--- a/src/features/pdf/AutomaticPDFLayout.tsx
+++ b/src/features/pdf/AutomaticPDFLayout.tsx
@@ -39,6 +39,7 @@ const renderComponents = new Set([...summaryComponents, ...presentationComponent
 interface IAutomaticPDFLayout {
   layouts: ILayouts;
   pdfFormat: IPdfFormat;
+  pageOrder: string[];
   hidden: string[];
 }
 
@@ -74,7 +75,7 @@ const AutomaticPDFSummaryComponent = ({
   }
 };
 
-const AutomaticPDFLayout = ({ layouts, pdfFormat, hidden }: IAutomaticPDFLayout) => {
+const AutomaticPDFLayout = ({ layouts, pdfFormat, pageOrder, hidden }: IAutomaticPDFLayout) => {
   const excludedPages = new Set(pdfFormat.excludedPages);
   const excludedComponents = new Set(pdfFormat.excludedComponents);
   const hiddenPages = new Set(hidden);
@@ -82,8 +83,8 @@ const AutomaticPDFLayout = ({ layouts, pdfFormat, hidden }: IAutomaticPDFLayout)
   const layoutAndComponents = Object.entries(layouts as ILayouts)
     .filter(([pageRef]) => !excludedPages.has(pageRef))
     .filter(([pageRef]) => !hiddenPages.has(pageRef))
-    .filter(([pageRef]) => pdfFormat.pageOrder.includes(pageRef))
-    .sort(([pA], [pB]) => pdfFormat.pageOrder.indexOf(pA) - pdfFormat.pageOrder.indexOf(pB))
+    .filter(([pageRef]) => pageOrder.includes(pageRef))
+    .sort(([pA], [pB]) => pageOrder.indexOf(pA) - pageOrder.indexOf(pB))
     .map(([pageRef, layout]: [string, ILayoutComponentOrGroup[]]) => [
       pageRef,
       topLevelComponents(layout).filter((c) => renderComponents.has(c.type) && !excludedComponents.has(c.id)),

--- a/src/features/pdf/AutomaticPDFLayout.tsx
+++ b/src/features/pdf/AutomaticPDFLayout.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import type { IPdfFormat } from '.';
+
 import { SummaryComponent } from 'src/components/summary/SummaryComponent';
 import css from 'src/features/pdf/PDFView.module.css';
 import { GenericComponent } from 'src/layout/GenericComponent';
@@ -36,10 +38,8 @@ const renderComponents = new Set([...summaryComponents, ...presentationComponent
 
 interface IAutomaticPDFLayout {
   layouts: ILayouts;
-  excludePageFromPdf: Set<string>;
-  excludeComponentFromPdf: Set<string>;
-  pageOrder: string[];
-  hiddenPages: Set<string>;
+  pdfFormat: IPdfFormat;
+  hidden: string[];
 }
 
 const AutomaticPDFSummaryComponent = ({
@@ -74,21 +74,19 @@ const AutomaticPDFSummaryComponent = ({
   }
 };
 
-const AutomaticPDFLayout = ({
-  layouts,
-  excludePageFromPdf,
-  excludeComponentFromPdf,
-  pageOrder,
-  hiddenPages,
-}: IAutomaticPDFLayout) => {
+const AutomaticPDFLayout = ({ layouts, pdfFormat, hidden }: IAutomaticPDFLayout) => {
+  const excludedPages = new Set(pdfFormat.excludedPages);
+  const excludedComponents = new Set(pdfFormat.excludedComponents);
+  const hiddenPages = new Set(hidden);
+
   const layoutAndComponents = Object.entries(layouts as ILayouts)
-    .filter(([pageRef]) => !excludePageFromPdf.has(pageRef))
+    .filter(([pageRef]) => !excludedPages.has(pageRef))
     .filter(([pageRef]) => !hiddenPages.has(pageRef))
-    .filter(([pageRef]) => pageOrder.includes(pageRef))
-    .sort(([pA], [pB]) => pageOrder.indexOf(pA) - pageOrder.indexOf(pB))
+    .filter(([pageRef]) => pdfFormat.pageOrder.includes(pageRef))
+    .sort(([pA], [pB]) => pdfFormat.pageOrder.indexOf(pA) - pdfFormat.pageOrder.indexOf(pB))
     .map(([pageRef, layout]: [string, ILayoutComponentOrGroup[]]) => [
       pageRef,
-      topLevelComponents(layout).filter((c) => renderComponents.has(c.type) && !excludeComponentFromPdf.has(c.id)),
+      topLevelComponents(layout).filter((c) => renderComponents.has(c.type) && !excludedComponents.has(c.id)),
     ])
     .flatMap(([pageRef, components]: [string, ILayoutComponentOrGroup[]]) => components.map((comp) => [pageRef, comp]));
 
@@ -119,7 +117,7 @@ const AutomaticPDFLayout = ({
           <AutomaticPDFSummaryComponent
             component={component}
             pageRef={pageRef}
-            excludedChildren={Array.from(excludeComponentFromPdf)}
+            excludedChildren={pdfFormat.excludedComponents}
           />
         </div>
       ))}

--- a/src/features/pdf/PDFView.tsx
+++ b/src/features/pdf/PDFView.tsx
@@ -32,6 +32,7 @@ const PDFView = ({ appName, appOwner }: PDFViewProps) => {
   const applicationSettings = useAppSelector((state) => state.applicationSettings.applicationSettings);
   const applicationMetadata = useAppSelector((state) => state.applicationMetadata.applicationMetadata);
   const formData = useAppSelector((state) => state.formData.formData);
+  const unsavedChanges = useAppSelector((state) => state.formData.unsavedChanges);
   const hiddenFields = useAppSelector((state) => state.formLayout.uiConfig.hiddenFields);
   const parties = useAppSelector((state) => state.party.parties);
   const language = useAppSelector((state) => state.language.language);
@@ -53,7 +54,8 @@ const PDFView = ({ appName, appOwner }: PDFViewProps) => {
       excludedPages &&
       excludedComponents &&
       pageOrder &&
-      !pdfLayout
+      !pdfLayout &&
+      !unsavedChanges
     ) {
       const dataGuid = getCurrentTaskDataElementId(applicationMetadata, instance, layoutSets);
       if (typeof dataGuid === 'string') {
@@ -65,7 +67,16 @@ const PDFView = ({ appName, appOwner }: PDFViewProps) => {
         setPdfFormat({ excludedPages, excludedComponents, pageOrder });
       }
     }
-  }, [applicationMetadata, excludedComponents, excludedPages, instance, layoutSets, pageOrder, pdfLayout]);
+  }, [
+    applicationMetadata,
+    excludedComponents,
+    excludedPages,
+    instance,
+    layoutSets,
+    pageOrder,
+    pdfLayout,
+    unsavedChanges,
+  ]);
 
   if (
     optionsLoading ||

--- a/src/features/pdf/PDFView.tsx
+++ b/src/features/pdf/PDFView.tsx
@@ -2,13 +2,16 @@ import React from 'react';
 
 import cn from 'classnames';
 
+import type { IPdfFormat } from '.';
+
 import { useAppSelector } from 'src/common/hooks';
 import AutomaticPDFLayout from 'src/features/pdf/AutomaticPDFLayout';
 import CustomPDFLayout from 'src/features/pdf/CustomPDFLayout';
 import css from 'src/features/pdf/PDFView.module.css';
 import { ReadyForPrint } from 'src/shared/components/ReadyForPrint';
-import { getInstanceContextSelector } from 'src/utils/instanceContext';
-import type { IInstanceContext } from 'src/types/shared';
+import { getCurrentTaskDataElementId } from 'src/utils/appMetadata';
+import { get } from 'src/utils/network/networking';
+import { getPdfFormatUrl } from 'src/utils/urls/appUrlHelper';
 
 interface PDFViewProps {
   appName: string;
@@ -17,18 +20,18 @@ interface PDFViewProps {
 
 const PDFView = ({ appName, appOwner }: PDFViewProps) => {
   const layouts = useAppSelector((state) => state.formLayout.layouts);
-  const excludePageFromPdf = useAppSelector((state) => new Set(state.formLayout.uiConfig.excludePageFromPdf));
-  const excludeComponentFromPdf = useAppSelector((state) => new Set(state.formLayout.uiConfig.excludeComponentFromPdf));
+  const layoutSets = useAppSelector((state) => state.formLayout.layoutsets);
+  const excludedPages = useAppSelector((state) => state.formLayout.uiConfig.excludePageFromPdf);
+  const excludedComponents = useAppSelector((state) => state.formLayout.uiConfig.excludeComponentFromPdf);
   const pageOrder = useAppSelector((state) => state.formLayout.uiConfig.tracks.order);
-  const hiddenPages = useAppSelector((state) => new Set(state.formLayout.uiConfig.tracks.hidden));
+  const hidden = useAppSelector((state) => state.formLayout.uiConfig.tracks.hidden);
   const pdfLayoutName = useAppSelector((state) => state.formLayout.uiConfig.pdfLayoutName);
   const optionsLoading = useAppSelector((state) => state.optionState.loading);
   const dataListLoading = useAppSelector((state) => state.dataListState.loading);
   const repeatingGroups = useAppSelector((state) => state.formLayout.uiConfig.repeatingGroups);
-  const instanceContextSelector = getInstanceContextSelector();
-  const instanceContext: IInstanceContext = useAppSelector(instanceContextSelector);
   const applicationSettings = useAppSelector((state) => state.applicationSettings.applicationSettings);
-  const formData = useAppSelector((state) => state.formData?.formData);
+  const applicationMetadata = useAppSelector((state) => state.applicationMetadata.applicationMetadata);
+  const formData = useAppSelector((state) => state.formData.formData);
   const hiddenFields = useAppSelector((state) => state.formLayout.uiConfig.hiddenFields);
   const parties = useAppSelector((state) => state.party.parties);
   const language = useAppSelector((state) => state.language.language);
@@ -37,25 +40,37 @@ const PDFView = ({ appName, appOwner }: PDFViewProps) => {
   const allOrgs = useAppSelector((state) => state.organisationMetaData.allOrgs);
   const profile = useAppSelector((state) => state.profile.profile);
 
+  // Fetch PdfFormat from backend
+  const [pdfFormat, setPdfFormat] = React.useState<IPdfFormat | null>(null);
+  React.useEffect(() => {
+    if (applicationMetadata && instance && layoutSets && excludedPages && excludedComponents && pageOrder) {
+      const dataGuid = getCurrentTaskDataElementId(applicationMetadata, instance, layoutSets);
+      if (typeof dataGuid === 'string') {
+        const url = getPdfFormatUrl(instance.id, dataGuid);
+        get(url)
+          .then((pdfFormat: IPdfFormat) => setPdfFormat(pdfFormat))
+          .catch(() => setPdfFormat({ excludedPages, excludedComponents, pageOrder }));
+      } else {
+        setPdfFormat({ excludedPages, excludedComponents, pageOrder });
+      }
+    }
+  }, [applicationMetadata, excludedComponents, excludedPages, instance, layoutSets, pageOrder]);
+
   if (
     optionsLoading ||
     dataListLoading ||
     !layouts ||
-    !excludePageFromPdf ||
-    !excludeComponentFromPdf ||
-    !pageOrder ||
-    !hiddenPages ||
+    !hidden ||
     !repeatingGroups ||
-    !instanceContext ||
     !applicationSettings ||
     !formData ||
     !hiddenFields ||
     !parties ||
     !language ||
     !textResources ||
-    !instance ||
     !allOrgs ||
-    !profile
+    !profile ||
+    !pdfFormat
   ) {
     return null;
   }
@@ -78,11 +93,9 @@ const PDFView = ({ appName, appOwner }: PDFViewProps) => {
         <CustomPDFLayout layout={pdfLayout} />
       ) : (
         <AutomaticPDFLayout
-          excludeComponentFromPdf={excludeComponentFromPdf}
-          excludePageFromPdf={excludePageFromPdf}
-          hiddenPages={hiddenPages}
+          pdfFormat={pdfFormat}
+          hidden={hidden}
           layouts={layouts}
-          pageOrder={pageOrder}
         />
       )}
       <ReadyForPrint />

--- a/src/features/pdf/PDFView.tsx
+++ b/src/features/pdf/PDFView.tsx
@@ -49,7 +49,7 @@ const PDFView = ({ appName, appOwner }: PDFViewProps) => {
     if (
       applicationMetadata &&
       instance &&
-      layoutSets &&
+      (instance?.data?.length === 1 || layoutSets) &&
       excludedPages &&
       excludedComponents &&
       pageOrder &&

--- a/src/features/pdf/PDFView.tsx
+++ b/src/features/pdf/PDFView.tsx
@@ -40,10 +40,21 @@ const PDFView = ({ appName, appOwner }: PDFViewProps) => {
   const allOrgs = useAppSelector((state) => state.organisationMetaData.allOrgs);
   const profile = useAppSelector((state) => state.profile.profile);
 
+  // Custom pdf layout
+  const pdfLayout = pdfLayoutName && layouts ? layouts[pdfLayoutName] : undefined;
+
   // Fetch PdfFormat from backend
   const [pdfFormat, setPdfFormat] = React.useState<IPdfFormat | null>(null);
   React.useEffect(() => {
-    if (applicationMetadata && instance && layoutSets && excludedPages && excludedComponents && pageOrder) {
+    if (
+      applicationMetadata &&
+      instance &&
+      layoutSets &&
+      excludedPages &&
+      excludedComponents &&
+      pageOrder &&
+      !pdfLayout
+    ) {
       const dataGuid = getCurrentTaskDataElementId(applicationMetadata, instance, layoutSets);
       if (typeof dataGuid === 'string') {
         const url = getPdfFormatUrl(instance.id, dataGuid);
@@ -54,7 +65,7 @@ const PDFView = ({ appName, appOwner }: PDFViewProps) => {
         setPdfFormat({ excludedPages, excludedComponents, pageOrder });
       }
     }
-  }, [applicationMetadata, excludedComponents, excludedPages, instance, layoutSets, pageOrder]);
+  }, [applicationMetadata, excludedComponents, excludedPages, instance, layoutSets, pageOrder, pdfLayout]);
 
   if (
     optionsLoading ||
@@ -70,12 +81,10 @@ const PDFView = ({ appName, appOwner }: PDFViewProps) => {
     !textResources ||
     !allOrgs ||
     !profile ||
-    !pdfFormat
+    (!pdfFormat && !pdfLayout)
   ) {
     return null;
   }
-
-  const pdfLayout = pdfLayoutName ? layouts[pdfLayoutName] : undefined;
 
   document.body.style.backgroundColor = 'white';
   return (
@@ -93,7 +102,7 @@ const PDFView = ({ appName, appOwner }: PDFViewProps) => {
         <CustomPDFLayout layout={pdfLayout} />
       ) : (
         <AutomaticPDFLayout
-          pdfFormat={pdfFormat}
+          pdfFormat={pdfFormat as IPdfFormat}
           hidden={hidden}
           layouts={layouts}
         />

--- a/src/features/pdf/PDFView.tsx
+++ b/src/features/pdf/PDFView.tsx
@@ -53,7 +53,6 @@ const PDFView = ({ appName, appOwner }: PDFViewProps) => {
       (instance?.data?.length === 1 || layoutSets) &&
       excludedPages &&
       excludedComponents &&
-      pageOrder &&
       !pdfLayout &&
       !unsavedChanges
     ) {
@@ -62,21 +61,12 @@ const PDFView = ({ appName, appOwner }: PDFViewProps) => {
         const url = getPdfFormatUrl(instance.id, dataGuid);
         get(url)
           .then((pdfFormat: IPdfFormat) => setPdfFormat(pdfFormat))
-          .catch(() => setPdfFormat({ excludedPages, excludedComponents, pageOrder }));
+          .catch(() => setPdfFormat({ excludedPages, excludedComponents }));
       } else {
-        setPdfFormat({ excludedPages, excludedComponents, pageOrder });
+        setPdfFormat({ excludedPages, excludedComponents });
       }
     }
-  }, [
-    applicationMetadata,
-    excludedComponents,
-    excludedPages,
-    instance,
-    layoutSets,
-    pageOrder,
-    pdfLayout,
-    unsavedChanges,
-  ]);
+  }, [applicationMetadata, excludedComponents, excludedPages, instance, layoutSets, pdfLayout, unsavedChanges]);
 
   if (
     optionsLoading ||
@@ -92,6 +82,7 @@ const PDFView = ({ appName, appOwner }: PDFViewProps) => {
     !textResources ||
     !allOrgs ||
     !profile ||
+    !pageOrder ||
     (!pdfFormat && !pdfLayout)
   ) {
     return null;
@@ -113,6 +104,7 @@ const PDFView = ({ appName, appOwner }: PDFViewProps) => {
       ) : (
         <AutomaticPDFLayout
           pdfFormat={pdfFormat as IPdfFormat}
+          pageOrder={pageOrder}
           hidden={hidden}
           layouts={layouts}
         />

--- a/src/features/pdf/index.d.ts
+++ b/src/features/pdf/index.d.ts
@@ -1,5 +1,4 @@
 export interface IPdfFormat {
   excludedPages: string[];
   excludedComponents: string[];
-  pageOrder: string[];
 }

--- a/src/features/pdf/index.d.ts
+++ b/src/features/pdf/index.d.ts
@@ -1,0 +1,5 @@
+export interface IPdfFormat {
+  excludedPages: string[];
+  excludedComponents: string[];
+  pageOrder: string[];
+}

--- a/src/utils/urls/appUrlHelper.ts
+++ b/src/utils/urls/appUrlHelper.ts
@@ -39,6 +39,9 @@ export const getValidationUrl = (instanceId: string) => `${appPath}/instances/${
 export const getDataValidationUrl = (instanceId: string, dataGuid: string) =>
   `${appPath}/instances/${instanceId}/data/${dataGuid}/validate`;
 
+export const getPdfFormatUrl = (instanceId: string, dataGuid: string) =>
+  `${appPath}/instances/${instanceId}/data/${dataGuid}/pdfformat`;
+
 export const getProcessNextUrl = (taskId?: string | null) => {
   if (taskId) {
     return `${appPath}/instances/${altinnWindow.instanceId}/process/next?elementId=${encodeURIComponent(taskId)}`;

--- a/src/utils/urls/appUrlHelper.ts
+++ b/src/utils/urls/appUrlHelper.ts
@@ -40,7 +40,7 @@ export const getDataValidationUrl = (instanceId: string, dataGuid: string) =>
   `${appPath}/instances/${instanceId}/data/${dataGuid}/validate`;
 
 export const getPdfFormatUrl = (instanceId: string, dataGuid: string) =>
-  `${appPath}/instances/${instanceId}/data/${dataGuid}/pdfformat`;
+  `${appPath}/instances/${instanceId}/data/${dataGuid}/pdf/format`;
 
 export const getProcessNextUrl = (taskId?: string | null) => {
   if (taskId) {


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the Title above
  Describe your change(s) in detail here

  Also add the relevant label in the column on the right:
    Breaking changes: kind/breaking-change
    New features:     kind/product-feature
    Bug fixes:        kind/bug
    Dependencies:     kind/dependencies
    Other changes:    kind/other
-->
PDF view now fetches PDF format from backend and uses this for `excludeComponents` and `excludedPages`. If this fails, it will use what it has in `layoutSettings`. If `IPdfFormatter` is not used, then the backend simply returns whatever is in the static `Settings.json` file. When a custom layout is used, it will not bother fetching pdf format from the backend as this is not used in that case.

When in pdf preview mode (`?pdf=preview`), it will fetch the pdf format whenever the formData is saved so that any dynamic rules based on the formData is up to date and ready for preview.

Tested a lot on frontend-test app, and seems to work well both for `?pdf=preview` and `?pdf=1` (only loads format once).

Also tested on my sogndal app which does not use layout sets and it fetches fine. (except that it is not v7 so it gets a 404 which is handeled by using the data from redux instead. I checked that the URL is correct at least).

## Related Issue(s)

- closes #818 
- depends on https://github.com/Altinn/app-lib-dotnet/pull/157

## Verification

- Manual testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added
  - [ ] Cypress E2E test(s) have been added
  - [ ] No automatic tests are needed here
  - [ ] I want someone to help me make some tests
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [x] Has been updated
  <!--- insert link to PR here -->
    - https://github.com/Altinn/altinn-studio-docs/pull/795
  - [ ] No changes/updates needed
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board <!--- If you don't have permissions for this, someone else will do it for you -->
