### PR TITLE
Upgrading design system to v0.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "@altinn/altinn-design-system": "0.27.6",
     "@babel/polyfill": "7.12.1",
     "@date-io/moment": "1.3.13",
-    "@digdir/design-system-react": "0.10.2",
+    "@digdir/design-system-react": "0.11.0",
     "@material-ui/core": "4.12.4",
     "@material-ui/icons": "4.11.3",
     "@material-ui/pickers": "3.3.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2661,9 +2661,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@digdir/design-system-react@npm:0.10.2":
-  version: 0.10.2
-  resolution: "@digdir/design-system-react@npm:0.10.2"
+"@digdir/design-system-react@npm:0.11.0":
+  version: 0.11.0
+  resolution: "@digdir/design-system-react@npm:0.11.0"
   dependencies:
     "@altinn/figma-design-tokens": ^6.0.1
     "@floating-ui/react": 0.17.0
@@ -2672,7 +2672,7 @@ __metadata:
   peerDependencies:
     react: ">=16.8"
     react-dom: ">=16.8"
-  checksum: 7c37ccdfcb58109683ad640b79c8c83453e600e2fe62f209f127f2b36e659c38e1c7c0ff42b07e573720d8d78656c869594c97b3c975a756f4b9c9dfbf4e368f
+  checksum: 1c8d436225903e195d1aaa78153cb2ff854555c1bf211a13120489f1864c07c318eefaba4b248089bf5fe55d6b3489b489f7dc37cfcf15b485d79a5ea74b95f0
   languageName: node
   linkType: hard
 
@@ -5453,7 +5453,7 @@ __metadata:
     "@babel/runtime": ^7.21.0
     "@babel/runtime-corejs3": ^7.21.0
     "@date-io/moment": 1.3.13
-    "@digdir/design-system-react": 0.10.2
+    "@digdir/design-system-react": 0.11.0
     "@material-ui/core": 4.12.4
     "@material-ui/icons": 4.11.3
     "@material-ui/pickers": 3.3.10


### PR DESCRIPTION
## Description
Upgrading `@digdir/design-system-react`. Apparently my changes (se the PR linked below) did not arrive properly in v0.10.2 (I guess I made a mistake 🤷), but they should arrive in v0.11.0. 🤞 

This relates to the flaky cypress tests we've had lately. Sometimes it seems a call to `.clear()` on a numeric input field fails to actually clear the value, but it's very inconsistent. When I tried debugging it, it seems Cypress sends a simulated selection change event (to select everything in the text field) and then it simulates a delete-button-press (not backspace, as the documentation says, btw). In the design system text input field we had some keydown event listeners that were working around an issue in react-number-format that manipulated the input text selection,so I suspected that was the reason why this could sometimes fail (i.e. that in some rare timing circumstances the keydown listener would change the selection to be set to the last character in the input before cypress pressed delete, causing nothing to be deleted).

Hoping this fixes the issue, as it happened again in #1055 now, after v0.10.2 was merged (see [github action run report](https://github.com/Altinn/app-frontend-react/actions/runs/4568755157/jobs/8064203419?pr=1055) or [cypress report](https://cloud.cypress.io/projects/y2jhp6/runs/3195/overview)). If this doesn't fix the issue, maybe I'll make a `.superClear()` that makes Cypress retry until the field is cleared.. 😆 

## Related Issue(s)

- #1063 
- https://github.com/digdir/designsystem/pull/276

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [x] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
