### PR TITLE
Ensure to hide rows regardless of the edit mode if the "hiddenRow" expression evaluates to true.

### DIFF
--- a/src/features/form/containers/RepeatingGroupsEditContainer.tsx
+++ b/src/features/form/containers/RepeatingGroupsEditContainer.tsx
@@ -56,6 +56,11 @@ export function RepeatingGroupsEditContainer({
     return null;
   }
 
+  const shouldHideRow = node.isRepGroup() && node.item.rows[editIndex]?.groupExpressions?.hiddenRow;
+  if (shouldHideRow) {
+    return null;
+  }
+
   return (
     <RepeatingGroupsEditContainerInternal
       id={id}


### PR DESCRIPTION
## Description

**The bug:**
When _editMode_ was set to _showAll_ and _hiddenRow_ was true, the rows were rendered but as empty rows, like the image below shows.

**Expected behaviour:**
Expected the row not to be rendered at all and to be invisible.

**Solution:**
We do not expect the rows to be shown as empty rows when `hiddenRow` is true, they should not be rendered at all. This PR ensures that rows are hidden when `hiddenRow` is true regardless of the edit mode.

![image](https://user-images.githubusercontent.com/46874830/228942249-f1137b0a-624b-4cfc-8558-12cc4f59b660.png)

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
