### PR TITLE
Show presentation texts and dueBefore on the select-instance page

### DIFF
--- a/src/features/instantiate/containers/InstanceSelection.tsx
+++ b/src/features/instantiate/containers/InstanceSelection.tsx
@@ -23,7 +23,8 @@ export interface IInstanceSelectionProps {
   onNewInstance: () => void;
 }
 
-function getDateDisplayString(timeStamp: string) {
+function getDateDisplayString(timeStamp?: string) {
+  if (!timeStamp) return '';
   let date = new Date(timeStamp);
   const offset = date.getTimezoneOffset();
   date = new Date(date.getTime() - offset * 60 * 1000);
@@ -75,11 +76,21 @@ export default function InstanceSelection({ instances, onNewInstance }: IInstanc
                 items={[
                   {
                     key: 1,
+                    label: getLanguageFromKey('instance_selection.presentation_texts', language),
+                    value: Object.values(instance.presentationTexts ?? {}).join(' '),
+                  },
+                  {
+                    key: 2,
+                    label: getLanguageFromKey('instance_selection.due_before', language),
+                    value: getDateDisplayString(instance.dueBefore),
+                  },
+                  {
+                    key: 3,
                     label: getLanguageFromKey('instance_selection.last_changed', language),
                     value: getDateDisplayString(instance.lastChanged),
                   },
                   {
-                    key: 2,
+                    key: 4,
                     label: getLanguageFromKey('instance_selection.changed_by', language),
                     value: instance.lastChangedBy,
                   },
@@ -98,10 +109,16 @@ export default function InstanceSelection({ instances, onNewInstance }: IInstanc
   };
 
   const renderTable = () => {
+    const has_presentation_values = instances.some((i) => i.presentationTexts && Object.keys(i.presentationTexts));
+    const has_due_before = instances.some((i) => i.dueBefore);
     return (
       <AltinnTable id='instance-selection-table'>
         <AltinnTableHeader id='instance-selection-table-header'>
           <AltinnTableRow>
+            {has_presentation_values && (
+              <TableCell>{getLanguageFromKey('instance_selection.presentation_texts', language)}</TableCell>
+            )}
+            {has_due_before && <TableCell>{getLanguageFromKey('instance_selection.due_before', language)}</TableCell>}
             <TableCell>{getLanguageFromKey('instance_selection.last_changed', language)}</TableCell>
             <TableCell>{getLanguageFromKey('instance_selection.changed_by', language)}</TableCell>
           </AltinnTableRow>
@@ -110,6 +127,10 @@ export default function InstanceSelection({ instances, onNewInstance }: IInstanc
           {instances.map((instance: ISimpleInstance) => {
             return (
               <AltinnTableRow key={instance.id}>
+                {has_presentation_values && (
+                  <TableCell>{Object.values(instance.presentationTexts ?? {}).join(' ')}</TableCell>
+                )}
+                {has_due_before && <TableCell>{getDateDisplayString(instance.dueBefore)}</TableCell>}
                 <TableCell>{getDateDisplayString(instance.lastChanged)}</TableCell>
                 <TableCell>{instance.lastChangedBy}</TableCell>
                 <TableCell style={buttonCell}>

--- a/src/language/texts/en.ts
+++ b/src/language/texts/en.ts
@@ -147,10 +147,12 @@ export function en() {
       changed_by: 'Changed by',
       continue: 'Continue here',
       description: 'Choose if you want to continue on an existing form, or if you want to start on a new one.',
+      due_before: 'Due Before',
       header: 'You have already started filling out this form.',
       last_changed: 'Last changed',
       left_of: 'Continue where you left of',
       new_instance: 'Start over',
+      presentation_texts: 'Text',
     },
     instantiate: {
       all_forms: 'all forms',

--- a/src/language/texts/nb.ts
+++ b/src/language/texts/nb.ts
@@ -147,10 +147,12 @@ export function nb() {
       changed_by: 'Endret av',
       continue: 'Fortsett her',
       description: 'Velg om du vil fortsette på et skjema du har begynt på, eller om du vil starte på ny.',
+      due_before: 'Frist',
       header: 'Du har allerede startet å fylle ut dette skjemaet.',
       last_changed: 'Sist endret',
       left_of: 'Fortsett der du slapp',
       new_instance: 'Start på nytt',
+      presentation_texts: 'Text',
     },
     instantiate: {
       all_forms: 'alle skjema',

--- a/src/language/texts/nn.ts
+++ b/src/language/texts/nn.ts
@@ -147,10 +147,12 @@ export function nn() {
       changed_by: 'Endra av',
       continue: 'Hald fram her',
       description: 'Vel om du vil halde fram med eit skjema du har byrja på, eller om du vil starte på ny.',
+      due_before: 'Frist',
       header: 'Du har allereie starta å fylle ut dette skjemaet.',
       last_changed: 'Sist endra',
       left_of: 'Hald fram der du slapp',
       new_instance: 'Start på nytt',
+      presentation_texts: 'Text',
     },
     instantiate: {
       all_forms: 'alle skjema',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -138,6 +138,8 @@ export interface ISchemaValidator {
 
 export interface ISimpleInstance {
   id: string;
+  presentationTexts?: { [key: string]: string };
+  dueBefore?: string;
   lastChanged: string;
   lastChangedBy: string;
 }


### PR DESCRIPTION
This builds on 
- https://github.com/Altinn/app-lib-dotnet/pull/179
- https://github.com/Altinn/app-lib-dotnet/pull/177

and exposes that information in the frontend. It is fully backwards compatible with older versions of nuget packages (but will only show the new columns on newer package versions).

TODO:
* Find a better header for `PresentationTexts` (I went with `Texts`)
* Fix mobile layout to only show the new columns when they have values.
* Fix mobile layout. It looks ugly.

Images:
![image](https://user-images.githubusercontent.com/131616/216069399-58c85079-3b59-4150-862f-73103eeb2569.png)
![image](https://user-images.githubusercontent.com/131616/216069483-b5470827-f770-4996-84a6-c8f3f4fa80c3.png)


## Related Issue(s)


## Verification

- Manual testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added
  - [ ] Cypress E2E test(s) have been added
  - [ ] No automatic tests are needed here
  - [ ] I want someone to help me make some tests
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been updated
  <!--- insert link to PR here -->
  - [ ] No changes/updates needed
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [ ] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board <!--- If you don't have permissions for this, someone else will do it for you -->
