### PR TITLE
WCAG: AltinnSpinner should accessibile and validation errors onBlur should be informative

### DIFF
--- a/src/components/AltinnSpinner.test.tsx
+++ b/src/components/AltinnSpinner.test.tsx
@@ -16,7 +16,7 @@ describe('tests to make sure to follow accessibility requirements', () => {
 
     expect(spinnerText).toHaveTextContent('Loading form');
     expect(spinnerText).toHaveAttribute('aria-busy', 'true');
-    expect(spinnerText).toBeVisible();
+    expect(spinnerText).toHaveTextContent('Loading form');
   });
 
   test('should fallback spinnerText to "Laster innhold", but hidden from visual view to stay accessible"', () => {

--- a/src/components/AltinnSpinner.test.tsx
+++ b/src/components/AltinnSpinner.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+
+import AltinnSpinner from 'src/components/AltinnSpinner';
+
+describe('tests to make sure to follow accessibility requirements', () => {
+  test('should have role progressbar', () => {
+    render(<AltinnSpinner />);
+    expect(screen.getByRole('progressbar'));
+  });
+
+  test('should have role alert on spinner text to make sure screen readers is focus the text content', () => {
+    render(<AltinnSpinner spinnerText='Loading form' />);
+    const spinnerText = screen.getByRole('alert');
+
+    expect(spinnerText).toHaveTextContent('Loading form');
+    expect(spinnerText).toHaveAttribute('aria-busy', 'true');
+    expect(spinnerText).toBeVisible();
+  });
+
+  test('should fallback spinnerText to "Laster innhold", but hidden from visual view to stay accessible"', () => {
+    render(<AltinnSpinner />);
+    const spinnerText = screen.getByText('Laster innhold');
+
+    expect(spinnerText).toBeTruthy();
+    expect(spinnerText).not.toBeVisible();
+  });
+});

--- a/src/components/AltinnSpinner.test.tsx
+++ b/src/components/AltinnSpinner.test.tsx
@@ -21,9 +21,8 @@ describe('tests to make sure to follow accessibility requirements', () => {
 
   test('should fallback spinnerText to "Laster innhold", but hidden from visual view to stay accessible"', () => {
     render(<AltinnSpinner />);
-    const spinnerText = screen.getByText('Laster innhold');
-
-    expect(spinnerText).toBeTruthy();
-    expect(spinnerText).not.toBeVisible();
+    const spinnerText = screen.getByLabelText('Laster innhold');
+    expect(spinnerText).toBeInTheDocument();
+    expect(spinnerText).toHaveTextContent('');
   });
 });

--- a/src/components/AltinnSpinner.tsx
+++ b/src/components/AltinnSpinner.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 
 import { CircularProgress, createStyles, createTheme, makeStyles, Typography } from '@material-ui/core';
 import classNames from 'classnames';
-import type { Theme } from '@material-ui/core';
 import type { ArgumentArray } from 'classnames';
 
 import altinnTheme from 'src/theme/altinnStudioTheme';
@@ -15,7 +14,7 @@ export interface IAltinnSpinnerComponentProvidedProps {
 
 const theme = createTheme(altinnTheme);
 
-const useStyles = makeStyles<Theme, IAltinnSpinnerComponentProvidedProps>(() =>
+const useStyles = makeStyles(() =>
   createStyles({
     spinner: {
       color: theme.altinnPalette.primary.blueDark,
@@ -29,7 +28,6 @@ const useStyles = makeStyles<Theme, IAltinnSpinnerComponentProvidedProps>(() =>
       marginLeft: '10px',
       verticalAlign: 'middle',
       marginBottom: '25px',
-      visibility: ({ spinnerText }) => (spinnerText ? 'visible' : 'hidden'),
     },
   }),
 );
@@ -53,8 +51,9 @@ const AltinnSpinner = (props: IAltinnSpinnerComponentProvidedProps) => {
         className={classNames(classes.spinnerText)}
         role='alert'
         aria-busy={true}
+        aria-label={spinnerText || 'Laster innhold'}
       >
-        {spinnerText || 'Laster innhold'}
+        {spinnerText || ''}
       </Typography>
     </div>
   );

--- a/src/components/AltinnSpinner.tsx
+++ b/src/components/AltinnSpinner.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import { CircularProgress, createStyles, createTheme, makeStyles, Typography } from '@material-ui/core';
 import classNames from 'classnames';
+import type { Theme } from '@material-ui/core';
 import type { ArgumentArray } from 'classnames';
 
 import altinnTheme from 'src/theme/altinnStudioTheme';
@@ -14,7 +15,7 @@ export interface IAltinnSpinnerComponentProvidedProps {
 
 const theme = createTheme(altinnTheme);
 
-const useStyles = makeStyles(() =>
+const useStyles = makeStyles<Theme, IAltinnSpinnerComponentProvidedProps>(() =>
   createStyles({
     spinner: {
       color: theme.altinnPalette.primary.blueDark,
@@ -28,23 +29,33 @@ const useStyles = makeStyles(() =>
       marginLeft: '10px',
       verticalAlign: 'middle',
       marginBottom: '25px',
+      visibility: ({ spinnerText }) => (spinnerText ? 'visible' : 'hidden'),
     },
   }),
 );
 
 const AltinnSpinner = (props: IAltinnSpinnerComponentProvidedProps) => {
+  const { id, spinnerText, styleObj } = props;
   const classes = useStyles(props);
 
   return (
     <div
-      className={classNames(props.styleObj)}
+      className={classNames(styleObj)}
       data-testid='altinn-spinner'
     >
       <CircularProgress
+        role='progressbar'
         className={classNames(classes.spinner)}
-        id={props.id ? props.id : undefined}
+        id={id}
       />
-      {props.spinnerText && <Typography className={classNames(classes.spinnerText)}>{props.spinnerText}</Typography>}
+
+      <Typography
+        className={classNames(classes.spinnerText)}
+        role='alert'
+        aria-busy={true}
+      >
+        {spinnerText || 'Laster innhold'}
+      </Typography>
     </div>
   );
 };

--- a/src/language/texts/nb.ts
+++ b/src/language/texts/nb.ts
@@ -10,7 +10,7 @@ export function nb() {
       simplified: 'Enkel',
       title_text_binding: 'Søk etter ledetekst for Adressekomponenten',
       zip_code: 'Postnr',
-      validation_error_zipcode: 'Postnummer er ugyldig',
+      validation_error_zipcode: 'Postnummer er ugyldig. Et postnummer består kun av 4 siffer.',
       validation_error_house_number: 'Bolignummer er ugyldig',
     },
     confirm: {

--- a/src/language/texts/nn.ts
+++ b/src/language/texts/nn.ts
@@ -10,7 +10,7 @@ export function nn() {
       simplified: 'Enkel',
       title_text_binding: 'Søk etter ledetekst for Adressekomponenten',
       zip_code: 'Postnr',
-      validation_error_zipcode: 'Postnummer er ugyldig',
+      validation_error_zipcode: 'Postnummer er ugyldig. Eit postnummer består berre av 4 siffer.',
       validation_error_house_number: 'Bustadnummer er ugyldig',
     },
     confirm: {


### PR DESCRIPTION
AltinnSpinner should be accessible by implementing correct roles and aria-*. If SpinnerText is not provided as a prop I have implemented a fallback to "Laster innhold" as an aria-label which is only presented to screen readers.

Improved validation message for postal code to be more informative.

## Related Issue(s)

- closes #25 

## Verification

- Manual testing
  - [x] I have tested these changes manually
  - [x] Creator of the original issue (or service owner) has been contacted for manual testing
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added
  - [ ] Cypress E2E test(s) have been added
  - [ ] No automatic tests are needed here
  - [ ] I want someone to help me make some tests
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been updated
  <!--- insert link to PR here -->
  - [x] No changes/updates needed
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board <!--- If you don't have permissions for this, someone else will do it for you -->
