### PR TITLE
Use resolved node in summary switch

### DIFF
--- a/src/components/summary/SummaryComponent.tsx
+++ b/src/components/summary/SummaryComponent.tsx
@@ -163,7 +163,7 @@ export function SummaryComponent(_props: ISummaryComponent) {
     }
   }, [formValidations, layout, pageRef, formComponent, componentRef]);
 
-  if (hidden || !formComponent || !formComponentLegacy) {
+  if (hidden || !formComponent || !formComponentLegacy || formComponent.type === 'Summary') {
     return null;
   }
 
@@ -192,11 +192,7 @@ export function SummaryComponent(_props: ISummaryComponent) {
         )}
       />
     );
-  } else if (
-    layoutComponent?.getComponentType() === ComponentType.Presentation &&
-    formComponent?.type !== 'Summary' &&
-    formComponent?.type !== 'Group'
-  ) {
+  } else if (layoutComponent?.getComponentType() === ComponentType.Presentation && formComponent?.type !== 'Group') {
     // Render non-input components as normal
     return <GenericComponent {...formComponent} />;
   }
@@ -222,7 +218,7 @@ export function SummaryComponent(_props: ISummaryComponent) {
         <SummaryComponentSwitch
           id={id}
           change={change}
-          formComponent={formComponentLegacy}
+          formComponent={formComponent}
           label={label}
           hasValidationMessages={hasValidationMessages}
           formData={calculatedFormData}

--- a/src/components/summary/SummaryComponentSwitch.tsx
+++ b/src/components/summary/SummaryComponentSwitch.tsx
@@ -8,17 +8,16 @@ import { AttachmentSummaryComponent } from 'src/layout/FileUpload/AttachmentSumm
 import { AttachmentWithTagSummaryComponent } from 'src/layout/FileUploadWithTag/AttachmentWithTagSummaryComponent';
 import { MapComponentSummary } from 'src/layout/Map/MapComponentSummary';
 import { useResolvedNode } from 'src/utils/layout/ExprContext';
-import type { ExprUnresolved } from 'src/features/expressions/types';
-import type { ILayoutGroup } from 'src/layout/Group/types';
-import type { ILayoutComponent } from 'src/layout/layout';
+import type { ExprResolved } from 'src/features/expressions/types';
 import type { ILayoutCompSummary } from 'src/layout/Summary/types';
+import type { AnyItem } from 'src/utils/layout/hierarchy.types';
 
 export interface ISummaryComponentSwitch extends Omit<ILayoutCompSummary, 'type'> {
   change: {
     onChangeClick: () => void;
     changeText: string | null;
   };
-  formComponent?: ExprUnresolved<ILayoutComponent | ILayoutGroup>;
+  formComponent?: ExprResolved<AnyItem>;
   hasValidationMessages?: boolean;
   label?: JSX.Element | JSX.Element[] | null | undefined;
   formData?: any;

--- a/src/components/summary/SummaryComponentSwitch.tsx
+++ b/src/components/summary/SummaryComponentSwitch.tsx
@@ -7,7 +7,6 @@ import { MultipleChoiceSummary } from 'src/layout/Checkboxes/MultipleChoiceSumma
 import { AttachmentSummaryComponent } from 'src/layout/FileUpload/AttachmentSummaryComponent';
 import { AttachmentWithTagSummaryComponent } from 'src/layout/FileUploadWithTag/AttachmentWithTagSummaryComponent';
 import { MapComponentSummary } from 'src/layout/Map/MapComponentSummary';
-import { useResolvedNode } from 'src/utils/layout/ExprContext';
 import type { ExprResolved } from 'src/features/expressions/types';
 import type { ILayoutCompSummary } from 'src/layout/Summary/types';
 import type { AnyItem } from 'src/utils/layout/hierarchy.types';
@@ -37,8 +36,6 @@ export function SummaryComponentSwitch({
   groupProps = {},
   display,
 }: ISummaryComponentSwitch) {
-  const resolved = useResolvedNode(formComponent)?.item;
-
   if (!formComponent) {
     return null;
   }
@@ -94,7 +91,7 @@ export function SummaryComponentSwitch({
         label={label}
         hasValidationMessages={!!hasValidationMessages}
         formData={formData}
-        readOnlyComponent={resolved?.readOnly}
+        readOnlyComponent={formComponent.readOnly}
         display={display}
       />
     );
@@ -123,7 +120,7 @@ export function SummaryComponentSwitch({
       label={label}
       hasValidationMessages={!!hasValidationMessages}
       formData={formData}
-      readOnlyComponent={resolved?.readOnly}
+      readOnlyComponent={formComponent.readOnly}
       display={display}
     />
   );


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

Fixes so that readonly correctly resolves for repeating group summary.

Tested in `krt-1230a-1` and everything resolves correctly now:

![Screenshot 2023-03-03 at 08 57 00](https://user-images.githubusercontent.com/47412359/222664270-7a450e1c-57a2-4e4f-a9be-e91a0738477f.png)


## Related Issue(s)

- closes #747 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [?] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
