### PR TITLE
PDF: Fix issue when components are undefined in settings

### DIFF
--- a/src/features/form/layout/formLayoutSlice.ts
+++ b/src/features/form/layout/formLayoutSlice.ts
@@ -138,10 +138,8 @@ const formLayoutSlice = createSagaSlice((mkAction: MkActionType<ILayoutState>) =
             }
           }
         }
-        if (settings && settings.components) {
-          const { excludeFromPdf = state.uiConfig.excludeComponentFromPdf } = settings.components;
-          state.uiConfig.excludeComponentFromPdf = excludeFromPdf ?? [];
-        }
+        state.uiConfig.excludeComponentFromPdf = settings?.components?.excludeFromPdf ?? [];
+        state.uiConfig.excludePageFromPdf = settings?.pages?.excludeFromPdf ?? [];
       },
     }),
     fetchSettingsRejected: mkAction<LayoutTypes.IFormLayoutActionRejected>({
@@ -352,7 +350,7 @@ const updateCommonPageSettings = (
   state: ILayoutState,
   page: Pick<
     IPagesSettings,
-    'hideCloseButton' | 'showLanguageSelector' | 'showProgress' | 'triggers' | 'excludeFromPdf' | 'pdfLayoutName'
+    'hideCloseButton' | 'showLanguageSelector' | 'showProgress' | 'triggers' | 'pdfLayoutName'
   >,
 ) => {
   const {
@@ -360,7 +358,6 @@ const updateCommonPageSettings = (
     showLanguageSelector = state.uiConfig.showLanguageSelector,
     showProgress = state.uiConfig.showProgress,
     triggers = state.uiConfig.pageTriggers,
-    excludeFromPdf = state.uiConfig.excludePageFromPdf,
     pdfLayoutName = state.uiConfig.pdfLayoutName,
   } = page;
 
@@ -368,7 +365,6 @@ const updateCommonPageSettings = (
   state.uiConfig.showProgress = showProgress;
   state.uiConfig.showLanguageSelector = showLanguageSelector;
   state.uiConfig.pageTriggers = triggers;
-  state.uiConfig.excludePageFromPdf = excludeFromPdf ?? [];
   state.uiConfig.pdfLayoutName = pdfLayoutName;
 };
 


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the Title above
  Describe your change(s) in detail here

  Also add the relevant label in the column on the right:
    Breaking changes: kind/breaking-change
    New features:     kind/product-feature
    Bug fixes:        kind/bug
    Dependencies:     kind/dependencies
    Other changes:    kind/other
-->

[This issue](https://altinndevops.slack.com/archives/C045EB3JA9X/p1675197258028169) was caused by the saga not taking into account that the `components` property of `Settings.json` could be undefined, and so it would not initialize it to an empty list and would therefore assume that excludedComponents had not loaded yet.