### PR TITLE
Added aria-label to edit btn in summary page

### DIFF
--- a/src/layout/Group/SummaryGroupComponent.tsx
+++ b/src/layout/Group/SummaryGroupComponent.tsx
@@ -184,6 +184,7 @@ export function SummaryGroupComponent({
             <EditButton
               onClick={onChangeClick}
               editText={changeText}
+              label={title}
             />
           ) : null}
         </div>

--- a/src/layout/Group/__snapshots__/SummaryGroupComponent.test.tsx.snap
+++ b/src/layout/Group/__snapshots__/SummaryGroupComponent.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`SummaryGroupComponent SummaryGroupComponent -- should match snapshot 1`
         Mock group
       </span>
       <button
+        aria-label="Change Mock group"
         class="Button-module_button__2ZuB7 Button-module_small__l39oh Button-module_quiet__1KlhF Button-module_secondary__R0waJ"
         type="button"
       >

--- a/src/layout/Summary/EditButton.tsx
+++ b/src/layout/Summary/EditButton.tsx
@@ -6,7 +6,7 @@ import { Edit } from '@navikt/ds-icons';
 export interface IEditButtonProps {
   onClick: () => void;
   editText: string | null;
-  label?: React.ReactNode;
+  label: React.ReactNode;
 }
 
 export function EditButton(props: IEditButtonProps) {

--- a/src/layout/Summary/EditButton.tsx
+++ b/src/layout/Summary/EditButton.tsx
@@ -6,6 +6,7 @@ import { Edit } from '@navikt/ds-icons';
 export interface IEditButtonProps {
   onClick: () => void;
   editText: string | null;
+  label?: React.ReactNode;
 }
 
 export function EditButton(props: IEditButtonProps) {
@@ -16,6 +17,7 @@ export function EditButton(props: IEditButtonProps) {
       icon={<Edit aria-hidden={true} />}
       iconPlacement='right'
       onClick={props.onClick}
+      aria-label={`${props.editText} ${props.label}`}
     >
       {props.editText}
     </Button>

--- a/src/layout/Summary/SummaryBoilerplate.tsx
+++ b/src/layout/Summary/SummaryBoilerplate.tsx
@@ -5,6 +5,7 @@ import cn from 'classnames';
 
 import { EditButton } from 'src/layout/Summary/EditButton';
 import { AltinnAppTheme } from 'src/theme/altinnAppTheme';
+import { getPlainTextFromNode } from 'src/utils/stringHelper';
 import type { ISummaryComponent } from 'src/layout/Summary/SummaryComponent';
 import type { LayoutNodeFromType } from 'src/utils/layout/hierarchy.types';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
@@ -12,7 +13,7 @@ import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 export interface SummaryBoilerplateProps {
   onChangeClick: () => void;
   changeText: string | null;
-  label: any;
+  label: React.ReactNode;
   summaryNode: LayoutNodeFromType<'Summary'>;
   targetNode: LayoutNode;
   overrides: ISummaryComponent['overrides'];
@@ -72,6 +73,7 @@ export function SummaryBoilerplate({
           <EditButton
             onClick={onChangeClick}
             editText={changeText}
+            label={getPlainTextFromNode(label)}
           />
         )}
       </div>


### PR DESCRIPTION
## Description
Added aria-label to edit button in summary page. 

This makes it easier for users with screen reader to understand which component the edit button belongs to.

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes #1100 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [x] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
