### PR TITLE
Rename data type to "organization" to match data in store

### DIFF
--- a/src/shared/components/altinnAppHeader.test.tsx
+++ b/src/shared/components/altinnAppHeader.test.tsx
@@ -13,7 +13,7 @@ describe('AltinnAppHeader', () => {
   it('should show organisation name when profile has party, and party has organisation with name, and "type" is not set', () => {
     const profile = getProfileStateMock();
     if (profile.profile.party) {
-      profile.profile.party.organisation = organisationMock;
+      profile.profile.party.organization = organisationMock;
     }
 
     render({
@@ -27,7 +27,7 @@ describe('AltinnAppHeader', () => {
   it('should not show organisation name when profile has party, and party has organisation with name, and "type" is set', () => {
     const profile = getProfileStateMock();
     if (profile.profile.party) {
-      profile.profile.party.organisation = organisationMock;
+      profile.profile.party.organization = organisationMock;
     }
 
     render({

--- a/src/shared/components/altinnAppHeader.tsx
+++ b/src/shared/components/altinnAppHeader.tsx
@@ -170,14 +170,14 @@ export const AltinnAppHeader = ({ type, profile, language }: IHeaderProps) => {
                     <span className={`d-block ${blueClass}`}>{renderParty(profile)}</span>
                     <span className={blueClass}>
                       {party &&
-                        party.organisation &&
-                        `${getLanguageFromKey('general.for', language)} ${party.organisation.name.toUpperCase()}`}
+                        party.organization &&
+                        `${getLanguageFromKey('general.for', language)} ${party.organization.name.toUpperCase()}`}
                     </span>
                   </>
                 )}
                 <span className='d-block' />
               </span>
-              {party && party.organisation ? (
+              {party && party.organization ? (
                 <i
                   className={`fa fa-corp-circle-big ${classes.partyIcon} ${blueClass}`}
                   aria-hidden='true'

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -153,7 +153,7 @@ export interface IParty {
   isDeleted: boolean;
   onlyHierarchyElementWithNoAccess: boolean;
   person?: IPerson;
-  organisation?: IOrganisation;
+  organization?: IOrganisation;
   childParties?: IParty[];
 }
 


### PR DESCRIPTION
## Description

Different spelling of type organization causes the data to be inaccessible in code. In the store "organization" is used and this PR renames every instance of the word to this.

Redux store:
![image](https://user-images.githubusercontent.com/25097385/221531592-0576d547-3d3a-4ab3-9fb6-ad1b6b49414d.png)

This is just a suggestion, but I thought it was better to provide a fix than to just create an issue.


## Verification/QA

- Manual functionality testing
  - [X] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [X] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [X] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [X] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [X] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [X] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
  - [X] Not relevant
- Labels
  - [ ] I have added a `kind/*` label to this PR for proper release notes grouping
  - [X] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
