### PR TITLE
Error message - remove long ID, duplication fix

### DIFF
--- a/src/components/message/ErrorReport.tsx
+++ b/src/components/message/ErrorReport.tsx
@@ -68,6 +68,14 @@ export const ErrorReport = ({ components }: IErrorReportProps) => {
     return null;
   }
 
+  if (errorsMapped.length > 0) {
+    errorsMapped.forEach((error, index) => {
+      if (error.componentId === 'fileUploadWithTags-changename') {
+        errorsMapped[index].message = error.message.slice(37);
+      }
+    });
+  }
+
   const handleErrorClick = (error: FlatError) => (ev: React.KeyboardEvent | React.MouseEvent) => {
     if (ev.type === 'keydown' && (ev as React.KeyboardEvent).key !== 'Enter') {
       return;

--- a/src/components/message/ErrorReport.tsx
+++ b/src/components/message/ErrorReport.tsx
@@ -9,6 +9,7 @@ import { FullWidthWrapper } from 'src/features/form/components/FullWidthWrapper'
 import { renderLayoutComponent } from 'src/features/form/containers/Form';
 import { FormLayoutActions } from 'src/features/form/layout/formLayoutSlice';
 import { getLanguageFromKey, getParsedLanguageFromText } from 'src/language/sharedLanguage';
+import { AsciiUnitSeparator } from 'src/utils/attachment';
 import { nodesInLayouts } from 'src/utils/layout/hierarchy';
 import { getMappedErrors, getUnmappedErrors } from 'src/utils/validation/validation';
 import type { ILayout } from 'src/layout/layout';
@@ -66,14 +67,6 @@ export const ErrorReport = ({ components }: IErrorReportProps) => {
 
   if (!hasErrors) {
     return null;
-  }
-
-  if (errorsMapped.length > 0) {
-    errorsMapped.forEach((error, index) => {
-      if (error.componentId === 'fileUploadWithTags-changename') {
-        errorsMapped[index].message = error.message.slice(37);
-      }
-    });
   }
 
   const handleErrorClick = (error: FlatError) => (ev: React.KeyboardEvent | React.MouseEvent) => {
@@ -166,9 +159,16 @@ export const ErrorReport = ({ components }: IErrorReportProps) => {
                       onClick={handleErrorClick(error)}
                       onKeyDown={handleErrorClick(error)}
                     >
-                      {getParsedLanguageFromText(error.message, {
-                        disallowedTags: ['a'],
-                      })}
+                      {error.message.includes(AsciiUnitSeparator)
+                        ? getParsedLanguageFromText(
+                            error.message.substring(error.message.indexOf(AsciiUnitSeparator) + 1),
+                            {
+                              disallowedTags: ['a'],
+                            },
+                          )
+                        : getParsedLanguageFromText(error.message, {
+                            disallowedTags: ['a'],
+                          })}
                     </button>
                   </li>
                 ))}

--- a/src/components/message/ErrorReport.tsx
+++ b/src/components/message/ErrorReport.tsx
@@ -122,6 +122,10 @@ export const ErrorReport = ({ components }: IErrorReportProps) => {
     );
   };
 
+  const errorMessage = (message: string) => {
+    return message.includes(AsciiUnitSeparator) ? message.substring(message.indexOf(AsciiUnitSeparator) + 1) : message;
+  };
+
   return (
     <Grid
       data-testid='ErrorReport'
@@ -159,16 +163,9 @@ export const ErrorReport = ({ components }: IErrorReportProps) => {
                       onClick={handleErrorClick(error)}
                       onKeyDown={handleErrorClick(error)}
                     >
-                      {error.message.includes(AsciiUnitSeparator)
-                        ? getParsedLanguageFromText(
-                            error.message.substring(error.message.indexOf(AsciiUnitSeparator) + 1),
-                            {
-                              disallowedTags: ['a'],
-                            },
-                          )
-                        : getParsedLanguageFromText(error.message, {
-                            disallowedTags: ['a'],
-                          })}
+                      {getParsedLanguageFromText(errorMessage(error.message), {
+                        disallowedTags: ['a'],
+                      })}
                     </button>
                   </li>
                 ))}

--- a/src/layout/FileUploadWithTag/FileListComponent.tsx
+++ b/src/layout/FileUploadWithTag/FileListComponent.tsx
@@ -149,6 +149,7 @@ export function FileList(props: FileListProps): JSX.Element | null {
   if (!props.attachments || props.attachments.length === 0) {
     return null;
   }
+
   return (
     <Grid
       container={true}
@@ -290,6 +291,7 @@ export function FileList(props: FileListProps): JSX.Element | null {
                   </TableRow>
                 );
               }
+
               return (
                 <TableRow key={`altinn-unchosen-option-attachment-row-${index}`}>
                   <TableCell
@@ -301,7 +303,11 @@ export function FileList(props: FileListProps): JSX.Element | null {
                       id={props.id}
                       dataModelBindings={props.dataModelBindings}
                       attachment={props.attachments[index]}
-                      attachmentValidations={props.attachmentValidations}
+                      attachmentValidations={[
+                        ...new Map(
+                          props.attachmentValidations.map((validation) => [validation['id'], validation]),
+                        ).values(),
+                      ]}
                       language={props.language}
                       mobileView={props.mobileView}
                       readOnly={props.readOnly}

--- a/test/e2e/integration/app-frontend/validation.ts
+++ b/test/e2e/integration/app-frontend/validation.ts
@@ -173,6 +173,18 @@ describe('Validation', () => {
       .should('contain.text', texts.attachmentError);
   });
 
+  it('Validation on uploaded attachment type with tag', () => {
+    cy.goto('changename');
+    cy.get(appFrontend.changeOfName.uploadWithTag.uploadZone).selectFile('test/e2e/fixtures/test.pdf', { force: true });
+    cy.get(appFrontend.changeOfName.uploadWithTag.saveTag).click({ multiple: true });
+    cy.get(appFrontend.changeOfName.uploadWithTag.error)
+      .should('exist')
+      .should('be.visible')
+      .should('not.contain.text', appFrontend.changeOfName.uploadWithTag.unwantedChar);
+    cy.get('#toNextTask').click();
+    cy.get(appFrontend.errorReport).should('not.contain.text', appFrontend.changeOfName.uploadWithTag.unwantedChar);
+  });
+
   it('Client side validation from json schema', () => {
     cy.goto('changename');
     cy.get(appFrontend.changeOfName.newLastName).should('be.visible').type('client').blur();

--- a/test/e2e/pageobjects/app-frontend.ts
+++ b/test/e2e/pageobjects/app-frontend.ts
@@ -107,6 +107,8 @@ export class AppFrontend {
       saveTag: '[id^="attachment-save-tag-button"]',
       delete: 'button[class*="makeStyles-deleteButton"]',
       uploaded: '#tagFile',
+      error: '[id^="attachment-error"]',
+      unwantedChar: String.fromCharCode(31),
     },
     reasonRelationship: '#reasonRelationship',
     summaryNameChanges: '#nameChanges',


### PR DESCRIPTION
## Description

This PR addresses two bugs related to file upload with tag.

- ID being displayed in error message.
- While working on the ID-bug above I encountered a second bug where the error message being duplicated if user try to save without a tag and then try to navigate to next page. 

The ID being displayed in the error message/report also includes an ascii unit. Added errorMessage function to check if this is included in the string. If that is the case a substring is returned and otherwise return string as is.
Added cypress tests to secure that this functionality doesn't break on a later stage.

For the duplicated error, I use the Map object to only display error messages that contains unique ID's for file upload elements. 
`let uniqueObjArray = [...new Map(objArray.map((item) => [item["id"], item])).values()];`
For more info about Map: [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map)

<img src="https://user-images.githubusercontent.com/74791975/220366649-6d1bc5e1-6c14-4e10-87ca-e569bf92b862.png" width="500" height="400">


<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes #444 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
