### PR TITLE
Selected Language stored in localstorage should be saved per user

### DIFF
--- a/src/__mocks__/initialStateMock.ts
+++ b/src/__mocks__/initialStateMock.ts
@@ -56,7 +56,6 @@ export function getInitialStateMock(customStates?: Partial<IRuntimeState>): IRun
     },
     language: {
       language: getLanguageFromCode('nb'),
-      selectedAppLanguage: '',
       error: null,
     },
     organisationMetaData: {

--- a/src/__mocks__/profileStateMock.ts
+++ b/src/__mocks__/profileStateMock.ts
@@ -16,6 +16,7 @@ export function getProfileStateMock(customStates?: Partial<IProfileState>): IPro
         doNotPromptForParty: false,
       },
     },
+    selectedAppLanguage: '',
   };
 
   return {

--- a/src/components/hooks/useDelayedSavedState.ts
+++ b/src/components/hooks/useDelayedSavedState.ts
@@ -29,7 +29,9 @@ export function useDelayedSavedState(
 
   const updateFormData = useCallback(
     (value: string | undefined, skipValidation = false): void => {
-      if (value === formValue) return;
+      if (value === formValue) {
+        return;
+      }
 
       const shouldValidate = !skipNextValidation && !skipValidation;
       handleDataChange(value, { validate: shouldValidate });

--- a/src/components/presentation/LanguageSelector.tsx
+++ b/src/components/presentation/LanguageSelector.tsx
@@ -7,7 +7,7 @@ import { useAppSelector } from 'src/common/hooks/useAppSelector';
 import { AltinnSpinner } from 'src/components/AltinnSpinner';
 import { appLanguageStateSelector } from 'src/selectors/appLanguageStateSelector';
 import { useGetAppLanguageQuery } from 'src/services/LanguageApi';
-import { LanguageActions } from 'src/shared/resources/language/languageSlice';
+import { ProfileActions } from 'src/shared/resources/profile/profileSlice';
 import { getTextFromAppOrDefault } from 'src/utils/textResource';
 
 export const LanguageSelector = () => {
@@ -19,7 +19,7 @@ export const LanguageSelector = () => {
   const dispatch = useAppDispatch();
 
   const handleAppLanguageChange = (languageCode: string) => {
-    dispatch(LanguageActions.updateSelectedAppLanguage({ selected: languageCode }));
+    dispatch(ProfileActions.updateSelectedAppLanguage({ selected: languageCode }));
   };
 
   if (appLanguageError) {

--- a/src/components/presentation/NavBar.test.tsx
+++ b/src/components/presentation/NavBar.test.tsx
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event';
 import mockAxios from 'jest-mock-axios';
 
 import { getFormLayoutStateMock } from 'src/__mocks__/formLayoutStateMock';
+import { getProfileStateMock } from 'src/__mocks__/profileStateMock';
 import { getUiConfigStateMock } from 'src/__mocks__/uiConfigStateMock';
 import { NavBar } from 'src/components/presentation/NavBar';
 import { getLanguageFromCode } from 'src/language/languages';
@@ -42,10 +43,10 @@ const renderNavBar = ({
     {
       preloadedState: {
         language: {
-          selectedAppLanguage: 'nb',
           language: getLanguageFromCode('nb'),
           error: null,
         },
+        profile: getProfileStateMock({ selectedAppLanguage: 'nb' }),
         textResources: {
           resources: textResources,
           language: 'nb',

--- a/src/features/instantiate/containers/InstantiateContainer.test.tsx
+++ b/src/features/instantiate/containers/InstantiateContainer.test.tsx
@@ -75,7 +75,6 @@ describe('InstantiateContainer', () => {
             starting: 'instantiate.starting',
           },
         },
-        selectedAppLanguage: '',
         error: null,
       },
     });

--- a/src/layout/NavigationBar/NavigationBarComponent.test.tsx
+++ b/src/layout/NavigationBar/NavigationBarComponent.test.tsx
@@ -114,7 +114,6 @@ const render = ({ dispatch = jest.fn() }: Props = {}) => {
       state.language = {
         language: {},
         error: null,
-        selectedAppLanguage: 'nb',
       };
     },
     manipulateStore: (store) => {

--- a/src/selectors/appLanguageStateSelector.test.ts
+++ b/src/selectors/appLanguageStateSelector.test.ts
@@ -1,6 +1,7 @@
 import { getProfileStateMock } from 'src/__mocks__/profileStateMock';
 import { statelessAndAllowAnonymousMock } from 'src/__mocks__/statelessAndAllowAnonymousMock';
 import { appLanguageStateSelector } from 'src/selectors/appLanguageStateSelector';
+import type { IRuntimeState } from 'src/types';
 
 describe('appLanguageStateSelector', () => {
   interface ISetupProps {
@@ -23,13 +24,13 @@ describe('appLanguageStateSelector', () => {
             language: profileLanguage,
           },
         },
+        selectedAppLanguage: selectedLanguage,
       },
       language: {
         language: {},
         error: null,
-        selectedAppLanguage: selectedLanguage,
       },
-    };
+    } satisfies IRuntimeState;
   };
 
   it('should select profile language when allowAnonymous false and selected language not set', () => {

--- a/src/selectors/appLanguageStateSelector.ts
+++ b/src/selectors/appLanguageStateSelector.ts
@@ -3,7 +3,7 @@ import { profileStateSelector } from 'src/selectors/simpleSelectors';
 import type { IRuntimeState } from 'src/types';
 import type { IProfile } from 'src/types/shared';
 
-const selectedAppLanguageStateSelector = (state: IRuntimeState) => state.language.selectedAppLanguage;
+const selectedAppLanguageStateSelector = (state: IRuntimeState) => state.profile.selectedAppLanguage;
 
 export const appLanguageStateSelector = (state: IRuntimeState) => {
   let selectedAppLanguage = selectedAppLanguageStateSelector(state);

--- a/src/shared/components/altinnParty.test.tsx
+++ b/src/shared/components/altinnParty.test.tsx
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event';
 
 import { getInitialStateMock } from 'src/__mocks__/initialStateMock';
 import { partyMock } from 'src/__mocks__/partyMock';
+import { getProfileStateMock } from 'src/__mocks__/profileStateMock';
 import { AltinnParty } from 'src/shared/components/altinnParty';
 import { renderWithProviders } from 'src/testUtils';
 import type { IAltinnPartyProps } from 'src/shared/components/altinnParty';
@@ -111,8 +112,8 @@ const render = (props: Partial<IAltinnPartyProps> = {}) => {
       language: {
         language: {},
         error: null,
-        selectedAppLanguage: 'nb',
       },
+      profile: getProfileStateMock({ selectedAppLanguage: 'nb' }),
     },
   });
 };

--- a/src/shared/components/altinnPartySearch.test.tsx
+++ b/src/shared/components/altinnPartySearch.test.tsx
@@ -4,6 +4,7 @@ import { act, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { getInitialStateMock } from 'src/__mocks__/initialStateMock';
+import { getProfileStateMock } from 'src/__mocks__/profileStateMock';
 import { AltinnPartySearch } from 'src/shared/components/altinnPartySearch';
 import { renderWithProviders } from 'src/testUtils';
 import type { IAltinnPartySearchProps } from 'src/shared/components/altinnPartySearch';
@@ -37,8 +38,8 @@ const render = (props: Partial<IAltinnPartySearchProps> = {}) => {
       language: {
         language: {},
         error: null,
-        selectedAppLanguage: 'nb',
       },
+      profile: getProfileStateMock({ selectedAppLanguage: 'nb' }),
     },
   });
 };

--- a/src/shared/resources/language/fetch/fetchLanguageSagas.test.ts
+++ b/src/shared/resources/language/fetch/fetchLanguageSagas.test.ts
@@ -8,6 +8,7 @@ import { makeGetAllowAnonymousSelector } from 'src/selectors/getAllowAnonymous';
 import { ApplicationMetadataActions } from 'src/shared/resources/applicationMetadata/applicationMetadataSlice';
 import { fetchLanguageSaga, watchFetchLanguageSaga } from 'src/shared/resources/language/fetch/fetchLanguageSagas';
 import { LanguageActions } from 'src/shared/resources/language/languageSlice';
+import { ProfileActions } from 'src/shared/resources/profile/profileSlice';
 import { waitFor } from 'src/utils/sagas';
 
 describe('languageActions', () => {
@@ -51,7 +52,7 @@ describe('fetchLanguageSagas', () => {
     expect(generator.next().value).toEqual(select(makeGetAllowAnonymousSelector()));
     expect(generator.next().value).toEqual(waitFor(expect.anything()));
     expect(generator.next().value).toEqual(call(fetchLanguageSaga));
-    expect(generator.next().value).toEqual(takeLatest(LanguageActions.updateSelectedAppLanguage, fetchLanguageSaga));
+    expect(generator.next().value).toEqual(takeLatest(ProfileActions.updateSelectedAppLanguage, fetchLanguageSaga));
     expect(generator.next().done).toBeTruthy();
   });
 

--- a/src/shared/resources/language/fetch/fetchLanguageSagas.ts
+++ b/src/shared/resources/language/fetch/fetchLanguageSagas.ts
@@ -7,6 +7,7 @@ import { appLanguageStateSelector } from 'src/selectors/appLanguageStateSelector
 import { makeGetAllowAnonymousSelector } from 'src/selectors/getAllowAnonymous';
 import { ApplicationMetadataActions } from 'src/shared/resources/applicationMetadata/applicationMetadataSlice';
 import { LanguageActions } from 'src/shared/resources/language/languageSlice';
+import { ProfileActions } from 'src/shared/resources/profile/profileSlice';
 import { QueueActions } from 'src/shared/resources/queue/queueSlice';
 import { waitFor } from 'src/utils/sagas';
 
@@ -36,5 +37,5 @@ export function* watchFetchLanguageSaga(): SagaIterator {
   }
 
   yield call(fetchLanguageSaga);
-  yield takeLatest(LanguageActions.updateSelectedAppLanguage, fetchLanguageSaga);
+  yield takeLatest(ProfileActions.updateSelectedAppLanguage, fetchLanguageSaga);
 }

--- a/src/shared/resources/language/languageSlice.ts
+++ b/src/shared/resources/language/languageSlice.ts
@@ -1,36 +1,26 @@
-import { call, put, take } from 'redux-saga/effects';
+import { call, take } from 'redux-saga/effects';
 import type { SagaIterator } from 'redux-saga';
 
 import { fetchLanguageSaga, watchFetchLanguageSaga } from 'src/shared/resources/language/fetch/fetchLanguageSagas';
-import { OptionsActions } from 'src/shared/resources/options/optionsSlice';
 import { createSagaSlice } from 'src/shared/resources/utils/sagaSlice';
 import type { MkActionType } from 'src/shared/resources/utils/sagaSlice';
-import type { IAltinnWindow } from 'src/types';
 import type { ILanguage } from 'src/types/shared';
 
 export interface IFetchLanguageFulfilled {
   language: ILanguage;
 }
+
 export interface IFetchLanguageRejected {
   error: Error;
-}
-export interface IUpdateSelectedAppLanguage {
-  selected: string;
 }
 
 export interface ILanguageState {
   language: ILanguage | null;
-  selectedAppLanguage: string;
   error: Error | null;
 }
 
-const altinnWindow = window as Window as IAltinnWindow;
-const { app } = altinnWindow;
-const localStorageSlectedAppLanguageKey = `selectedAppLanguage${app}`;
-
 export const initialState: ILanguageState = {
   language: null,
-  selectedAppLanguage: localStorage.getItem(localStorageSlectedAppLanguageKey) || '',
   error: null,
 };
 
@@ -58,16 +48,6 @@ export const languageSlice = createSagaSlice((mkAction: MkActionType<ILanguageSt
       reducer: (state, action) => {
         const { error } = action.payload;
         state.error = error;
-      },
-    }),
-    updateSelectedAppLanguage: mkAction<IUpdateSelectedAppLanguage>({
-      *takeLatest() {
-        yield put(OptionsActions.fetch());
-      },
-      reducer: (state, action) => {
-        const { selected } = action.payload;
-        localStorage.setItem(localStorageSlectedAppLanguageKey, selected);
-        state.selectedAppLanguage = selected;
       },
     }),
   },

--- a/src/shared/resources/profile/index.d.ts
+++ b/src/shared/resources/profile/index.d.ts
@@ -2,6 +2,7 @@ import type { IProfile } from 'src/types/shared';
 
 export interface IProfileState {
   profile: IProfile;
+  selectedAppLanguage: string;
   error: Error | null;
 }
 

--- a/src/shared/resources/profile/profileSlice.test.ts
+++ b/src/shared/resources/profile/profileSlice.test.ts
@@ -1,0 +1,33 @@
+import { getProfileStateMock } from 'src/__mocks__/profileStateMock';
+import { initialState, ProfileActions, profileSlice } from 'src/shared/resources/profile/profileSlice';
+import { createStorageMock } from 'src/testUtils';
+
+describe('profileSlice', () => {
+  beforeEach(() => {
+    window.localStorage = createStorageMock();
+    window.app = 'test-app';
+  });
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+  it('should set selected app language for user when no userId', () => {
+    const nextState = profileSlice.reducer(
+      initialState,
+      ProfileActions.updateSelectedAppLanguage({
+        selected: 'en',
+      }),
+    );
+    expect(window.localStorage.getItem('selectedAppLanguagetest-app')).toEqual('en');
+    expect(nextState.selectedAppLanguage).toEqual('en');
+  });
+  it('should set selected app language for user with userId', () => {
+    const nextState = profileSlice.reducer(
+      getProfileStateMock(),
+      ProfileActions.updateSelectedAppLanguage({
+        selected: 'po',
+      }),
+    );
+    expect(window.localStorage.getItem('selectedAppLanguagetest-app12345')).toEqual('po');
+    expect(nextState.selectedAppLanguage).toEqual('po');
+  });
+});

--- a/src/shared/resources/profile/profileSlice.test.ts
+++ b/src/shared/resources/profile/profileSlice.test.ts
@@ -5,8 +5,8 @@ import type { IAltinnWindow } from 'src/types';
 
 describe('profileSlice', () => {
   beforeEach(() => {
-    const altinnWinow = window as any as IAltinnWindow;
-    altinnWinow.localStorage = createStorageMock();
+    const altinnWinow = window as Window as IAltinnWindow;
+    Object.defineProperty(altinnWinow, 'localStorage', { value: createStorageMock() });
     altinnWinow.app = 'test-app';
   });
   afterEach(() => {

--- a/src/shared/resources/profile/profileSlice.test.ts
+++ b/src/shared/resources/profile/profileSlice.test.ts
@@ -1,11 +1,13 @@
 import { getProfileStateMock } from 'src/__mocks__/profileStateMock';
 import { initialState, ProfileActions, profileSlice } from 'src/shared/resources/profile/profileSlice';
 import { createStorageMock } from 'src/testUtils';
+import type { IAltinnWindow } from 'src/types';
 
 describe('profileSlice', () => {
   beforeEach(() => {
-    window.localStorage = createStorageMock();
-    window.app = 'test-app';
+    const altinnWinow = window as any as IAltinnWindow;
+    altinnWinow.localStorage = createStorageMock();
+    altinnWinow.app = 'test-app';
   });
   afterEach(() => {
     window.localStorage.clear();
@@ -29,5 +31,13 @@ describe('profileSlice', () => {
     );
     expect(window.localStorage.getItem('selectedAppLanguagetest-app12345')).toEqual('po');
     expect(nextState.selectedAppLanguage).toEqual('po');
+  });
+  it('should use selected app language from localstorage if it exists for user', () => {
+    window.localStorage.setItem('selectedAppLanguagetest-app12345', 'nn');
+    const nextState = profileSlice.reducer(
+      initialState,
+      ProfileActions.fetchFulfilled({ profile: getProfileStateMock().profile }),
+    );
+    expect(nextState.selectedAppLanguage).toEqual('nn');
   });
 });

--- a/src/shared/resources/profile/profileSlice.ts
+++ b/src/shared/resources/profile/profileSlice.ts
@@ -1,3 +1,6 @@
+import { put } from 'redux-saga/effects';
+
+import { OptionsActions } from 'src/shared/resources/options/optionsSlice';
 import { fetchProfileSaga } from 'src/shared/resources/profile/fetch/fetchProfileSagas';
 import { createSagaSlice } from 'src/shared/resources/utils/sagaSlice';
 import type {
@@ -7,14 +10,23 @@ import type {
   IProfileState,
 } from 'src/shared/resources/profile';
 import type { MkActionType } from 'src/shared/resources/utils/sagaSlice';
+import type { IAltinnWindow } from 'src/types';
 import type { IProfile } from 'src/types/shared';
 
-const initialState: IProfileState = {
+export interface IUpdateSelectedAppLanguage {
+  selected: string;
+}
+
+const altinnWindow = window as Window as IAltinnWindow;
+const getLanguageStorageKey = (userId: number | undefined) => `selectedAppLanguage${altinnWindow.app}${userId ?? ''}`;
+
+export const initialState: IProfileState = {
   profile: {
     profileSettingPreference: {
       language: 'nb',
     },
   } as IProfile,
+  selectedAppLanguage: '',
   error: null,
 };
 
@@ -28,11 +40,22 @@ export const profileSlice = createSagaSlice((mkAction: MkActionType<IProfileStat
     fetchFulfilled: mkAction<IFetchProfileFulfilled>({
       reducer: (state, action) => {
         state.profile = action.payload.profile;
+        state.selectedAppLanguage = localStorage.getItem(getLanguageStorageKey(state.profile.userId)) ?? '';
       },
     }),
     fetchRejected: mkAction<IFetchProfileRejected>({
       reducer: (state, action) => {
         state.error = action.payload.error;
+      },
+    }),
+    updateSelectedAppLanguage: mkAction<IUpdateSelectedAppLanguage>({
+      *takeLatest() {
+        yield put(OptionsActions.fetch());
+      },
+      reducer: (state, action) => {
+        const { selected } = action.payload;
+        localStorage.setItem(getLanguageStorageKey(state.profile.userId), selected);
+        state.selectedAppLanguage = selected;
       },
     }),
   },

--- a/src/shared/resources/profile/profileSlice.ts
+++ b/src/shared/resources/profile/profileSlice.ts
@@ -26,7 +26,7 @@ export const initialState: IProfileState = {
       language: 'nb',
     },
   } as IProfile,
-  selectedAppLanguage: '',
+  selectedAppLanguage: localStorage.getItem(getLanguageStorageKey(undefined)) ?? '',
   error: null,
 };
 

--- a/src/shared/resources/textResources/fetch/fetchTextResourcesSagas.test.ts
+++ b/src/shared/resources/textResources/fetch/fetchTextResourcesSagas.test.ts
@@ -6,7 +6,7 @@ import { appLanguageStateSelector } from 'src/selectors/appLanguageStateSelector
 import { makeGetAllowAnonymousSelector } from 'src/selectors/getAllowAnonymous';
 import { profileStateSelector } from 'src/selectors/simpleSelectors';
 import { ApplicationMetadataActions } from 'src/shared/resources/applicationMetadata/applicationMetadataSlice';
-import { LanguageActions } from 'src/shared/resources/language/languageSlice';
+import { ProfileActions } from 'src/shared/resources/profile/profileSlice';
 import {
   fetchTextResources,
   watchFetchTextResourcesSaga,
@@ -31,7 +31,7 @@ describe('fetchTextResourcesSagas', () => {
     expect(generator.next().value).toEqual(waitFor(expect.anything()));
     expect(generator.next().value).toEqual(call(fetchTextResources));
     expect(generator.next().value).toEqual(takeLatest(TextResourcesActions.fetch, fetchTextResources));
-    expect(generator.next().value).toEqual(takeLatest(LanguageActions.updateSelectedAppLanguage, fetchTextResources));
+    expect(generator.next().value).toEqual(takeLatest(ProfileActions.updateSelectedAppLanguage, fetchTextResources));
     expect(generator.next().done).toBeTruthy();
   });
   it('should fetch text resources using default language when allowAnonymous is true', () => {

--- a/src/shared/resources/textResources/fetch/fetchTextResourcesSagas.ts
+++ b/src/shared/resources/textResources/fetch/fetchTextResourcesSagas.ts
@@ -5,7 +5,7 @@ import { FormLayoutActions } from 'src/features/form/layout/formLayoutSlice';
 import { appLanguageStateSelector } from 'src/selectors/appLanguageStateSelector';
 import { makeGetAllowAnonymousSelector } from 'src/selectors/getAllowAnonymous';
 import { ApplicationMetadataActions } from 'src/shared/resources/applicationMetadata/applicationMetadataSlice';
-import { LanguageActions } from 'src/shared/resources/language/languageSlice';
+import { ProfileActions } from 'src/shared/resources/profile/profileSlice';
 import { QueueActions } from 'src/shared/resources/queue/queueSlice';
 import { TextResourcesActions } from 'src/shared/resources/textResources/textResourcesSlice';
 import { httpGet } from 'src/utils/network/networking';
@@ -57,5 +57,5 @@ export function* watchFetchTextResourcesSaga(): SagaIterator {
 
   yield call(fetchTextResources);
   yield takeLatest(TextResourcesActions.fetch, fetchTextResources);
-  yield takeLatest(LanguageActions.updateSelectedAppLanguage, fetchTextResources);
+  yield takeLatest(ProfileActions.updateSelectedAppLanguage, fetchTextResources);
 }

--- a/src/testUtils.tsx
+++ b/src/testUtils.tsx
@@ -176,3 +176,27 @@ export const mockComponentProps: IComponentProps & { id: string } = {
   },
   text: undefined,
 };
+
+export const createStorageMock = (): Storage => {
+  let storage: Record<string, string> = {};
+  return {
+    setItem: (key, value) => {
+      console.log('key Halle:', key);
+      storage[key] = value || '';
+    },
+    getItem: (key) => (key in storage ? storage[key] : null),
+    clear: () => {
+      storage = {};
+    },
+    removeItem: (key) => {
+      delete storage[key];
+    },
+    get length() {
+      return Object.keys(storage).length;
+    },
+    key: (i) => {
+      const keys = Object.keys(storage);
+      return keys[i] || null;
+    },
+  };
+};

--- a/src/testUtils.tsx
+++ b/src/testUtils.tsx
@@ -181,7 +181,6 @@ export const createStorageMock = (): Storage => {
   let storage: Record<string, string> = {};
   return {
     setItem: (key, value) => {
-      console.log('key Halle:', key);
       storage[key] = value || '';
     },
     getItem: (key) => (key in storage ? storage[key] : null),


### PR DESCRIPTION
## Description
selectedAppLanguage state is moved to profileState in Redux store (It made more sense to me). When the selectedAppLanguage is changed the language is saved to localStorage as before. BUT the localStorage key include the userId (New). 

I believe this is a breaking change for the users who has changed their language (For them it will default back to profile preferences). 

## Related Issue(s)

- closes #1005

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
