### PR TITLE
WCAG: Added `aria-expanded` to repeating group edit button

### DIFF
--- a/src/features/form/containers/RepeatingGroupTableRow.tsx
+++ b/src/features/form/containers/RepeatingGroupTableRow.tsx
@@ -237,12 +237,14 @@ export function RepeatingGroupTableRow({
           >
             <div className={classes.buttonInCellWrapper}>
               <Button
+                aria-expanded={isEditingRow}
+                aria-controls={isEditingRow ? `group-edit-container-${id}-${index}` : undefined}
                 variant={ButtonVariant.Quiet}
                 color={ButtonColor.Secondary}
                 icon={rowHasErrors ? <ErrorIcon aria-hidden='true' /> : <EditIcon aria-hidden='true' />}
                 iconPlacement='right'
                 onClick={onEditClick}
-                aria-label={`${editButtonText}-${firstCellData}`}
+                aria-label={`${editButtonText} ${firstCellData}`}
                 data-testid='edit-button'
                 className={classes.tableButton}
               >
@@ -301,12 +303,14 @@ export function RepeatingGroupTableRow({
         >
           <div className={classes.buttonInCellWrapper}>
             <Button
+              aria-expanded={isEditingRow}
+              aria-controls={isEditingRow ? `group-edit-container-${id}-${index}` : undefined}
               variant={ButtonVariant.Quiet}
               color={ButtonColor.Secondary}
               icon={rowHasErrors ? <ErrorIcon aria-hidden='true' /> : <EditIcon aria-hidden='true' />}
               iconPlacement='right'
               onClick={onEditClick}
-              aria-label={`${editButtonText}-${firstCellData}`}
+              aria-label={`${editButtonText} ${firstCellData}`}
               data-testid='edit-button'
               className={classes.tableButton}
             >

--- a/src/features/form/containers/RepeatingGroupsEditContainer.tsx
+++ b/src/features/form/containers/RepeatingGroupsEditContainer.tsx
@@ -139,6 +139,7 @@ export function RepeatingGroupsEditContainer({
 
   return (
     <div
+      id={`group-edit-container-${id}-${editIndex}`}
       className={cn(
         isNested ? classes.nestedEditContainer : classes.editContainer,
         { [classes.hideTable]: hideTable, [classes.nestedHideTable]: hideTable && isNested },


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the Title above
  Describe your change(s) in detail here

  Also add the relevant label in the column on the right:
    Breaking changes: kind/breaking-change
    New features:     kind/product-feature
    Bug fixes:        kind/bug
    Dependencies:     kind/dependencies
    Other changes:    kind/other
-->

Added an `aria-expanded` attribute to the edit button in repeating groups that is set to true when the group row is open for editing. It also sets `aria-control` to the `RepeatingGroupsEditContainer`, but only when the element is open, since it is not present in the DOM when closed.

## Related Issue(s)

- closes #898 

## Verification

- Manual testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added
  - [ ] Cypress E2E test(s) have been added
  - [x] No automatic tests are needed here
  - [ ] I want someone to help me make some tests
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been updated
  <!--- insert link to PR here -->
  - [x] No changes/updates needed
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board <!--- If you don't have permissions for this, someone else will do it for you -->
