### PR TITLE
Supporting Cypress tests in newer LocalTest with http mode

### DIFF
--- a/test/e2e/support/app-frontend.ts
+++ b/test/e2e/support/app-frontend.ts
@@ -60,8 +60,8 @@ Cypress.Commands.add('reduxDispatch', (action) => {
   return cy.window().its('reduxStore').invoke('dispatch', action);
 });
 
-Cypress.Commands.add('interceptLayout', (layoutName, mutator, wholeLayoutMutator) => {
-  cy.intercept({ method: 'GET', url: `**/api/layouts/${layoutName}`, times: 1 }, (req) => {
+Cypress.Commands.add('interceptLayout', (taskName, mutator, wholeLayoutMutator) => {
+  cy.intercept({ method: 'GET', url: `**/api/layouts/${taskName}`, times: 1 }, (req) => {
     req.reply((res) => {
       const set = JSON.parse(res.body);
       for (const layout of Object.values(set)) {
@@ -72,5 +72,5 @@ Cypress.Commands.add('interceptLayout', (layoutName, mutator, wholeLayoutMutator
       }
       res.send(JSON.stringify(set));
     });
-  }).as(`interceptLayout(${layoutName})`);
+  }).as(`interceptLayout(${taskName})`);
 });

--- a/test/e2e/support/global.d.ts
+++ b/test/e2e/support/global.d.ts
@@ -111,7 +111,7 @@ declare global {
        * Must be called in the beginning of your test.
        */
       interceptLayout(
-        layoutName: FrontendTestTask | string,
+        taskName: FrontendTestTask | string,
         mutator: (component: ILayoutComponentOrGroup) => void,
         wholeLayoutMutator?: (layoutSet: any) => void,
       ): Chainable<null>;

--- a/test/e2e/support/start-app-instance.ts
+++ b/test/e2e/support/start-app-instance.ts
@@ -45,8 +45,16 @@ Cypress.Commands.add('startAppInstance', (appName, anonymous = false) => {
       cy.visit(`${Cypress.config('baseUrl')}/ttd/${appName}/`, visitOptions);
     } else {
       cy.visit('/', visitOptions);
-      cy.get(appFrontend.appSelection).select(appName);
-      cy.get(appFrontend.startButton).click();
+      cy.get('body')
+        .then(($body) => {
+          const appSelection = $body.find(appFrontend.appSelection);
+          if (appSelection) {
+            appSelection.find(`option[value="${appName}"]`).select();
+          }
+
+          return $body.find(appFrontend.startButton);
+        })
+        .click();
     }
   } else {
     if (!anonymous) {


### PR DESCRIPTION
## Description
I found that Cypress tests no longer worked locally when I'm running apps in the http-mode (only one app at a time), as the app selector dropdown is gone now.

## Related Issue(s)

- closes #{issue number}

## Verification

- Manual testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added
  - [x] Cypress E2E test(s) have been added
  - [ ] No automatic tests are needed here
  - [ ] I want someone to help me make some tests
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been updated
  <!--- insert link to PR here -->
  - [x] No changes/updates needed
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board <!--- If you don't have permissions for this, someone else will do it for you -->
