### PR TITLE
PDF: Hidden expressions in automatic layout not working for `GenericComponent`

### DIFF
--- a/src/features/form/layout/formLayoutSlice.ts
+++ b/src/features/form/layout/formLayoutSlice.ts
@@ -1,7 +1,8 @@
-import { put, takeLatest } from 'redux-saga/effects';
+import { call, put, takeLatest } from 'redux-saga/effects';
 import type { SagaIterator } from 'redux-saga';
 
 import { FormDataActions } from 'src/features/form/data/formDataSlice';
+import { checkIfConditionalRulesShouldRunSaga } from 'src/features/form/dynamics/conditionalRendering/conditionalRenderingSagas';
 import {
   fetchLayoutSetsSaga,
   watchFetchFormLayoutSaga,
@@ -343,7 +344,10 @@ export const formLayoutSlice = createSagaSlice((mkAction: MkActionType<ILayoutSt
         state.uiConfig.keepScrollPos = undefined;
       },
     }),
-    updateLayout: mkAction<ILayouts>({
+    updateLayouts: mkAction<ILayouts>({
+      takeEvery: function* () {
+        yield call(checkIfConditionalRulesShouldRunSaga, { payload: {}, type: '' });
+      },
       reducer: (state, action) => {
         state.layouts = { ...state.layouts, ...action.payload };
       },

--- a/src/features/pdf/data/generatePdfSagas.ts
+++ b/src/features/pdf/data/generatePdfSagas.ts
@@ -23,7 +23,7 @@ import { getPdfFormatUrl } from 'src/utils/urls/appUrlHelper';
 import type { ExprUnresolved } from 'src/features/expressions/types';
 import type { IPdfFormat, IPdfMethod } from 'src/features/pdf/data/types';
 import type { ILayoutCompInstanceInformation } from 'src/layout/InstanceInformation/types';
-import type { ILayout, ILayoutComponent, ILayoutComponentOrGroup, ILayouts } from 'src/layout/layout';
+import type { ILayout, ILayoutComponentOrGroup, ILayouts } from 'src/layout/layout';
 import type { ILayoutCompSummary } from 'src/layout/Summary/types.d';
 import type { IApplicationMetadata } from 'src/shared/resources/applicationMetadata';
 import type { ILayoutSets, IRuntimeState, IUiConfig } from 'src/types';
@@ -76,7 +76,11 @@ function generateAutomaticLayout(pdfFormat: IPdfFormat, uiConfig: IUiConfig, lay
     .map(([pageRef, component]) => {
       const layoutComponent = getLayoutComponentObject(component.type);
 
-      if (component.type === 'Group' || layoutComponent?.getComponentType() === ComponentType.Form) {
+      if (
+        component.type === 'Group' ||
+        layoutComponent?.getComponentType() === ComponentType.Form ||
+        layoutComponent?.getComponentType() === ComponentType.Presentation
+      ) {
         return {
           id: `__pdf__${component.id}`,
           type: 'Summary',
@@ -84,12 +88,6 @@ function generateAutomaticLayout(pdfFormat: IPdfFormat, uiConfig: IUiConfig, lay
           pageRef,
           excludedChildren: pdfFormat?.excludedComponents,
         } as ExprUnresolved<ILayoutCompSummary>;
-      }
-      if (layoutComponent?.getComponentType() === ComponentType.Presentation) {
-        return {
-          ...component,
-          id: `__pdf__${component.id}`,
-        } as ExprUnresolved<ILayoutComponent>;
       }
       return null;
     })
@@ -112,7 +110,7 @@ function* generatePdfSaga(): SagaIterator {
     if (method == 'auto') {
       // Automatic layout
       const pdfLayout = generateAutomaticLayout(pdfFormat, uiConfig, layouts);
-      yield put(FormLayoutActions.updateLayout({ [PDF_LAYOUT_NAME]: pdfLayout }));
+      yield put(FormLayoutActions.updateLayouts({ [PDF_LAYOUT_NAME]: pdfLayout }));
     }
 
     yield put(PdfActions.generateFulfilled());


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

Another oversight, hidden expressions come from `uiConfig.hiddenFields` instead of the evaluated props directly. This PR makes sure that hidden components are checked every time the layout is updated, and also changes `generateAutomaticLayout` to always use `Summary` components even for "presentation" components, since these can now be rendered properly through the `Summary` component anyways, and that avoids other potential issues arising from copying components with a different ID. Its probably time to create some cypress tests soon.

## Related Issue(s)

- https://altinn.slack.com/archives/C02EVE4RU82/p1677656670724259

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
