### PR TITLE
Give dev a compact navbar option (#906)

### DIFF
--- a/schemas/json/layout/layout.schema.v1.json
+++ b/schemas/json/layout/layout.schema.v1.json
@@ -139,7 +139,7 @@
         { "if": {"properties": {"type": { "const": "Likert"}}}, "then": { "$ref": "#/definitions/radioAndCheckboxComponents"}},
         { "if": {"properties": {"type": { "const": "MultipleSelect"}}}, "then": { "$ref": "#/definitions/selectionComponents"}},
         { "if": {"properties": {"type": { "const": "NavigationButtons"}}}, "then": { "$ref": "#/definitions/navigationButtonsComponent"}},
-        { "if": {"properties": {"type": { "const": "navigationBarComponent"}}}, "then": { "$ref": "#/definitions/navigationBarComponent"}},
+        { "if": {"properties": {"type": { "const": "NavigationBar"}}}, "then": { "$ref": "#/definitions/navigationBarComponent"}},
         { "if": {"properties": {"type": { "const": "RadioButtons"}}}, "then": { "$ref": "#/definitions/radioAndCheckboxComponents"}},
         { "if": {"properties": {"type": { "const": "Summary"}}}, "then": {"$ref": "#/definitions/summaryComponent"}},
         { "if": {"properties": {"type": { "const": "Header"}}}, "then": {"$ref": "#/definitions/headerComponent"}},
@@ -285,7 +285,7 @@
     "navigationBarComponent": {
       "properties": {
         "compact": {
-          "type": "boolean",
+          "type":"boolean",
           "title": "Compact navbar menu",
           "description": "Change appearance of navbar as compact in desktop view"
         }

--- a/schemas/json/layout/layout.schema.v1.json
+++ b/schemas/json/layout/layout.schema.v1.json
@@ -139,6 +139,7 @@
         { "if": {"properties": {"type": { "const": "Likert"}}}, "then": { "$ref": "#/definitions/radioAndCheckboxComponents"}},
         { "if": {"properties": {"type": { "const": "MultipleSelect"}}}, "then": { "$ref": "#/definitions/selectionComponents"}},
         { "if": {"properties": {"type": { "const": "NavigationButtons"}}}, "then": { "$ref": "#/definitions/navigationButtonsComponent"}},
+        { "if": {"properties": {"type": { "const": "navigationBarComponent"}}}, "then": { "$ref": "#/definitions/navigationBarComponent"}},
         { "if": {"properties": {"type": { "const": "RadioButtons"}}}, "then": { "$ref": "#/definitions/radioAndCheckboxComponents"}},
         { "if": {"properties": {"type": { "const": "Summary"}}}, "then": {"$ref": "#/definitions/summaryComponent"}},
         { "if": {"properties": {"type": { "const": "Header"}}}, "then": {"$ref": "#/definitions/headerComponent"}},
@@ -278,6 +279,15 @@
           "type": "boolean",
           "title": "Show back button",
           "description": "Shows two buttons (back/next) instead of just 'next'."
+        }
+      }
+    },
+    "navigationBarComponent": {
+      "properties": {
+        "compact": {
+          "type": "boolean",
+          "title": "Compact navbar menu",
+          "description": "Change appearance of navbar as compact in desktop view"
         }
       }
     },

--- a/src/layout/NavigationBar/NavigationBarComponent.test.tsx
+++ b/src/layout/NavigationBar/NavigationBarComponent.test.tsx
@@ -177,23 +177,6 @@ describe('NavigationBar', () => {
       setScreenWidth(500);
     });
 
-    it('should show navigation buttons when clicking navigation toggle button, and hide toggle button', async () => {
-      render();
-
-      const navMenu = screen.getByTestId('navigation-menu');
-      const toggleButton = screen.getByRole('button', {
-        name: /1\/3 page1/i,
-      });
-
-      expect(navMenu).toHaveProperty('hidden', true);
-      expect(toggleButton).toHaveProperty('hidden', false);
-
-      await act(() => userEvent.click(toggleButton));
-
-      expect(navMenu).toHaveProperty('hidden', false);
-      expect(toggleButton).toHaveProperty('hidden', true);
-    });
-
     it('should automatically focus the first item in the navigation menu when it is displayed', async () => {
       render();
 

--- a/src/layout/NavigationBar/NavigationBarComponent.test.tsx
+++ b/src/layout/NavigationBar/NavigationBarComponent.test.tsx
@@ -177,17 +177,6 @@ describe('NavigationBar', () => {
       setScreenWidth(500);
     });
 
-    it('should hide navigation buttons and show a button to toggle the navigation menu', async () => {
-      render();
-
-      expect(screen.getByTestId('navigation-menu')).toHaveProperty('hidden', true);
-      expect(
-        screen.getByRole('button', {
-          name: /1\/3 page1/i,
-        }),
-      ).toBeInTheDocument();
-    });
-
     it('should show navigation buttons when clicking navigation toggle button, and hide toggle button', async () => {
       render();
 

--- a/src/layout/NavigationBar/NavigationBarComponent.tsx
+++ b/src/layout/NavigationBar/NavigationBarComponent.tsx
@@ -24,6 +24,9 @@ const useStyles = makeStyles((theme) => ({
       flexDirection: 'column',
     },
   },
+  menuCompact: {
+    flexDirection: 'column',
+  },
   containerBase: {
     borderRadius: '40px',
 
@@ -101,7 +104,7 @@ const NavigationButton = React.forwardRef(
 
 NavigationButton.displayName = 'NavigationButton';
 
-export const NavigationBarComponent = ({ triggers }: INavigationBar) => {
+export const NavigationBarComponent = ({ triggers, compact }: INavigationBar) => {
   const classes = useStyles();
   const dispatch = useAppDispatch();
   const pageIds = useAppSelector(selectLayoutOrder);
@@ -113,7 +116,7 @@ export const NavigationBarComponent = ({ triggers }: INavigationBar) => {
   const language = useAppSelector((state) => state.language.language);
   const [showMenu, setShowMenu] = React.useState(false);
   const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down(600));
+  const isMobile = useMediaQuery(theme.breakpoints.down(600)) || compact;
   const firstPageLink = React.useRef<HTMLButtonElement>();
 
   const handleNavigationClick = (pageId: string) => {
@@ -176,7 +179,9 @@ export const NavigationBarComponent = ({ triggers }: INavigationBar) => {
           hidden={!shouldShowMenu}
           id='navigation-menu'
           data-testid='navigation-menu'
-          className={classes.menu}
+          className={cn(classes.menu, {
+            [classes.menuCompact]: isMobile,
+          })}
         >
           {pageIds.map((pageId, index) => {
             return (

--- a/src/layout/NavigationBar/NavigationBarComponent.tsx
+++ b/src/layout/NavigationBar/NavigationBarComponent.tsx
@@ -116,7 +116,8 @@ export const NavigationBarComponent = ({ triggers, compact }: INavigationBar) =>
   const language = useAppSelector((state) => state.language.language);
   const [showMenu, setShowMenu] = React.useState(false);
   const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down(600)) || compact;
+  const isMobile = useMediaQuery(theme.breakpoints.down(600)) || compact === true;
+
   const firstPageLink = React.useRef<HTMLButtonElement>();
 
   const handleNavigationClick = (pageId: string) => {

--- a/src/layout/NavigationBar/NavigationBarComponent.tsx
+++ b/src/layout/NavigationBar/NavigationBarComponent.tsx
@@ -153,6 +153,7 @@ export const NavigationBarComponent = ({ triggers, compact }: INavigationBar) =>
   return (
     <Grid container>
       <Grid
+        data-testid='NavigationBar'
         item
         component='nav'
         xs={12}
@@ -176,31 +177,32 @@ export const NavigationBarComponent = ({ triggers, compact }: INavigationBar) =>
             </span>
           </NavigationButton>
         )}
-        <ul
-          hidden={!shouldShowMenu}
-          id='navigation-menu'
-          data-testid='navigation-menu'
-          className={cn(classes.menu, {
-            [classes.menuCompact]: isMobile,
-          })}
-        >
-          {pageIds.map((pageId, index) => {
-            return (
-              <li
-                key={pageId}
-                className={classes.containerBase}
-              >
-                <NavigationButton
-                  current={currentPageId === pageId}
-                  onClick={() => handleNavigationClick(pageId)}
-                  ref={index === 0 ? firstPageLink : null}
+        {shouldShowMenu && (
+          <ul
+            id='navigation-menu'
+            data-testid='navigation-menu'
+            className={cn(classes.menu, {
+              [classes.menuCompact]: isMobile,
+            })}
+          >
+            {pageIds.map((pageId, index) => {
+              return (
+                <li
+                  key={pageId}
+                  className={classes.containerBase}
                 >
-                  {index + 1}. {getTextResource(pageId, textResources)}
-                </NavigationButton>
-              </li>
-            );
-          })}
-        </ul>
+                  <NavigationButton
+                    current={currentPageId === pageId}
+                    onClick={() => handleNavigationClick(pageId)}
+                    ref={index === 0 ? firstPageLink : null}
+                  >
+                    {index + 1}. {getTextResource(pageId, textResources)}
+                  </NavigationButton>
+                </li>
+              );
+            })}
+          </ul>
+        )}
       </Grid>
     </Grid>
   );

--- a/src/layout/NavigationBar/types.d.ts
+++ b/src/layout/NavigationBar/types.d.ts
@@ -1,3 +1,5 @@
 import type { ILayoutCompBase } from 'src/layout/layout';
 
-export type ILayoutCompNavBar = ILayoutCompBase<'NavigationBar'>;
+export interface ILayoutCompNavBar extends ILayoutCompBase<'NavigationBar'> {
+  compact?: boolean;
+}

--- a/test/e2e/integration/app-frontend/components.ts
+++ b/test/e2e/integration/app-frontend/components.ts
@@ -83,6 +83,20 @@ describe('UI Components', () => {
           .and('have.css', 'background-color', 'rgb(2, 47, 81)');
         cy.get(appFrontend.changeOfName.summaryNameChanges).should('be.visible');
       });
+    cy.viewport('samsung-s10');
+    cy.get(appFrontend.navMenu).should('not.exist');
+    cy.get('[data-testid="NavigationBar"]').find('button:contains("form")').should('not.exist');
+    cy.get('[data-testid="NavigationBar"]').find('button:contains("summary")').should('be.visible');
+    cy.viewport('macbook-16');
+    cy.interceptLayout('changename', (component) => {
+      if (component.type === 'NavigationBar') {
+        component.compact = true;
+      }
+    });
+    cy.reload();
+    cy.get(appFrontend.navMenu).should('not.exist');
+    cy.get('[data-testid="NavigationBar"]').find('button:contains("form")').should('not.exist');
+    cy.get('[data-testid="NavigationBar"]').find('button:contains("summary")').should('be.visible');
   });
 
   it('address component fetches post place from zip code', () => {

--- a/test/e2e/integration/app-frontend/mobile.ts
+++ b/test/e2e/integration/app-frontend/mobile.ts
@@ -33,15 +33,15 @@ describe('Mobile', () => {
     cy.addItemToGroup(1, 2, 'automation');
     cy.get(appFrontend.nextButton).click();
     cy.get(appFrontend.group.sendersName).should('be.visible').type('automation');
-    cy.get(appFrontend.navMenu).should('have.attr', 'hidden');
+    cy.get(appFrontend.navMenu).should('not.exist');
     cy.get(appFrontend.group.navigationBarButton)
       .should('be.visible')
       .and('have.attr', 'aria-expanded', 'false')
       .click();
     cy.get(appFrontend.group.navigationBarButton).should('have.attr', 'aria-expanded', 'true');
-    cy.get(appFrontend.navMenu).should('not.have.attr', 'hidden');
+    cy.get(appFrontend.navMenu).should('be.visible');
     cy.get(appFrontend.navMenu).find('li > button').last().click();
-    cy.get(appFrontend.navMenu).should('have.attr', 'hidden');
+    cy.get(appFrontend.navMenu).should('not.exist');
     cy.sendIn();
     likertPage.selectRequiredRadiosInMobile();
     cy.sendIn();


### PR DESCRIPTION
## Description
Compact navbar feature – option to configure navbar as compact.

Added a boolean type property “compact” to the layout component NavigationBar. Gives app builder the option to configure if they want to make the navbar appearance as a menu, regardless of the width of the viewport. If this is the case, "compact" is set to true in the layout: ``
 {
        "id": "nav1",
        "type": "NavigationBar",
        "compact": true
      }
``

NB! This must be configured on each layout page. Maybe on a later stage this can be implemented in Altinn Studio.




## Related Issue(s)

- closes #906 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [x] Has been added/updated
https://github.com/Altinn/altinn-studio-docs/pull/848
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [x] Changes are reflected in both `src/layout/NavigationBar/types.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [ ] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
