### PR TITLE
Devtools: Basic component inspector

### DIFF
--- a/src/features/devtools/DevTools.module.css
+++ b/src/features/devtools/DevTools.module.css
@@ -38,6 +38,9 @@
 
 .panelContent {
   padding: 8px 16px;
+  height: calc(100% - 10px);
+  display: flex;
+  flex-direction: column;
 }
 
 .header {
@@ -48,6 +51,8 @@
 }
 
 .controlsWrapper {
+  flex: 1;
+  overflow: hidden;
   display: flex;
   flex-direction: column;
   align-items: flex-start;

--- a/src/features/devtools/DevTools.module.css
+++ b/src/features/devtools/DevTools.module.css
@@ -37,24 +37,41 @@
 }
 
 .panelContent {
-  padding: 8px 16px;
   height: calc(100% - 10px);
+  width: 100%;
+}
+
+.closeButton > button {
+  height: 32px;
+  width: 32px;
+  position: absolute;
+  top: 10px;
+  right: 0;
+  z-index: 10001;
+}
+
+.tabs {
+  height: 100%;
+  width: 100%;
+}
+
+.tabs > div {
+  height: 100%;
+  width: 100%;
   display: flex;
   flex-direction: column;
 }
 
-.header {
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  margin-bottom: 8px;
+.tabs [role='tabpanel'] {
+  min-height: 0;
+  flex: 1;
+  margin: 0;
 }
 
-.controlsWrapper {
-  flex: 1;
-  overflow: hidden;
+.page {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 16px;
+  gap: 12px;
+  padding: 12px;
 }

--- a/src/features/devtools/DevToolsControls.tsx
+++ b/src/features/devtools/DevToolsControls.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+import { Tabs } from '@digdir/design-system-react';
+
+import { DevNavigationButtons } from 'src/features/devtools/components/DevNavigationButtons/DevNavigationButtons';
+import { LayoutInspector } from 'src/features/devtools/components/LayoutInspector/LayoutInspector';
+import { PDFPreviewButton } from 'src/features/devtools/components/PDFPreviewButton/PDFPreviewButton';
+import classes from 'src/features/devtools/DevTools.module.css';
+
+export const DevToolsControls = () => (
+  <div className={classes.tabs}>
+    <Tabs
+      items={[
+        {
+          name: 'Generelt',
+          content: (
+            <div className={classes.page}>
+              <PDFPreviewButton />
+              <DevNavigationButtons />
+            </div>
+          ),
+        },
+        {
+          name: 'Komponenter',
+          content: <LayoutInspector />,
+        },
+      ]}
+    />
+  </div>
+);

--- a/src/features/devtools/DevToolsPanel.tsx
+++ b/src/features/devtools/DevToolsPanel.tsx
@@ -5,8 +5,7 @@ import type { ReactNode } from 'react';
 import { Button, ButtonColor, ButtonVariant } from '@digdir/design-system-react';
 import { Close } from '@navikt/ds-icons';
 
-import { DevNavigationButtons } from 'src/features/devtools/components/DevNavigationButtons/DevNavigationButtons';
-import { PDFPreviewButton } from 'src/features/devtools/components/PDFPreviewButton/PDFPreviewButton';
+import { LayoutInspector } from 'src/features/devtools/components/LayoutInspector/LayoutInspector';
 import classes from 'src/features/devtools/DevTools.module.css';
 
 function clampHeight(height: number): number {
@@ -61,6 +60,7 @@ export const DevToolsPanel = ({ isOpen, close, children }: IDevToolsPanelProps) 
   return (
     <>
       <div
+        id='appContainer'
         className={classes.appContainer}
         style={{ paddingBottom: isOpen ? height : 0 }}
       >
@@ -89,8 +89,9 @@ export const DevToolsPanel = ({ isOpen, close, children }: IDevToolsPanelProps) 
               />
             </div>
             <div className={classes.controlsWrapper}>
-              <PDFPreviewButton />
-              <DevNavigationButtons />
+              {/*<PDFPreviewButton />
+              <DevNavigationButtons />*/}
+              <LayoutInspector />
             </div>
           </div>
         </div>

--- a/src/features/devtools/DevToolsPanel.tsx
+++ b/src/features/devtools/DevToolsPanel.tsx
@@ -5,8 +5,8 @@ import type { ReactNode } from 'react';
 import { Button, ButtonColor, ButtonVariant } from '@digdir/design-system-react';
 import { Close } from '@navikt/ds-icons';
 
-import { LayoutInspector } from 'src/features/devtools/components/LayoutInspector/LayoutInspector';
 import classes from 'src/features/devtools/DevTools.module.css';
+import { DevToolsControls } from 'src/features/devtools/DevToolsControls';
 
 function clampHeight(height: number): number {
   return Math.min(Math.max(height, 10), window.innerHeight);
@@ -78,8 +78,7 @@ export const DevToolsPanel = ({ isOpen, close, children }: IDevToolsPanelProps) 
             onTouchStart={resizeHandlerMobile}
           />
           <div className={classes.panelContent}>
-            <div className={classes.header}>
-              <h2>Utviklerverktøy</h2>
+            <div className={classes.closeButton}>
               <Button
                 onClick={close}
                 variant={ButtonVariant.Quiet}
@@ -88,11 +87,7 @@ export const DevToolsPanel = ({ isOpen, close, children }: IDevToolsPanelProps) 
                 icon={<Close aria-hidden />}
               />
             </div>
-            <div className={classes.controlsWrapper}>
-              {/*<PDFPreviewButton />
-              <DevNavigationButtons />*/}
-              <LayoutInspector />
-            </div>
+            <DevToolsControls />
           </div>
         </div>
       )}

--- a/src/features/devtools/components/LayoutInspector/LayoutInspector.module.css
+++ b/src/features/devtools/components/LayoutInspector/LayoutInspector.module.css
@@ -1,0 +1,27 @@
+.container {
+  flex: 1;
+  overflow-y: auto;
+  width: 100%;
+  background-color: #333;
+}
+
+.item {
+  padding: 0 6px;
+  color: white;
+  list-style: none;
+}
+
+.item:hover {
+  background-color: #555;
+}
+
+.componentType {
+}
+
+.componentId {
+  text-align: center;
+  vertical-align: middle;
+  margin-left: 12px;
+  color: #eee;
+  font-size: 0.8rem;
+}

--- a/src/features/devtools/components/LayoutInspector/LayoutInspector.module.css
+++ b/src/features/devtools/components/LayoutInspector/LayoutInspector.module.css
@@ -1,27 +1,30 @@
 .container {
-  flex: 1;
+  height: 100%;
   overflow-y: auto;
   width: 100%;
-  background-color: #333;
 }
 
 .item {
   padding: 0 6px;
-  color: white;
   list-style: none;
 }
 
+.item span {
+  cursor: default;
+}
+
 .item:hover {
-  background-color: #555;
+  background-color: #ccc;
 }
 
 .componentType {
+  font-weight: bold;
 }
 
 .componentId {
   text-align: center;
   vertical-align: middle;
   margin-left: 12px;
-  color: #eee;
+  color: #333;
   font-size: 0.8rem;
 }

--- a/src/features/devtools/components/LayoutInspector/LayoutInspector.tsx
+++ b/src/features/devtools/components/LayoutInspector/LayoutInspector.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import classes from 'src/features/devtools/components/LayoutInspector/LayoutInspector.module.css';
+import { LayoutInspectorItem } from 'src/features/devtools/components/LayoutInspector/LayoutInspectorItem';
+import { useAppSelector } from 'src/hooks/useAppSelector';
+
+export const LayoutInspector = () => {
+  const { currentView } = useAppSelector((state) => state.formLayout.uiConfig);
+  const layouts = useAppSelector((state) => state.formLayout.layouts);
+
+  const currentLayout = layouts?.[currentView];
+
+  return (
+    <div className={classes.container}>
+      <ul>
+        {currentLayout?.map((component) => (
+          <LayoutInspectorItem
+            key={component.id}
+            component={component}
+          />
+        ))}
+      </ul>
+    </div>
+  );
+};

--- a/src/features/devtools/components/LayoutInspector/LayoutInspectorItem.tsx
+++ b/src/features/devtools/components/LayoutInspector/LayoutInspectorItem.tsx
@@ -1,0 +1,53 @@
+import React, { useRef } from 'react';
+
+import classes from 'src/features/devtools/components/LayoutInspector/LayoutInspector.module.css';
+import type { ExprUnresolved } from 'src/features/expressions/types';
+import type { ILayoutComponentOrGroup } from 'src/layout/layout';
+
+interface ILayoutInspectorItemProps {
+  component: ExprUnresolved<ILayoutComponentOrGroup>;
+}
+
+function setHighlightStyle(highlightElement: HTMLElement, referenceElement: HTMLElement): void {
+  highlightElement.style.position = 'absolute';
+  const { top, left, bottom, right } = referenceElement.getBoundingClientRect();
+  const width = right - left;
+  const height = bottom - top;
+  highlightElement.style.top = `${top + window.scrollY}px`;
+  highlightElement.style.left = `${left}px`;
+  highlightElement.style.width = `${width}px`;
+  highlightElement.style.height = `${height}px`;
+  highlightElement.style.backgroundColor = 'rgba(0, 200, 255, 0.33)';
+  highlightElement.style.border = '3px solid rgb(0, 200, 255)';
+  highlightElement.style.zIndex = '5000';
+}
+
+export const LayoutInspectorItem = ({ component }: ILayoutInspectorItemProps) => {
+  const highlightRef = useRef<Element[]>([]);
+
+  function onMouseEnter() {
+    const referenceElements = document.querySelectorAll(`[data-componentid="${component.id}"]`);
+    referenceElements.forEach((referenceElement) => {
+      const highlightElement = document.createElement('div');
+      setHighlightStyle(highlightElement, referenceElement as HTMLElement);
+      document.body.appendChild(highlightElement);
+      highlightRef.current.push(highlightElement);
+    });
+  }
+
+  function onMouseLeave() {
+    highlightRef.current.forEach((el) => el.remove());
+    highlightRef.current = [];
+  }
+
+  return (
+    <li
+      className={classes.item}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+    >
+      <span className={classes.componentType}>{component.type}</span>
+      <span className={classes.componentId}>{component.id}</span>
+    </li>
+  );
+};

--- a/src/layout/GenericComponent.tsx
+++ b/src/layout/GenericComponent.tsx
@@ -269,6 +269,7 @@ export function GenericComponent<Type extends ComponentTypes = ComponentTypes>({
   return (
     <FormComponentContext.Provider value={formComponentContext}>
       <Grid
+        data-componentId={item.baseComponentId ?? item.id}
         ref={gridRef}
         item={true}
         container={true}

--- a/src/layout/Group/DisplayGroupContainer.tsx
+++ b/src/layout/Group/DisplayGroupContainer.tsx
@@ -50,6 +50,7 @@ export function DisplayGroupContainer({ groupNode, id, onlyRowIndex, renderLayou
       spacing={3}
       alignItems='flex-start'
       data-testid='display-group-container'
+      data-componentId={container.baseComponentId ?? container.id}
     >
       {title && (
         <Grid

--- a/src/layout/Group/GroupContainer.tsx
+++ b/src/layout/Group/GroupContainer.tsx
@@ -170,6 +170,7 @@ export function GroupContainer({ id }: IGroupProps): JSX.Element | null {
     <Grid
       container={true}
       item={true}
+      data-componentId={node.item.baseComponentId ?? node.item.id}
     >
       {(!edit?.mode || edit?.mode === 'showTable' || (edit?.mode === 'hideTable' && editIndex < 0)) && (
         <RepeatingGroupTable

--- a/src/layout/Likert/LikertComponent.tsx
+++ b/src/layout/Likert/LikertComponent.tsx
@@ -54,7 +54,10 @@ const RadioGroupTableRow = ({
   const RenderLegend = legend;
   const rowLabelId = `row-label-${id}`;
   return (
-    <TableRow aria-labelledby={rowLabelId}>
+    <TableRow
+      aria-labelledby={rowLabelId}
+      data-componentId={node.item.baseComponentId ?? node.item.id}
+    >
       <th
         scope='row'
         id={rowLabelId}

--- a/src/layout/Likert/RepeatingGroupsLikertContainer.tsx
+++ b/src/layout/Likert/RepeatingGroupsLikertContainer.tsx
@@ -47,6 +47,7 @@ export const RepeatingGroupsLikertContainer = ({ id }: RepeatingGroupsLikertCont
     <Grid
       item={true}
       xs={12}
+      data-componentId={node?.item.baseComponentId ?? node?.item.id}
     >
       {title && (
         <Typography

--- a/src/layout/Panel/PanelGroupContainer.tsx
+++ b/src/layout/Panel/PanelGroupContainer.tsx
@@ -96,7 +96,10 @@ export function PanelGroupContainer({ id }: IPanelGroupContainerProps) {
   }
 
   return (
-    <Grid item={true}>
+    <Grid
+      item={true}
+      data-componentId={node.item.baseComponentId ?? node.item.id}
+    >
       <ConditionalWrapper
         condition={fullWidth}
         wrapper={(child) => <FullWidthWrapper>{child}</FullWidthWrapper>}


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

This adds a "component inspector" that is currently just a list of your components from the current layout file. Note, this is not a hierarchy inspector, that could be a separate thing later. This inspector should be extended to also show the component properties when clicking a component from the list. This is relatively easy to implement, but we should consider adding some sort of panel resizing component to make this work well. This also adds tabs to the devtools panels, since it would get very cluttered to include this on the same page.