### PR TITLE
Ignore all backend validations that uses the code: "required"

### DIFF
--- a/src/utils/validation/validation.ts
+++ b/src/utils/validation/validation.ts
@@ -904,6 +904,17 @@ export function mapDataElementValidationToRedux(
     return validationResult;
   }
   validations.forEach((validation) => {
+    if (validation.code == 'required' && validation.code != validation.description) {
+      // Ignore required validations from backend. They will be duplicated by frontend running the same logic.
+      // verify that code != description because user validations always have code == description
+      // and we don't want issues in case someone wants to set additional required validations in backend
+      // and uses "required" as a key.
+
+      // Using "required" as key will likeliy be OK in the future, if we manage to inteligently deduplicate
+      // errors with a shared code. (eg, only display one error with code "required" per component)
+      return;
+    }
+
     // for each validation, map to correct component and field key
     const layoutIds = findLayoutIdsFromValidationIssue(layouts || {}, validation);
     if (layoutIds.length === 0) {


### PR DESCRIPTION
A little safety feature is that I only ignore when .code and .description is different, so that user validations that uses the text code "required" isn't affected.

## Related Issue(s)

- Improves https://github.com/Altinn/app-frontend-react/issues/1062

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [ ] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
