### PR TITLE
screen reader - error report

### DIFF
--- a/src/features/form/containers/Form.tsx
+++ b/src/features/form/containers/Form.tsx
@@ -130,7 +130,9 @@ export function Form() {
         alignItems='flex-start'
       >
         {mainComponents.map((component) => renderLayoutComponent(component, layout))}
-        <ErrorReport components={errorReportComponents} />
+        <div aria-live='polite'>
+          <ErrorReport components={errorReportComponents} />
+        </div>
       </Grid>
       <ReadyForPrint />
     </>

--- a/test/e2e/integration/app-frontend/validation.ts
+++ b/test/e2e/integration/app-frontend/validation.ts
@@ -125,6 +125,7 @@ describe('Validation', () => {
     cy.get(appFrontend.nextButton).click();
     cy.wait('@validateData');
     cy.get(appFrontend.errorReport)
+      .parent()
       .should('exist')
       .should('be.visible')
       .should('be.inViewport')


### PR DESCRIPTION
## Description
Announce error summary in screen reader when user is blocked from continuing when clicking "next" on a page with form errors.

The "error report" component isn't present in the DOM on page load. Without taking this into account, the screen reader doesn't read the messages being displayed in the error report, without focusing.

By adding a parent div, to error component, that is present in the DOM on page load, and adding a aria-live="polite" to this parent div, the screen reader reads the messages that occurs inside the error component. [Docs for "aria-live"](https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA19). 

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes #903 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [x] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
