### PR TITLE
Fixed many issues with different modes of repeating groups

### DIFF
--- a/src/features/form/containers/GroupContainer.tsx
+++ b/src/features/form/containers/GroupContainer.tsx
@@ -5,8 +5,10 @@ import { Grid } from '@material-ui/core';
 import { Add as AddIcon } from '@navikt/ds-icons';
 
 import { useAppDispatch, useAppSelector } from 'src/common/hooks';
+import { ConditionalWrapper } from 'src/components/ConditionalWrapper';
 import { ExprDefaultsForGroup } from 'src/features/expressions';
 import { useExpressions } from 'src/features/expressions/useExpressions';
+import { FullWidthWrapper } from 'src/features/form/components/FullWidthWrapper';
 import { RepeatingGroupsEditContainer } from 'src/features/form/containers/RepeatingGroupsEditContainer';
 import { RepeatingGroupTable } from 'src/features/form/containers/RepeatingGroupTable';
 import { FormLayoutActions } from 'src/features/form/layout/formLayoutSlice';
@@ -189,6 +191,8 @@ export function GroupContainer({ id, container, components }: IGroupProps): JSX.
     return null;
   }
 
+  const isNested = typeof container.baseComponentId === 'string';
+
   if (edit?.mode === 'likert') {
     return (
       <>
@@ -233,58 +237,71 @@ export function GroupContainer({ id, container, components }: IGroupProps): JSX.
           filteredIndexes={filteredIndexList}
         />
       )}
-      <Grid
-        container={true}
-        justifyContent='flex-end'
-      />
       {edit?.mode !== 'showAll' &&
         edit?.addButton !== false &&
         editIndex < 0 &&
         repeatingGroupIndex + 1 < (container.maxCount === undefined ? -99 : container.maxCount) &&
         addButton()}
       {editIndex >= 0 && edit?.mode === 'hideTable' && (
-        <RepeatingGroupsEditContainer
-          container={container}
-          editIndex={editIndex}
-          setEditIndex={setEditIndex}
-          repeatingGroupIndex={repeatingGroupIndex}
-          id={id}
-          language={language}
-          textResources={textResources}
-          layout={layout}
-          repeatingGroupDeepCopyComponents={repeatingGroupDeepCopyComponents}
-          multiPageIndex={multiPageIndex}
-          setMultiPageIndex={setMultiPageIndex}
-          filteredIndexes={filteredIndexList}
-        />
+        <ConditionalWrapper
+          condition={!isNested}
+          wrapper={(children) => <FullWidthWrapper>{children}</FullWidthWrapper>}
+        >
+          <RepeatingGroupsEditContainer
+            container={container}
+            editIndex={editIndex}
+            setEditIndex={setEditIndex}
+            repeatingGroupIndex={repeatingGroupIndex}
+            id={id}
+            language={language}
+            textResources={textResources}
+            layout={layout}
+            repeatingGroupDeepCopyComponents={repeatingGroupDeepCopyComponents}
+            multiPageIndex={multiPageIndex}
+            setMultiPageIndex={setMultiPageIndex}
+            filteredIndexes={filteredIndexList}
+          />
+        </ConditionalWrapper>
       )}
-      {edit?.mode === 'showAll' &&
+      {edit?.mode === 'showAll' && (
         // Generate array of length repeatingGroupIndex and iterate over indexes
-        Array(repeatingGroupIndex + 1)
-          .fill(0)
-          .map((_, index) => {
-            if (filteredIndexList && filteredIndexList.length > 0 && !filteredIndexList.includes(index)) {
-              return null;
-            }
+        <ConditionalWrapper
+          condition={!isNested}
+          wrapper={(children) => <FullWidthWrapper>{children}</FullWidthWrapper>}
+        >
+          <>
+            {Array(repeatingGroupIndex + 1)
+              .fill(0)
+              .map((_, index) => {
+                if (filteredIndexList && filteredIndexList.length > 0 && !filteredIndexList.includes(index)) {
+                  return null;
+                }
 
-            return (
-              <RepeatingGroupsEditContainer
-                key={index}
-                editIndex={index}
-                repeatingGroupIndex={repeatingGroupIndex}
-                container={container}
-                id={id}
-                language={language}
-                deleting={deletingIndexes.includes(index)}
-                textResources={textResources}
-                layout={layout}
-                setEditIndex={setEditIndex}
-                onClickRemove={onClickRemove}
-                repeatingGroupDeepCopyComponents={repeatingGroupDeepCopyComponents}
-                forceHideSaveButton={true}
-              />
-            );
-          })}
+                return (
+                  <div
+                    key={index}
+                    style={{ width: '100%', marginBottom: !isNested && index == repeatingGroupIndex ? 15 : 0 }}
+                  >
+                    <RepeatingGroupsEditContainer
+                      editIndex={index}
+                      repeatingGroupIndex={repeatingGroupIndex}
+                      container={container}
+                      id={id}
+                      language={language}
+                      deleting={deletingIndexes.includes(index)}
+                      textResources={textResources}
+                      layout={layout}
+                      setEditIndex={setEditIndex}
+                      onClickRemove={onClickRemove}
+                      repeatingGroupDeepCopyComponents={repeatingGroupDeepCopyComponents}
+                      forceHideSaveButton={true}
+                    />
+                  </div>
+                );
+              })}
+          </>
+        </ConditionalWrapper>
+      )}
       {edit?.mode === 'showAll' &&
         edit?.addButton !== false &&
         repeatingGroupIndex + 1 < (container.maxCount === undefined ? -99 : container.maxCount) &&

--- a/src/features/form/containers/GroupContainer.tsx
+++ b/src/features/form/containers/GroupContainer.tsx
@@ -242,35 +242,30 @@ export function GroupContainer({ id, container, components }: IGroupProps): JSX.
         editIndex < 0 &&
         repeatingGroupIndex + 1 < (container.maxCount === undefined ? -99 : container.maxCount) &&
         addButton()}
-      {editIndex >= 0 && edit?.mode === 'hideTable' && (
-        <ConditionalWrapper
-          condition={!isNested}
-          wrapper={(children) => <FullWidthWrapper>{children}</FullWidthWrapper>}
-        >
-          <RepeatingGroupsEditContainer
-            container={container}
-            editIndex={editIndex}
-            setEditIndex={setEditIndex}
-            repeatingGroupIndex={repeatingGroupIndex}
-            id={id}
-            language={language}
-            textResources={textResources}
-            layout={layout}
-            repeatingGroupDeepCopyComponents={repeatingGroupDeepCopyComponents}
-            multiPageIndex={multiPageIndex}
-            setMultiPageIndex={setMultiPageIndex}
-            filteredIndexes={filteredIndexList}
-          />
-        </ConditionalWrapper>
-      )}
-      {edit?.mode === 'showAll' && (
-        // Generate array of length repeatingGroupIndex and iterate over indexes
-        <ConditionalWrapper
-          condition={!isNested}
-          wrapper={(children) => <FullWidthWrapper>{children}</FullWidthWrapper>}
-        >
-          <>
-            {Array(repeatingGroupIndex + 1)
+      <ConditionalWrapper
+        condition={!isNested}
+        wrapper={(children) => <FullWidthWrapper>{children}</FullWidthWrapper>}
+      >
+        <>
+          {editIndex >= 0 && edit?.mode === 'hideTable' && (
+            <RepeatingGroupsEditContainer
+              container={container}
+              editIndex={editIndex}
+              setEditIndex={setEditIndex}
+              repeatingGroupIndex={repeatingGroupIndex}
+              id={id}
+              language={language}
+              textResources={textResources}
+              layout={layout}
+              repeatingGroupDeepCopyComponents={repeatingGroupDeepCopyComponents}
+              multiPageIndex={multiPageIndex}
+              setMultiPageIndex={setMultiPageIndex}
+              filteredIndexes={filteredIndexList}
+            />
+          )}
+          {edit?.mode === 'showAll' &&
+            // Generate array of length repeatingGroupIndex and iterate over indexes
+            Array(repeatingGroupIndex + 1)
               .fill(0)
               .map((_, index) => {
                 if (filteredIndexList && filteredIndexList.length > 0 && !filteredIndexList.includes(index)) {
@@ -299,9 +294,8 @@ export function GroupContainer({ id, container, components }: IGroupProps): JSX.
                   </div>
                 );
               })}
-          </>
-        </ConditionalWrapper>
-      )}
+        </>
+      </ConditionalWrapper>
       {edit?.mode === 'showAll' &&
         edit?.addButton !== false &&
         repeatingGroupIndex + 1 < (container.maxCount === undefined ? -99 : container.maxCount) &&

--- a/src/features/form/containers/RepeatingGroupTable.tsx
+++ b/src/features/form/containers/RepeatingGroupTable.tsx
@@ -105,7 +105,6 @@ const useStyles = makeStyles({
   editContainerRow: {
     borderTop: `1px solid ${theme.altinnPalette.primary.blueLight}`,
     borderBottom: `2px dotted ${theme.altinnPalette.primary.blueMedium}`,
-    backgroundColor: '#f1fbff',
     '& > td > div': {
       margin: 0,
     },

--- a/src/features/form/containers/RepeatingGroupsEditContainer.tsx
+++ b/src/features/form/containers/RepeatingGroupsEditContainer.tsx
@@ -35,6 +35,7 @@ export interface IRepeatingGroupsEditContainer {
 
 const useStyles = makeStyles({
   editContainer: {
+    backgroundColor: '#f1fbff',
     width: '100%',
     display: 'inline-block',
     padding: '12px 24px',
@@ -46,19 +47,19 @@ const useStyles = makeStyles({
     },
   },
   nestedEditContainer: {
+    backgroundColor: '#f1fbff',
     width: '100%',
     display: 'inline-block',
     padding: '12px 24px',
   },
-  deleteItem: {
-    paddingBottom: '0px !important',
-    paddingTop: '0px !important',
-  },
-  showAll: {
-    backgroundColor: '#f1fbff',
+  hideTable: {
     borderTop: `2px dotted ${theme.altinnPalette.primary.blueMedium}`,
     borderBottom: `2px dotted ${theme.altinnPalette.primary.blueMedium}`,
     marginBottom: '-2px',
+  },
+  nestedHideTable: {
+    borderRight: `2px dotted ${theme.altinnPalette.primary.blueMedium}`,
+    borderLeft: `2px dotted ${theme.altinnPalette.primary.blueMedium}`,
   },
 });
 
@@ -85,8 +86,6 @@ export function RepeatingGroupsEditContainer({
   const group = useExpressionsForComponent(container, {
     rowIndex: editIndex,
   });
-
-  const hideSaveButton = forceHideSaveButton || group.edit?.saveButton === false;
 
   let nextIndex: number | null = null;
   if (filteredIndexes) {
@@ -117,48 +116,52 @@ export function RepeatingGroupsEditContainer({
   };
 
   const isNested = typeof group.baseComponentId === 'string';
-  const saveButtonVisible = !hideSaveButton || (group.edit?.saveAndNextButton === true && nextIndex === null);
-  const saveAndNextButtonVisible = group.edit?.saveAndNextButton === true && nextIndex !== null;
+  const saveButtonVisible =
+    !forceHideSaveButton &&
+    (group.edit?.saveButton !== false || (group.edit?.saveAndNextButton === true && nextIndex === null));
+  const saveAndNextButtonVisible = !forceHideSaveButton && group.edit?.saveAndNextButton === true && nextIndex !== null;
+
+  const hideTable = group.edit?.mode === 'hideTable' || group.edit?.mode === 'showAll';
 
   return (
     <div
       className={cn(
         isNested ? classes.nestedEditContainer : classes.editContainer,
-        { [classes.showAll]: group.edit?.mode === 'showAll' },
+        { [classes.hideTable]: hideTable, [classes.nestedHideTable]: hideTable && isNested },
         className,
       )}
+      style={{ marginBottom: isNested && group.edit?.mode === 'showAll' ? 15 : undefined }}
       data-testid='group-edit-container'
     >
+      {group.edit?.deleteButton !== false && group.edit?.mode === 'showAll' && (
+        <Grid
+          item={true}
+          container={true}
+          direction='column'
+          alignItems='flex-end'
+          spacing={3}
+        >
+          <Grid item={true}>
+            <Button
+              variant={ButtonVariant.Quiet}
+              color={ButtonColor.Danger}
+              icon={<DeleteIcon />}
+              iconPlacement='right'
+              disabled={deleting}
+              onClick={removeClicked}
+              data-testid='delete-button'
+            >
+              {getLanguageFromKey('general.delete', language)}
+            </Button>
+          </Grid>
+        </Grid>
+      )}
       <Grid
         container={true}
         item={true}
         direction='row'
         spacing={3}
       >
-        {group.edit?.deleteButton !== false && group.edit?.mode === 'showAll' && (
-          <Grid
-            item={true}
-            container={true}
-            direction='column'
-            alignItems='flex-end'
-            spacing={3}
-            className={classes.deleteItem}
-          >
-            <Grid item={true}>
-              <Button
-                variant={ButtonVariant.Quiet}
-                color={ButtonColor.Danger}
-                icon={<DeleteIcon />}
-                iconPlacement='right'
-                disabled={deleting}
-                onClick={removeClicked}
-                data-testid='delete-button'
-              >
-                {getLanguageFromKey('general.delete', language)}
-              </Button>
-            </Grid>
-          </Grid>
-        )}
         <Grid
           container={true}
           alignItems='flex-start'


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the Title above
  Describe your change(s) in detail here

  Also add the relevant label in the column on the right:
    Breaking changes: kind/breaking-change
    New features:     kind/product-feature
    Bug fixes:        kind/bug
    Dependencies:     kind/dependencies
    Other changes:    kind/other
-->
Was made aware that `mode: showAll` did not display properly, it did not fill the full width. This lead me down a rabbit hole of many display issues related to using different modes in both regular and nested repeating groups. The only real issue that could potentially use a cypress test is that the "save and close" and "save and next" buttons were not hidden in `mode: showAll`.

## Related Issue(s)

- n/a

## Verification

- Manual testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added
  - [ ] Cypress E2E test(s) have been added
  - [ ] No automatic tests are needed here
  - [ ] I want someone to help me make some tests
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been updated
  <!--- insert link to PR here -->
  - [x] No changes/updates needed
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board <!--- If you don't have permissions for this, someone else will do it for you -->
