### PR TITLE
Fixing flaky cypress tests, stale data use when clicking checkboxes/radios very quickly

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "@altinn/altinn-design-system": "0.27.6",
     "@babel/polyfill": "7.12.1",
     "@date-io/moment": "1.3.13",
-    "@digdir/design-system-react": "0.9.0",
+    "@digdir/design-system-react": "0.10.2",
     "@material-ui/core": "4.12.4",
     "@material-ui/icons": "4.11.3",
     "@material-ui/pickers": "3.3.10",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "core-js": "^3.29.1",
     "cross-env": "7.0.3",
     "css-loader": "6.7.3",
-    "cypress": "12.8.1",
+    "cypress": "12.9.0",
     "cypress-axe": "1.4.0",
     "cypress-plugin-tab": "1.0.5",
     "cypress-wait-until": "^1.7.2",

--- a/src/components/hooks/useDelayedSavedState.test.tsx
+++ b/src/components/hooks/useDelayedSavedState.test.tsx
@@ -1,11 +1,80 @@
-import { act, renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
 
 import { useDelayedSavedState } from 'src/components/hooks/useDelayedSavedState';
 
-test('should debounce input by default', async () => {
-  const handleDataChangeMock = jest.fn();
-  const { result } = renderHook(() => useDelayedSavedState(handleDataChangeMock));
+describe('useDelayedSaveState', () => {
+  jest.useFakeTimers();
 
-  act(() => result.current.setValue('great text'));
-  await waitFor(() => expect(result.current.value).toBe('great text'));
+  function render(initial: string) {
+    const handleDataChangeMock = jest.fn();
+    const { result, rerender } = renderHook((props: { formData?: string }) =>
+      useDelayedSavedState(handleDataChangeMock, props?.formData || initial),
+    );
+
+    return { result, rerender, handleDataChangeMock };
+  }
+
+  it('should debounce input by default', () => {
+    const { result, handleDataChangeMock } = render('initial value');
+
+    expect(result.current.value).toBe('initial value');
+    act(() => result.current.setValue('great text'));
+
+    expect(result.current.value).toBe('great text');
+    expect(handleDataChangeMock).toHaveBeenCalledTimes(0);
+    jest.runOnlyPendingTimers();
+
+    expect(result.current.value).toBe('great text');
+    expect(handleDataChangeMock).toHaveBeenCalledTimes(1);
+    expect(handleDataChangeMock).toHaveBeenCalledWith('great text', { validate: true });
+
+    act(() => result.current.setValue('great text 2'));
+    expect(result.current.value).toBe('great text 2');
+    expect(handleDataChangeMock).toHaveBeenCalledTimes(1);
+    jest.runOnlyPendingTimers();
+
+    expect(result.current.value).toBe('great text 2');
+    expect(handleDataChangeMock).toHaveBeenCalledTimes(2);
+    expect(handleDataChangeMock).toHaveBeenCalledWith('great text 2', { validate: true });
+  });
+
+  it('should alter the current value if re-rendered with a new value', () => {
+    const { result, rerender, handleDataChangeMock } = render('1');
+
+    expect(result.current.value).toBe('1');
+    act(() => result.current.setValue('2'));
+    rerender({ formData: '3' });
+
+    expect(result.current.value).toBe('3');
+    expect(handleDataChangeMock).toHaveBeenCalledTimes(0);
+    jest.runOnlyPendingTimers();
+
+    expect(result.current.value).toBe('3');
+    expect(handleDataChangeMock).toHaveBeenCalledTimes(0);
+  });
+
+  it('should not alter the current value if re-rendered with the previous value', () => {
+    const { result, rerender, handleDataChangeMock } = render('1');
+
+    expect(result.current.value).toBe('1');
+    act(() => result.current.setValue('2'));
+    rerender({ formData: '1' });
+
+    expect(result.current.value).toBe('2');
+    expect(handleDataChangeMock).toHaveBeenCalledTimes(0);
+    jest.runOnlyPendingTimers();
+
+    expect(result.current.value).toBe('2');
+    expect(handleDataChangeMock).toHaveBeenCalledTimes(1);
+    expect(handleDataChangeMock).toHaveBeenCalledWith('2', { validate: true });
+    rerender({ formData: '2' });
+
+    // But if handleDataChangeMock has been called, and we saved 2 and got re-rendered with it, it's now OK to
+    // overwrite the data again from the outside with 1
+    rerender({ formData: '1' });
+    expect(result.current.value).toBe('1');
+    jest.runOnlyPendingTimers();
+    expect(result.current.value).toBe('1');
+    expect(handleDataChangeMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/components/hooks/useDelayedSavedState.ts
+++ b/src/components/hooks/useDelayedSavedState.ts
@@ -15,7 +15,7 @@ export function useDelayedSavedState(
   saveAfter?: number | boolean,
 ): DelayedSavedStateRetVal {
   const [immediateState, _setImmediateState] = useState(formValue);
-  const immediateStatePrevRef = useRef([formValue, performance.now()]);
+  const immediateStatePrevRef = useRef<[string | undefined, number] | undefined>(undefined);
   const immediateStateRef = useRef(formValue);
   const [saveNextChangeImmediately, setSaveNextChangeImmediately] = useState(false);
   const [skipNextValidation, setSkipNextValidation] = useState(false);
@@ -38,6 +38,7 @@ export function useDelayedSavedState(
 
       const shouldValidate = !skipNextValidation && !skipValidation;
       handleDataChange(value, { validate: shouldValidate });
+      immediateStatePrevRef.current = undefined;
 
       if (skipNextValidation) {
         setSkipNextValidation(false);
@@ -68,9 +69,9 @@ export function useDelayedSavedState(
     if (formValue === immediateStateRef.current) {
       return;
     }
-    if (formValue === immediateStatePrevRef.current[0]) {
-      const change =
-        typeof immediateStatePrevRef.current[1] === 'number' ? immediateStatePrevRef.current[1] : performance.now();
+    const prev = immediateStatePrevRef.current;
+    if (prev && formValue === prev[0]) {
+      const change = typeof prev[1] === 'number' ? prev[1] : performance.now();
       const timeSinceChange = performance.now() - change;
       if (timeSinceChange < saveAfterMs) {
         return;

--- a/src/components/hooks/useDelayedSavedState.ts
+++ b/src/components/hooks/useDelayedSavedState.ts
@@ -15,12 +15,15 @@ export function useDelayedSavedState(
   saveAfter?: number | boolean,
 ): DelayedSavedStateRetVal {
   const [immediateState, _setImmediateState] = useState(formValue);
+  const immediateStatePrevRef = useRef([formValue, performance.now()]);
   const immediateStateRef = useRef(formValue);
   const [saveNextChangeImmediately, setSaveNextChangeImmediately] = useState(false);
   const [skipNextValidation, setSkipNextValidation] = useState(false);
+  const saveAfterMs = typeof saveAfter === 'number' ? saveAfter : 400;
 
   const setImmediateState = useCallback(
     (value: string | undefined) => {
+      immediateStatePrevRef.current = [immediateStateRef.current, performance.now()];
       immediateStateRef.current = value;
       _setImmediateState(value);
     },
@@ -55,21 +58,38 @@ export function useDelayedSavedState(
   );
 
   useEffect(() => {
+    // When the value is controlled from the outside, by updating formData, we'll want to ignore
+    // outside updates that are caused by React being slow. This code is hit by two entirely
+    // different cases:
+    // 1. When some outside change has been made to our value (i.e. a server calculation change, etc)
+    // 2. When we called handleDataChange(), redux updated its state, the React tree re-rendered, and our
+    //    component finally got their result back. In cases where the user made changes to the value before
+    //    React did all its work, we'll want to ignore the change.
+    if (formValue === immediateStateRef.current) {
+      return;
+    }
+    if (formValue === immediateStatePrevRef.current[0]) {
+      const change =
+        typeof immediateStatePrevRef.current[1] === 'number' ? immediateStatePrevRef.current[1] : performance.now();
+      const timeSinceChange = performance.now() - change;
+      if (timeSinceChange < saveAfterMs) {
+        return;
+      }
+    }
     setImmediateState(formValue);
-  }, [formValue, setImmediateState]);
+  }, [formValue, setImmediateState, saveAfterMs]);
 
   useEffect(() => {
     if (saveAfter === false) {
       return;
     }
 
-    const timeout = typeof saveAfter === 'number' ? saveAfter : 400;
     const timeoutId = setTimeout(() => {
       updateFormData(immediateState);
-    }, timeout);
+    }, saveAfterMs);
 
     return () => clearTimeout(timeoutId);
-  }, [immediateState, updateFormData, formValue, saveAfter]);
+  }, [immediateState, updateFormData, saveAfter, saveAfterMs]);
 
   return {
     value: immediateState,

--- a/test/e2e/integration/app-frontend/attachments-in-group.ts
+++ b/test/e2e/integration/app-frontend/attachments-in-group.ts
@@ -23,21 +23,17 @@ describe('Repeating group attachments', () => {
   const runReloadTests = true;
 
   const addNewRow = () => {
-    cy.get(appFrontend.group.addNewItem).should('be.visible').click();
+    cy.get(appFrontend.group.addNewItem).click();
   };
 
   const gotoSecondPage = () => {
-    cy.get(appFrontend.group.mainGroup)
-      .find(appFrontend.group.editContainer)
-      .find(appFrontend.group.next)
-      .should('be.visible')
-      .click();
+    cy.get(appFrontend.group.mainGroup).find(appFrontend.group.editContainer).find(appFrontend.group.next).click();
   };
 
   beforeEach(() => {
     cy.goto('group');
     cy.get(appFrontend.nextButton).click();
-    cy.get(appFrontend.group.showGroupToContinue).should('be.visible').find('input').dsCheck();
+    cy.get(appFrontend.group.showGroupToContinue).find('input').dsCheck();
     addNewRow();
     gotoSecondPage();
   });
@@ -55,9 +51,9 @@ describe('Repeating group attachments', () => {
     deletedAttachments: string[] = [],
   ) => {
     if (deletedAttachments.includes(fileName)) {
-      cy.get(item.tableRowPreview).should('be.visible').should('not.contain.text', fileName);
+      cy.get(item.tableRowPreview).should('not.contain.text', fileName);
     } else {
-      cy.get(item.tableRowPreview).should('be.visible').should('contain.text', fileName);
+      cy.get(item.tableRowPreview).should('contain.text', fileName);
     }
   };
 
@@ -67,12 +63,12 @@ describe('Repeating group attachments', () => {
 
     const attachment = item.attachments(idx);
     if (attachment.tagSelector !== undefined && attachment.tagSave !== undefined) {
-      cy.get(attachment.tagSelector).should('be.visible').select('altinn');
+      cy.get(attachment.tagSelector).select('altinn');
       cy.get(attachment.tagSave).click();
     }
 
-    cy.get(attachment.status).should('be.visible').should('contain.text', texts.finishedUploading);
-    cy.get(attachment.name).should('be.visible').should('contain.text', fileName);
+    cy.get(attachment.status).should('contain.text', texts.finishedUploading);
+    cy.get(attachment.name).should('contain.text', fileName);
 
     if (verifyTableRow) {
       cy.get(tableRow.editBtn).click();
@@ -281,9 +277,7 @@ describe('Repeating group attachments', () => {
     waitForFormDataSave();
 
     // The next attachment filename should now replace the deleted one:
-    cy.get(appFrontend.group.row(0).uploadMulti.attachments(1).name)
-      .should('be.visible')
-      .should('contain.text', filenames[0].multi[2]);
+    cy.get(appFrontend.group.row(0).uploadMulti.attachments(1).name).should('contain.text', filenames[0].multi[2]);
 
     // This verifies that the deleted filename is no longer part of the table header preview:
     cy.get(appFrontend.group.row(0).editBtn).click();
@@ -303,9 +297,10 @@ describe('Repeating group attachments', () => {
     waitForFormDataSave();
 
     // The next filename should have replaced it:
-    cy.get(appFrontend.group.row(1).nestedGroup.row(1).uploadTagMulti.attachments(1).name)
-      .should('be.visible')
-      .should('contain.text', filenames[1].nested[1][2]);
+    cy.get(appFrontend.group.row(1).nestedGroup.row(1).uploadTagMulti.attachments(1).name).should(
+      'contain.text',
+      filenames[1].nested[1][2],
+    );
 
     cy.get(appFrontend.group.row(1).editBtn).click();
     verifyPreview();

--- a/test/e2e/integration/app-frontend/attachments-in-group.ts
+++ b/test/e2e/integration/app-frontend/attachments-in-group.ts
@@ -37,7 +37,7 @@ describe('Repeating group attachments', () => {
   beforeEach(() => {
     cy.goto('group');
     cy.get(appFrontend.nextButton).click();
-    cy.get(appFrontend.group.showGroupToContinue).should('be.visible').find('input').check({ force: true });
+    cy.get(appFrontend.group.showGroupToContinue).should('be.visible').find('input').check();
     addNewRow();
     gotoSecondPage();
   });
@@ -63,7 +63,7 @@ describe('Repeating group attachments', () => {
 
   const uploadFile = ({ item, idx, fileName, verifyTableRow, tableRow, secondPage = false }: IUploadFileArgs) => {
     cy.get(item.dropZoneContainer).should('be.visible');
-    cy.get(item.dropZone).selectFile(makeTestFile(fileName), { force: true });
+    cy.get(item.dropZone).selectFile(makeTestFile(fileName));
 
     const attachment = item.attachments(idx);
     if (attachment.tagSelector !== undefined && attachment.tagSave !== undefined) {

--- a/test/e2e/integration/app-frontend/attachments-in-group.ts
+++ b/test/e2e/integration/app-frontend/attachments-in-group.ts
@@ -37,7 +37,7 @@ describe('Repeating group attachments', () => {
   beforeEach(() => {
     cy.goto('group');
     cy.get(appFrontend.nextButton).click();
-    cy.get(appFrontend.group.showGroupToContinue).should('be.visible').find('input').check();
+    cy.get(appFrontend.group.showGroupToContinue).should('be.visible').find('input').dsCheck();
     addNewRow();
     gotoSecondPage();
   });
@@ -63,7 +63,7 @@ describe('Repeating group attachments', () => {
 
   const uploadFile = ({ item, idx, fileName, verifyTableRow, tableRow, secondPage = false }: IUploadFileArgs) => {
     cy.get(item.dropZoneContainer).should('be.visible');
-    cy.get(item.dropZone).selectFile(makeTestFile(fileName));
+    cy.get(item.dropZone).selectFile(makeTestFile(fileName), { force: true });
 
     const attachment = item.attachments(idx);
     if (attachment.tagSelector !== undefined && attachment.tagSave !== undefined) {

--- a/test/e2e/integration/app-frontend/calculate-page-order.ts
+++ b/test/e2e/integration/app-frontend/calculate-page-order.ts
@@ -112,7 +112,7 @@ describe('Calculate Page Order', () => {
     cy.goto('group');
     cy.get(appFrontend.navMenuButtons).should('have.length', 4);
 
-    cy.get(appFrontend.group.prefill.stor).click();
+    cy.get(appFrontend.group.prefill.stor).dsCheck();
     cy.get(appFrontend.nextButton).click();
 
     // Both pages the 'repeating' and 'hide' pages are now hidden

--- a/test/e2e/integration/app-frontend/calculate-page-order.ts
+++ b/test/e2e/integration/app-frontend/calculate-page-order.ts
@@ -28,7 +28,7 @@ describe('Calculate Page Order', () => {
 
     cy.goto('group');
     cy.get(appFrontend.nextButton).click();
-    cy.get(appFrontend.group.showGroupToContinue).should('be.visible').find('input').dsCheck();
+    cy.get(appFrontend.group.showGroupToContinue).find('input').dsCheck();
 
     cy.get(appFrontend.navMenuButtons).should('have.length', 4);
 

--- a/test/e2e/integration/app-frontend/calculate-page-order.ts
+++ b/test/e2e/integration/app-frontend/calculate-page-order.ts
@@ -28,7 +28,7 @@ describe('Calculate Page Order', () => {
 
     cy.goto('group');
     cy.get(appFrontend.nextButton).click();
-    cy.get(appFrontend.group.showGroupToContinue).should('be.visible').find('input').check({ force: true });
+    cy.get(appFrontend.group.showGroupToContinue).should('be.visible').find('input').check();
 
     cy.get(appFrontend.navMenuButtons).should('have.length', 4);
 
@@ -74,7 +74,7 @@ describe('Calculate Page Order', () => {
 
     const reproduceBug = JSON.parse('false');
     if (reproduceBug) {
-      cy.get(appFrontend.group.prefill.liten).click({ force: true });
+      cy.get(appFrontend.group.prefill.liten).click();
       cy.get(appFrontend.nextButton).click();
 
       // And this is, in essence, a bug. Navigating to the next page should consider what the next page is, even if
@@ -112,7 +112,7 @@ describe('Calculate Page Order', () => {
     cy.goto('group');
     cy.get(appFrontend.navMenuButtons).should('have.length', 4);
 
-    cy.get(appFrontend.group.prefill.stor).click({ force: true });
+    cy.get(appFrontend.group.prefill.stor).click();
     cy.get(appFrontend.nextButton).click();
 
     // Both pages the 'repeating' and 'hide' pages are now hidden

--- a/test/e2e/integration/app-frontend/calculate-page-order.ts
+++ b/test/e2e/integration/app-frontend/calculate-page-order.ts
@@ -28,7 +28,7 @@ describe('Calculate Page Order', () => {
 
     cy.goto('group');
     cy.get(appFrontend.nextButton).click();
-    cy.get(appFrontend.group.showGroupToContinue).should('be.visible').find('input').check();
+    cy.get(appFrontend.group.showGroupToContinue).should('be.visible').find('input').dsCheck();
 
     cy.get(appFrontend.navMenuButtons).should('have.length', 4);
 

--- a/test/e2e/integration/app-frontend/components.ts
+++ b/test/e2e/integration/app-frontend/components.ts
@@ -30,7 +30,7 @@ describe('UI Components', () => {
   it('is possible to upload and delete attachments', () => {
     cy.goto('changename');
     cy.get(appFrontend.changeOfName.uploadDropZone).should('be.visible');
-    cy.get(appFrontend.changeOfName.upload).selectFile('test/e2e/fixtures/test.pdf');
+    cy.get(appFrontend.changeOfName.upload).selectFile('test/e2e/fixtures/test.pdf', { force: true });
     cy.get(appFrontend.changeOfName.uploadedTable).should('be.visible');
     cy.get(appFrontend.changeOfName.uploadingAnimation).should('be.visible');
     cy.get(appFrontend.changeOfName.uploadSuccess).should('exist');

--- a/test/e2e/integration/app-frontend/components.ts
+++ b/test/e2e/integration/app-frontend/components.ts
@@ -12,18 +12,16 @@ describe('UI Components', () => {
     cy.get(appFrontend.loadingAnimation).should('be.visible');
     cy.get(appFrontend.closeButton).should('be.visible');
     cy.get(appFrontend.header).should('contain.text', appFrontend.apps.frontendTest).and('contain.text', texts.ttd);
-    cy.get(appFrontend.message.logo)
-      .should('be.visible')
-      .then((image) => {
-        cy.wrap(image).find('img').should('have.attr', 'alt', 'Altinn logo');
-        cy.wrap(image)
-          .parentsUntil(appFrontend.message.logoFormContent)
-          .eq(1)
-          .should('have.css', 'justify-content', 'center');
-        cy.wrap(image).parent().siblings().find(appFrontend.helpText.open).click();
-        cy.get(appFrontend.helpText.alert).contains('Altinn logo').type('{esc}');
-        cy.get(appFrontend.helpText.alert).should('not.exist');
-      });
+    cy.get(appFrontend.message.logo).then((image) => {
+      cy.wrap(image).find('img').should('have.attr', 'alt', 'Altinn logo');
+      cy.wrap(image)
+        .parentsUntil(appFrontend.message.logoFormContent)
+        .eq(1)
+        .should('have.css', 'justify-content', 'center');
+      cy.wrap(image).parent().siblings().find(appFrontend.helpText.open).click();
+      cy.get(appFrontend.helpText.alert).contains('Altinn logo').type('{esc}');
+      cy.get(appFrontend.helpText.alert).should('not.exist');
+    });
     cy.get('body').should('have.css', 'background-color', 'rgb(239, 239, 239)');
   });
 
@@ -47,8 +45,8 @@ describe('UI Components', () => {
       force: true,
     });
     cy.get(appFrontend.changeOfName.uploadWithTag.editWindow).should('be.visible');
-    cy.get(appFrontend.changeOfName.uploadWithTag.tagsDropDown).should('be.visible').select('address');
-    cy.get(appFrontend.changeOfName.uploadWithTag.saveTag).should('be.visible').click();
+    cy.get(appFrontend.changeOfName.uploadWithTag.tagsDropDown).select('address');
+    cy.get(appFrontend.changeOfName.uploadWithTag.saveTag).click();
     cy.wait('@saveTags');
     cy.get(appFrontend.changeOfName.uploadWithTag.uploaded).then((table) => {
       cy.wrap(table).should('be.visible');
@@ -58,7 +56,7 @@ describe('UI Components', () => {
     });
     cy.get(appFrontend.changeOfName.uploadWithTag.editWindow)
       .find('button:contains("Slett")')
-      .should('be.visible')
+
       .click();
     cy.get(appFrontend.changeOfName.uploadWithTag.editWindow).should('not.exist');
   });
@@ -66,9 +64,9 @@ describe('UI Components', () => {
   it('is possible to navigate between pages using navigation bar', () => {
     cy.goto('changename');
     cy.get(appFrontend.navMenu)
-      .should('be.visible')
+
       .find('li > button')
-      .should('be.visible')
+
       .and('have.length', 2)
       .then((navButtons) => {
         cy.wrap(navButtons)
@@ -106,8 +104,8 @@ describe('UI Components', () => {
 
   it('address component fetches post place from zip code', () => {
     cy.goto('changename');
-    cy.get(appFrontend.changeOfName.address.street_name).should('be.visible').type('Sesame Street 1A').blur();
-    cy.get(appFrontend.changeOfName.address.zip_code).should('be.visible').type('0174').blur();
+    cy.get(appFrontend.changeOfName.address.street_name).type('Sesame Street 1A').blur();
+    cy.get(appFrontend.changeOfName.address.zip_code).type('0174').blur();
     cy.get(appFrontend.changeOfName.address.post_place).should('have.value', 'OSLO');
   });
 
@@ -123,24 +121,24 @@ describe('UI Components', () => {
     cy.goto('changename');
     cy.get(appFrontend.changeOfName.newFirstName).type('Per').blur();
     cy.get(appFrontend.changeOfName.newLastName).type('Hansen').blur();
-    cy.get(appFrontend.changeOfName.confirmChangeName).should('be.visible').find('label').click();
+    cy.get(appFrontend.changeOfName.confirmChangeName).find('label').click();
     cy.get(appFrontend.changeOfName.reasons).should('be.visible');
 
     cy.get(appFrontend.changeOfName.newMiddleName).type('checkbox_readOnly').blur();
 
-    cy.get(appFrontend.changeOfName.confirmChangeName).should('be.visible').find('label').click(); // No effect
+    cy.get(appFrontend.changeOfName.confirmChangeName).find('label').click(); // No effect
 
     // Assert the last click had no effect
     cy.get(appFrontend.changeOfName.reasons).should('be.visible');
 
-    cy.get(appFrontend.changeOfName.reasons).findByText('Gårdsbruk').should('be.visible').click();
+    cy.get(appFrontend.changeOfName.reasons).findByText('Gårdsbruk').click();
 
     cy.get(appFrontend.changeOfName.newMiddleName).clear().type('radio_readOnly').blur();
     cy.get(appFrontend.changeOfName.confirmChangeName).find('label').click();
     cy.get(appFrontend.changeOfName.reasons).should('not.exist');
     cy.get(appFrontend.changeOfName.confirmChangeName).find('label').click();
     cy.get(appFrontend.changeOfName.reasons).should('be.visible');
-    cy.get(appFrontend.changeOfName.reasons).findByText('Slektskap').should('be.visible').click(); // No effect
+    cy.get(appFrontend.changeOfName.reasons).findByText('Slektskap').click(); // No effect
 
     // Assert the last click had no effect
     cy.get('#form-content-reasonFarm3').should('be.visible');

--- a/test/e2e/integration/app-frontend/components.ts
+++ b/test/e2e/integration/app-frontend/components.ts
@@ -30,7 +30,7 @@ describe('UI Components', () => {
   it('is possible to upload and delete attachments', () => {
     cy.goto('changename');
     cy.get(appFrontend.changeOfName.uploadDropZone).should('be.visible');
-    cy.get(appFrontend.changeOfName.upload).selectFile('test/e2e/fixtures/test.pdf', { force: true });
+    cy.get(appFrontend.changeOfName.upload).selectFile('test/e2e/fixtures/test.pdf');
     cy.get(appFrontend.changeOfName.uploadedTable).should('be.visible');
     cy.get(appFrontend.changeOfName.uploadingAnimation).should('be.visible');
     cy.get(appFrontend.changeOfName.uploadSuccess).should('exist');

--- a/test/e2e/integration/app-frontend/dynamics.ts
+++ b/test/e2e/integration/app-frontend/dynamics.ts
@@ -25,7 +25,7 @@ describe('Dynamics', () => {
     cy.goto('changename');
     cy.get(appFrontend.changeOfName.newFirstName).should('be.visible').type('test').blur();
     cy.get(appFrontend.changeOfName.newLastName).should('be.visible').type('test').blur();
-    cy.get(appFrontend.changeOfName.confirmChangeName).should('be.visible').find('input').check();
+    cy.get(appFrontend.changeOfName.confirmChangeName).should('be.visible').find('input').dsCheck();
     cy.get(appFrontend.changeOfName.reasons).should('be.visible');
   });
 

--- a/test/e2e/integration/app-frontend/dynamics.ts
+++ b/test/e2e/integration/app-frontend/dynamics.ts
@@ -25,7 +25,7 @@ describe('Dynamics', () => {
     cy.goto('changename');
     cy.get(appFrontend.changeOfName.newFirstName).should('be.visible').type('test').blur();
     cy.get(appFrontend.changeOfName.newLastName).should('be.visible').type('test').blur();
-    cy.get(appFrontend.changeOfName.confirmChangeName).should('be.visible').find('input').check({ force: true });
+    cy.get(appFrontend.changeOfName.confirmChangeName).should('be.visible').find('input').check();
     cy.get(appFrontend.changeOfName.reasons).should('be.visible');
   });
 

--- a/test/e2e/integration/app-frontend/dynamics.ts
+++ b/test/e2e/integration/app-frontend/dynamics.ts
@@ -7,7 +7,7 @@ describe('Dynamics', () => {
   it('Show and hide confirm name change checkbox on changing firstname', () => {
     cy.goto('changename');
     cy.get(appFrontend.changeOfName.newFirstName)
-      .should('be.visible')
+
       .type('test')
       .then(() => {
         cy.get(appFrontend.changeOfName.newMiddleName).focus();
@@ -23,9 +23,9 @@ describe('Dynamics', () => {
 
   it('Show and hide name change reasons radio buttons', () => {
     cy.goto('changename');
-    cy.get(appFrontend.changeOfName.newFirstName).should('be.visible').type('test').blur();
-    cy.get(appFrontend.changeOfName.newLastName).should('be.visible').type('test').blur();
-    cy.get(appFrontend.changeOfName.confirmChangeName).should('be.visible').find('input').dsCheck();
+    cy.get(appFrontend.changeOfName.newFirstName).type('test').blur();
+    cy.get(appFrontend.changeOfName.newLastName).type('test').blur();
+    cy.get(appFrontend.changeOfName.confirmChangeName).find('input').dsCheck();
     cy.get(appFrontend.changeOfName.reasons).should('be.visible');
   });
 
@@ -37,18 +37,12 @@ describe('Dynamics', () => {
     });
     cy.goto('changename');
     cy.get(appFrontend.changeOfName.newFirstName).type('test');
-    cy.get(appFrontend.errorReport)
-      .should('exist')
-      .should('be.visible')
-      .should('contain.text', texts.testIsNotValidValue);
+    cy.get(appFrontend.errorReport).should('contain.text', texts.testIsNotValidValue);
     cy.get(appFrontend.changeOfName.newLastName).type('hideFirstName');
     cy.get(appFrontend.errorReport).should('not.exist');
     cy.get(appFrontend.changeOfName.newLastName).clear();
     cy.get(appFrontend.changeOfName.newFirstName).should('be.visible');
-    cy.get(appFrontend.errorReport)
-      .should('exist')
-      .should('be.visible')
-      .should('contain.text', texts.testIsNotValidValue);
+    cy.get(appFrontend.errorReport).should('contain.text', texts.testIsNotValidValue);
   });
 
   it('Page interdependent dynamics with component lookups', () => {

--- a/test/e2e/integration/app-frontend/formatting.ts
+++ b/test/e2e/integration/app-frontend/formatting.ts
@@ -17,13 +17,12 @@ describe('Formatting', () => {
     cy.gotoAndComplete('changename');
     cy.get(appFrontend.backButton).should('be.visible');
     cy.intercept('**/api/layoutsettings/group').as('getLayoutGroup');
-    cy.get(appFrontend.sendinButton).should('be.visible').click();
+    cy.get(appFrontend.sendinButton).click();
     cy.wait('@getLayoutGroup');
     cy.get(appFrontend.nextButton).click();
     cy.get(appFrontend.group.showGroupToContinue).find('input').dsCheck();
-    cy.get(appFrontend.group.addNewItem).should('be.visible').click();
+    cy.get(appFrontend.group.addNewItem).click();
     cy.get(appFrontend.group.currentValue)
-      .should('be.visible')
       .type('1')
       .should('have.value', 'NOK 1')
       .and('have.css', 'text-align', 'right');

--- a/test/e2e/integration/app-frontend/formatting.ts
+++ b/test/e2e/integration/app-frontend/formatting.ts
@@ -20,7 +20,7 @@ describe('Formatting', () => {
     cy.get(appFrontend.sendinButton).should('be.visible').click();
     cy.wait('@getLayoutGroup');
     cy.get(appFrontend.nextButton).click();
-    cy.get(appFrontend.group.showGroupToContinue).find('input').check({ force: true });
+    cy.get(appFrontend.group.showGroupToContinue).find('input').check();
     cy.get(appFrontend.group.addNewItem).should('be.visible').click();
     cy.get(appFrontend.group.currentValue)
       .should('be.visible')

--- a/test/e2e/integration/app-frontend/formatting.ts
+++ b/test/e2e/integration/app-frontend/formatting.ts
@@ -20,7 +20,7 @@ describe('Formatting', () => {
     cy.get(appFrontend.sendinButton).should('be.visible').click();
     cy.wait('@getLayoutGroup');
     cy.get(appFrontend.nextButton).click();
-    cy.get(appFrontend.group.showGroupToContinue).find('input').check();
+    cy.get(appFrontend.group.showGroupToContinue).find('input').dsCheck();
     cy.get(appFrontend.group.addNewItem).should('be.visible').click();
     cy.get(appFrontend.group.currentValue)
       .should('be.visible')

--- a/test/e2e/integration/app-frontend/formatting.ts
+++ b/test/e2e/integration/app-frontend/formatting.ts
@@ -11,7 +11,7 @@ describe('Formatting', () => {
       .parent()
       .should('have.css', 'border-bottom', '1px dashed rgb(148, 148, 148)');
     cy.get(appFrontend.changeOfName.mobilenummer)
-      .should('be.visible')
+
       .type('44444444')
       .should('have.value', '+47 444 44 444');
     cy.gotoAndComplete('changename');

--- a/test/e2e/integration/app-frontend/group.ts
+++ b/test/e2e/integration/app-frontend/group.ts
@@ -37,19 +37,19 @@ describe('Group', () => {
         .then((table) => {
           cy.wrap(table).find(mui.tableElement).first().invoke('text').should('equal', 'NOK 1');
           cy.wrap(table).find(mui.tableElement).eq(1).invoke('text').should('equal', 'NOK 2');
-          cy.wrap(table).find(mui.tableElement).find(appFrontend.group.edit).should('be.visible').click();
+          cy.wrap(table).find(mui.tableElement).find(appFrontend.group.edit).click();
         });
       cy.get(appFrontend.group.mainGroup)
         .find(appFrontend.group.editContainer)
         .find(appFrontend.group.next)
-        .should('be.visible')
+
         .click();
       cy.get(appFrontend.group.subGroup)
         .find(mui.tableBody)
         .then((table) => {
           cy.wrap(table).find(mui.tableElement).first().invoke('text').should('equal', 'automation');
-          cy.wrap(table).find(mui.tableElement).find(appFrontend.group.edit).should('be.visible').click();
-          cy.wrap(table).find(mui.tableElement).find(appFrontend.group.delete).should('be.visible').click();
+          cy.wrap(table).find(mui.tableElement).find(appFrontend.group.edit).click();
+          cy.wrap(table).find(mui.tableElement).find(appFrontend.group.delete).click();
         });
 
       if (openByDefault) {
@@ -64,12 +64,12 @@ describe('Group', () => {
       cy.get(appFrontend.group.mainGroup)
         .find(appFrontend.group.editContainer)
         .find(appFrontend.group.back)
-        .should('be.visible')
+
         .click();
       cy.get(appFrontend.group.mainGroup)
         .find(mui.tableBody)
         .then((table) => {
-          cy.wrap(table).find(mui.tableElement).find(appFrontend.group.delete).should('be.visible').click();
+          cy.wrap(table).find(mui.tableElement).find(appFrontend.group.delete).click();
         });
 
       if (openByDefault) {
@@ -87,7 +87,7 @@ describe('Group', () => {
     init();
     cy.get(appFrontend.group.showGroupToContinue).find('input').dsCheck();
     cy.get(appFrontend.group.addNewItem).click();
-    cy.get(appFrontend.group.currentValue).should('be.visible').type('1337').blur();
+    cy.get(appFrontend.group.currentValue).type('1337').blur();
     // DataProcessingHandler.cs for frontend-test changes 1337 to 1338.
     cy.get(appFrontend.group.currentValue).should('have.value', 'NOK 1 338');
     cy.get(appFrontend.group.newValueLabel).should('contain.text', '2. Endre verdi 1338 til');
@@ -97,32 +97,25 @@ describe('Group', () => {
     init();
     cy.get(appFrontend.group.showGroupToContinue).find('input').dsCheck();
     cy.get(appFrontend.group.addNewItem).click();
-    cy.get(appFrontend.group.currentValue).should('be.visible').type('1').blur();
-    cy.get(appFrontend.group.newValue).should('be.visible').type('0').blur();
-    cy.get(appFrontend.fieldValidationError.replace('field', 'newValue'))
-      .should('exist')
-      .should('be.visible')
-      .should('have.text', texts.zeroIsNotValid);
-    cy.get(appFrontend.group.newValue).should('be.visible').clear().type('1').blur();
+    cy.get(appFrontend.group.currentValue).type('1').blur();
+    cy.get(appFrontend.group.newValue).type('0').blur();
+    cy.get(appFrontend.fieldValidationError.replace('field', 'newValue')).should('have.text', texts.zeroIsNotValid);
+    cy.get(appFrontend.group.newValue).clear().type('1').blur();
     cy.get(appFrontend.fieldValidationError.replace('field', 'newValue')).should('not.exist');
     cy.get(appFrontend.group.mainGroup).siblings(appFrontend.group.tableErrors).should('not.exist');
-    cy.get(appFrontend.group.mainGroup)
-      .find(appFrontend.group.editContainer)
-      .find(appFrontend.group.next)
-      .should('be.visible')
-      .click();
+    cy.get(appFrontend.group.mainGroup).find(appFrontend.group.editContainer).find(appFrontend.group.next).click();
     cy.get(appFrontend.group.addNewItem).should('not.exist');
     cy.get(appFrontend.group.comments).type('test').blur();
-    cy.get(appFrontend.fieldValidationError.replace('field', 'comments'))
-      .should('exist')
-      .should('be.visible')
-      .should('have.text', texts.testIsNotValidValue);
+    cy.get(appFrontend.fieldValidationError.replace('field', 'comments')).should(
+      'have.text',
+      texts.testIsNotValidValue,
+    );
     cy.get(appFrontend.group.comments).clear().type('automation').blur();
     cy.get(appFrontend.fieldValidationError.replace('field', 'comments')).should('not.exist');
     cy.get(appFrontend.group.subGroup).siblings(appFrontend.group.tableErrors).should('not.exist');
     cy.get(appFrontend.group.mainGroup).siblings(appFrontend.group.tableErrors).should('not.exist');
-    cy.get(appFrontend.group.saveSubGroup).should('be.visible').click().should('not.exist');
-    cy.get(appFrontend.group.saveMainGroup).should('be.visible').click().should('not.exist');
+    cy.get(appFrontend.group.saveSubGroup).click().should('not.exist');
+    cy.get(appFrontend.group.saveMainGroup).click().should('not.exist');
   });
 
   [Triggers.Validation, Triggers.ValidateRow].forEach((trigger) => {
@@ -145,22 +138,20 @@ describe('Group', () => {
       cy.get(appFrontend.group.showGroupToContinue).find('input').dsCheck();
 
       cy.get(appFrontend.group.addNewItem).click();
-      cy.get(appFrontend.group.currentValue).should('be.visible').type('123').blur();
-      cy.get(appFrontend.group.newValue).should('be.visible').type('1').blur();
+      cy.get(appFrontend.group.currentValue).type('123').blur();
+      cy.get(appFrontend.group.newValue).type('1').blur();
       cy.get(appFrontend.group.saveMainGroup).click();
 
       cy.get(appFrontend.group.addNewItem).click();
-      cy.get(appFrontend.group.currentValue).should('be.visible').type('123').blur();
+      cy.get(appFrontend.group.currentValue).type('123').blur();
 
-      cy.get(appFrontend.group.row(0).editBtn).should('exist').and('be.visible').focus().click();
+      cy.get(appFrontend.group.row(0).editBtn).click();
       cy.get(appFrontend.group.saveMainGroup).click();
 
       cy.wait('@validate');
 
       if (trigger === 'validation') {
         cy.get(appFrontend.errorReport)
-          .should('exist')
-          .should('be.visible')
           .should('contain.text', texts.requiredFieldToValue)
           .should('not.contain.text', texts.requiredFieldFromValue);
       } else {
@@ -169,21 +160,18 @@ describe('Group', () => {
       }
 
       cy.get(appFrontend.group.row(0).editBtn).click();
-      cy.get(appFrontend.group.currentValue).clear().blur();
+      cy.get(appFrontend.group.currentValue).clear();
+      cy.get(appFrontend.group.currentValue).should('have.value', '');
       cy.get(appFrontend.group.saveMainGroup).click();
 
       cy.wait('@validate');
 
       if (trigger === 'validation') {
         cy.get(appFrontend.errorReport)
-          .should('exist')
-          .should('be.visible')
           .should('contain.text', texts.requiredFieldToValue)
           .should('contain.text', texts.requiredFieldFromValue);
       } else {
         cy.get(appFrontend.errorReport)
-          .should('exist')
-          .should('be.visible')
           .should('contain.text', texts.requiredFieldFromValue)
           .should('not.contain.text', texts.requiredFieldToValue);
       }
@@ -195,10 +183,10 @@ describe('Group', () => {
     cy.get(appFrontend.group.showGroupToContinue).find('input').dsCheck();
     cy.get(appFrontend.group.secondGroup_add).click();
     cy.get(appFrontend.group.secondGroup_add_to_reference_group).click();
-    cy.get(appFrontend.group.secondGroup_currentValue).should('be.visible').type('1').blur();
-    cy.get(appFrontend.group.secondGroup_newValue).should('be.visible').type('2').blur();
-    cy.get(appFrontend.group.secondGroup_save).focus().should('be.visible').click();
-    cy.get(appFrontend.group.secondGroup_save_and_close).focus().should('be.visible').click();
+    cy.get(appFrontend.group.secondGroup_currentValue).type('1').blur();
+    cy.get(appFrontend.group.secondGroup_newValue).type('2').blur();
+    cy.get(appFrontend.group.secondGroup_save).click();
+    cy.get(appFrontend.group.secondGroup_save_and_close).click();
     cy.get(appFrontend.group.secondGroup_table).find('tbody').find('tr').its('length').should('eq', 1);
   });
 
@@ -282,21 +270,23 @@ describe('Group', () => {
 
     cy.get(appFrontend.group.saveMainGroup).click();
 
-    cy.get(appFrontend.fieldValidationError.replace('field', 'currentValue-0'))
-      .should('be.visible')
-      .should('have.text', texts.requiredFieldFromValue);
+    cy.get(appFrontend.fieldValidationError.replace('field', 'currentValue-0')).should(
+      'have.text',
+      texts.requiredFieldFromValue,
+    );
 
     cy.findByLabelText(/1\. Endre fra/i).type('123');
     cy.get(appFrontend.group.saveMainGroup).click();
 
-    cy.get(appFrontend.fieldValidationError.replace('field', 'newValue-0'))
-      .should('be.visible')
-      .should('have.text', texts.requiredFieldToValue);
+    cy.get(appFrontend.fieldValidationError.replace('field', 'newValue-0')).should(
+      'have.text',
+      texts.requiredFieldToValue,
+    );
 
     cy.get(appFrontend.group.mainGroup)
       .find(mui.tableBody)
       .then((table) => {
-        cy.wrap(table).find(appFrontend.group.delete).should('be.visible').click();
+        cy.wrap(table).find(appFrontend.group.delete).click();
       });
 
     cy.get(appFrontend.nextButton).click();
@@ -384,7 +374,7 @@ describe('Group', () => {
       .children()
       .eq(0)
       .find(appFrontend.group.delete)
-      .should('be.visible')
+
       .click();
     cy.get(appFrontend.group.mainGroupTableBody).find(appFrontend.group.saveMainGroup).should('not.exist');
   });
@@ -405,32 +395,32 @@ describe('Group', () => {
       .then((table) => {
         cy.wrap(table).find(mui.tableElement).first().invoke('text').should('equal', 'NOK 1');
         cy.wrap(table).find(mui.tableElement).eq(1).invoke('text').should('equal', 'NOK 2');
-        cy.wrap(table).find(mui.tableElement).find(appFrontend.group.edit).should('be.visible').click();
+        cy.wrap(table).find(mui.tableElement).find(appFrontend.group.edit).click();
       });
 
     // Navigate to nested group and test delete warning popoup cancel and confirm
     cy.get(appFrontend.group.mainGroup)
       .find(appFrontend.group.editContainer)
       .find(appFrontend.group.next)
-      .should('be.visible')
+
       .click();
     cy.get(appFrontend.group.subGroup)
       .find(mui.tableBody)
       .then((table) => {
         cy.wrap(table).find(mui.tableElement).first().invoke('text').should('equal', 'automation');
-        cy.wrap(table).find(mui.tableElement).find(appFrontend.group.delete).should('be.visible').click();
+        cy.wrap(table).find(mui.tableElement).find(appFrontend.group.delete).click();
         cy.wrap(table)
           .find(mui.tableElement)
           .find(appFrontend.designSystemPanel)
           .find(appFrontend.group.popOverCancelButton)
-          .should('be.visible')
+
           .click();
-        cy.wrap(table).find(mui.tableElement).find(appFrontend.group.delete).should('be.visible').click();
+        cy.wrap(table).find(mui.tableElement).find(appFrontend.group.delete).click();
         cy.wrap(table)
           .find(mui.tableElement)
           .find(appFrontend.designSystemPanel)
           .find(appFrontend.group.popOverDeleteButton)
-          .should('be.visible')
+
           .click();
       });
     cy.get(appFrontend.group.subGroup)
@@ -443,24 +433,24 @@ describe('Group', () => {
     cy.get(appFrontend.group.mainGroup)
       .find(appFrontend.group.editContainer)
       .find(appFrontend.group.back)
-      .should('be.visible')
+
       .click();
     cy.get(appFrontend.group.mainGroup)
       .find(mui.tableBody)
       .then((table) => {
-        cy.wrap(table).find(mui.tableElement).find(appFrontend.group.delete).should('be.visible').click();
+        cy.wrap(table).find(mui.tableElement).find(appFrontend.group.delete).click();
         cy.wrap(table)
           .find(mui.tableElement)
           .find(appFrontend.designSystemPanel)
           .find(appFrontend.group.popOverCancelButton)
-          .should('be.visible')
+
           .click();
-        cy.wrap(table).find(mui.tableElement).find(appFrontend.group.delete).should('be.visible').click();
+        cy.wrap(table).find(mui.tableElement).find(appFrontend.group.delete).click();
         cy.wrap(table)
           .find(mui.tableElement)
           .find(appFrontend.designSystemPanel)
           .find(appFrontend.group.popOverDeleteButton)
-          .should('be.visible')
+
           .click();
       });
     cy.get(appFrontend.group.mainGroup).should('not.exist');

--- a/test/e2e/integration/app-frontend/group.ts
+++ b/test/e2e/integration/app-frontend/group.ts
@@ -17,7 +17,7 @@ describe('Group', () => {
   it('Dynamics on group', () => {
     init();
     cy.get(appFrontend.group.addNewItem).should('not.exist');
-    cy.get(appFrontend.group.showGroupToContinue).find('input').check({ force: true });
+    cy.get(appFrontend.group.showGroupToContinue).find('input').check();
     cy.get(appFrontend.group.addNewItem).should('exist').and('be.visible');
   });
 
@@ -30,7 +30,7 @@ describe('Group', () => {
       });
       init();
 
-      cy.get(appFrontend.group.showGroupToContinue).find('input').check({ force: true });
+      cy.get(appFrontend.group.showGroupToContinue).find('input').check();
       cy.addItemToGroup(1, 2, 'automation', openByDefault);
       cy.get(appFrontend.group.mainGroup)
         .find(mui.tableBody)
@@ -85,7 +85,7 @@ describe('Group', () => {
 
   it('Calculation on Item in Main Group should update value', () => {
     init();
-    cy.get(appFrontend.group.showGroupToContinue).find('input').check({ force: true });
+    cy.get(appFrontend.group.showGroupToContinue).find('input').check();
     cy.get(appFrontend.group.addNewItem).click();
     cy.get(appFrontend.group.currentValue).should('be.visible').type('1337').blur();
     // DataProcessingHandler.cs for frontend-test changes 1337 to 1338.
@@ -95,7 +95,7 @@ describe('Group', () => {
 
   it('Validation on group', () => {
     init();
-    cy.get(appFrontend.group.showGroupToContinue).find('input').check({ force: true });
+    cy.get(appFrontend.group.showGroupToContinue).find('input').check();
     cy.get(appFrontend.group.addNewItem).click();
     cy.get(appFrontend.group.currentValue).should('be.visible').type('1').blur();
     cy.get(appFrontend.group.newValue).should('be.visible').type('0').blur();
@@ -142,7 +142,7 @@ describe('Group', () => {
       });
       init();
 
-      cy.get(appFrontend.group.showGroupToContinue).find('input').check({ force: true });
+      cy.get(appFrontend.group.showGroupToContinue).find('input').check();
 
       cy.get(appFrontend.group.addNewItem).click();
       cy.get(appFrontend.group.currentValue).should('be.visible').type('123').blur();
@@ -192,7 +192,7 @@ describe('Group', () => {
 
   it('should support panel group adding item to referenced group', () => {
     init();
-    cy.get(appFrontend.group.showGroupToContinue).find('input').check({ force: true });
+    cy.get(appFrontend.group.showGroupToContinue).find('input').check();
     cy.get(appFrontend.group.secondGroup_add).click();
     cy.get(appFrontend.group.secondGroup_add_to_reference_group).click();
     cy.get(appFrontend.group.secondGroup_currentValue).should('be.visible').type('1').blur();
@@ -226,14 +226,14 @@ describe('Group', () => {
         });
     };
 
-    cy.get(appFrontend.group.showGroupToContinue).find('input').check({ force: true });
+    cy.get(appFrontend.group.showGroupToContinue).find('input').check();
     expectRows();
 
     cy.intercept('PUT', '**/instances/*/*/data/*').as('updateInstance');
     function clickOnPrefills(...items: (keyof typeof appFrontend.group.prefill)[]) {
       cy.get(appFrontend.prevButton).click();
       for (const item of items) {
-        cy.get(appFrontend.group.prefill[item]).click({ force: true });
+        cy.get(appFrontend.group.prefill[item]).click();
       }
       cy.wait('@updateInstance');
       cy.get(appFrontend.nextButton).click();
@@ -275,7 +275,7 @@ describe('Group', () => {
     });
     init();
 
-    cy.get(appFrontend.group.showGroupToContinue).find('input').check({ force: true });
+    cy.get(appFrontend.group.showGroupToContinue).find('input').check();
     cy.get(appFrontend.group.addNewItem).click();
 
     cy.get(appFrontend.group.saveMainGroup).click();
@@ -305,7 +305,7 @@ describe('Group', () => {
     init();
 
     cy.intercept('PUT', '**/instances/*/*/data/*').as('updateInstance');
-    cy.get(appFrontend.group.showGroupToContinue).find('input').check({ force: true });
+    cy.get(appFrontend.group.showGroupToContinue).find('input').check();
     cy.wait('@updateInstance');
 
     ['first' as const, 'last' as const, true, false].forEach((openByDefault) => {
@@ -396,7 +396,7 @@ describe('Group', () => {
     init();
 
     // Add test-data and verify
-    cy.get(appFrontend.group.showGroupToContinue).find('input').check({ force: true });
+    cy.get(appFrontend.group.showGroupToContinue).find('input').check();
     cy.addItemToGroup(1, 2, 'automation');
     cy.get(appFrontend.group.mainGroup)
       .find(mui.tableBody)

--- a/test/e2e/integration/app-frontend/group.ts
+++ b/test/e2e/integration/app-frontend/group.ts
@@ -17,7 +17,7 @@ describe('Group', () => {
   it('Dynamics on group', () => {
     init();
     cy.get(appFrontend.group.addNewItem).should('not.exist');
-    cy.get(appFrontend.group.showGroupToContinue).find('input').check();
+    cy.get(appFrontend.group.showGroupToContinue).find('input').dsCheck();
     cy.get(appFrontend.group.addNewItem).should('exist').and('be.visible');
   });
 
@@ -30,7 +30,7 @@ describe('Group', () => {
       });
       init();
 
-      cy.get(appFrontend.group.showGroupToContinue).find('input').check();
+      cy.get(appFrontend.group.showGroupToContinue).find('input').dsCheck();
       cy.addItemToGroup(1, 2, 'automation', openByDefault);
       cy.get(appFrontend.group.mainGroup)
         .find(mui.tableBody)
@@ -85,7 +85,7 @@ describe('Group', () => {
 
   it('Calculation on Item in Main Group should update value', () => {
     init();
-    cy.get(appFrontend.group.showGroupToContinue).find('input').check();
+    cy.get(appFrontend.group.showGroupToContinue).find('input').dsCheck();
     cy.get(appFrontend.group.addNewItem).click();
     cy.get(appFrontend.group.currentValue).should('be.visible').type('1337').blur();
     // DataProcessingHandler.cs for frontend-test changes 1337 to 1338.
@@ -95,7 +95,7 @@ describe('Group', () => {
 
   it('Validation on group', () => {
     init();
-    cy.get(appFrontend.group.showGroupToContinue).find('input').check();
+    cy.get(appFrontend.group.showGroupToContinue).find('input').dsCheck();
     cy.get(appFrontend.group.addNewItem).click();
     cy.get(appFrontend.group.currentValue).should('be.visible').type('1').blur();
     cy.get(appFrontend.group.newValue).should('be.visible').type('0').blur();
@@ -142,7 +142,7 @@ describe('Group', () => {
       });
       init();
 
-      cy.get(appFrontend.group.showGroupToContinue).find('input').check();
+      cy.get(appFrontend.group.showGroupToContinue).find('input').dsCheck();
 
       cy.get(appFrontend.group.addNewItem).click();
       cy.get(appFrontend.group.currentValue).should('be.visible').type('123').blur();
@@ -192,7 +192,7 @@ describe('Group', () => {
 
   it('should support panel group adding item to referenced group', () => {
     init();
-    cy.get(appFrontend.group.showGroupToContinue).find('input').check();
+    cy.get(appFrontend.group.showGroupToContinue).find('input').dsCheck();
     cy.get(appFrontend.group.secondGroup_add).click();
     cy.get(appFrontend.group.secondGroup_add_to_reference_group).click();
     cy.get(appFrontend.group.secondGroup_currentValue).should('be.visible').type('1').blur();
@@ -226,32 +226,34 @@ describe('Group', () => {
         });
     };
 
-    cy.get(appFrontend.group.showGroupToContinue).find('input').check();
+    cy.get(appFrontend.group.showGroupToContinue).find('input').dsCheck();
     expectRows();
 
-    cy.intercept('PUT', '**/instances/*/*/data/*').as('updateInstance');
-    function clickOnPrefills(...items: (keyof typeof appFrontend.group.prefill)[]) {
+    function checkPrefills(items: { [key in keyof typeof appFrontend.group.prefill]?: boolean }) {
       cy.get(appFrontend.prevButton).click();
-      for (const item of items) {
-        cy.get(appFrontend.group.prefill[item]).click();
+      for (const item of Object.keys(items)) {
+        if (items[item] === true) {
+          cy.get(appFrontend.group.prefill[item]).dsCheck();
+        } else {
+          cy.get(appFrontend.group.prefill[item]).dsUncheck();
+        }
       }
-      cy.wait('@updateInstance');
       cy.get(appFrontend.nextButton).click();
     }
 
-    clickOnPrefills('liten');
+    checkPrefills({ liten: true });
     expectRows(['NOK 1', 'NOK 5']);
 
-    clickOnPrefills('middels', 'svaer');
+    checkPrefills({ middels: true, svaer: true });
     expectRows(['NOK 1', 'NOK 5'], ['NOK 120', 'NOK 350'], ['NOK 80 323', 'NOK 123 455']);
 
-    clickOnPrefills('middels', 'svaer');
+    checkPrefills({ middels: false, svaer: false });
     expectRows(['NOK 1', 'NOK 5']);
 
-    clickOnPrefills('enorm', 'liten');
+    checkPrefills({ enorm: true, liten: false });
     expectRows(['NOK 9 872 345', 'NOK 18 872 345']);
 
-    clickOnPrefills('liten');
+    checkPrefills({ liten: true });
     expectRows(['NOK 9 872 345', 'NOK 18 872 345'], ['NOK 1', 'NOK 5']);
 
     cy.get(appFrontend.group.row(0).editBtn).should('have.text', 'Se innhold');
@@ -275,7 +277,7 @@ describe('Group', () => {
     });
     init();
 
-    cy.get(appFrontend.group.showGroupToContinue).find('input').check();
+    cy.get(appFrontend.group.showGroupToContinue).find('input').dsCheck();
     cy.get(appFrontend.group.addNewItem).click();
 
     cy.get(appFrontend.group.saveMainGroup).click();
@@ -305,7 +307,7 @@ describe('Group', () => {
     init();
 
     cy.intercept('PUT', '**/instances/*/*/data/*').as('updateInstance');
-    cy.get(appFrontend.group.showGroupToContinue).find('input').check();
+    cy.get(appFrontend.group.showGroupToContinue).find('input').dsCheck();
     cy.wait('@updateInstance');
 
     ['first' as const, 'last' as const, true, false].forEach((openByDefault) => {
@@ -396,7 +398,7 @@ describe('Group', () => {
     init();
 
     // Add test-data and verify
-    cy.get(appFrontend.group.showGroupToContinue).find('input').check();
+    cy.get(appFrontend.group.showGroupToContinue).find('input').dsCheck();
     cy.addItemToGroup(1, 2, 'automation');
     cy.get(appFrontend.group.mainGroup)
       .find(mui.tableBody)

--- a/test/e2e/integration/app-frontend/hide-row-in-group.ts
+++ b/test/e2e/integration/app-frontend/hide-row-in-group.ts
@@ -4,7 +4,7 @@ const appFrontend = new AppFrontend();
 
 it('should be possible to hide rows when "Endre fra" is greater or equals to', () => {
   cy.goto('group');
-  cy.get(appFrontend.group.prefill.liten).click().blur();
+  cy.get(appFrontend.group.prefill.liten).dsCheck();
   cy.get(appFrontend.nextButton).click();
   cy.get(appFrontend.group.showGroupToContinue).find('input').dsCheck();
   cy.get(appFrontend.group.edit).should('be.visible');

--- a/test/e2e/integration/app-frontend/hide-row-in-group.ts
+++ b/test/e2e/integration/app-frontend/hide-row-in-group.ts
@@ -6,7 +6,7 @@ it('should be possible to hide rows when "Endre fra" is greater or equals to', (
   cy.goto('group');
   cy.get(appFrontend.group.prefill.liten).click().blur();
   cy.get(appFrontend.nextButton).click();
-  cy.get(appFrontend.group.showGroupToContinue).find('input').check();
+  cy.get(appFrontend.group.showGroupToContinue).find('input').dsCheck();
   cy.get(appFrontend.group.edit).should('be.visible');
   cy.get(appFrontend.group.hideRepeatingGroupRow).clear().type('1');
   cy.get(appFrontend.group.edit).should('not.exist');

--- a/test/e2e/integration/app-frontend/hide-row-in-group.ts
+++ b/test/e2e/integration/app-frontend/hide-row-in-group.ts
@@ -4,9 +4,9 @@ const appFrontend = new AppFrontend();
 
 it('should be possible to hide rows when "Endre fra" is greater or equals to', () => {
   cy.goto('group');
-  cy.get(appFrontend.group.prefill.liten).click({ force: true }).blur();
+  cy.get(appFrontend.group.prefill.liten).click().blur();
   cy.get(appFrontend.nextButton).click();
-  cy.get(appFrontend.group.showGroupToContinue).find('input').check({ force: true });
+  cy.get(appFrontend.group.showGroupToContinue).find('input').check();
   cy.get(appFrontend.group.edit).should('be.visible');
   cy.get(appFrontend.group.hideRepeatingGroupRow).clear().type('1');
   cy.get(appFrontend.group.edit).should('not.exist');

--- a/test/e2e/integration/app-frontend/list-component.ts
+++ b/test/e2e/integration/app-frontend/list-component.ts
@@ -90,7 +90,7 @@ describe('List component', () => {
   });
   it('Search works with list as intended', () => {
     cy.goto('datalist');
-    cy.get(dataListPage.searchInput).should('be.visible').type('Johanne');
+    cy.get(dataListPage.searchInput).type('Johanne');
     cy.get(dataListPage.tableBody)
       .contains('Johanne')
       .parent('td')

--- a/test/e2e/integration/app-frontend/mobile.ts
+++ b/test/e2e/integration/app-frontend/mobile.ts
@@ -20,13 +20,13 @@ describe('Mobile', () => {
     cy.sendIn();
     cy.wait('@getLayoutGroup');
     cy.get(appFrontend.nextButton).click();
-    cy.get(appFrontend.group.showGroupToContinue).should('be.visible').find('input').dsCheck();
+    cy.get(appFrontend.group.showGroupToContinue).find('input').dsCheck();
     cy.addItemToGroup(1, 2, 'automation');
     cy.get(appFrontend.nextButton).click();
-    cy.get(appFrontend.group.sendersName).should('be.visible').type('automation');
+    cy.get(appFrontend.group.sendersName).type('automation');
     cy.get(appFrontend.navMenu).should('not.exist');
     cy.get(appFrontend.group.navigationBarButton)
-      .should('be.visible')
+
       .and('have.attr', 'aria-expanded', 'false')
       .click();
     cy.get(appFrontend.group.navigationBarButton).should('have.attr', 'aria-expanded', 'true');
@@ -40,7 +40,7 @@ describe('Mobile', () => {
     cy.get(appFrontend.nextButton).click();
     cy.sendIn();
 
-    cy.get(appFrontend.confirm.sendIn).should('be.visible').click();
+    cy.get(appFrontend.confirm.sendIn).click();
     cy.get(appFrontend.confirm.sendIn).should('not.exist');
     cy.get(appFrontend.receipt.container).should('be.visible');
     cy.get(appFrontend.receipt.linkToArchive).should('be.visible');

--- a/test/e2e/integration/app-frontend/mobile.ts
+++ b/test/e2e/integration/app-frontend/mobile.ts
@@ -20,7 +20,7 @@ describe('Mobile', () => {
     cy.sendIn();
     cy.wait('@getLayoutGroup');
     cy.get(appFrontend.nextButton).click();
-    cy.get(appFrontend.group.showGroupToContinue).should('be.visible').find('input').check();
+    cy.get(appFrontend.group.showGroupToContinue).should('be.visible').find('input').dsCheck();
     cy.addItemToGroup(1, 2, 'automation');
     cy.get(appFrontend.nextButton).click();
     cy.get(appFrontend.group.sendersName).should('be.visible').type('automation');

--- a/test/e2e/integration/app-frontend/mobile.ts
+++ b/test/e2e/integration/app-frontend/mobile.ts
@@ -20,7 +20,7 @@ describe('Mobile', () => {
     cy.sendIn();
     cy.wait('@getLayoutGroup');
     cy.get(appFrontend.nextButton).click();
-    cy.get(appFrontend.group.showGroupToContinue).should('be.visible').find('input').check({ force: true });
+    cy.get(appFrontend.group.showGroupToContinue).should('be.visible').find('input').check();
     cy.addItemToGroup(1, 2, 'automation');
     cy.get(appFrontend.nextButton).click();
     cy.get(appFrontend.group.sendersName).should('be.visible').type('automation');

--- a/test/e2e/integration/app-frontend/multipart-save.ts
+++ b/test/e2e/integration/app-frontend/multipart-save.ts
@@ -123,14 +123,14 @@ describe('Multipart save', () => {
     // Checking the checkbox should update with a 'null' previous value
     const root = 'Endringsmelding-grp-9786';
     const showGroupKey = `${root}.Avgiver-grp-9787.KontaktpersonEPost-datadef-27688.value`;
-    cy.get(appFrontend.group.showGroupToContinue).find('input').check().blur();
+    cy.get(appFrontend.group.showGroupToContinue).find('input').dsCheck().blur();
     expectSave(showGroupKey, 'Ja', null);
 
     // And then unchecking it should do the inverse
-    cy.get(appFrontend.group.showGroupToContinue).find('input').uncheck().blur();
+    cy.get(appFrontend.group.showGroupToContinue).find('input').dsUncheck().blur();
     expectSave(showGroupKey, undefined, 'Ja');
 
-    cy.get(appFrontend.group.showGroupToContinue).find('input').check().blur();
+    cy.get(appFrontend.group.showGroupToContinue).find('input').dsCheck().blur();
     expectSave(showGroupKey, 'Ja', null);
 
     const groupKey = `${root}.OversiktOverEndringene-grp-9788`;
@@ -179,19 +179,19 @@ describe('Multipart save', () => {
     cy.get(appFrontend.group.row(0).nestedGroup.row(1).nestedDynamics).click().blur();
     expectSave(`${groupKey}[0].${subGroupKey}[1].extraOptionsToggle`, 'Ja', null);
 
-    cy.get(appFrontend.group.row(0).nestedGroup.row(1).nestedOptions[2]).check().blur();
+    cy.get(appFrontend.group.row(0).nestedGroup.row(1).nestedOptions[2]).dsCheck().blur();
     expectSave(`${groupKey}[0].${subGroupKey}[1].extraOptions`, 'o111', null);
 
-    cy.get(appFrontend.group.row(0).nestedGroup.row(1).nestedOptions[1]).check().blur();
+    cy.get(appFrontend.group.row(0).nestedGroup.row(1).nestedOptions[1]).dsCheck().blur();
     expectSave(`${groupKey}[0].${subGroupKey}[1].extraOptions`, ['o111', 'o1'], ['o111']);
 
-    cy.get(appFrontend.group.row(0).nestedGroup.row(1).nestedOptions[0]).check().blur();
+    cy.get(appFrontend.group.row(0).nestedGroup.row(1).nestedOptions[0]).dsCheck().blur();
     expectSave(`${groupKey}[0].${subGroupKey}[1].extraOptions`, ['o111', 'o1', 'o11'], ['o111', 'o1']);
 
-    cy.get(appFrontend.group.row(0).nestedGroup.row(1).nestedOptions[2]).uncheck().blur();
+    cy.get(appFrontend.group.row(0).nestedGroup.row(1).nestedOptions[2]).dsUncheck().blur();
     expectSave(`${groupKey}[0].${subGroupKey}[1].extraOptions`, ['o1', 'o11'], ['o111', 'o1', 'o11']);
 
-    cy.get(appFrontend.group.row(0).nestedGroup.row(1).nestedOptions[1]).uncheck().blur();
+    cy.get(appFrontend.group.row(0).nestedGroup.row(1).nestedOptions[1]).dsUncheck().blur();
     expectSave(`${groupKey}[0].${subGroupKey}[1].extraOptions`, ['o11'], ['o1', 'o11']);
 
     cy.get(appFrontend.group.saveSubGroup).click();

--- a/test/e2e/integration/app-frontend/multipart-save.ts
+++ b/test/e2e/integration/app-frontend/multipart-save.ts
@@ -145,18 +145,18 @@ describe('Multipart save', () => {
       expectSave(`${groupKey}[${index}].${subGroupKey}[0].source`, 'altinn', null);
       cy.get(appFrontend.group.mainGroup).find(appFrontend.group.back).click();
 
-      cy.get(appFrontend.group.currentValue).should('be.visible').type(oldValue).blur();
+      cy.get(appFrontend.group.currentValue).type(oldValue).blur();
       expectSave(`${groupKey}[${index}].${currentValueKey}`, oldValue, null);
 
-      cy.get(appFrontend.group.newValue).should('be.visible').type(newValue).blur();
+      cy.get(appFrontend.group.newValue).type(newValue).blur();
       expectSave(`${groupKey}[${index}].${newValueKey}`, newValue, null);
 
       cy.get(appFrontend.group.mainGroup).find(appFrontend.group.next).click();
-      cy.get(appFrontend.group.comments).should('be.visible').type(comment).blur();
+      cy.get(appFrontend.group.comments).type(comment).blur();
       expectSave(`${groupKey}[${index}].${subGroupKey}[0].${commentKey}`, comment, null);
 
-      cy.get(appFrontend.group.saveSubGroup).should('be.visible').click().should('not.exist');
-      cy.get(appFrontend.group.saveMainGroup).should('be.visible').click().should('not.exist');
+      cy.get(appFrontend.group.saveSubGroup).click().should('not.exist');
+      cy.get(appFrontend.group.saveMainGroup).click().should('not.exist');
     }
 
     // Add some rows to the group

--- a/test/e2e/integration/app-frontend/multipart-save.ts
+++ b/test/e2e/integration/app-frontend/multipart-save.ts
@@ -123,14 +123,14 @@ describe('Multipart save', () => {
     // Checking the checkbox should update with a 'null' previous value
     const root = 'Endringsmelding-grp-9786';
     const showGroupKey = `${root}.Avgiver-grp-9787.KontaktpersonEPost-datadef-27688.value`;
-    cy.get(appFrontend.group.showGroupToContinue).find('input').dsCheck().blur();
+    cy.get(appFrontend.group.showGroupToContinue).find('input').dsCheck();
     expectSave(showGroupKey, 'Ja', null);
 
     // And then unchecking it should do the inverse
-    cy.get(appFrontend.group.showGroupToContinue).find('input').dsUncheck().blur();
+    cy.get(appFrontend.group.showGroupToContinue).find('input').dsUncheck();
     expectSave(showGroupKey, undefined, 'Ja');
 
-    cy.get(appFrontend.group.showGroupToContinue).find('input').dsCheck().blur();
+    cy.get(appFrontend.group.showGroupToContinue).find('input').dsCheck();
     expectSave(showGroupKey, 'Ja', null);
 
     const groupKey = `${root}.OversiktOverEndringene-grp-9788`;
@@ -176,22 +176,22 @@ describe('Multipart save', () => {
     cy.get(appFrontend.group.comments).type('third comment in first row').blur();
     expectSave(`${groupKey}[0].${subGroupKey}[1].${commentKey}`, 'third comment in first row', null);
 
-    cy.get(appFrontend.group.row(0).nestedGroup.row(1).nestedDynamics).click().blur();
+    cy.get(appFrontend.group.row(0).nestedGroup.row(1).nestedDynamics).dsCheck();
     expectSave(`${groupKey}[0].${subGroupKey}[1].extraOptionsToggle`, 'Ja', null);
 
-    cy.get(appFrontend.group.row(0).nestedGroup.row(1).nestedOptions[2]).dsCheck().blur();
+    cy.get(appFrontend.group.row(0).nestedGroup.row(1).nestedOptions[2]).dsCheck();
     expectSave(`${groupKey}[0].${subGroupKey}[1].extraOptions`, 'o111', null);
 
-    cy.get(appFrontend.group.row(0).nestedGroup.row(1).nestedOptions[1]).dsCheck().blur();
+    cy.get(appFrontend.group.row(0).nestedGroup.row(1).nestedOptions[1]).dsCheck();
     expectSave(`${groupKey}[0].${subGroupKey}[1].extraOptions`, ['o111', 'o1'], ['o111']);
 
-    cy.get(appFrontend.group.row(0).nestedGroup.row(1).nestedOptions[0]).dsCheck().blur();
+    cy.get(appFrontend.group.row(0).nestedGroup.row(1).nestedOptions[0]).dsCheck();
     expectSave(`${groupKey}[0].${subGroupKey}[1].extraOptions`, ['o111', 'o1', 'o11'], ['o111', 'o1']);
 
-    cy.get(appFrontend.group.row(0).nestedGroup.row(1).nestedOptions[2]).dsUncheck().blur();
+    cy.get(appFrontend.group.row(0).nestedGroup.row(1).nestedOptions[2]).dsUncheck();
     expectSave(`${groupKey}[0].${subGroupKey}[1].extraOptions`, ['o1', 'o11'], ['o111', 'o1', 'o11']);
 
-    cy.get(appFrontend.group.row(0).nestedGroup.row(1).nestedOptions[1]).dsUncheck().blur();
+    cy.get(appFrontend.group.row(0).nestedGroup.row(1).nestedOptions[1]).dsUncheck();
     expectSave(`${groupKey}[0].${subGroupKey}[1].extraOptions`, ['o11'], ['o1', 'o11']);
 
     cy.get(appFrontend.group.saveSubGroup).click();

--- a/test/e2e/integration/app-frontend/multipart-save.ts
+++ b/test/e2e/integration/app-frontend/multipart-save.ts
@@ -123,14 +123,14 @@ describe('Multipart save', () => {
     // Checking the checkbox should update with a 'null' previous value
     const root = 'Endringsmelding-grp-9786';
     const showGroupKey = `${root}.Avgiver-grp-9787.KontaktpersonEPost-datadef-27688.value`;
-    cy.get(appFrontend.group.showGroupToContinue).find('input').check({ force: true }).blur();
+    cy.get(appFrontend.group.showGroupToContinue).find('input').check().blur();
     expectSave(showGroupKey, 'Ja', null);
 
     // And then unchecking it should do the inverse
-    cy.get(appFrontend.group.showGroupToContinue).find('input').uncheck({ force: true }).blur();
+    cy.get(appFrontend.group.showGroupToContinue).find('input').uncheck().blur();
     expectSave(showGroupKey, undefined, 'Ja');
 
-    cy.get(appFrontend.group.showGroupToContinue).find('input').check({ force: true }).blur();
+    cy.get(appFrontend.group.showGroupToContinue).find('input').check().blur();
     expectSave(showGroupKey, 'Ja', null);
 
     const groupKey = `${root}.OversiktOverEndringene-grp-9788`;
@@ -176,22 +176,22 @@ describe('Multipart save', () => {
     cy.get(appFrontend.group.comments).type('third comment in first row').blur();
     expectSave(`${groupKey}[0].${subGroupKey}[1].${commentKey}`, 'third comment in first row', null);
 
-    cy.get(appFrontend.group.row(0).nestedGroup.row(1).nestedDynamics).click({ force: true }).blur();
+    cy.get(appFrontend.group.row(0).nestedGroup.row(1).nestedDynamics).click().blur();
     expectSave(`${groupKey}[0].${subGroupKey}[1].extraOptionsToggle`, 'Ja', null);
 
-    cy.get(appFrontend.group.row(0).nestedGroup.row(1).nestedOptions[2]).check({ force: true }).blur();
+    cy.get(appFrontend.group.row(0).nestedGroup.row(1).nestedOptions[2]).check().blur();
     expectSave(`${groupKey}[0].${subGroupKey}[1].extraOptions`, 'o111', null);
 
-    cy.get(appFrontend.group.row(0).nestedGroup.row(1).nestedOptions[1]).check({ force: true }).blur();
+    cy.get(appFrontend.group.row(0).nestedGroup.row(1).nestedOptions[1]).check().blur();
     expectSave(`${groupKey}[0].${subGroupKey}[1].extraOptions`, ['o111', 'o1'], ['o111']);
 
-    cy.get(appFrontend.group.row(0).nestedGroup.row(1).nestedOptions[0]).check({ force: true }).blur();
+    cy.get(appFrontend.group.row(0).nestedGroup.row(1).nestedOptions[0]).check().blur();
     expectSave(`${groupKey}[0].${subGroupKey}[1].extraOptions`, ['o111', 'o1', 'o11'], ['o111', 'o1']);
 
-    cy.get(appFrontend.group.row(0).nestedGroup.row(1).nestedOptions[2]).uncheck({ force: true }).blur();
+    cy.get(appFrontend.group.row(0).nestedGroup.row(1).nestedOptions[2]).uncheck().blur();
     expectSave(`${groupKey}[0].${subGroupKey}[1].extraOptions`, ['o1', 'o11'], ['o111', 'o1', 'o11']);
 
-    cy.get(appFrontend.group.row(0).nestedGroup.row(1).nestedOptions[1]).uncheck({ force: true }).blur();
+    cy.get(appFrontend.group.row(0).nestedGroup.row(1).nestedOptions[1]).uncheck().blur();
     expectSave(`${groupKey}[0].${subGroupKey}[1].extraOptions`, ['o11'], ['o1', 'o11']);
 
     cy.get(appFrontend.group.saveSubGroup).click();

--- a/test/e2e/integration/app-frontend/on-entry.ts
+++ b/test/e2e/integration/app-frontend/on-entry.ts
@@ -19,10 +19,8 @@ describe('On Entry', () => {
     cy.startAppInstance(appFrontend.apps.frontendTest);
     cy.get(appFrontend.closeButton).should('be.visible');
     cy.get(appFrontend.selectInstance.container).should('be.visible');
-    cy.get(appFrontend.selectInstance.header).should('be.visible').should('contain.text', texts.alreadyStartedForm);
-    cy.get(appFrontend.selectInstance.description)
-      .should('be.visible')
-      .should('contain.text', texts.continueOrStartNew);
+    cy.get(appFrontend.selectInstance.header).should('contain.text', texts.alreadyStartedForm);
+    cy.get(appFrontend.selectInstance.description).should('contain.text', texts.continueOrStartNew);
     cy.get(appFrontend.selectInstance.tableBody)
       .find('tr')
       .should('have.length', 1)
@@ -43,7 +41,7 @@ describe('On Entry', () => {
     cy.get(appFrontend.closeButton).should('be.visible');
     cy.get(appFrontend.selectInstance.container).should('be.visible');
     cy.intercept('POST', `/ttd/frontend-test/instances?instanceOwnerPartyId*`).as('createdInstance');
-    cy.get(appFrontend.selectInstance.newInstance).should('be.visible').click();
+    cy.get(appFrontend.selectInstance.newInstance).click();
     cy.wait('@createdInstance').its('response.statusCode').should('eq', 201);
     cy.url().should('not.contain', instanceIdExample);
   });

--- a/test/e2e/integration/app-frontend/options.ts
+++ b/test/e2e/integration/app-frontend/options.ts
@@ -29,7 +29,7 @@ describe('Options', () => {
     cy.goto('group');
     cy.get(appFrontend.navMenu).should('be.visible');
     cy.get(appFrontend.nextButton).click();
-    cy.get(appFrontend.group.showGroupToContinue).find('input').check();
+    cy.get(appFrontend.group.showGroupToContinue).find('input').dsCheck();
     cy.addItemToGroup(1, 2, 'automation');
     cy.addItemToGroup(3, 4, 'altinn');
     cy.get(appFrontend.group.options).then((options) => {

--- a/test/e2e/integration/app-frontend/options.ts
+++ b/test/e2e/integration/app-frontend/options.ts
@@ -15,14 +15,14 @@ describe('Options', () => {
 
     //Secure options
     cy.get(appFrontend.changeOfName.reference2).get('option[value=1]').should('be.visible');
-    cy.get(appFrontend.changeOfName.reference2).should('be.visible').select('1').and('have.value', '1');
+    cy.get(appFrontend.changeOfName.reference2).select('1').and('have.value', '1');
 
     // Select a different source, expect previous selection to be cleared and
     // new value to be selectable in the reference option
     cy.get(appFrontend.changeOfName.sources).select('digdir');
-    cy.get(appFrontend.changeOfName.reference).should('be.visible').and('have.value', '');
+    cy.get(appFrontend.changeOfName.reference).and('have.value', '');
     cy.get(appFrontend.changeOfName.reference).select('salt').should('have.value', 'salt');
-    cy.get(appFrontend.changeOfName.reference2).should('be.visible').select('2').and('have.value', '2');
+    cy.get(appFrontend.changeOfName.reference2).select('2').and('have.value', '2');
   });
 
   it('is possible to build options from repeating groups', () => {

--- a/test/e2e/integration/app-frontend/options.ts
+++ b/test/e2e/integration/app-frontend/options.ts
@@ -29,7 +29,7 @@ describe('Options', () => {
     cy.goto('group');
     cy.get(appFrontend.navMenu).should('be.visible');
     cy.get(appFrontend.nextButton).click();
-    cy.get(appFrontend.group.showGroupToContinue).find('input').check({ force: true });
+    cy.get(appFrontend.group.showGroupToContinue).find('input').check();
     cy.addItemToGroup(1, 2, 'automation');
     cy.addItemToGroup(3, 4, 'altinn');
     cy.get(appFrontend.group.options).then((options) => {

--- a/test/e2e/integration/app-frontend/prefill.ts
+++ b/test/e2e/integration/app-frontend/prefill.ts
@@ -7,7 +7,7 @@ describe('Prefill', () => {
     const userFullName = Cypress.env('defaultFullName');
     cy.goto('changename');
     cy.get(appFrontend.changeOfName.currentName).then((name) => {
-      cy.wrap(name).should('be.visible').and('have.value', userFullName).and('have.attr', 'readonly');
+      cy.wrap(name).and('have.value', userFullName).and('have.attr', 'readonly');
     });
   });
 });

--- a/test/e2e/integration/app-frontend/print-button.ts
+++ b/test/e2e/integration/app-frontend/print-button.ts
@@ -13,7 +13,7 @@ describe('Print button', () => {
     cy.window().then((win) => {
       const printStub = cy.stub(win, 'print');
       cy.contains('button', 'Print / Lagre PDF')
-        .should('be.visible')
+
         .click()
         .then(() => {
           expect(printStub).to.be.called;

--- a/test/e2e/integration/app-frontend/receipt.ts
+++ b/test/e2e/integration/app-frontend/receipt.ts
@@ -9,9 +9,9 @@ const appFrontend = new AppFrontend();
 describe('Receipt', () => {
   it('Receipt page displays links and attachments', () => {
     cy.goto('confirm', 'with-data');
-    cy.get(appFrontend.confirm.sendIn).should('be.visible').click();
+    cy.get(appFrontend.confirm.sendIn).click();
     cy.get(appFrontend.receipt.container)
-      .should('be.visible')
+
       .find(mui.tableBody)
       .then((table) => {
         cy.wrap(table).should('exist').and('be.visible');
@@ -60,22 +60,17 @@ describe('Receipt', () => {
       });
     }).as('FormLayout');
     cy.goto('confirm', 'with-data');
-    cy.get(appFrontend.confirm.sendIn).should('be.visible').click();
+    cy.get(appFrontend.confirm.sendIn).click();
 
     cy.get(appFrontend.receipt.container).should('not.exist');
     cy.get('[data-testId=custom-receipt]').should('exist').and('be.visible');
     cy.get('#form-content-r-instance').should('exist').and('be.visible');
-    cy.get('#form-content-r-header').should('exist').and('be.visible').and('contain.text', 'Custom kvittering');
-    cy.get('#form-content-r-paragraph')
-      .should('exist')
-      .and('be.visible')
-      .and('contain.text', 'Takk for din innsending, dette er en veldig fin custom kvittering.');
-    cy.get('#form-content-r-attachments')
-      .should('exist')
-      .and('be.visible')
-      .find('[data-testId=attachment-list]')
-      .children()
-      .should('have.length', 5);
+    cy.get('#form-content-r-header').should('contain.text', 'Custom kvittering');
+    cy.get('#form-content-r-paragraph').should(
+      'contain.text',
+      'Takk for din innsending, dette er en veldig fin custom kvittering.',
+    );
+    cy.get('#form-content-r-attachments').find('[data-testId=attachment-list]').children().should('have.length', 5);
 
     /*
       Verify that layout and settings are not fetched on refresh

--- a/test/e2e/integration/app-frontend/reportee-selection.ts
+++ b/test/e2e/integration/app-frontend/reportee-selection.ts
@@ -22,15 +22,15 @@ describe('Reportee selection', () => {
   it('Reportee selection in data app', () => {
     cy.startAppInstance(appFrontend.apps.frontendTest);
     cy.get(appFrontend.reporteeSelection.appHeader).should('be.visible');
-    cy.get(appFrontend.reporteeSelection.error).should('be.visible').contains(texts.selectNewReportee);
-    cy.get(appFrontend.reporteeSelection.seeSubUnits).should('be.visible').click();
+    cy.get(appFrontend.reporteeSelection.error).contains(texts.selectNewReportee);
+    cy.get(appFrontend.reporteeSelection.seeSubUnits).click();
     cy.contains(appFrontend.reporteeSelection.subUnits, 'Bergen').should('be.visible');
     cy.contains(appFrontend.reporteeSelection.reportee, 'slettet').should('not.exist');
     cy.get(appFrontend.reporteeSelection.checkbox).eq(0).click();
     cy.contains(appFrontend.reporteeSelection.reportee, 'slettet').should('be.visible');
     cy.get(appFrontend.reporteeSelection.checkbox).eq(1).click();
     cy.get(appFrontend.reporteeSelection.seeSubUnits).should('not.exist');
-    cy.get(appFrontend.reporteeSelection.searchReportee).should('be.visible').type('DDG');
+    cy.get(appFrontend.reporteeSelection.searchReportee).type('DDG');
     cy.get(appFrontend.reporteeSelection.reportee).should('have.length', 1).contains('DDG');
   });
 });

--- a/test/e2e/integration/app-frontend/rules.ts
+++ b/test/e2e/integration/app-frontend/rules.ts
@@ -11,7 +11,6 @@ describe('Rules', () => {
       .type('fun')
       .then(() => {
         cy.get(appFrontend.changeOfName.newFullName)
-          .focus()
           .should('have.value', 'automation is fun')
           .parents()
           .eq(2)
@@ -23,8 +22,8 @@ describe('Rules', () => {
     cy.goto('changename');
     // We update newLastName which triggers a calculation backend that updates NewMiddleName to 'MiddleNameFromCalculation'
     // This should then trigger function which concatenates first + middle + last name to the newFullName field
-    cy.get(appFrontend.changeOfName.newLastName).should('be.visible').type('LastName').blur();
-    cy.get(appFrontend.changeOfName.newFirstName).should('be.visible').type('TriggerCalculation').blur();
+    cy.get(appFrontend.changeOfName.newLastName).type('LastName').blur();
+    cy.get(appFrontend.changeOfName.newFirstName).type('TriggerCalculation').blur();
     cy.get(appFrontend.changeOfName.newFullName).should(
       'have.value',
       'TriggerCalculation MiddleNameFromCalculation LastName',

--- a/test/e2e/integration/app-frontend/summary.ts
+++ b/test/e2e/integration/app-frontend/summary.ts
@@ -49,37 +49,34 @@ describe('Summary', () => {
 
     // Summary displays change button for editable fields and does not for readonly fields
     // navigate back to form and clear date
-    cy.get(appFrontend.changeOfName.summaryNameChanges)
-      .should('be.visible')
-      .then((summary) => {
-        cy.wrap(summary)
-          .children()
-          .contains(mui.gridContainer, 'Til:')
-          .children()
-          .then((items) => {
-            cy.wrap(items).should('contain.text', 'a a');
-            cy.wrap(items).find('button').should('not.exist');
-          });
+    cy.get(appFrontend.changeOfName.summaryNameChanges).then((summary) => {
+      cy.wrap(summary)
+        .children()
+        .contains(mui.gridContainer, 'Til:')
+        .children()
+        .then((items) => {
+          cy.wrap(items).should('contain.text', 'a a');
+          cy.wrap(items).find('button').should('not.exist');
+        });
 
-        cy.wrap(summary)
-          .siblings()
-          .contains(mui.gridContainer, texts.dateOfEffect)
-          .then((summaryDate) => {
-            cy.wrap(summaryDate).children().find('button').should('exist').and('be.visible').click();
-            cy.get(appFrontend.changeOfName.dateOfEffect).clear();
-            cy.get(appFrontend.changeOfName.upload).selectFile('test/e2e/fixtures/test.pdf', { force: true });
-            cy.get(appFrontend.changeOfName.uploadWithTag.uploadZone).selectFile('test/e2e/fixtures/test.pdf', {
-              force: true,
-            });
-            cy.get(appFrontend.changeOfName.uploadWithTag.tagsDropDown).should('be.visible').select('address');
-            cy.get(appFrontend.changeOfName.uploadWithTag.saveTag).should('be.visible').click();
-            cy.get(appFrontend.backToSummaryButton).should('be.visible').click();
+      cy.wrap(summary)
+        .siblings()
+        .contains(mui.gridContainer, texts.dateOfEffect)
+        .then((summaryDate) => {
+          cy.wrap(summaryDate).children().find('button').click();
+          cy.get(appFrontend.changeOfName.dateOfEffect).clear();
+          cy.get(appFrontend.changeOfName.upload).selectFile('test/e2e/fixtures/test.pdf', { force: true });
+          cy.get(appFrontend.changeOfName.uploadWithTag.uploadZone).selectFile('test/e2e/fixtures/test.pdf', {
+            force: true,
           });
-      });
+          cy.get(appFrontend.changeOfName.uploadWithTag.tagsDropDown).select('address');
+          cy.get(appFrontend.changeOfName.uploadWithTag.saveTag).click();
+          cy.get(appFrontend.backToSummaryButton).click();
+        });
+    });
 
     // Summary of attachment components
     cy.get(appFrontend.changeOfName.summaryNameChanges)
-      .should('exist')
       .siblings()
       .then((summary) => {
         cy.wrap(summary)
@@ -89,33 +86,30 @@ describe('Summary', () => {
         cy.wrap(summary)
           .contains(mui.gridContainer, texts.uploadWithTag)
           .contains(mui.gridItem, 'test.pdf')
-          .should('be.visible')
-          .and('contain.text', 'Adresse');
+          .should('contain.text', 'Adresse');
       });
 
     // Summary displays error when required field is not filled
     // Navigate to form and fill the required field
     cy.get(appFrontend.changeOfName.summaryNameChanges)
-      .should('exist')
       .siblings()
       .contains(mui.gridContainer, texts.dateOfEffect)
       .then((summaryDate) => {
         cy.wrap(summaryDate).contains(texts.dateOfEffect).should('have.css', 'color', 'rgb(213, 32, 59)');
         cy.wrap(summaryDate).contains(mui.gridContainer, texts.requiredFieldDateFrom).should('be.visible');
-        cy.wrap(summaryDate).contains('button', texts.goToRightPage).should('be.visible').click();
+        cy.wrap(summaryDate).contains('button', texts.goToRightPage).click();
         cy.get(appFrontend.changeOfName.dateOfEffect)
           .siblings()
           .children('button')
           .click()
           .then(() => {
             cy.get(mui.selectedDate).parent().click();
-            cy.get(appFrontend.backToSummaryButton).should('be.visible').click();
+            cy.get(appFrontend.backToSummaryButton).click();
           });
       });
 
     // Error in summary field is removed when the required field is filled
     cy.get(appFrontend.changeOfName.summaryNameChanges)
-      .should('exist')
       .siblings()
       .contains(mui.gridContainer, texts.dateOfEffect)
       .then((summaryDate) => {
@@ -179,15 +173,13 @@ describe('Summary', () => {
     cy.get(appFrontend.navMenu).find('li > button').last().click();
     cy.get('[data-testid=summary-group-component] > div')
       .last()
-      .should('exist')
-      .and('be.visible')
-      .and('contain.text', 'Du har ikke lagt inn informasjon her');
+      .should('contain.text', 'Du har ikke lagt inn informasjon her');
     cy.get(appFrontend.navMenu).find('li > button').first().click();
 
     cy.gotoAndComplete('group');
 
     cy.get(appFrontend.group.mainGroupSummary)
-      .should('be.visible')
+
       .and('have.length', 1)
       .first()
       .children(mui.gridItem)
@@ -229,7 +221,7 @@ describe('Summary', () => {
     cy.get(appFrontend.backToSummaryButton).click();
 
     cy.get(appFrontend.group.mainGroupSummary)
-      .should('be.visible')
+
       .and('have.length', 1)
       .first()
       .children(mui.gridItem)
@@ -297,34 +289,24 @@ describe('Summary', () => {
     cy.get('#summary-mainGroup-4 > [data-testid=summary-currentValue-4] > div')
       .children()
       .last()
-      .should('exist')
-      .and('be.visible')
-      .and('contain.text', 'Du har ikke lagt inn informasjon her');
+      .should('contain.text', 'Du har ikke lagt inn informasjon her');
     cy.get('#summary-mainGroup-4 > [data-testid=summary-newValue-4] > div')
       .children()
       .last()
-      .should('exist')
-      .and('be.visible')
-      .and('contain.text', 'Du har ikke lagt inn informasjon her');
+      .should('contain.text', 'Du har ikke lagt inn informasjon her');
     cy.get('#summary-mainGroup-4 > [data-testid=summary-mainUploaderSingle-4] > div')
       .children()
       .last()
-      .should('exist')
-      .and('be.visible')
-      .and('contain.text', 'Du har ikke lagt inn informasjon her');
+      .should('contain.text', 'Du har ikke lagt inn informasjon her');
     cy.get('#summary-mainGroup-4 > [data-testid=summary-mainUploaderMulti-4] > div')
       .children()
       .last()
-      .should('exist')
-      .and('be.visible')
-      .and('contain.text', 'Du har ikke lagt inn informasjon her');
+      .should('contain.text', 'Du har ikke lagt inn informasjon her');
     cy.get('#summary-mainGroup-4 > [data-testid=summary-subGroup-4] > div > [data-testid=summary-group-component]')
       .children()
       .last()
       .first()
-      .should('exist')
-      .and('be.visible')
-      .and('contain.text', 'Kommentarer : Du har ikke lagt inn informasjon her')
+      .should('contain.text', 'Kommentarer : Du har ikke lagt inn informasjon her')
       .and('contain.text', 'Nested uploader with tags : Du har ikke lagt inn informasjon her')
       .and('contain.text', 'Vis tillegg : Du har ikke lagt inn informasjon her')
       .and('contain.text', 'Referanse : Du har ikke lagt inn informasjon her')
@@ -332,15 +314,11 @@ describe('Summary', () => {
     cy.get('#summary-mainGroup-4 > [data-testid=summary-source-4] > div')
       .children()
       .last()
-      .should('exist')
-      .and('be.visible')
-      .and('contain.text', 'Du har ikke lagt inn informasjon her');
+      .should('contain.text', 'Du har ikke lagt inn informasjon her');
     cy.get('#summary-mainGroup-4 > [data-testid=summary-reference-4] > div')
       .children()
       .last()
-      .should('exist')
-      .and('be.visible')
-      .and('contain.text', 'Du har ikke lagt inn informasjon her');
+      .should('contain.text', 'Du har ikke lagt inn informasjon her');
 
     // Hiding the group should hide the group summary as well
     cy.get('[data-testid=summary-summary-1]').should('be.visible');
@@ -366,15 +344,15 @@ describe('Summary', () => {
     cy.get(appFrontend.group.mainGroup).find(appFrontend.group.editContainer).find(appFrontend.group.next).click();
 
     cy.get(appFrontend.group.comments).type('first comment').blur();
-    cy.get(appFrontend.group.saveSubGroup).should('be.visible').click().should('not.exist');
+    cy.get(appFrontend.group.saveSubGroup).click().should('not.exist');
     cy.get(appFrontend.group.addNewItemSubGroup).click();
 
     cy.get(appFrontend.group.comments).type('second comment').blur();
-    cy.get(appFrontend.group.saveSubGroup).should('be.visible').click().should('not.exist');
+    cy.get(appFrontend.group.saveSubGroup).click().should('not.exist');
     cy.get(appFrontend.group.addNewItemSubGroup).click();
 
     cy.get(appFrontend.group.comments).type('third comment').blur();
-    cy.get(appFrontend.group.saveSubGroup).should('be.visible').click().should('not.exist');
+    cy.get(appFrontend.group.saveSubGroup).click().should('not.exist');
 
     cy.get(appFrontend.navMenu).find('li > button').last().click();
     //Skjul kommentar felt
@@ -383,9 +361,7 @@ describe('Summary', () => {
       .last()
       .children()
       .eq(0)
-      .should('exist')
-      .and('be.visible')
-      .and('contain.text', 'Kommentarer : first comment')
+      .should('contain.text', 'Kommentarer : first comment')
       .and('contain.text', 'Nested uploader with tags : Du har ikke lagt inn informasjon her')
       .and('contain.text', 'Vis tillegg : Du har ikke lagt inn informasjon her')
       .and('contain.text', 'Referanse : Du har ikke lagt inn informasjon her')
@@ -395,9 +371,7 @@ describe('Summary', () => {
       .last()
       .children()
       .eq(1)
-      .should('exist')
-      .and('be.visible')
-      .and('not.contain.text', 'Kommentarer')
+      .should('not.contain.text', 'Kommentarer')
       .and('contain.text', 'Nested uploader with tags : Du har ikke lagt inn informasjon her')
       .and('contain.text', 'Vis tillegg : Du har ikke lagt inn informasjon her')
       .and('contain.text', 'Referanse : Du har ikke lagt inn informasjon her')
@@ -407,9 +381,7 @@ describe('Summary', () => {
       .last()
       .children()
       .eq(2)
-      .should('exist')
-      .and('be.visible')
-      .and('contain.text', 'Kommentarer : third comment')
+      .should('contain.text', 'Kommentarer : third comment')
       .and('contain.text', 'Nested uploader with tags : Du har ikke lagt inn informasjon her')
       .and('contain.text', 'Vis tillegg : Du har ikke lagt inn informasjon her')
       .and('contain.text', 'Referanse : Du har ikke lagt inn informasjon her')
@@ -436,13 +408,13 @@ describe('Summary', () => {
         cy.get(appFrontend.navMenu).find('li > button').eq(1).should('have.attr', 'aria-current', 'page');
       } else {
         cy.get(appFrontend.navMenu).find('li > button').eq(0).should('have.attr', 'aria-current', 'page');
-        cy.get(appFrontend.errorReport).should('exist').and('contain.text', texts.requiredFieldLastName);
+        cy.get(appFrontend.errorReport).should('contain.text', texts.requiredFieldLastName);
         cy.get(appFrontend.changeOfName.newLastName).type('a').blur();
         cy.get(appFrontend.nextButton).click();
       }
 
       if (trigger === Triggers.ValidateAllPages) {
-        cy.get(appFrontend.errorReport).should('exist').and('contain.text', 'Du må fylle ut page3required');
+        cy.get(appFrontend.errorReport).should('contain.text', 'Du må fylle ut page3required');
         cy.get(appFrontend.navMenu).find('li > button').eq(1).click();
       } else if (trigger !== undefined) {
         cy.get(appFrontend.navMenu).find('li > button').eq(1).should('have.attr', 'aria-current', 'page');
@@ -452,7 +424,7 @@ describe('Summary', () => {
 
       const assertErrorReport = () => {
         if (trigger === Triggers.ValidateAllPages) {
-          cy.get(appFrontend.errorReport).should('exist').and('contain.text', 'Du må fylle ut page3required');
+          cy.get(appFrontend.errorReport).should('contain.text', 'Du må fylle ut page3required');
         } else {
           cy.get(appFrontend.errorReport).should('not.exist');
         }
@@ -469,7 +441,7 @@ describe('Summary', () => {
       assertErrorReport();
       cy.get(exampleSummary).find('button').click();
       assertErrorReport();
-      cy.get(appFrontend.backToSummaryButton).should('exist').click();
+      cy.get(appFrontend.backToSummaryButton).click();
       cy.get(appFrontend.backToSummaryButton).should('not.exist');
       assertErrorReport();
       cy.get(appFrontend.navMenu).find('li > button').last().click();
@@ -483,7 +455,7 @@ describe('Summary', () => {
 
       // Sending in always validates all pages
       cy.get(appFrontend.sendinButton).click();
-      cy.get(appFrontend.errorReport).should('exist').and('contain.text', 'Du må fylle ut page3required');
+      cy.get(appFrontend.errorReport).should('contain.text', 'Du må fylle ut page3required');
     }
   });
 
@@ -494,8 +466,8 @@ describe('Summary', () => {
     cy.get(appFrontend.changeOfName.newLastName).clear().blur();
     cy.get(appFrontend.navMenu).find('li > button').last().click();
     cy.get('#page3-submit').click();
-    cy.get(appFrontend.errorReport).should('exist').and('contain.text', 'Du må fylle ut page3required');
-    cy.get(appFrontend.errorReport).should('exist').and('contain.text', texts.requiredFieldLastName);
+    cy.get(appFrontend.errorReport).should('contain.text', 'Du må fylle ut page3required');
+    cy.get(appFrontend.errorReport).should('contain.text', texts.requiredFieldLastName);
 
     // Clicking the error should lead us to the first page
     cy.get(appFrontend.errorReport).find(`li:contains("${texts.requiredFieldLastName}")`).find('button').click();

--- a/test/e2e/integration/app-frontend/summary.ts
+++ b/test/e2e/integration/app-frontend/summary.ts
@@ -67,7 +67,7 @@ describe('Summary', () => {
           .then((summaryDate) => {
             cy.wrap(summaryDate).children().find('button').should('exist').and('be.visible').click();
             cy.get(appFrontend.changeOfName.dateOfEffect).clear();
-            cy.get(appFrontend.changeOfName.upload).selectFile('test/e2e/fixtures/test.pdf', { force: true });
+            cy.get(appFrontend.changeOfName.upload).selectFile('test/e2e/fixtures/test.pdf');
             cy.get(appFrontend.changeOfName.uploadWithTag.uploadZone).selectFile('test/e2e/fixtures/test.pdf', {
               force: true,
             });
@@ -178,7 +178,7 @@ describe('Summary', () => {
 
     // Verify empty group summary
     cy.get(appFrontend.navMenu).find('li > button').eq(1).click();
-    cy.get(appFrontend.group.showGroupToContinue).find('input').check({ force: true });
+    cy.get(appFrontend.group.showGroupToContinue).find('input').check();
     cy.get(appFrontend.navMenu).find('li > button').last().click();
     cy.get('[data-testid=summary-group-component] > div')
       .last()
@@ -222,7 +222,7 @@ describe('Summary', () => {
     // Check to show a couple of nested options, then go back to the summary
     cy.get(appFrontend.group.row(0).editBtn).click();
     cy.get(appFrontend.group.mainGroup).find(appFrontend.group.editContainer).find(appFrontend.group.next).click();
-    cy.get(appFrontend.group.row(0).nestedGroup.row(0).nestedDynamics).click({ force: true });
+    cy.get(appFrontend.group.row(0).nestedGroup.row(0).nestedDynamics).click();
 
     const workAroundSlowSave = JSON.parse('true');
     if (workAroundSlowSave) {
@@ -232,13 +232,13 @@ describe('Summary', () => {
       // and in the future we should fix this properly by simplifying to save data immediately in the redux state
       // but delay the PUT request instead.
       // See https://github.com/Altinn/app-frontend-react/issues/339#issuecomment-1321920974
-      cy.get(appFrontend.group.row(0).nestedGroup.row(0).nestedOptions[1]).check({ force: true }).blur();
+      cy.get(appFrontend.group.row(0).nestedGroup.row(0).nestedOptions[1]).check().blur();
       cy.wait('@updateInstance');
-      cy.get(appFrontend.group.row(0).nestedGroup.row(0).nestedOptions[2]).check({ force: true }).blur();
+      cy.get(appFrontend.group.row(0).nestedGroup.row(0).nestedOptions[2]).check().blur();
       cy.wait('@updateInstance');
     } else {
-      cy.get(appFrontend.group.row(0).nestedGroup.row(0).nestedOptions[1]).check({ force: true });
-      cy.get(appFrontend.group.row(0).nestedGroup.row(0).nestedOptions[2]).check({ force: true });
+      cy.get(appFrontend.group.row(0).nestedGroup.row(0).nestedOptions[1]).check();
+      cy.get(appFrontend.group.row(0).nestedGroup.row(0).nestedOptions[2]).check();
     }
 
     cy.get(appFrontend.group.row(0).nestedGroup.saveBtn).click();
@@ -258,9 +258,9 @@ describe('Summary', () => {
       });
 
     cy.get(appFrontend.navMenu).find('li > button').first().click();
-    cy.get(appFrontend.group.prefill.liten).click({ force: true }).blur();
-    cy.get(appFrontend.group.prefill.middels).click({ force: true }).blur();
-    cy.get(appFrontend.group.prefill.svaer).click({ force: true }).blur();
+    cy.get(appFrontend.group.prefill.liten).click().blur();
+    cy.get(appFrontend.group.prefill.middels).click().blur();
+    cy.get(appFrontend.group.prefill.svaer).click().blur();
     cy.get(appFrontend.navMenu).find('li > button').last().click();
 
     function assertSummaryItem(groupRow: number, items: { [key: string]: boolean }) {
@@ -362,7 +362,7 @@ describe('Summary', () => {
     // Hiding the group should hide the group summary as well
     cy.get('[data-testid=summary-summary-1]').should('be.visible');
     cy.get(appFrontend.navMenu).find('li > button').eq(1).click();
-    cy.get(appFrontend.group.showGroupToContinue).find('input[type=checkbox]').uncheck({ force: true });
+    cy.get(appFrontend.group.showGroupToContinue).find('input[type=checkbox]').uncheck();
     cy.get(appFrontend.navMenu).find('li > button').last().click();
     cy.get('[data-testid=summary-summary-1]').should('not.exist');
   });
@@ -375,9 +375,9 @@ describe('Summary', () => {
     });
     cy.goto('group');
 
-    cy.get(appFrontend.group.prefill['liten']).click({ force: true }).blur();
+    cy.get(appFrontend.group.prefill['liten']).click().blur();
     cy.get(appFrontend.navMenu).find('li > button').eq(1).click();
-    cy.get(appFrontend.group.showGroupToContinue).find('input').check({ force: true });
+    cy.get(appFrontend.group.showGroupToContinue).find('input').check();
     // Add data
     cy.get(appFrontend.group.row(0).editBtn).click();
     cy.get(appFrontend.group.mainGroup).find(appFrontend.group.editContainer).find(appFrontend.group.next).click();

--- a/test/e2e/integration/app-frontend/summary.ts
+++ b/test/e2e/integration/app-frontend/summary.ts
@@ -179,8 +179,7 @@ describe('Summary', () => {
     cy.gotoAndComplete('group');
 
     cy.get(appFrontend.group.mainGroupSummary)
-
-      .and('have.length', 1)
+      .should('have.length', 1)
       .first()
       .children(mui.gridItem)
       .should('have.length', 8)
@@ -221,8 +220,7 @@ describe('Summary', () => {
     cy.get(appFrontend.backToSummaryButton).click();
 
     cy.get(appFrontend.group.mainGroupSummary)
-
-      .and('have.length', 1)
+      .should('have.length', 1)
       .first()
       .children(mui.gridItem)
       .should('have.length', 8)

--- a/test/e2e/integration/app-frontend/summary.ts
+++ b/test/e2e/integration/app-frontend/summary.ts
@@ -67,7 +67,7 @@ describe('Summary', () => {
           .then((summaryDate) => {
             cy.wrap(summaryDate).children().find('button').should('exist').and('be.visible').click();
             cy.get(appFrontend.changeOfName.dateOfEffect).clear();
-            cy.get(appFrontend.changeOfName.upload).selectFile('test/e2e/fixtures/test.pdf');
+            cy.get(appFrontend.changeOfName.upload).selectFile('test/e2e/fixtures/test.pdf', { force: true });
             cy.get(appFrontend.changeOfName.uploadWithTag.uploadZone).selectFile('test/e2e/fixtures/test.pdf', {
               force: true,
             });
@@ -132,8 +132,8 @@ describe('Summary', () => {
 
     // Test summary of non-repeating group
     cy.get(appFrontend.navMenu).find('li > button').first().click();
-    cy.get('#reference').should('exist').and('be.visible').select('Ola Nordmann');
-    cy.get('#reference2').should('exist').and('be.visible').select('Ole');
+    cy.get('#reference').select('Ola Nordmann');
+    cy.get('#reference2').select('Ole');
     cy.get(appFrontend.navMenu).find('li > button').last().click();
     cy.get('[data-testid=summary-summary-reference] [data-testid=summary-item-compact]')
       .and('have.length', 3)
@@ -144,11 +144,9 @@ describe('Summary', () => {
       });
 
     cy.get(appFrontend.navMenu).find('li > button').first().click();
-    cy.intercept('GET', '**/options/*').as('getOptions');
-    cy.get('#sources').should('exist').and('be.visible').select('Digitaliseringsdirektoratet');
-    cy.wait(['@getOptions', '@getOptions']);
-    cy.get('#reference').should('exist').and('be.visible').select('Sophie Salt');
-    cy.get('#reference2').should('exist').and('be.visible').select('Dole');
+    cy.get('#sources').select('Digitaliseringsdirektoratet').blur();
+    cy.get('#reference').select('Sophie Salt').blur();
+    cy.get('#reference2').select('Dole').blur();
     cy.get(appFrontend.navMenu).find('li > button').last().click();
     cy.get('[data-testid=summary-summary-reference] [data-testid=summary-item-compact]')
       .and('have.length', 3)
@@ -159,10 +157,9 @@ describe('Summary', () => {
       });
 
     cy.get(appFrontend.navMenu).find('li > button').first().click();
-    cy.get('#sources').should('exist').and('be.visible').select('Annet');
-    cy.wait(['@getOptions', '@getOptions']);
-    cy.get('#reference').should('exist').and('be.visible').select('Test');
-    cy.get('#reference2').should('exist').and('be.visible').select('Doffen');
+    cy.get('#sources').select('Annet').blur();
+    cy.get('#reference').select('Test').blur();
+    cy.get('#reference2').select('Doffen').blur();
     cy.get(appFrontend.navMenu).find('li > button').last().click();
     cy.get('[data-testid=summary-summary-reference] [data-testid=summary-item-compact]')
       .and('have.length', 3)
@@ -178,7 +175,7 @@ describe('Summary', () => {
 
     // Verify empty group summary
     cy.get(appFrontend.navMenu).find('li > button').eq(1).click();
-    cy.get(appFrontend.group.showGroupToContinue).find('input').check();
+    cy.get(appFrontend.group.showGroupToContinue).find('input').dsCheck();
     cy.get(appFrontend.navMenu).find('li > button').last().click();
     cy.get('[data-testid=summary-group-component] > div')
       .last()
@@ -222,24 +219,10 @@ describe('Summary', () => {
     // Check to show a couple of nested options, then go back to the summary
     cy.get(appFrontend.group.row(0).editBtn).click();
     cy.get(appFrontend.group.mainGroup).find(appFrontend.group.editContainer).find(appFrontend.group.next).click();
-    cy.get(appFrontend.group.row(0).nestedGroup.row(0).nestedDynamics).click();
+    cy.get(appFrontend.group.row(0).nestedGroup.row(0).nestedDynamics).dsCheck();
 
-    const workAroundSlowSave = JSON.parse('true');
-    if (workAroundSlowSave) {
-      cy.intercept('PUT', '**/instances/*/*/data/*').as('updateInstance');
-      // Blurring each of these works around a problem where clicking these too fast will overwrite the immedateState
-      // value in useDelayedSaveState(). This is a fundamental problem with the useDelayedSaveState() functionality,
-      // and in the future we should fix this properly by simplifying to save data immediately in the redux state
-      // but delay the PUT request instead.
-      // See https://github.com/Altinn/app-frontend-react/issues/339#issuecomment-1321920974
-      cy.get(appFrontend.group.row(0).nestedGroup.row(0).nestedOptions[1]).check().blur();
-      cy.wait('@updateInstance');
-      cy.get(appFrontend.group.row(0).nestedGroup.row(0).nestedOptions[2]).check().blur();
-      cy.wait('@updateInstance');
-    } else {
-      cy.get(appFrontend.group.row(0).nestedGroup.row(0).nestedOptions[1]).check();
-      cy.get(appFrontend.group.row(0).nestedGroup.row(0).nestedOptions[2]).check();
-    }
+    cy.get(appFrontend.group.row(0).nestedGroup.row(0).nestedOptions[1]).dsCheck();
+    cy.get(appFrontend.group.row(0).nestedGroup.row(0).nestedOptions[2]).dsCheck();
 
     cy.get(appFrontend.group.row(0).nestedGroup.saveBtn).click();
     cy.get(appFrontend.group.saveMainGroup).click();
@@ -258,9 +241,9 @@ describe('Summary', () => {
       });
 
     cy.get(appFrontend.navMenu).find('li > button').first().click();
-    cy.get(appFrontend.group.prefill.liten).click().blur();
-    cy.get(appFrontend.group.prefill.middels).click().blur();
-    cy.get(appFrontend.group.prefill.svaer).click().blur();
+    cy.get(appFrontend.group.prefill.liten).dsCheck();
+    cy.get(appFrontend.group.prefill.middels).dsCheck();
+    cy.get(appFrontend.group.prefill.svaer).dsCheck();
     cy.get(appFrontend.navMenu).find('li > button').last().click();
 
     function assertSummaryItem(groupRow: number, items: { [key: string]: boolean }) {
@@ -362,7 +345,7 @@ describe('Summary', () => {
     // Hiding the group should hide the group summary as well
     cy.get('[data-testid=summary-summary-1]').should('be.visible');
     cy.get(appFrontend.navMenu).find('li > button').eq(1).click();
-    cy.get(appFrontend.group.showGroupToContinue).find('input[type=checkbox]').uncheck();
+    cy.get(appFrontend.group.showGroupToContinue).find('input[type=checkbox]').dsUncheck();
     cy.get(appFrontend.navMenu).find('li > button').last().click();
     cy.get('[data-testid=summary-summary-1]').should('not.exist');
   });
@@ -375,9 +358,9 @@ describe('Summary', () => {
     });
     cy.goto('group');
 
-    cy.get(appFrontend.group.prefill['liten']).click().blur();
+    cy.get(appFrontend.group.prefill['liten']).dsCheck();
     cy.get(appFrontend.navMenu).find('li > button').eq(1).click();
-    cy.get(appFrontend.group.showGroupToContinue).find('input').check();
+    cy.get(appFrontend.group.showGroupToContinue).find('input').dsCheck();
     // Add data
     cy.get(appFrontend.group.row(0).editBtn).click();
     cy.get(appFrontend.group.mainGroup).find(appFrontend.group.editContainer).find(appFrontend.group.next).click();

--- a/test/e2e/integration/app-frontend/texts.ts
+++ b/test/e2e/integration/app-frontend/texts.ts
@@ -8,11 +8,11 @@ describe('Texts', () => {
   });
 
   it('Variable in texts work and are updated if the variable is updated with a calculation backend', () => {
-    cy.get(appFrontend.changeOfName.newMiddleName).should('be.visible').type('Steffen').blur();
+    cy.get(appFrontend.changeOfName.newMiddleName).type('Steffen').blur();
     cy.get(appFrontend.changeOfName.newMiddleNameDescription).should('contain.text', 'Steffen');
 
     // We update newLastName which triggers a calculation backend that updates NewMiddleName
-    cy.get(appFrontend.changeOfName.newFirstName).should('be.visible').type('TriggerCalculation').blur();
+    cy.get(appFrontend.changeOfName.newFirstName).type('TriggerCalculation').blur();
     cy.get(appFrontend.changeOfName.newMiddleNameDescription).should('contain.text', 'MiddleNameFromCalculation');
   });
 });

--- a/test/e2e/integration/app-frontend/validation.ts
+++ b/test/e2e/integration/app-frontend/validation.ts
@@ -42,7 +42,7 @@ describe('Validation', () => {
 
     cy.get(appFrontend.changeOfName.newMiddleName).should('be.visible').focus().type('Some middle name').blur();
 
-    cy.get(appFrontend.changeOfName.confirmChangeName).should('be.visible').find('input').check({ force: true });
+    cy.get(appFrontend.changeOfName.confirmChangeName).should('be.visible').find('input').check();
     cy.get(appFrontend.changeOfName.reasonRelationship).should('be.visible').click().type('test');
     cy.get(appFrontend.changeOfName.dateOfEffect)
       .siblings()
@@ -118,7 +118,7 @@ describe('Validation', () => {
   it('Page validation on clicking next', () => {
     cy.goto('changename');
     cy.get(appFrontend.changeOfName.newFirstName).should('be.visible').clear().type('test').blur();
-    cy.get(appFrontend.changeOfName.confirmChangeName).should('be.visible').find('input').check({ force: true });
+    cy.get(appFrontend.changeOfName.confirmChangeName).should('be.visible').find('input').check();
     cy.intercept('GET', '**/validate').as('validateData');
     cy.get(appFrontend.nextButton).should('be.visible').scrollIntoView();
     cy.get(appFrontend.nextButton).should('be.inViewport');
@@ -174,7 +174,7 @@ describe('Validation', () => {
 
   it('Validation on uploaded attachment type', () => {
     cy.goto('changename');
-    cy.get(appFrontend.changeOfName.upload).selectFile('test/e2e/fixtures/test.png', { force: true });
+    cy.get(appFrontend.changeOfName.upload).selectFile('test/e2e/fixtures/test.png');
     cy.get(appFrontend.fieldValidationError.replace('field', appFrontend.changeOfName.upload.substring(1)))
       .should('exist')
       .should('be.visible')
@@ -183,7 +183,7 @@ describe('Validation', () => {
 
   it('Validation on uploaded attachment type with tag', () => {
     cy.goto('changename');
-    cy.get(appFrontend.changeOfName.uploadWithTag.uploadZone).selectFile('test/e2e/fixtures/test.pdf', { force: true });
+    cy.get(appFrontend.changeOfName.uploadWithTag.uploadZone).selectFile('test/e2e/fixtures/test.pdf');
     cy.get(appFrontend.changeOfName.uploadWithTag.saveTag).click({ multiple: true });
     cy.get(appFrontend.changeOfName.uploadWithTag.error)
       .should('exist')
@@ -221,7 +221,7 @@ describe('Validation', () => {
     // Init and add data to group
     cy.goto('group');
     cy.get(appFrontend.nextButton).click();
-    cy.get(appFrontend.group.showGroupToContinue).should('be.visible').find('input').check({ force: true });
+    cy.get(appFrontend.group.showGroupToContinue).should('be.visible').find('input').check();
     cy.get(appFrontend.group.addNewItem).should('be.visible').click();
     cy.get(appFrontend.group.currentValue).should('be.visible').type('123');
     cy.get(appFrontend.group.newValue).should('be.visible').type('321');
@@ -240,7 +240,7 @@ describe('Validation', () => {
     cy.get(appFrontend.errorReport).should('exist').should('be.visible');
 
     // Hide field that contains validation error and verify validation messages are gone
-    cy.get(appFrontend.group.hideCommentField).should('be.visible').find('input').check({ force: true });
+    cy.get(appFrontend.group.hideCommentField).should('be.visible').find('input').check();
     cy.get(appFrontend.group.comments).should('not.exist');
     cy.get(appFrontend.fieldValidationError.replace('field', 'comments')).should('not.exist');
     cy.get(appFrontend.errorReport).should('not.exist');

--- a/test/e2e/integration/app-frontend/validation.ts
+++ b/test/e2e/integration/app-frontend/validation.ts
@@ -42,7 +42,7 @@ describe('Validation', () => {
 
     cy.get(appFrontend.changeOfName.newMiddleName).should('be.visible').focus().type('Some middle name').blur();
 
-    cy.get(appFrontend.changeOfName.confirmChangeName).should('be.visible').find('input').check();
+    cy.get(appFrontend.changeOfName.confirmChangeName).should('be.visible').find('input').dsCheck();
     cy.get(appFrontend.changeOfName.reasonRelationship).should('be.visible').click().type('test');
     cy.get(appFrontend.changeOfName.dateOfEffect)
       .siblings()
@@ -118,7 +118,7 @@ describe('Validation', () => {
   it('Page validation on clicking next', () => {
     cy.goto('changename');
     cy.get(appFrontend.changeOfName.newFirstName).should('be.visible').clear().type('test').blur();
-    cy.get(appFrontend.changeOfName.confirmChangeName).should('be.visible').find('input').check();
+    cy.get(appFrontend.changeOfName.confirmChangeName).should('be.visible').find('input').dsCheck();
     cy.intercept('GET', '**/validate').as('validateData');
     cy.get(appFrontend.nextButton).should('be.visible').scrollIntoView();
     cy.get(appFrontend.nextButton).should('be.inViewport');
@@ -174,7 +174,7 @@ describe('Validation', () => {
 
   it('Validation on uploaded attachment type', () => {
     cy.goto('changename');
-    cy.get(appFrontend.changeOfName.upload).selectFile('test/e2e/fixtures/test.png');
+    cy.get(appFrontend.changeOfName.upload).selectFile('test/e2e/fixtures/test.png', { force: true });
     cy.get(appFrontend.fieldValidationError.replace('field', appFrontend.changeOfName.upload.substring(1)))
       .should('exist')
       .should('be.visible')
@@ -183,7 +183,7 @@ describe('Validation', () => {
 
   it('Validation on uploaded attachment type with tag', () => {
     cy.goto('changename');
-    cy.get(appFrontend.changeOfName.uploadWithTag.uploadZone).selectFile('test/e2e/fixtures/test.pdf');
+    cy.get(appFrontend.changeOfName.uploadWithTag.uploadZone).selectFile('test/e2e/fixtures/test.pdf', { force: true });
     cy.get(appFrontend.changeOfName.uploadWithTag.saveTag).click({ multiple: true });
     cy.get(appFrontend.changeOfName.uploadWithTag.error)
       .should('exist')
@@ -221,7 +221,7 @@ describe('Validation', () => {
     // Init and add data to group
     cy.goto('group');
     cy.get(appFrontend.nextButton).click();
-    cy.get(appFrontend.group.showGroupToContinue).should('be.visible').find('input').check();
+    cy.get(appFrontend.group.showGroupToContinue).should('be.visible').find('input').dsCheck();
     cy.get(appFrontend.group.addNewItem).should('be.visible').click();
     cy.get(appFrontend.group.currentValue).should('be.visible').type('123');
     cy.get(appFrontend.group.newValue).should('be.visible').type('321');
@@ -240,7 +240,7 @@ describe('Validation', () => {
     cy.get(appFrontend.errorReport).should('exist').should('be.visible');
 
     // Hide field that contains validation error and verify validation messages are gone
-    cy.get(appFrontend.group.hideCommentField).should('be.visible').find('input').check();
+    cy.get(appFrontend.group.hideCommentField).should('be.visible').find('input').dsCheck();
     cy.get(appFrontend.group.comments).should('not.exist');
     cy.get(appFrontend.fieldValidationError.replace('field', 'comments')).should('not.exist');
     cy.get(appFrontend.errorReport).should('not.exist');

--- a/test/e2e/integration/app-frontend/validation.ts
+++ b/test/e2e/integration/app-frontend/validation.ts
@@ -12,44 +12,29 @@ describe('Validation', () => {
     // This field has server-side validations marking it as required, overriding the frontend validation functionality
     // which normally postpones the empty fields validation until the page validation runs. We need to type something,
     // send it to the server and clear the value to show this validation error.
-    cy.get(appFrontend.changeOfName.newFirstName)
-      .should('be.visible')
-      .focus()
-      .type('Some value')
-      .blur()
-      .focus()
-      .clear()
-      .blur();
-    cy.get(appFrontend.fieldValidationError.replace('field', appFrontend.changeOfName.newFirstName.substring(1)))
-      .should('exist')
-      .should('be.visible')
-      .should('have.text', texts.requiredFieldFromBackend);
+    cy.get(appFrontend.changeOfName.newFirstName).type('Some value').blur().clear();
+    cy.get(
+      appFrontend.fieldValidationError.replace('field', appFrontend.changeOfName.newFirstName.substring(1)),
+    ).should('have.text', texts.requiredFieldFromBackend);
 
     // Doing the same for any other field (without server-side required validation) should not show an error
-    cy.get(appFrontend.changeOfName.newMiddleName)
-      .should('be.visible')
-      .focus()
-      .type('Some value')
-      .blur()
-      .focus()
-      .clear()
-      .blur();
+    cy.get(appFrontend.changeOfName.newMiddleName).type('Some value').blur().focus().clear().blur();
     cy.get(
       appFrontend.fieldValidationError.replace('field', appFrontend.changeOfName.newMiddleName.substring(1)),
     ).should('not.exist');
 
-    cy.get(appFrontend.changeOfName.newFirstName).should('be.visible').focus().type('Some first name').blur();
+    cy.get(appFrontend.changeOfName.newFirstName).type('Some first name').blur();
 
-    cy.get(appFrontend.changeOfName.newMiddleName).should('be.visible').focus().type('Some middle name').blur();
+    cy.get(appFrontend.changeOfName.newMiddleName).type('Some middle name').blur();
 
-    cy.get(appFrontend.changeOfName.confirmChangeName).should('be.visible').find('input').dsCheck();
-    cy.get(appFrontend.changeOfName.reasonRelationship).should('be.visible').click().type('test');
+    cy.get(appFrontend.changeOfName.confirmChangeName).find('input').dsCheck();
+    cy.get(appFrontend.changeOfName.reasonRelationship).click().type('test');
     cy.get(appFrontend.changeOfName.dateOfEffect)
       .siblings()
       .children(mui.buttonIcon)
       .click()
       .then(() => {
-        cy.get(mui.selectedDate).should('be.visible').click();
+        cy.get(mui.selectedDate).click();
       });
 
     cy.get(appFrontend.nextButton).click();
@@ -62,20 +47,18 @@ describe('Validation', () => {
       appFrontend.fieldValidationError.replace('field', appFrontend.changeOfName.newMiddleName.substring(1)),
     ).should('not.exist');
 
-    cy.get(appFrontend.fieldValidationError.replace('field', appFrontend.changeOfName.newLastName.substring(1)))
-      .should('exist')
-      .should('be.visible')
-      .should('have.text', texts.requiredFieldLastName);
+    cy.get(appFrontend.fieldValidationError.replace('field', appFrontend.changeOfName.newLastName.substring(1))).should(
+      'have.text',
+      texts.requiredFieldLastName,
+    );
   });
 
   it('Custom field validation - error', () => {
     cy.goto('changename');
     cy.intercept('GET', '**/validate').as('validateData');
-    cy.get(appFrontend.changeOfName.newFirstName).should('be.visible').type('test').blur();
+    cy.get(appFrontend.changeOfName.newFirstName).type('test').blur();
     cy.wait('@validateData');
     cy.get(appFrontend.fieldValidationError.replace('field', appFrontend.changeOfName.newFirstName.substring(1)))
-      .should('exist')
-      .should('be.visible')
       .should('have.text', texts.testIsNotValidValue)
       .then((error) => {
         cy.wrap(error).find('a[href="https://www.altinn.no/"]').should('exist');
@@ -85,48 +68,43 @@ describe('Validation', () => {
   it('Soft validation - warning', () => {
     cy.goto('changename');
     cy.intercept('GET', '**/validate').as('validateData');
-    cy.get(appFrontend.changeOfName.newMiddleName).should('be.visible').type('test').blur();
+    cy.get(appFrontend.changeOfName.newMiddleName).type('test').blur();
     cy.wait('@validateData');
-    cy.get(appFrontend.fieldValidationWarning.replace('field', appFrontend.changeOfName.newMiddleName.substring(1)))
-      .should('exist')
-      .should('be.visible')
-      .should('have.text', texts.testIsNotValidValue);
+    cy.get(
+      appFrontend.fieldValidationWarning.replace('field', appFrontend.changeOfName.newMiddleName.substring(1)),
+    ).should('have.text', texts.testIsNotValidValue);
   });
 
   it('Soft validation - info', () => {
     cy.goto('changename');
     cy.intercept('GET', '**/validate').as('validateData');
-    cy.get(appFrontend.changeOfName.newMiddleName).should('be.visible').type('info').blur();
+    cy.get(appFrontend.changeOfName.newMiddleName).type('info').blur();
     cy.wait('@validateData');
-    cy.get(appFrontend.fieldValidationInfo.replace('field', appFrontend.changeOfName.newMiddleName.substring(1)))
-      .should('exist')
-      .should('be.visible')
-      .should('have.text', texts.infoMessage);
+    cy.get(
+      appFrontend.fieldValidationInfo.replace('field', appFrontend.changeOfName.newMiddleName.substring(1)),
+    ).should('have.text', texts.infoMessage);
   });
 
   it('Soft validation - success', () => {
     cy.goto('changename');
     cy.intercept('GET', '**/validate').as('validateData');
-    cy.get(appFrontend.changeOfName.newMiddleName).should('be.visible').type('success').blur();
+    cy.get(appFrontend.changeOfName.newMiddleName).type('success').blur();
     cy.wait('@validateData');
-    cy.get(appFrontend.fieldValidationSuccess.replace('field', appFrontend.changeOfName.newMiddleName.substring(1)))
-      .should('exist')
-      .should('be.visible')
-      .should('have.text', texts.successMessage);
+    cy.get(
+      appFrontend.fieldValidationSuccess.replace('field', appFrontend.changeOfName.newMiddleName.substring(1)),
+    ).should('have.text', texts.successMessage);
   });
 
   it('Page validation on clicking next', () => {
     cy.goto('changename');
-    cy.get(appFrontend.changeOfName.newFirstName).should('be.visible').clear().type('test').blur();
-    cy.get(appFrontend.changeOfName.confirmChangeName).should('be.visible').find('input').dsCheck();
+    cy.get(appFrontend.changeOfName.newFirstName).clear().type('test').blur();
+    cy.get(appFrontend.changeOfName.confirmChangeName).find('input').dsCheck();
     cy.intercept('GET', '**/validate').as('validateData');
-    cy.get(appFrontend.nextButton).should('be.visible').scrollIntoView();
+    cy.get(appFrontend.nextButton).scrollIntoView();
     cy.get(appFrontend.nextButton).should('be.inViewport');
     cy.get(appFrontend.nextButton).click();
     cy.wait('@validateData');
     cy.get(appFrontend.errorReport)
-      .should('exist')
-      .should('be.visible')
       .should('be.inViewport')
       .should('contain.text', texts.errorReport)
       .should('contain.text', texts.requiredFieldLastName)
@@ -159,7 +137,7 @@ describe('Validation', () => {
     // Go to the summary page
     cy.get(appFrontend.navMenu).find('li > button').last().click();
     cy.get(appFrontend.errorReport)
-      .should('be.visible')
+
       .should('contain.text', texts.errorReport)
       .should('contain.text', texts.requiredFieldLastName)
       .should('contain.text', texts.requiredFieldDateFrom);
@@ -175,31 +153,31 @@ describe('Validation', () => {
   it('Validation on uploaded attachment type', () => {
     cy.goto('changename');
     cy.get(appFrontend.changeOfName.upload).selectFile('test/e2e/fixtures/test.png', { force: true });
-    cy.get(appFrontend.fieldValidationError.replace('field', appFrontend.changeOfName.upload.substring(1)))
-      .should('exist')
-      .should('be.visible')
-      .should('contain.text', texts.attachmentError);
+    cy.get(appFrontend.fieldValidationError.replace('field', appFrontend.changeOfName.upload.substring(1))).should(
+      'contain.text',
+      texts.attachmentError,
+    );
   });
 
   it('Validation on uploaded attachment type with tag', () => {
     cy.goto('changename');
     cy.get(appFrontend.changeOfName.uploadWithTag.uploadZone).selectFile('test/e2e/fixtures/test.pdf', { force: true });
     cy.get(appFrontend.changeOfName.uploadWithTag.saveTag).click({ multiple: true });
-    cy.get(appFrontend.changeOfName.uploadWithTag.error)
-      .should('exist')
-      .should('be.visible')
-      .should('not.contain.text', appFrontend.changeOfName.uploadWithTag.unwantedChar);
+    cy.get(appFrontend.changeOfName.uploadWithTag.error).should(
+      'not.contain.text',
+      appFrontend.changeOfName.uploadWithTag.unwantedChar,
+    );
     cy.get('#toNextTask').click();
     cy.get(appFrontend.errorReport).should('not.contain.text', appFrontend.changeOfName.uploadWithTag.unwantedChar);
   });
 
   it('Client side validation from json schema', () => {
     cy.goto('changename');
-    cy.get(appFrontend.changeOfName.newLastName).should('be.visible').type('client').blur();
-    cy.get(appFrontend.fieldValidationError.replace('field', appFrontend.changeOfName.newLastName.substring(1)))
-      .should('exist')
-      .should('be.visible')
-      .should('have.text', texts.clientSide);
+    cy.get(appFrontend.changeOfName.newLastName).type('client').blur();
+    cy.get(appFrontend.fieldValidationError.replace('field', appFrontend.changeOfName.newLastName.substring(1))).should(
+      'have.text',
+      texts.clientSide,
+    );
   });
 
   it('Task validation', () => {
@@ -213,34 +191,30 @@ describe('Validation', () => {
         description: 'task validation',
       },
     ]);
-    cy.get(appFrontend.sendinButton).should('be.visible').click();
-    cy.get(appFrontend.errorReport).should('exist').should('be.visible').should('contain.text', 'task validation');
+    cy.get(appFrontend.sendinButton).click();
+    cy.get(appFrontend.errorReport).should('contain.text', 'task validation');
   });
 
   it('Validations are removed for hidden fields', () => {
     // Init and add data to group
     cy.goto('group');
     cy.get(appFrontend.nextButton).click();
-    cy.get(appFrontend.group.showGroupToContinue).should('be.visible').find('input').dsCheck();
-    cy.get(appFrontend.group.addNewItem).should('be.visible').click();
-    cy.get(appFrontend.group.currentValue).should('be.visible').type('123');
-    cy.get(appFrontend.group.newValue).should('be.visible').type('321');
+    cy.get(appFrontend.group.showGroupToContinue).find('input').dsCheck();
+    cy.get(appFrontend.group.addNewItem).click();
+    cy.get(appFrontend.group.currentValue).type('123');
+    cy.get(appFrontend.group.newValue).type('321');
 
     // Create validation error
-    cy.get(appFrontend.group.mainGroup)
-      .find(appFrontend.group.editContainer)
-      .find(appFrontend.group.next)
-      .should('be.visible')
-      .click();
+    cy.get(appFrontend.group.mainGroup).find(appFrontend.group.editContainer).find(appFrontend.group.next).click();
     cy.get(appFrontend.group.comments).type('test').blur();
-    cy.get(appFrontend.fieldValidationError.replace('field', 'comments'))
-      .should('exist')
-      .should('be.visible')
-      .should('have.text', texts.testIsNotValidValue);
+    cy.get(appFrontend.fieldValidationError.replace('field', 'comments')).should(
+      'have.text',
+      texts.testIsNotValidValue,
+    );
     cy.get(appFrontend.errorReport).should('exist').should('be.visible');
 
     // Hide field that contains validation error and verify validation messages are gone
-    cy.get(appFrontend.group.hideCommentField).should('be.visible').find('input').dsCheck();
+    cy.get(appFrontend.group.hideCommentField).find('input').dsCheck();
     cy.get(appFrontend.group.comments).should('not.exist');
     cy.get(appFrontend.fieldValidationError.replace('field', 'comments')).should('not.exist');
     cy.get(appFrontend.errorReport).should('not.exist');

--- a/test/e2e/integration/app-frontend/wcag.ts
+++ b/test/e2e/integration/app-frontend/wcag.ts
@@ -23,7 +23,7 @@ describe('WCAG', () => {
     cy.get(appFrontend.group.mainGroup)
       .find(appFrontend.group.editContainer)
       .find(appFrontend.group.next)
-      .should('be.visible')
+
       .click();
     cy.testWcag();
   });

--- a/test/e2e/integration/app-stateless-anonymous/validation.ts
+++ b/test/e2e/integration/app-stateless-anonymous/validation.ts
@@ -16,9 +16,9 @@ describe('Validation in anonymous stateless app', () => {
     const nameError = appFrontend.fieldValidationError.replace('field', appFrontend.stateless.name.substring(1));
 
     cy.get(appFrontend.stateless.name).should('be.visible');
-    cy.get(nameError).should('be.visible').should('have.text', texts.requiredFieldName);
+    cy.get(nameError).should('have.text', texts.requiredFieldName);
     cy.get(appFrontend.errorReport)
-      .should('be.visible')
+
       .should('be.inViewport')
       .should('contain.text', texts.errorReport)
       .should('contain.text', texts.requiredFieldName);

--- a/test/e2e/integration/app-stateless/feedback.ts
+++ b/test/e2e/integration/app-stateless/feedback.ts
@@ -14,8 +14,8 @@ describe('Feedback', () => {
   it('is possible to move app instance to feedback stage', () => {
     cy.startStateFullFromStateless();
     cy.intercept('PUT', '**/process/next').as('nextProcess');
-    cy.get(appFrontend.sendinButton).should('be.visible').click();
+    cy.get(appFrontend.sendinButton).click();
     cy.wait('@nextProcess').its('response.statusCode').should('eq', 200);
-    cy.get(appFrontend.feedback).should('be.visible').and('contain.text', texts.feedback);
+    cy.get(appFrontend.feedback).and('contain.text', texts.feedback);
   });
 });

--- a/test/e2e/integration/app-stateless/receipt.ts
+++ b/test/e2e/integration/app-stateless/receipt.ts
@@ -12,7 +12,7 @@ describe('Receipt', () => {
     cy.wait('@getLayoutStateless');
     cy.startStateFullFromStateless();
     cy.intercept('PUT', '**/process/next').as('nextProcess');
-    cy.get(appFrontend.sendinButton).should('be.visible').click();
+    cy.get(appFrontend.sendinButton).click();
     cy.wait('@nextProcess').its('response.statusCode').should('eq', 200);
     cy.url().then((url) => {
       const maybeInstanceId = getInstanceIdRegExp().exec(url);

--- a/test/e2e/integration/app-stateless/stateless.ts
+++ b/test/e2e/integration/app-stateless/stateless.ts
@@ -29,7 +29,7 @@ describe('Stateless', () => {
   });
 
   it('Logout from appfrontend', () => {
-    cy.get(appFrontend.profileIconButton).should('be.visible').click();
+    cy.get(appFrontend.profileIconButton).click();
     cy.get(appFrontend.logOut).should('be.visible');
     cy.get(appFrontend.logOutLink).should('exist').and('be.visible');
   });

--- a/test/e2e/pageobjects/likert.ts
+++ b/test/e2e/pageobjects/likert.ts
@@ -28,13 +28,13 @@ export class Likert {
 
   selectRadio(question, option) {
     cy.findByRole('row', { name: question }).within(() => {
-      cy.findByRole('radio', { name: new RegExp(option) }).click();
+      cy.findByRole('radio', { name: new RegExp(option) }).dsCheck();
     });
   }
 
   selectRadioInMobile(question, option) {
     cy.findByRole('group', { name: question }).within(() => {
-      cy.findByRole('radio', { name: new RegExp(option) }).click();
+      cy.findByRole('radio', { name: new RegExp(option) }).dsCheck();
     });
   }
 

--- a/test/e2e/pageobjects/likert.ts
+++ b/test/e2e/pageobjects/likert.ts
@@ -28,13 +28,13 @@ export class Likert {
 
   selectRadio(question, option) {
     cy.findByRole('row', { name: question }).within(() => {
-      cy.findByRole('radio', { name: new RegExp(option) }).click({ force: true });
+      cy.findByRole('radio', { name: new RegExp(option) }).click();
     });
   }
 
   selectRadioInMobile(question, option) {
     cy.findByRole('group', { name: question }).within(() => {
-      cy.findByRole('radio', { name: new RegExp(option) }).click({ force: true });
+      cy.findByRole('radio', { name: new RegExp(option) }).click();
     });
   }
 

--- a/test/e2e/support/app-frontend.ts
+++ b/test/e2e/support/app-frontend.ts
@@ -14,12 +14,12 @@ Cypress.Commands.add(
       cy.get(appFrontend.group.addNewItem).click();
     }
 
-    cy.get(appFrontend.group.currentValue).should('be.visible').type(`${oldValue}`).blur();
-    cy.get(appFrontend.group.newValue).should('be.visible').type(`${newValue}`).blur();
+    cy.get(appFrontend.group.currentValue).type(`${oldValue}`).blur();
+    cy.get(appFrontend.group.newValue).type(`${newValue}`).blur();
     cy.get(appFrontend.group.mainGroup)
       .find(appFrontend.group.editContainer)
       .find(appFrontend.group.next)
-      .should('be.visible')
+
       .click();
 
     if (openByDefault || typeof openByDefault === 'undefined') {
@@ -28,16 +28,16 @@ Cypress.Commands.add(
       cy.get(appFrontend.group.addNewItemSubGroup).click();
     }
 
-    cy.get(appFrontend.group.comments).should('be.visible').type(comment).blur();
-    cy.get(appFrontend.group.saveSubGroup).should('be.visible').click().should('not.exist');
-    cy.get(appFrontend.group.saveMainGroup).should('be.visible').click().should('not.exist');
+    cy.get(appFrontend.group.comments).type(comment).blur();
+    cy.get(appFrontend.group.saveSubGroup).click().should('not.exist');
+    cy.get(appFrontend.group.saveMainGroup).click().should('not.exist');
   },
 );
 
 Cypress.Commands.add('startStateFullFromStateless', () => {
   cy.intercept('POST', '**/instances/create').as('createInstance');
   cy.intercept('**/api/layoutsettings/statefull').as('getLayoutSettings');
-  cy.get(appFrontend.instantiationButton).should('be.visible').click();
+  cy.get(appFrontend.instantiationButton).click();
   cy.wait('@createInstance').its('response.statusCode').should('eq', 201);
   cy.wait('@getLayoutSettings');
 });

--- a/test/e2e/support/custom.ts
+++ b/test/e2e/support/custom.ts
@@ -8,11 +8,15 @@ Cypress.Commands.add('isVisible', { prevSubject: true }, (subject) => {
 Cypress.Commands.add('dsCheck', { prevSubject: true }, (subject: JQueryWithSelector | undefined) => {
   if (subject && !subject.is(':checked')) {
     cy.wrap(subject).parent().click();
+  } else {
+    throw new Error('Tried unchecking a checked radio/checkbox');
   }
 });
 
 Cypress.Commands.add('dsUncheck', { prevSubject: true }, (subject: JQueryWithSelector | undefined) => {
   if (subject && subject.is(':checked')) {
     cy.wrap(subject).parent().click();
+  } else {
+    throw new Error('Tried unchecking an unchecked radio/checkbox');
   }
 });

--- a/test/e2e/support/custom.ts
+++ b/test/e2e/support/custom.ts
@@ -1,10 +1,18 @@
-Cypress.Commands.add(
-  'isVisible',
-  {
-    prevSubject: true,
-  },
-  (subject) => {
-    const isVisible = (elem) => !!(elem.offsetWidth || elem.offsetHeight || elem.getClientRects().length);
-    expect(isVisible(subject[0])).to.be.true;
-  },
-);
+import JQueryWithSelector = Cypress.JQueryWithSelector;
+
+Cypress.Commands.add('isVisible', { prevSubject: true }, (subject) => {
+  const isVisible = (elem) => !!(elem.offsetWidth || elem.offsetHeight || elem.getClientRects().length);
+  expect(isVisible(subject[0])).to.be.true;
+});
+
+Cypress.Commands.add('dsCheck', { prevSubject: true }, (subject: JQueryWithSelector | undefined) => {
+  if (subject && !subject.is(':checked')) {
+    cy.wrap(subject).parent().click();
+  }
+});
+
+Cypress.Commands.add('dsUncheck', { prevSubject: true }, (subject: JQueryWithSelector | undefined) => {
+  if (subject && subject.is(':checked')) {
+    cy.wrap(subject).parent().click();
+  }
+});

--- a/test/e2e/support/custom.ts
+++ b/test/e2e/support/custom.ts
@@ -8,15 +8,11 @@ Cypress.Commands.add('isVisible', { prevSubject: true }, (subject) => {
 Cypress.Commands.add('dsCheck', { prevSubject: true }, (subject: JQueryWithSelector | undefined) => {
   if (subject && !subject.is(':checked')) {
     cy.wrap(subject).parent().click();
-  } else {
-    throw new Error('Tried unchecking a checked radio/checkbox');
   }
 });
 
 Cypress.Commands.add('dsUncheck', { prevSubject: true }, (subject: JQueryWithSelector | undefined) => {
   if (subject && subject.is(':checked')) {
     cy.wrap(subject).parent().click();
-  } else {
-    throw new Error('Tried unchecking an unchecked radio/checkbox');
   }
 });

--- a/test/e2e/support/global.d.ts
+++ b/test/e2e/support/global.d.ts
@@ -121,6 +121,19 @@ declare global {
 
       switchUser(user: user): any;
       assertUser(user: user): any;
+
+      /**
+       * Check a checkbox/radio from the design system.
+       * Our design system radios/checkboxes are a little special, as they hide the HTML input element and provide
+       * their own stylized variant. Cypress can't check/uncheck a hidden input field, and although we can tell
+       * cypress to force it, that just circumvents a lot of other checks that we want cypress to run.
+       */
+      dsCheck(): Chainable<null>;
+
+      /**
+       * Uncheck a checkbox/radio from the design system. See the comment above for dsCheck()
+       */
+      dsUncheck(): Chainable<null>;
     }
   }
 }

--- a/test/e2e/support/navigation.ts
+++ b/test/e2e/support/navigation.ts
@@ -117,7 +117,7 @@ const completeFormSlow: { [key in FrontendTestTask]: () => void } = {
       .then(() => {
         cy.get(appFrontend.changeOfName.newFirstName).should('be.visible').type('a').blur();
         cy.get(appFrontend.changeOfName.newLastName).should('be.visible').type('a').blur();
-        cy.get(appFrontend.changeOfName.confirmChangeName).should('be.visible').find('input').check();
+        cy.get(appFrontend.changeOfName.confirmChangeName).should('be.visible').find('input').dsCheck();
         cy.get(appFrontend.changeOfName.reasonRelationship).should('be.visible').click().type('test');
         cy.get(appFrontend.changeOfName.dateOfEffect)
           .siblings()
@@ -126,7 +126,7 @@ const completeFormSlow: { [key in FrontendTestTask]: () => void } = {
           .then(() => {
             cy.get(mui.selectedDate).should('be.visible').click();
           });
-        cy.get(appFrontend.changeOfName.upload).selectFile('test/e2e/fixtures/test.pdf');
+        cy.get(appFrontend.changeOfName.upload).selectFile('test/e2e/fixtures/test.pdf', { force: true });
         cy.get(appFrontend.nextButton).click();
       });
   },
@@ -139,7 +139,7 @@ const completeFormSlow: { [key in FrontendTestTask]: () => void } = {
     });
 
     cy.get(appFrontend.nextButton).click();
-    cy.get(appFrontend.group.showGroupToContinue).should('be.visible').find('input').check();
+    cy.get(appFrontend.group.showGroupToContinue).should('be.visible').find('input').dsCheck();
     cy.addItemToGroup(1, 2, 'automation');
     cy.get(appFrontend.group.row(0).editBtn).click();
     cy.get(appFrontend.group.editContainer).find(appFrontend.group.next).click();
@@ -156,6 +156,7 @@ const completeFormSlow: { [key in FrontendTestTask]: () => void } = {
     cy.get(appFrontend.group.row(0).nestedGroup.row(0).editBtn).click();
     cy.get(appFrontend.group.row(0).nestedGroup.row(0).uploadTagMulti.dropZone).selectFile(
       mkFile('attachment-in-nested.pdf'),
+      { force: true },
     );
     cy.get(appFrontend.group.row(0).nestedGroup.row(0).uploadTagMulti.attachments(0).tagSelector || 'nothing')
       .should('be.visible')
@@ -165,19 +166,16 @@ const completeFormSlow: { [key in FrontendTestTask]: () => void } = {
       'not.exist',
     );
 
-    cy.intercept('GET', '**/options/*').as('getOptions');
-    cy.get('#nested-source-0-0').should('exist').and('be.visible').select('Annet');
-    cy.wait('@getOptions');
-    cy.get('#nested-reference-0-0').should('exist').and('be.visible').select('Test');
+    cy.get('#nested-source-0-0').select('Annet').blur();
+    cy.get('#nested-reference-0-0').select('Test').blur();
     cy.get(appFrontend.group.editContainer).find(appFrontend.group.next).click();
-    cy.get('#source-0').should('exist').and('be.visible').select('Digitaliseringsdirektoratet');
-    cy.wait(['@getOptions', '@getOptions']);
-    cy.get('#reference-0').should('exist').and('be.visible').select('Sophie Salt');
+    cy.get('#source-0').select('Digitaliseringsdirektoratet').blur();
+    cy.get('#reference-0').select('Sophie Salt').blur();
 
-    cy.get(appFrontend.group.saveMainGroup).should('be.visible').click().should('not.exist');
+    cy.get(appFrontend.group.saveMainGroup).click().should('not.exist');
 
     cy.get(appFrontend.nextButton).click();
-    cy.get(appFrontend.group.sendersName).should('be.visible').type('automation');
+    cy.get(appFrontend.group.sendersName).type('automation');
     cy.get(appFrontend.nextButton).click();
     cy.get(appFrontend.group.summaryText).should('be.visible');
   },

--- a/test/e2e/support/navigation.ts
+++ b/test/e2e/support/navigation.ts
@@ -117,7 +117,7 @@ const completeFormSlow: { [key in FrontendTestTask]: () => void } = {
       .then(() => {
         cy.get(appFrontend.changeOfName.newFirstName).should('be.visible').type('a').blur();
         cy.get(appFrontend.changeOfName.newLastName).should('be.visible').type('a').blur();
-        cy.get(appFrontend.changeOfName.confirmChangeName).should('be.visible').find('input').check({ force: true });
+        cy.get(appFrontend.changeOfName.confirmChangeName).should('be.visible').find('input').check();
         cy.get(appFrontend.changeOfName.reasonRelationship).should('be.visible').click().type('test');
         cy.get(appFrontend.changeOfName.dateOfEffect)
           .siblings()
@@ -126,7 +126,7 @@ const completeFormSlow: { [key in FrontendTestTask]: () => void } = {
           .then(() => {
             cy.get(mui.selectedDate).should('be.visible').click();
           });
-        cy.get(appFrontend.changeOfName.upload).selectFile('test/e2e/fixtures/test.pdf', { force: true });
+        cy.get(appFrontend.changeOfName.upload).selectFile('test/e2e/fixtures/test.pdf');
         cy.get(appFrontend.nextButton).click();
       });
   },
@@ -139,7 +139,7 @@ const completeFormSlow: { [key in FrontendTestTask]: () => void } = {
     });
 
     cy.get(appFrontend.nextButton).click();
-    cy.get(appFrontend.group.showGroupToContinue).should('be.visible').find('input').check({ force: true });
+    cy.get(appFrontend.group.showGroupToContinue).should('be.visible').find('input').check();
     cy.addItemToGroup(1, 2, 'automation');
     cy.get(appFrontend.group.row(0).editBtn).click();
     cy.get(appFrontend.group.editContainer).find(appFrontend.group.next).click();
@@ -156,7 +156,6 @@ const completeFormSlow: { [key in FrontendTestTask]: () => void } = {
     cy.get(appFrontend.group.row(0).nestedGroup.row(0).editBtn).click();
     cy.get(appFrontend.group.row(0).nestedGroup.row(0).uploadTagMulti.dropZone).selectFile(
       mkFile('attachment-in-nested.pdf'),
-      { force: true },
     );
     cy.get(appFrontend.group.row(0).nestedGroup.row(0).uploadTagMulti.attachments(0).tagSelector || 'nothing')
       .should('be.visible')

--- a/test/e2e/support/navigation.ts
+++ b/test/e2e/support/navigation.ts
@@ -112,23 +112,21 @@ const completeFormSlow: { [key in FrontendTestTask]: () => void } = {
     cy.get(appFrontend.closeButton).should('be.visible');
   },
   changename: () => {
-    cy.get(appFrontend.changeOfName.currentName)
-      .should('be.visible')
-      .then(() => {
-        cy.get(appFrontend.changeOfName.newFirstName).should('be.visible').type('a').blur();
-        cy.get(appFrontend.changeOfName.newLastName).should('be.visible').type('a').blur();
-        cy.get(appFrontend.changeOfName.confirmChangeName).should('be.visible').find('input').dsCheck();
-        cy.get(appFrontend.changeOfName.reasonRelationship).should('be.visible').click().type('test');
-        cy.get(appFrontend.changeOfName.dateOfEffect)
-          .siblings()
-          .children(mui.buttonIcon)
-          .click()
-          .then(() => {
-            cy.get(mui.selectedDate).should('be.visible').click();
-          });
-        cy.get(appFrontend.changeOfName.upload).selectFile('test/e2e/fixtures/test.pdf', { force: true });
-        cy.get(appFrontend.nextButton).click();
-      });
+    cy.get(appFrontend.changeOfName.currentName).then(() => {
+      cy.get(appFrontend.changeOfName.newFirstName).type('a').blur();
+      cy.get(appFrontend.changeOfName.newLastName).type('a').blur();
+      cy.get(appFrontend.changeOfName.confirmChangeName).find('input').dsCheck();
+      cy.get(appFrontend.changeOfName.reasonRelationship).click().type('test');
+      cy.get(appFrontend.changeOfName.dateOfEffect)
+        .siblings()
+        .children(mui.buttonIcon)
+        .click()
+        .then(() => {
+          cy.get(mui.selectedDate).click();
+        });
+      cy.get(appFrontend.changeOfName.upload).selectFile('test/e2e/fixtures/test.pdf', { force: true });
+      cy.get(appFrontend.nextButton).click();
+    });
   },
   group: () => {
     const mkFile = (fileName) => ({
@@ -139,7 +137,7 @@ const completeFormSlow: { [key in FrontendTestTask]: () => void } = {
     });
 
     cy.get(appFrontend.nextButton).click();
-    cy.get(appFrontend.group.showGroupToContinue).should('be.visible').find('input').dsCheck();
+    cy.get(appFrontend.group.showGroupToContinue).find('input').dsCheck();
     cy.addItemToGroup(1, 2, 'automation');
     cy.get(appFrontend.group.row(0).editBtn).click();
     cy.get(appFrontend.group.editContainer).find(appFrontend.group.next).click();
@@ -158,9 +156,9 @@ const completeFormSlow: { [key in FrontendTestTask]: () => void } = {
       mkFile('attachment-in-nested.pdf'),
       { force: true },
     );
-    cy.get(appFrontend.group.row(0).nestedGroup.row(0).uploadTagMulti.attachments(0).tagSelector || 'nothing')
-      .should('be.visible')
-      .select('altinn');
+    cy.get(appFrontend.group.row(0).nestedGroup.row(0).uploadTagMulti.attachments(0).tagSelector || 'nothing').select(
+      'altinn',
+    );
     cy.get(appFrontend.group.row(0).nestedGroup.row(0).uploadTagMulti.attachments(0).tagSave || 'nothing').click();
     cy.get(appFrontend.group.row(0).nestedGroup.row(0).uploadTagMulti.attachments(0).tagSelector || 'nothing').should(
       'not.exist',
@@ -199,7 +197,7 @@ const sendInTask: { [key in FrontendTestTask]: () => void } = {
   likert: genericSendIn,
   datalist: genericSendIn,
   confirm: () => {
-    cy.get(appFrontend.confirm.sendIn).should('be.visible').click();
+    cy.get(appFrontend.confirm.sendIn).click();
     cy.get(appFrontend.confirm.sendIn).should('not.exist');
   },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5489,7 +5489,7 @@ __metadata:
     core-js: ^3.29.1
     cross-env: 7.0.3
     css-loader: 6.7.3
-    cypress: 12.8.1
+    cypress: 12.9.0
     cypress-axe: 1.4.0
     cypress-plugin-tab: 1.0.5
     cypress-wait-until: ^1.7.2
@@ -7191,9 +7191,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cypress@npm:12.8.1":
-  version: 12.8.1
-  resolution: "cypress@npm:12.8.1"
+"cypress@npm:12.9.0":
+  version: 12.9.0
+  resolution: "cypress@npm:12.9.0"
   dependencies:
     "@cypress/request": ^2.88.10
     "@cypress/xvfb": ^1.2.4
@@ -7239,7 +7239,7 @@ __metadata:
     yauzl: ^2.10.0
   bin:
     cypress: bin/cypress
-  checksum: a229f2b3ff20b1b533f6d4670303596aef596a394db77ea8eafe2fa8f175b79b9d48ba66262513fa806076be5c857e159539f6d8fd9acf4df9936a2fa649bf1e
+  checksum: aad2278310fe4897b2c4e1f23e22f28992c83bcac945a6c350d077b1b2fb1805e44d5c58e19e2a9d63ca04aa3f9eabdd3c661cab0ce5dddd75c72702262ac89e
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2661,18 +2661,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@digdir/design-system-react@npm:0.9.0":
-  version: 0.9.0
-  resolution: "@digdir/design-system-react@npm:0.9.0"
+"@digdir/design-system-react@npm:0.10.2":
+  version: 0.10.2
+  resolution: "@digdir/design-system-react@npm:0.10.2"
   dependencies:
     "@altinn/figma-design-tokens": ^6.0.1
     "@floating-ui/react": 0.17.0
     "@navikt/ds-icons": ^2.3.0
-    react-number-format: ^5.1.3
+    react-number-format: ^5.1.4
   peerDependencies:
     react: ">=16.8"
     react-dom: ">=16.8"
-  checksum: 7669fa3491b6cbed6891db120eb6852d7e36fb0b9412f31bd225f184a894b06f9e87b29548ba1b5bb6b4281a0627e341d50b44396b865bc562850eed8d45f77a
+  checksum: 7c37ccdfcb58109683ad640b79c8c83453e600e2fe62f209f127f2b36e659c38e1c7c0ff42b07e573720d8d78656c869594c97b3c975a756f4b9c9dfbf4e368f
   languageName: node
   linkType: hard
 
@@ -5453,7 +5453,7 @@ __metadata:
     "@babel/runtime": ^7.21.0
     "@babel/runtime-corejs3": ^7.21.0
     "@date-io/moment": 1.3.13
-    "@digdir/design-system-react": 0.9.0
+    "@digdir/design-system-react": 0.10.2
     "@material-ui/core": 4.12.4
     "@material-ui/icons": 4.11.3
     "@material-ui/pickers": 3.3.10
@@ -13299,15 +13299,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-number-format@npm:^5.1.3":
-  version: 5.1.3
-  resolution: "react-number-format@npm:5.1.3"
+"react-number-format@npm:^5.1.4":
+  version: 5.1.4
+  resolution: "react-number-format@npm:5.1.4"
   dependencies:
     prop-types: ^15.7.2
   peerDependencies:
-    react: ^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^18.0.0
-    react-dom: ^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^18.0.0
-  checksum: 354481a3ce15520d3e786f790a84a0363a94c56034519c6e2248d8f277095b696f31204a46745d3c64869559b7a81ba39ab9ad46c6582f762255f81d5c5d2e95
+    react: ^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
+  checksum: 770a1e86cd05d9df28aa5e6a12c5731351dd4a301464edd0ac5dcbc68d2f07eae37781ff14f6153566cbb7cccb28f13f0826d1844600d25ae6e12da060814282
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description
- Removes most usages of `{ force: true }`, only keeping them for file uploaders. This flag was used to trick Cypress into checking/unchecking hidden inputs (radio/checkboxes), but we should make tools for these things instead, to make our tests behave like our users would. Implemented `dsCheck()` and `dsUncheck()` for this purpose.
- Fixing a bug in `useDelayedSaveState()` where a slow re-render by React using a stale `formValue` would overwrite data after a user had made a newer change. Fixing this makes it possible for us to avoid the workarounds we had for this in our tests.
- Upgrading Cypress to `12.9.0` while I was at it
- Removed lots of `.should('exist').and('be.visible').click()` logic. We don't have to check if an element exists and is visible before trying to click it, because Cypress will retry the click until the element is visible -- or fail trying. Starting off with these verbose 'should be visible' assertions actually makes Cypress more flaky, as it can't retry finding the element to click if an older one (that was visible) became invisible during the chained run. Removing these makes for leaner test code, and makes the tests more stable. Read more here: https://docs.cypress.io/guides/core-concepts/retry-ability

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
