### PR TITLE
Easier preview for PDF development

### DIFF
--- a/src/features/pdf/PDFView.tsx
+++ b/src/features/pdf/PDFView.tsx
@@ -61,8 +61,6 @@ const PDFView = ({ appName, appOwner }: PDFViewProps) => {
   }
 
   const pdfLayout = pdfLayoutName ? layouts[pdfLayoutName] : undefined;
-
-  document.body.style.backgroundColor = 'white';
   return (
     <div className={css['pdf-wrapper']}>
       <h1 className={cn({ [css['title-margin']]: !appOwner })}>{appName}</h1>

--- a/src/index.css
+++ b/src/index.css
@@ -13,6 +13,12 @@ body {
   background-color: #efefef;
 }
 
+@media print {
+  body {
+    background-color: white !important;
+  }
+}
+
 input:checked + .slider {
   background-color: #1eaef7;
 }

--- a/src/shared/containers/ProcessWrapper.module.css
+++ b/src/shared/containers/ProcessWrapper.module.css
@@ -1,0 +1,15 @@
+.content {
+  display: contents;
+}
+
+@media print {
+  .hide-form {
+    display: none;
+  }
+}
+
+@media only screen {
+  .hide-pdf {
+    display: none;
+  }
+}

--- a/src/shared/containers/ProcessWrapper.tsx
+++ b/src/shared/containers/ProcessWrapper.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { useSearchParams } from 'react-router-dom';
 
+import cn from 'classnames';
+
 import { useAppSelector, useInstanceIdParams, useProcess } from 'src/common/hooks';
 import { useApiErrorCheck } from 'src/common/hooks/useApiErrorCheck';
 import { AltinnContentIconFormData, AltinnContentLoader } from 'src/components/shared';
@@ -11,6 +13,7 @@ import UnknownError from 'src/features/instantiate/containers/UnknownError';
 import PDFView from 'src/features/pdf/PDFView';
 import Receipt from 'src/features/receipt/containers/ReceiptContainer';
 import Presentation from 'src/shared/containers/Presentation';
+import css from 'src/shared/containers/ProcessWrapper.module.css';
 import { InstanceDataActions } from 'src/shared/resources/instanceData/instanceDataSlice';
 import { ProcessTaskType } from 'src/types';
 import { behavesLikeDataTask } from 'src/utils/formLayout';
@@ -27,7 +30,8 @@ const ProcessWrapper = () => {
   window['instanceId'] = instanceIdFromUrl;
 
   const [searchParams] = useSearchParams();
-  const pdf = searchParams.get('pdf') === '1';
+  const renderPDF = searchParams.get('pdf') === '1';
+  const previewPDF = searchParams.get('pdf') === 'preview';
 
   React.useEffect(() => {
     if (!instantiating && !instanceId) {
@@ -47,7 +51,7 @@ const ProcessWrapper = () => {
   }
   const { taskType } = process;
 
-  if (pdf) {
+  if (renderPDF) {
     return (
       <PDFView
         appName={appName as string}
@@ -57,30 +61,46 @@ const ProcessWrapper = () => {
   }
 
   return (
-    <Presentation
-      header={appName}
-      appOwner={appOwner}
-      type={taskType}
-    >
-      {isLoading === false ? (
-        <>
-          {taskType === ProcessTaskType.Data && <Form />}
-          {taskType === ProcessTaskType.Archived && <Receipt />}
-          {taskType === ProcessTaskType.Confirm &&
-            (behavesLikeDataTask(process.taskId, layoutSets) ? <Form /> : <Confirm />)}
-          {taskType === ProcessTaskType.Feedback && <Feedback />}
-        </>
-      ) : (
-        <div style={{ marginTop: '2.5rem' }}>
-          <AltinnContentLoader
-            width='100%'
-            height={700}
-          >
-            <AltinnContentIconFormData />
-          </AltinnContentLoader>
+    <>
+      <div
+        className={cn(css['content'], {
+          [css['hide-form']]: previewPDF,
+        })}
+      >
+        <Presentation
+          header={appName}
+          appOwner={appOwner}
+          type={taskType}
+        >
+          {isLoading === false ? (
+            <>
+              {taskType === ProcessTaskType.Data && <Form />}
+              {taskType === ProcessTaskType.Archived && <Receipt />}
+              {taskType === ProcessTaskType.Confirm &&
+                (behavesLikeDataTask(process.taskId, layoutSets) ? <Form /> : <Confirm />)}
+              {taskType === ProcessTaskType.Feedback && <Feedback />}
+            </>
+          ) : (
+            <div style={{ marginTop: '2.5rem' }}>
+              <AltinnContentLoader
+                width='100%'
+                height={700}
+              >
+                <AltinnContentIconFormData />
+              </AltinnContentLoader>
+            </div>
+          )}
+        </Presentation>
+      </div>
+      {previewPDF && (
+        <div className={cn(css['content'], css['hide-pdf'])}>
+          <PDFView
+            appName={appName as string}
+            appOwner={appOwner}
+          />
         </div>
       )}
-    </Presentation>
+    </>
   );
 };
 


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the Title above
  Describe your change(s) in detail here

  Also add the relevant label in the column on the right:
    Breaking changes: kind/breaking-change
    New features:     kind/product-feature
    Bug fixes:        kind/bug
    Dependencies:     kind/dependencies
    Other changes:    kind/other
-->

Made some changes to `ProcessWrapper` to make it easier to preview PDF while developing. Now there are three possible states of PDF rendering depending on the query parameter `?pdf`.

- `?pdf` is not defined: Only form is rendered as normal.
- `?pdf=1`: used for generating PDF. Only `PDFView` is rendered to keep PDF-generation fast.
- `?pdf=preview`: both form and `PDFView` are rendered at the same time, but form is hidden and `PDFView` is visible when in print-mode, and opposite if not in print mode (using css). This can potentially be very slow, and is only meant for development use.


Does this seem like a good solution? It makes it much easier to modify form data and quickly check how this changes the PDF without constantly changing the query-parameter back and fourth as I have been doing before.