### PR TITLE
Fix layout sets schema

### DIFF
--- a/schemas/json/layout/layout-sets.schema.v1.json
+++ b/schemas/json/layout/layout-sets.schema.v1.json
@@ -11,36 +11,36 @@
       "items": {
         "$ref": "#/definitions/layoutset"
       }
+    }
+  },
+  "definitions": {
+    "layoutset": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Settings regarding a specific layoutset",
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "id",
+          "description": "The layoutset ID. Must be unique within a given application."
+        },
+        "dataType": {
+          "type": "string",
+          "title": "dataType",
+          "description": "The datatype to use this layoyut."
+        },
+        "tasks": {
+          "$ref": "#/definitions/tasks"
+        }
+      }
     },
-    "definitions": {
-      "layoutset": {
-        "type": "object",
-        "additionalProperties": false,
-        "description": "Settings regarding a specific layoutset",
-        "properties": {
-          "id": {
-            "type": "string",
-            "title": "id",
-            "description": "The layoutset ID. Must be unique within a given application."
-          },
-          "type": {
-            "type": "string",
-            "title": "dataType",
-            "description": "The datatype to use this layoyut."
-          },
-          "tasks": {
-            "$ref": "#/definitions/tasks"
-          }
-        }
-      },
-      "tasks": {
-        "additionalProperties": false,
-        "description": "An array specifying which task to use a layoutset",
-        "type": "array",
-        "items": {
-          "description": "A layoutSet name, for instance 'Form1'",
-          "type": "string"
-        }
+    "tasks": {
+      "additionalProperties": false,
+      "description": "An array specifying which task to use a layoutset",
+      "type": "array",
+      "items": {
+        "description": "A layoutSet name, for instance 'Form1'",
+        "type": "string"
       }
     }
   }


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

The definitions were incorrectly positioned inside of properties, and the property `type` should be `dataType`. I have tested these changes locally.
