### PR TITLE
Bug: Fix excluded children

### DIFF
--- a/src/components/summary/SummaryGroupComponent.tsx
+++ b/src/components/summary/SummaryGroupComponent.tsx
@@ -91,8 +91,7 @@ export function SummaryGroupComponent({
 
   const removeExcludedChildren = (n: AnyNode<'resolved'>) =>
     !excludedChildren ||
-    !excludedChildren.includes(n.item.id) ||
-    !excludedChildren.includes(`${n.item.baseComponentId}`);
+    (!excludedChildren.includes(n.item.id) && !excludedChildren.includes(`${n.item.baseComponentId}`));
 
   const repeatingGroups = useAppSelector((state) => state.formLayout.uiConfig.repeatingGroups);
   const formData = useAppSelector((state) => state.formData.formData);

--- a/test/e2e/integration/app-frontend/summary.ts
+++ b/test/e2e/integration/app-frontend/summary.ts
@@ -4,6 +4,7 @@ import { Common } from 'test/e2e/pageobjects/common';
 
 import { Triggers } from 'src/types';
 import type { ILayout } from 'src/layout/layout';
+import type { ILayoutCompSummary } from 'src/layout/Summary/types.d';
 
 const appFrontend = new AppFrontend();
 const mui = new Common();
@@ -368,6 +369,78 @@ describe('Summary', () => {
     cy.get(appFrontend.group.showGroupToContinue).find('input[type=checkbox]').uncheck();
     cy.get(appFrontend.navMenu).find('li > button').last().click();
     cy.get('[data-testid=summary-summary-1]').should('not.exist');
+  });
+
+  it.only('Can exclude children from group summary', () => {
+    cy.interceptLayout('group', (component: ILayoutCompSummary) => {
+      if (component.id === 'summary-1') {
+        component.excludedChildren = ['comments-0-1', 'hideComment'];
+      }
+    });
+    cy.goto('group');
+
+    cy.get(appFrontend.group.prefill['liten']).click().blur();
+    cy.get(appFrontend.navMenu).find('li > button').eq(1).click();
+    cy.get(appFrontend.group.showGroupToContinue).get('input').check();
+    // Add data
+    cy.get(appFrontend.group.row(0).editBtn).click();
+    cy.get(appFrontend.group.mainGroup).find(appFrontend.group.editContainer).find(appFrontend.group.next).click();
+
+    cy.get(appFrontend.group.comments).type('first comment').blur();
+    cy.get(appFrontend.group.saveSubGroup).should('be.visible').click().should('not.exist');
+    cy.get(appFrontend.group.addNewItemSubGroup).should('exist').and('be.visible').focus().click();
+
+    cy.get(appFrontend.group.comments).type('second comment').blur();
+    cy.get(appFrontend.group.saveSubGroup).should('be.visible').click().should('not.exist');
+    cy.get(appFrontend.group.addNewItemSubGroup).should('exist').and('be.visible').focus().click();
+
+    cy.get(appFrontend.group.comments).type('third comment').blur();
+    cy.get(appFrontend.group.saveSubGroup).should('be.visible').click().should('not.exist');
+
+    cy.get(appFrontend.navMenu).find('li > button').last().click();
+    //Skjul kommentar felt
+    cy.get(
+      '#mainGroup-0-summary > [data-testid=summary-subGroup-0-summary-group] > div > [data-testid=summary-group-component]',
+    )
+      .children()
+      .last()
+      .children()
+      .eq(0)
+      .should('exist')
+      .and('be.visible')
+      .and('contain.text', 'Kommentarer : first comment')
+      .and('contain.text', 'Nested uploader with tags : Du har ikke lagt inn informasjon her')
+      .and('contain.text', 'Vis tillegg : Du har ikke lagt inn informasjon her')
+      .and('contain.text', 'Referanse : Du har ikke lagt inn informasjon her')
+      .and('not.contain.text', 'Skjul kommentar felt');
+    cy.get(
+      '#mainGroup-0-summary > [data-testid=summary-subGroup-0-summary-group] > div > [data-testid=summary-group-component]',
+    )
+      .children()
+      .last()
+      .children()
+      .eq(1)
+      .should('exist')
+      .and('be.visible')
+      .and('not.contain.text', 'Kommentarer')
+      .and('contain.text', 'Nested uploader with tags : Du har ikke lagt inn informasjon her')
+      .and('contain.text', 'Vis tillegg : Du har ikke lagt inn informasjon her')
+      .and('contain.text', 'Referanse : Du har ikke lagt inn informasjon her')
+      .and('not.contain.text', 'Skjul kommentar felt');
+    cy.get(
+      '#mainGroup-0-summary > [data-testid=summary-subGroup-0-summary-group] > div > [data-testid=summary-group-component]',
+    )
+      .children()
+      .last()
+      .children()
+      .eq(2)
+      .should('exist')
+      .and('be.visible')
+      .and('contain.text', 'Kommentarer : third comment')
+      .and('contain.text', 'Nested uploader with tags : Du har ikke lagt inn informasjon her')
+      .and('contain.text', 'Vis tillegg : Du har ikke lagt inn informasjon her')
+      .and('contain.text', 'Referanse : Du har ikke lagt inn informasjon her')
+      .and('not.contain.text', 'Skjul kommentar felt');
   });
 
   it('Navigation between summary and pages', () => {

--- a/test/e2e/integration/app-frontend/summary.ts
+++ b/test/e2e/integration/app-frontend/summary.ts
@@ -371,7 +371,7 @@ describe('Summary', () => {
     cy.get('[data-testid=summary-summary-1]').should('not.exist');
   });
 
-  it.only('Can exclude children from group summary', () => {
+  it('Can exclude children from group summary', () => {
     cy.interceptLayout('group', (component: ILayoutCompSummary) => {
       if (component.id === 'summary-1') {
         component.excludedChildren = ['comments-0-1', 'hideComment'];


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

It appears that the logic for excluding children in `SummaryGroupComponent` broke during a refactoring. Added a cypress test to prevent this happening again.

## Related Issue(s)

- closes #950 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
