### PR TITLE
Attachment with tag container, replaced button from material ui with design system

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "@material-ui/core": "4.12.4",
     "@material-ui/icons": "4.11.3",
     "@material-ui/pickers": "3.3.10",
-    "@navikt/aksel-icons": "^2.7.1",
+    "@navikt/aksel-icons": "^2.7.3",
     "@reduxjs/toolkit": "1.9.3",
     "ajv": "8.12.0",
     "ajv-formats": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "@material-ui/core": "4.12.4",
     "@material-ui/icons": "4.11.3",
     "@material-ui/pickers": "3.3.10",
+    "@navikt/aksel-icons": "^2.7.1",
     "@reduxjs/toolkit": "1.9.3",
     "ajv": "8.12.0",
     "ajv-formats": "2.1.1",

--- a/src/layout/FileUpload/FileUploadComponent.tsx
+++ b/src/layout/FileUpload/FileUploadComponent.tsx
@@ -3,6 +3,7 @@ import { isMobile } from 'react-device-detect';
 import type { FileRejection } from 'react-dropzone';
 
 import useMediaQuery from '@material-ui/core/useMediaQuery';
+import { TrashIcon } from '@navikt/aksel-icons';
 import { v4 as uuidv4 } from 'uuid';
 
 import { useAppDispatch } from 'src/common/hooks/useAppDispatch';
@@ -216,7 +217,7 @@ export function FileUploadComponent({
             {mobileView
               ? getLanguageFromKey('general.delete', language)
               : getLanguageFromKey('form_filler.file_uploader_list_delete', language)}
-            <i className='ai ai-trash' />
+            <TrashIcon />
           </>
         )}
       </div>

--- a/src/layout/FileUpload/FileUploadComponent.tsx
+++ b/src/layout/FileUpload/FileUploadComponent.tsx
@@ -3,7 +3,6 @@ import { isMobile } from 'react-device-detect';
 import type { FileRejection } from 'react-dropzone';
 
 import useMediaQuery from '@material-ui/core/useMediaQuery';
-import { TrashIcon } from '@navikt/aksel-icons';
 import { v4 as uuidv4 } from 'uuid';
 
 import { useAppDispatch } from 'src/common/hooks/useAppDispatch';
@@ -217,7 +216,7 @@ export function FileUploadComponent({
             {mobileView
               ? getLanguageFromKey('general.delete', language)
               : getLanguageFromKey('form_filler.file_uploader_list_delete', language)}
-            <TrashIcon />
+            <i className='ai ai-trash' />
           </>
         )}
       </div>

--- a/src/layout/FileUploadWithTag/EditWindowComponent.module.css
+++ b/src/layout/FileUploadWithTag/EditWindowComponent.module.css
@@ -1,0 +1,9 @@
+.iconButtonWrapper {
+  display: flex;
+  align-items: center;
+}
+
+.checkMark {
+  margin-left: 0.2rem;
+  font-size: 1.3rem;
+}

--- a/src/layout/FileUploadWithTag/EditWindowComponent.tsx
+++ b/src/layout/FileUploadWithTag/EditWindowComponent.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Button, ButtonColor, ButtonVariant } from '@digdir/design-system-react';
 import { Grid, makeStyles } from '@material-ui/core';
-import { Delete, Success } from '@navikt/ds-icons';
+import { CheckmarkCircleFillIcon, TrashIcon } from '@navikt/aksel-icons';
 import classNames from 'classnames';
 
 import { useAppDispatch } from 'src/common/hooks/useAppDispatch';
@@ -106,10 +106,11 @@ export function EditWindowComponent(props: EditWindowProps): JSX.Element {
                 {!props.mobileView
                   ? getLanguageFromKey('form_filler.file_uploader_list_status_done', props.language)
                   : undefined}
-                <Success
+                <CheckmarkCircleFillIcon
                   role='img'
                   aria-hidden={!props.mobileView}
                   aria-label={getLanguageFromKey('form_filler.file_uploader_list_status_done', props.language)}
+                  style={{ marginLeft: '0.2rem', fontSize: '1.3rem' }}
                 />
               </div>
             )}
@@ -128,7 +129,7 @@ export function EditWindowComponent(props: EditWindowProps): JSX.Element {
                 onClick={() => handleDeleteFile()}
                 variant={ButtonVariant.Quiet}
                 color={ButtonColor.Secondary}
-                icon={<Delete aria-hidden={true} />}
+                icon={<TrashIcon aria-hidden={true} />}
                 iconPlacement='right'
               >
                 {getLanguageFromKey('general.delete', props.language)}

--- a/src/layout/FileUploadWithTag/EditWindowComponent.tsx
+++ b/src/layout/FileUploadWithTag/EditWindowComponent.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Button, ButtonColor, ButtonVariant } from '@digdir/design-system-react';
 import { Grid, makeStyles } from '@material-ui/core';
-import { Delete } from '@navikt/ds-icons';
+import { Delete, Success } from '@navikt/ds-icons';
 import classNames from 'classnames';
 
 import { useAppDispatch } from 'src/common/hooks/useAppDispatch';
@@ -100,14 +100,13 @@ export function EditWindowComponent(props: EditWindowProps): JSX.Element {
           className={classes.textContainer}
           style={{ flexShrink: 0 }}
         >
-          <div style={{ display: 'flex' }}>
+          <div style={{ display: 'flex', alignItems: 'center' }}>
             {props.attachment.uploaded && (
               <div style={{ marginLeft: '0.9375rem', marginRight: '0.9375rem' }}>
                 {!props.mobileView
                   ? getLanguageFromKey('form_filler.file_uploader_list_status_done', props.language)
                   : undefined}
-                <i
-                  className='ai ai-check-circle'
+                <Success
                   role='img'
                   aria-hidden={!props.mobileView}
                   aria-label={getLanguageFromKey('form_filler.file_uploader_list_status_done', props.language)}

--- a/src/layout/FileUploadWithTag/EditWindowComponent.tsx
+++ b/src/layout/FileUploadWithTag/EditWindowComponent.tsx
@@ -122,7 +122,7 @@ export function EditWindowComponent(props: EditWindowProps): JSX.Element {
               <Button
                 onClick={() => handleDeleteFile()}
                 variant={ButtonVariant.Quiet}
-                color={ButtonColor.Secondary}
+                color={ButtonColor.Danger}
                 icon={<TrashIcon aria-hidden={true} />}
                 iconPlacement='right'
               >

--- a/src/layout/FileUploadWithTag/EditWindowComponent.tsx
+++ b/src/layout/FileUploadWithTag/EditWindowComponent.tsx
@@ -9,6 +9,7 @@ import { useAppDispatch } from 'src/common/hooks/useAppDispatch';
 import { AltinnLoader } from 'src/components/AltinnLoader';
 import { getLanguageFromKey } from 'src/language/sharedLanguage';
 import { FileName } from 'src/layout/FileUpload/shared/render';
+import css from 'src/layout/FileUploadWithTag/EditWindowComponent.module.css';
 import { AttachmentActions } from 'src/shared/resources/attachments/attachmentSlice';
 import { AltinnAppTheme } from 'src/theme/altinnAppTheme';
 import { renderValidationMessages } from 'src/utils/render';
@@ -95,7 +96,7 @@ export function EditWindowComponent(props: EditWindowProps): JSX.Element {
           className={classes.textContainer}
           style={{ flexShrink: 0 }}
         >
-          <div style={{ display: 'flex', alignItems: 'center' }}>
+          <div className={css.iconButtonWrapper}>
             {props.attachment.uploaded && (
               <div style={{ marginLeft: '0.9375rem', marginRight: '0.9375rem' }}>
                 {!props.mobileView
@@ -105,7 +106,7 @@ export function EditWindowComponent(props: EditWindowProps): JSX.Element {
                   role='img'
                   aria-hidden={!props.mobileView}
                   aria-label={getLanguageFromKey('form_filler.file_uploader_list_status_done', props.language)}
-                  style={{ marginLeft: '0.2rem', fontSize: '1.3rem' }}
+                  className={css.checkMark}
                 />
               </div>
             )}

--- a/src/layout/FileUploadWithTag/EditWindowComponent.tsx
+++ b/src/layout/FileUploadWithTag/EditWindowComponent.tsx
@@ -34,11 +34,6 @@ const useStyles = makeStyles({
     marginTop: '12px',
     marginBottom: '12px',
   },
-  deleteButton: {
-    padding: '0px',
-    color: 'black',
-    justifyContent: 'left',
-  },
   select: {
     fontSize: '1rem',
     '&:focus': {
@@ -125,7 +120,6 @@ export function EditWindowComponent(props: EditWindowProps): JSX.Element {
             )}
             <div>
               <Button
-                // classes={{ root: classes.deleteButton }}
                 onClick={() => handleDeleteFile()}
                 variant={ButtonVariant.Quiet}
                 color={ButtonColor.Secondary}

--- a/src/layout/FileUploadWithTag/EditWindowComponent.tsx
+++ b/src/layout/FileUploadWithTag/EditWindowComponent.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
-import { Button } from '@digdir/design-system-react';
-import { Grid, IconButton, makeStyles } from '@material-ui/core';
+import { Button, ButtonColor, ButtonVariant } from '@digdir/design-system-react';
+import { Grid, makeStyles } from '@material-ui/core';
+import { Delete } from '@navikt/ds-icons';
 import classNames from 'classnames';
 
 import { useAppDispatch } from 'src/common/hooks/useAppDispatch';
@@ -123,14 +124,16 @@ export function EditWindowComponent(props: EditWindowProps): JSX.Element {
               />
             )}
             <div>
-              <IconButton
-                classes={{ root: classes.deleteButton }}
+              <Button
+                // classes={{ root: classes.deleteButton }}
                 onClick={() => handleDeleteFile()}
-                tabIndex={0}
+                variant={ButtonVariant.Quiet}
+                color={ButtonColor.Secondary}
+                icon={<Delete aria-hidden={true} />}
+                iconPlacement='right'
               >
                 {getLanguageFromKey('general.delete', props.language)}
-                <i className='ai ai-trash' />
-              </IconButton>
+              </Button>
             </div>
           </div>
         </Grid>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3625,10 +3625,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@navikt/aksel-icons@npm:^2.7.1":
-  version: 2.7.1
-  resolution: "@navikt/aksel-icons@npm:2.7.1"
-  checksum: a07d3e5d7057e4d1debfe8e8af76d79dd92c51686a29a23df7be9ab51306bed0b544ac84aaa95b8a8088412334bdbc301663788cb2fc32c8618db2b1b62dec0f
+"@navikt/aksel-icons@npm:^2.7.3":
+  version: 2.7.3
+  resolution: "@navikt/aksel-icons@npm:2.7.3"
+  checksum: f8a64e488ef83487a34294b2c46671ee4e659c55af83259a9f49fb148fd51e88744262ec2c639be700099fdbb439a0a48e60c51c6db84da8712b0d409003aac8
   languageName: node
   linkType: hard
 
@@ -5547,7 +5547,7 @@ __metadata:
     "@material-ui/core": 4.12.4
     "@material-ui/icons": 4.11.3
     "@material-ui/pickers": 3.3.10
-    "@navikt/aksel-icons": ^2.7.1
+    "@navikt/aksel-icons": ^2.7.3
     "@pmmmwh/react-refresh-webpack-plugin": 0.5.10
     "@reduxjs/toolkit": 1.9.3
     "@testing-library/cypress": 9.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -3625,6 +3625,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@navikt/aksel-icons@npm:^2.7.1":
+  version: 2.7.1
+  resolution: "@navikt/aksel-icons@npm:2.7.1"
+  checksum: a07d3e5d7057e4d1debfe8e8af76d79dd92c51686a29a23df7be9ab51306bed0b544ac84aaa95b8a8088412334bdbc301663788cb2fc32c8618db2b1b62dec0f
+  languageName: node
+  linkType: hard
+
 "@navikt/ds-icons@npm:^2.0.0":
   version: 2.0.6
   resolution: "@navikt/ds-icons@npm:2.0.6"
@@ -5540,6 +5547,7 @@ __metadata:
     "@material-ui/core": 4.12.4
     "@material-ui/icons": 4.11.3
     "@material-ui/pickers": 3.3.10
+    "@navikt/aksel-icons": ^2.7.1
     "@pmmmwh/react-refresh-webpack-plugin": 0.5.10
     "@reduxjs/toolkit": 1.9.3
     "@testing-library/cypress": 9.0.0


### PR DESCRIPTION
## Description
Encountered that the delete button in container "upload attachment with tag" was too large compared to other elements in the container.

Replaced the button (material ui) and the icon (font awesome) with those from our [design system](https://digdir.github.io/designsystem/?path=/docs/komponentoversikt--page) and [Aksel - NAV  ](https://aksel.nav.no/).
While I was on it, also replaced the check mark icon with the one from Aksel NAV.

Before:
![old-example-of-delete-button](https://user-images.githubusercontent.com/74791975/224328265-9abd31aa-cede-4732-9780-dec568df83d3.png)

After:
![image](https://user-images.githubusercontent.com/74791975/224328430-45fc30d1-15c9-4e0c-b9b1-932bcc0421ad.png)

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [x] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
