### PR TITLE
WCAG: Fixed `aria-expanded` on delete button without popover

### DIFF
--- a/src/features/form/containers/RepeatingGroupTableRow.tsx
+++ b/src/features/form/containers/RepeatingGroupTableRow.tsx
@@ -267,8 +267,8 @@ export function RepeatingGroupTableRow({
                 )}
               >
                 <div className={classes.buttonInCellWrapper}>
-                  <DeleteWarningPopover
-                    trigger={
+                  {(() => {
+                    const deleteButton = (
                       <Button
                         variant={ButtonVariant.Quiet}
                         color={ButtonColor.Danger}
@@ -282,16 +282,26 @@ export function RepeatingGroupTableRow({
                       >
                         {deleteButtonText}
                       </Button>
+                    );
+
+                    if (edit?.alertOnDelete) {
+                      return (
+                        <DeleteWarningPopover
+                          trigger={deleteButton}
+                          side='left'
+                          language={language}
+                          deleteButtonText={getLanguageFromKey('group.row_popover_delete_button_confirm', language)}
+                          messageText={getLanguageFromKey('group.row_popover_delete_message', language)}
+                          open={popoverPanelIndex == index && popoverOpen}
+                          setPopoverOpen={setPopoverOpen}
+                          onCancelClick={() => onOpenChange(index)}
+                          onPopoverDeleteClick={onPopoverDeleteClick(index)}
+                        />
+                      );
+                    } else {
+                      return deleteButton;
                     }
-                    side='left'
-                    language={language}
-                    deleteButtonText={getLanguageFromKey('group.row_popover_delete_button_confirm', language)}
-                    messageText={getLanguageFromKey('group.row_popover_delete_message', language)}
-                    open={popoverPanelIndex == index && popoverOpen}
-                    setPopoverOpen={setPopoverOpen}
-                    onCancelClick={() => onOpenChange(index)}
-                    onPopoverDeleteClick={onPopoverDeleteClick(index)}
-                  />
+                  })()}
                 </div>
               </TableCell>
             )}
@@ -323,8 +333,8 @@ export function RepeatingGroupTableRow({
               typeof popoverOpen === 'boolean' && (
                 <>
                   <div style={{ height: 8 }} />
-                  <DeleteWarningPopover
-                    trigger={
+                  {(() => {
+                    const deleteButton = (
                       <Button
                         variant={ButtonVariant.Quiet}
                         color={ButtonColor.Danger}
@@ -338,16 +348,26 @@ export function RepeatingGroupTableRow({
                       >
                         {(isEditingRow || !mobileViewSmall) && deleteButtonText}
                       </Button>
+                    );
+
+                    if (edit?.alertOnDelete) {
+                      return (
+                        <DeleteWarningPopover
+                          trigger={deleteButton}
+                          side='left'
+                          language={language}
+                          deleteButtonText={getLanguageFromKey('group.row_popover_delete_button_confirm', language)}
+                          messageText={getLanguageFromKey('group.row_popover_delete_message', language)}
+                          open={popoverPanelIndex == index && popoverOpen}
+                          setPopoverOpen={setPopoverOpen}
+                          onCancelClick={() => onOpenChange(index)}
+                          onPopoverDeleteClick={onPopoverDeleteClick(index)}
+                        />
+                      );
+                    } else {
+                      return deleteButton;
                     }
-                    side='left'
-                    language={language}
-                    deleteButtonText={getLanguageFromKey('group.row_popover_delete_button_confirm', language)}
-                    messageText={getLanguageFromKey('group.row_popover_delete_message', language)}
-                    open={popoverPanelIndex == index && popoverOpen}
-                    setPopoverOpen={setPopoverOpen}
-                    onCancelClick={() => onOpenChange(index)}
-                    onPopoverDeleteClick={onPopoverDeleteClick(index)}
-                  />
+                  })()}
                 </>
               )}
           </div>


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the Title above
  Describe your change(s) in detail here

  Also add the relevant label in the column on the right:
    Breaking changes: kind/breaking-change
    New features:     kind/product-feature
    Bug fixes:        kind/bug
    Dependencies:     kind/dependencies
    Other changes:    kind/other
-->

This came up when testing this: https://github.com/Altinn/app-frontend-react/pull/900. Made it so that popover is not present unless alertOnDelete is true. Apparently the popover component itself was responsible for setting these attributes on the button.

## Related Issue(s)

- https://github.com/Altinn/app-frontend-react/issues/898

## Verification

- Manual testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added
  - [ ] Cypress E2E test(s) have been added
  - [x] No automatic tests are needed here
  - [ ] I want someone to help me make some tests
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been updated
  <!--- insert link to PR here -->
  - [x] No changes/updates needed
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board <!--- If you don't have permissions for this, someone else will do it for you -->
