### PR TITLE
PDF: Fix issue with automatic layout duplication

### DIFF
--- a/src/features/pdf/data/generatePdfSagas.ts
+++ b/src/features/pdf/data/generatePdfSagas.ts
@@ -16,6 +16,7 @@ import { PartyActions } from 'src/shared/resources/party/partySlice';
 import { QueueActions } from 'src/shared/resources/queue/queueSlice';
 import { TextResourcesActions } from 'src/shared/resources/textResources/textResourcesSlice';
 import { getCurrentTaskDataElementId } from 'src/utils/appMetadata';
+import { topLevelComponents } from 'src/utils/formLayout';
 import { httpGet } from 'src/utils/network/networking';
 import { pdfPreviewMode, shouldGeneratePdf } from 'src/utils/pdf';
 import { getPdfFormatUrl } from 'src/utils/urls/appUrlHelper';
@@ -64,11 +65,14 @@ function generateAutomaticLayout(pdfFormat: IPdfFormat, uiConfig: IUiConfig, lay
     .filter(([pageRef]) => !hiddenPages.has(pageRef))
     .filter(([pageRef]) => pageOrder?.includes(pageRef))
     .sort(([pA], [pB]) => (pageOrder ? pageOrder.indexOf(pA) - pageOrder.indexOf(pB) : 0))
+    .map(([pageRef, layout]) => [
+      pageRef,
+      topLevelComponents(layout ?? []).filter((component) => !excludedComponents.has(component.id)),
+    ])
     .flatMap(
-      ([pageRef, components]) =>
+      ([pageRef, components]: [string, ILayout]) =>
         components?.map((component) => [pageRef, component]) as [string, ILayoutComponentOrGroup][],
     )
-    .filter(([_, component]) => !excludedComponents.has(component.id))
     .map(([pageRef, component]) => {
       const layoutComponent = getLayoutComponentObject(component.type);
 


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

There was a small oversight when refactoring to using sagas that caused components to be duplicated in automatic layout. This happened because component id's are rewritten, which caused groups to include children with their original ids as they where supposed to, but also the children in the layout where included with rewritten ids as well. The solution is using the topLevelComponents function for each layout file before rewriting and merging them together, which was in the original `AutomaticLayout` file, but was changed in another refactoring leading too this oversight.

## Related Issue(s)

- https://altinn.slack.com/archives/C02EENC8KBR/p1677513448745799

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
