### PR TITLE
Check if current layout is visible after fetchsettings

### DIFF
--- a/src/features/form/layout/formLayoutSlice.ts
+++ b/src/features/form/layout/formLayoutSlice.ts
@@ -118,6 +118,7 @@ export const formLayoutSlice = createSagaSlice((mkAction: MkActionType<ILayoutSt
       saga: () => watchFetchFormLayoutSettingsSaga,
     }),
     fetchSettingsFulfilled: mkAction<LayoutTypes.IFetchLayoutSettingsFulfilled>({
+      takeEvery: findAndMoveToNextVisibleLayout,
       reducer: (state, action) => {
         const { settings } = action.payload;
         state.uiConfig.receiptLayoutName = settings?.receiptLayoutName;


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

The source of the problem was that after settings are fetched, it would set the current page to what was stored in localStorage, and if that was not set; the first page in the order. It does this without checking if the page was hidden, leading to the issue. The fix simply calls `findAndMoveToNextVisibleLayout` after each time settings are fetched. This saga has no effect if the current page is visible, but will move to the next visible page if it is hidden.

I have not added a specific test case for this, but the signing-tests will cover this functionality.

## Related Issue(s)

- closes #1044 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
