### PR TITLE
Added test case for custom receipt

### DIFF
--- a/test/e2e/integration/app-frontend/receipt.ts
+++ b/test/e2e/integration/app-frontend/receipt.ts
@@ -1,6 +1,7 @@
 import texts from 'test/e2e/fixtures/texts.json';
 import { AppFrontend } from 'test/e2e/pageobjects/app-frontend';
 import { Common } from 'test/e2e/pageobjects/common';
+import { customReceipt } from 'test/e2e/support/customReceipt';
 
 const mui = new Common();
 const appFrontend = new AppFrontend();
@@ -35,5 +36,40 @@ describe('Receipt', () => {
 
     cy.get('body').should('have.css', 'background-color', 'rgb(212, 249, 228)');
     cy.get(appFrontend.header).should('contain.text', texts.ttd);
+  });
+
+  it('Custom receipt shows as expected', () => {
+    cy.intercept('**/layoutsettings/**', (req) => {
+      req.on('response', (res) => {
+        // Layout settings is returned as text/plain for some reason
+        const settings = JSON.parse(res.body);
+        settings.receiptLayoutName = 'receipt';
+        res.body = JSON.stringify(settings);
+      });
+    }).as('LayoutSettings');
+    cy.intercept('**/layouts/**', (req) => {
+      req.on('response', (res) => {
+        // Layouts are returned as text/plain for some reason
+        const layouts = JSON.parse(res.body);
+        layouts.receipt = { data: { layout: customReceipt } };
+        res.body = JSON.stringify(layouts);
+      });
+    });
+    cy.goto('confirm', 'with-data');
+    cy.get(appFrontend.confirm.sendIn).should('be.visible').click();
+
+    cy.get('[data-testId=custom-receipt]').should('exist').and('be.visible');
+    cy.get('#form-content-r-instance').should('exist').and('be.visible');
+    cy.get('#form-content-r-header').should('exist').and('be.visible').and('contain.text', 'Custom kvittering');
+    cy.get('#form-content-r-paragraph')
+      .should('exist')
+      .and('be.visible')
+      .and('contain.text', 'Takk for din innsending, dette er en veldig fin custom kvittering.');
+    cy.get('#form-content-r-attachments')
+      .should('exist')
+      .and('be.visible')
+      .find('[data-testId=attachment-list]')
+      .children()
+      .should('have.length', 5);
   });
 });

--- a/test/e2e/support/customReceipt.ts
+++ b/test/e2e/support/customReceipt.ts
@@ -1,0 +1,12 @@
+import type { ILayout } from 'src/layout/layout';
+
+export const customReceipt: ILayout = [
+  { id: 'r-instance', type: 'InstanceInformation' },
+  { id: 'r-header', type: 'Header', textResourceBindings: { title: 'Custom kvittering' }, size: 'L' },
+  {
+    id: 'r-paragraph',
+    type: 'Paragraph',
+    textResourceBindings: { title: 'Takk for din innsending, dette er en veldig fin custom kvittering.' },
+  },
+  { id: 'r-attachments', type: 'AttachmentList', dataTypeIds: ['ref-data-as-pdf'], includePDF: true },
+];


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

Added a test case for custom receipt to prevent it from unknowingly breaking again.

## Related Issue(s)

- https://github.com/Altinn/app-frontend-react/pull/1024
