### PR TITLE
Fix component expression not finding "distant" components

### DIFF
--- a/src/features/expressions/index.ts
+++ b/src/features/expressions/index.ts
@@ -444,7 +444,8 @@ export const ExprFunctions = {
       }
 
       const node = this.failWithoutNode();
-      const component = node.closest((c) => c.id === id || c.baseComponentId === id);
+      const closestComponent = node.closest((c) => c.id === id || c.baseComponentId === id);
+      const component = closestComponent ?? (node instanceof LayoutPage ? node.findById(id) : node.top.findById(id));
       const binding = component?.item?.dataModelBindings?.simpleBinding;
       if (component && binding) {
         if (component.isHidden(this.dataSources.hiddenFields)) {

--- a/src/features/expressions/shared-tests/functions/component/distant-across-page.json
+++ b/src/features/expressions/shared-tests/functions/component/distant-across-page.json
@@ -1,0 +1,45 @@
+{
+  "name": "Lookup component that cannot be found using closest() across page",
+  "expression": ["component", "navn"],
+  "expects": "Kaptein Sabeltann",
+  "context": {
+    "component": "information",
+    "currentLayout": "Summary"
+  },
+  "dataModel": {
+    "Navn": "Kaptein Sabeltann"
+  },
+  "layouts": {
+    "Form": {
+      "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+      "data": {
+        "layout": [
+          {
+            "id": "group",
+            "type": "Group",
+            "dataModelBindings": {},
+            "children": ["navn"]
+          },
+          {
+            "id": "navn",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "Navn"
+            }
+          }
+        ]
+      }
+    },
+    "Summary": {
+      "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+      "data": {
+        "layout": [
+          {
+            "id": "information",
+            "type": "Panel"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/features/expressions/shared-tests/functions/component/distant.json
+++ b/src/features/expressions/shared-tests/functions/component/distant.json
@@ -1,0 +1,38 @@
+{
+  "name": "Lookup component that cannot be found using closest()",
+  "expression": ["component", "navn"],
+  "expects": "Kaptein Sabeltann",
+  "context": {
+    "component": "information",
+    "currentLayout": "Form"
+  },
+  "dataModel": {
+    "Navn": "Kaptein Sabeltann"
+  },
+  "layouts": {
+    "Form": {
+      "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+      "data": {
+        "layout": [
+          {
+            "id": "group",
+            "type": "Group",
+            "dataModelBindings": {},
+            "children": ["navn"]
+          },
+          {
+            "id": "navn",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "Navn"
+            }
+          },
+          {
+            "id": "information",
+            "type": "Panel"
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

@olemartinorg's suggested solution to #826  worked great, both for looking up components in groups on the same page and across pages. In both of these cases the component could not be found previously. The shared tests check these two cases, and both tests failed before this change. I named this case "distant" as it cannot be reached using the "closest()"-method, I could not come up with a better name 😅 

## Related Issue(s)

- closes #826 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
