### PR TITLE
Preventing crash on Party selection for users with names that contains abnormal spaces

### DIFF
--- a/src/utils/stringHelper.test.ts
+++ b/src/utils/stringHelper.test.ts
@@ -1,0 +1,15 @@
+import { capitalizeName } from 'src/utils/stringHelper';
+
+describe('stringHelper', () => {
+  it('can capitalize a name', () => {
+    expect(capitalizeName('åge ågesen')).toEqual('Åge Ågesen');
+    expect(capitalizeName('alf Prøysen')).toEqual('Alf Prøysen');
+    expect(capitalizeName('alf  Prøysen ')).toEqual('Alf Prøysen');
+    expect(capitalizeName('alf    Prøysen ')).toEqual('Alf Prøysen');
+    expect(capitalizeName('  alf    prøysen ')).toEqual('Alf Prøysen');
+    expect(capitalizeName('conan o’brien')).toEqual('Conan O’brien');
+    expect(capitalizeName('robert conner, jr.')).toEqual('Robert Conner, Jr.');
+    expect(capitalizeName('léonardo di caprio')).toEqual('Léonardo Di Caprio');
+    expect(capitalizeName('" \'')).toEqual('" \'');
+  });
+});

--- a/src/utils/stringHelper.ts
+++ b/src/utils/stringHelper.ts
@@ -1,8 +1,19 @@
-export const capitalizeName: (name: string) => string = (name: string) => {
+export const capitalizeName = (name: string) => {
   return name
     .toLowerCase()
     .split(' ')
-    .map((str: string) => [str.split('')[0].toUpperCase(), str.substring(1)].join(''))
+    .map((word) => word.trim())
+    .filter((word) => !!word)
+    .map((word) => {
+      const firstLetter = word[0];
+      const rest = word.substring(1);
+
+      if (firstLetter && rest) {
+        return firstLetter.toUpperCase() + rest;
+      }
+
+      return word;
+    })
     .join(' ')
     .trim();
 };


### PR DESCRIPTION
## Description
The nifty `capitalizeName` function, which is used in `PartySelection`, caused an app to crash when the new test data from Tenor contained a name with a space on the end of the string. Fixing this, and adding a unit test for the function.

## Related Issue(s)
- https://altinn.slack.com/archives/C02ESDSGPN1/p1675241690237699

## Verification
- Manual testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added
  - [ ] Cypress E2E test(s) have been added
  - [ ] No automatic tests are needed here
  - [ ] I want someone to help me make some tests
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been updated
  <!--- insert link to PR here -->
  - [x] No changes/updates needed
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board <!--- If you don't have permissions for this, someone else will do it for you -->
