### PR TITLE
Change line height in empty summary to match size

### DIFF
--- a/src/components/summary/SingleInputSummary.tsx
+++ b/src/components/summary/SingleInputSummary.tsx
@@ -30,6 +30,7 @@ const useStyles = makeStyles({
   emptyField: {
     fontStyle: 'italic',
     fontSize: '1rem',
+    lineHeight: 1.6875,
   },
 });
 

--- a/src/components/summary/SummaryGroupComponent.tsx
+++ b/src/components/summary/SummaryGroupComponent.tsx
@@ -71,6 +71,7 @@ const useStyles = makeStyles({
   emptyField: {
     fontStyle: 'italic',
     fontSize: '1rem',
+    lineHeight: 1.6875,
     marginTop: 4,
   },
 });

--- a/src/layout/FileUpload/AttachmentSummaryComponent.tsx
+++ b/src/layout/FileUpload/AttachmentSummaryComponent.tsx
@@ -14,6 +14,7 @@ const useStyles = makeStyles({
   emptyField: {
     fontStyle: 'italic',
     fontSize: '1rem',
+    lineHeight: 1.6875,
   },
 });
 

--- a/src/layout/FileUploadWithTag/AttachmentWithTagSummaryComponent.tsx
+++ b/src/layout/FileUploadWithTag/AttachmentWithTagSummaryComponent.tsx
@@ -25,6 +25,7 @@ const useStyles = makeStyles({
   emptyField: {
     fontStyle: 'italic',
     fontSize: '1rem',
+    lineHeight: 1.6875,
   },
 });
 

--- a/src/layout/Map/MapComponentSummary.tsx
+++ b/src/layout/Map/MapComponentSummary.tsx
@@ -25,6 +25,7 @@ export const useStyles = makeStyles(() => ({
   emptyField: {
     fontStyle: 'italic',
     fontSize: '1rem',
+    lineHeight: 1.6875,
   },
 }));
 


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

This is just a very small thing that has bothered me ever since I added the empty summary text. The text saying that a summary has no data is styled differently to not be mistaken for actual user input. However, since the font is slightly smaller they no longer line up when placed in a grid. This small change corrects for that by setting the line height so the borders line up perfectly.

Before:
<img width="907" alt="image" src="https://user-images.githubusercontent.com/47412359/223965620-3a9cb8d3-f53c-4d76-81b7-ff7d9aa78877.png">

After:
<img width="907" alt="image" src="https://user-images.githubusercontent.com/47412359/223965680-51afe9ca-7878-4471-9c91-66757b9a8b4a.png">


## Related Issue(s)

- ~~closes #{issue number}~~

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
