### PR TITLE
Expression schema: Fixing overlapping type reference

### DIFF
--- a/schemas/json/layout/expression.schema.v1.json
+++ b/schemas/json/layout/expression.schema.v1.json
@@ -113,8 +113,10 @@
     "string-or-number": {
       "title": "Any expression returning a string or number",
       "oneOf": [
-        { "$ref": "#/definitions/string" },
-        { "$ref": "#/definitions/number" }
+        { "type": "null", "title": "Null/missing value" },
+        { "$ref": "#/definitions/strict-string" },
+        { "$ref": "#/definitions/strict-number" },
+        { "$ref": "#/definitions/func-if" }
       ]
     },
     "func-if": {

--- a/schemas/json/layout/expression.schema.v1.json
+++ b/schemas/json/layout/expression.schema.v1.json
@@ -110,15 +110,6 @@
         { "type": "number", "title": "Numeric constant" }
       ]
     },
-    "string-or-number": {
-      "title": "Any expression returning a string or number",
-      "oneOf": [
-        { "type": "null", "title": "Null/missing value" },
-        { "$ref": "#/definitions/strict-string" },
-        { "$ref": "#/definitions/strict-number" },
-        { "$ref": "#/definitions/func-if" }
-      ]
-    },
     "func-if": {
       "title": "If/else conditional expression",
       "description": "This function will evaluate and return the result of either branch. If else is not given, null will be returned instead.",
@@ -194,7 +185,7 @@
       "items": [
         { "const":  "concat" }
       ],
-      "additionalItems": { "$ref": "#/definitions/string-or-number" }
+      "additionalItems": { "$ref": "#/definitions/string" }
     },
     "func-equals": {
       "title": "Equals function",
@@ -234,8 +225,8 @@
       "type": "array",
       "items": [
         { "const":  "greaterThan" },
-        { "$ref": "#/definitions/string-or-number" },
-        { "$ref": "#/definitions/string-or-number" }
+        { "$ref": "#/definitions/number" },
+        { "$ref": "#/definitions/number" }
       ],
       "additionalItems": false
     },
@@ -245,8 +236,8 @@
       "type": "array",
       "items": [
         { "const":  "greaterThanEq" },
-        { "$ref": "#/definitions/string-or-number" },
-        { "$ref": "#/definitions/string-or-number" }
+        { "$ref": "#/definitions/number" },
+        { "$ref": "#/definitions/number" }
       ],
       "additionalItems": false
     },
@@ -256,8 +247,8 @@
       "type": "array",
       "items": [
         { "const":  "lessThan" },
-        { "$ref": "#/definitions/string-or-number" },
-        { "$ref": "#/definitions/string-or-number" }
+        { "$ref": "#/definitions/number" },
+        { "$ref": "#/definitions/number" }
       ],
       "additionalItems": false
     },
@@ -267,8 +258,8 @@
       "type": "array",
       "items": [
         { "const":  "lessThanEq" },
-        { "$ref": "#/definitions/string-or-number" },
-        { "$ref": "#/definitions/string-or-number" }
+        { "$ref": "#/definitions/number" },
+        { "$ref": "#/definitions/number" }
       ],
       "additionalItems": false
     },


### PR DESCRIPTION
## Description
The expression schema contained a loose type reference that caused error messages when referencing the `lessThan`, `lessThanEq`, `greaterThan` and `greaterThanEq` functions (at least). After loosening the types and introducing optional `strict-<type>` definitions, the definitions for these functions were impossible to validate.

As an example, both of these examples failed:

`["lessThan", 5, 500]`

`["lessThan", ["dataModel", "something"], "80"]`

This was because the two arguments could match either a string or number, but each individual type (string and number) was at some point widened to also include the other type (number and string), so multiple paths contained valid solutions.

## Related Issue(s)

- closes #{issue number}

## Verification

- Manual testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added
  - [ ] Cypress E2E test(s) have been added
  - [x] No automatic tests are needed here
  - [ ] I want someone to help me make some tests
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been updated
  <!--- insert link to PR here -->
  - [x] No changes/updates needed
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board <!--- If you don't have permissions for this, someone else will do it for you -->
