### PR TITLE
Repeating groups: Exclude non-form components from table header

### DIFF
--- a/src/features/form/containers/RepeatingGroupTable.tsx
+++ b/src/features/form/containers/RepeatingGroupTable.tsx
@@ -12,6 +12,8 @@ import {
 } from 'src/features/form/components/FullWidthWrapper';
 import { RepeatingGroupsEditContainer } from 'src/features/form/containers/RepeatingGroupsEditContainer';
 import { RepeatingGroupTableRow } from 'src/features/form/containers/RepeatingGroupTableRow';
+import { ComponentType } from 'src/layout';
+import { getLayoutComponentObject } from 'src/layout/LayoutComponent';
 import altinnAppTheme from 'src/theme/altinnAppTheme';
 import { getTextResource } from 'src/utils/formComponentUtils';
 import { createRepeatingGroupComponents } from 'src/utils/formLayout';
@@ -22,7 +24,7 @@ import { componentHasValidations, repeatingGroupHasValidations } from 'src/utils
 import type { IFormData } from 'src/features/form/data';
 import type { ILayoutGroup } from 'src/layout/Group/types';
 import type { ILayoutCompInput } from 'src/layout/Input/types';
-import type { ComponentInGroup, ILayout, ILayoutComponent } from 'src/layout/layout';
+import type { ComponentExceptGroupAndSummary, ComponentInGroup, ILayout, ILayoutComponent } from 'src/layout/layout';
 import type { IAttachments } from 'src/shared/resources/attachments';
 import type { IOptions, IRepeatingGroups, ITextResource, ITextResourceBindings, IValidations } from 'src/types';
 import type { ILanguage } from 'src/types/shared';
@@ -193,6 +195,10 @@ export function RepeatingGroupTable({
 
   const componentsDeepCopy: ILayoutComponent[] = JSON.parse(JSON.stringify(components));
   const tableComponents = componentsDeepCopy.filter((component) => {
+    const layoutComponent = getLayoutComponentObject(component.type as ComponentExceptGroupAndSummary);
+    if (layoutComponent?.getComponentType() !== ComponentType.Form) {
+      return false;
+    }
     const childId = component.baseComponentId || component.id;
     return tableHeaderComponentIds.includes(childId);
   });


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the Title above
  Describe your change(s) in detail here

  Also add the relevant label in the column on the right:
    Breaking changes: kind/breaking-change
    New features:     kind/product-feature
    Bug fixes:        kind/bug
    Dependencies:     kind/dependencies
    Other changes:    kind/other
-->
Continuing with the new `getComponentType()`, I used this to not show irrelevant components in table headers. This hides both `ComponentType.Presentation` components as well as nested groups which does not have any form data to show in the table anyway, and would show up as `Elementer` with empty data.

Only `ComponentType.Form` is actually valid since only they have formData to put in the table. Previously, you would have to manually remove these by specifying `tableHeaders`.

<img width="299" alt="image" src="https://user-images.githubusercontent.com/47412359/215766824-fde99892-c20b-4cae-9305-a82cec55fcaa.png">


## Related Issue(s)

- n/a

## Verification

- Manual testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added
  - [ ] Cypress E2E test(s) have been added
  - [x] No automatic tests are needed here
  - [ ] I want someone to help me make some tests
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been updated
  <!--- insert link to PR here -->
  - [x] No changes/updates needed
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board <!--- If you don't have permissions for this, someone else will do it for you -->
