### PR TITLE
WCAG: Change group title from `p` to `h2`

### DIFF
--- a/src/features/form/containers/DisplayGroupContainer.tsx
+++ b/src/features/form/containers/DisplayGroupContainer.tsx
@@ -75,7 +75,7 @@ export function DisplayGroupContainer(props: IDisplayGroupContainer) {
         >
           <Typography
             className={classes.groupTitle}
-            variant='body1'
+            variant='h2'
           >
             {title}
           </Typography>


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the Title above
  Describe your change(s) in detail here

  Also add the relevant label in the column on the right:
    Breaking changes: kind/breaking-change
    New features:     kind/product-feature
    Bug fixes:        kind/bug
    Dependencies:     kind/dependencies
    Other changes:    kind/other
-->

This is a quick fix to the wcag error. Ideally group titles should be styled similarly to all other titles, but I think it is best to wait with this until we change the font. Additionally, maybe it should be possible to define which header level a group title should have? This could be its own task if the need arises.

## Related Issue(s)

- closes https://github.com/Altinn/app-frontend-react/issues/829

## Verification

- Manual testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added
  - [ ] Cypress E2E test(s) have been added
  - [ ] No automatic tests are needed here
  - [ ] I want someone to help me make some tests
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been updated
  <!--- insert link to PR here -->
  - [x] No changes/updates needed
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board <!--- If you don't have permissions for this, someone else will do it for you -->
