### PR TITLE
Fix `pageBreak` property in component schema

### DIFF
--- a/schemas/json/layout/layout.schema.v1.json
+++ b/schemas/json/layout/layout.schema.v1.json
@@ -118,7 +118,7 @@
         },
         "pageBreak": {
           "$ref": "#/definitions/pageBreak"
-        },
+        }
       },
       "required": ["id", "type"],
       "allOf": [

--- a/schemas/json/layout/layout.schema.v1.json
+++ b/schemas/json/layout/layout.schema.v1.json
@@ -115,10 +115,10 @@
               "xs": 12
             }
           ]
-        }
-      },
-      "pageBreak": {
-        "$ref": "#/definitions/pageBreak"
+        },
+        "pageBreak": {
+          "$ref": "#/definitions/pageBreak"
+        },
       },
       "required": ["id", "type"],
       "allOf": [


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the Title above
  Describe your change(s) in detail here

  Also add the relevant label in the column on the right:
    Breaking changes: kind/breaking-change
    New features:     kind/product-feature
    Bug fixes:        kind/bug
    Dependencies:     kind/dependencies
    Other changes:    kind/other
-->

The `pageBreak` property was accidentally place outside of the `properties` of the `component` definition.