### PR TITLE
DevTools: Basic expression playground

### DIFF
--- a/src/features/devtools/DevToolsControls.tsx
+++ b/src/features/devtools/DevToolsControls.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Tabs } from '@digdir/design-system-react';
 
 import { DevNavigationButtons } from 'src/features/devtools/components/DevNavigationButtons/DevNavigationButtons';
+import { ExpressionPlayground } from 'src/features/devtools/components/ExpressionPlayground/ExpressionPlayground';
 import { LayoutInspector } from 'src/features/devtools/components/LayoutInspector/LayoutInspector';
 import { PDFPreviewButton } from 'src/features/devtools/components/PDFPreviewButton/PDFPreviewButton';
 import classes from 'src/features/devtools/DevTools.module.css';
@@ -23,6 +24,10 @@ export const DevToolsControls = () => (
         {
           name: 'Komponenter',
           content: <LayoutInspector />,
+        },
+        {
+          name: 'Test uttrykk',
+          content: <ExpressionPlayground />,
         },
       ]}
     />

--- a/src/features/devtools/components/ExpressionPlayground/ExpressionPlayground.module.css
+++ b/src/features/devtools/components/ExpressionPlayground/ExpressionPlayground.module.css
@@ -1,0 +1,29 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 100%;
+  gap: 6px;
+}
+
+.textbox {
+  width: 100%;
+  height: 100%;
+  font-family: monospace;
+  line-height: 1.2;
+  resize: none;
+  font-size: 1rem;
+  outline: none;
+  white-space: pre;
+  overflow-wrap: normal;
+  overflow-x: auto;
+  padding: 8px;
+  border: none;
+}
+
+.input {
+}
+
+.output {
+  background: transparent;
+}

--- a/src/features/devtools/components/ExpressionPlayground/ExpressionPlayground.tsx
+++ b/src/features/devtools/components/ExpressionPlayground/ExpressionPlayground.tsx
@@ -1,0 +1,96 @@
+import React, { useEffect } from 'react';
+
+import cn from 'classnames';
+
+import classes from 'src/features/devtools/components/ExpressionPlayground/ExpressionPlayground.module.css';
+import { SplitView } from 'src/features/devtools/components/SplitView/SplitView';
+import { evalExpr } from 'src/features/expressions';
+import { ExprVal } from 'src/features/expressions/types';
+import { asExpression } from 'src/features/expressions/validation';
+import { useAppSelector } from 'src/hooks/useAppSelector';
+import { dataSourcesFromState, resolvedLayoutsFromState } from 'src/utils/layout/hierarchy';
+import type { ExprConfig, Expression } from 'src/features/expressions/types';
+import type { IAltinnWindow } from 'src/types';
+import type { LayoutNode } from 'src/utils/layout/LayoutNode';
+import type { LayoutPage } from 'src/utils/layout/LayoutPage';
+export const ExpressionPlayground = () => {
+  const [input, setInput] = React.useState('');
+  const [output, setOutput] = React.useState('');
+  const [isError, setIsError] = React.useState(false);
+
+  const formData = useAppSelector((state) => state.formData.formData);
+
+  useEffect(() => {
+    if (input.length > 0) {
+      try {
+        let maybeExpression: string;
+        try {
+          maybeExpression = JSON.parse(input);
+        } catch (e) {
+          throw new Error('Ugyldig JSON');
+        }
+        const forComponentId = null;
+
+        const config: ExprConfig<ExprVal.Any> = {
+          returnType: ExprVal.Any,
+          defaultValue: null,
+          resolvePerRow: false,
+        };
+
+        const expr = asExpression(maybeExpression, config);
+        if (!expr) {
+          throw new Error('Ugyldig uttrykk');
+        }
+
+        const state = (window as unknown as IAltinnWindow).reduxStore.getState();
+        const nodes = resolvedLayoutsFromState(state);
+        let layout: LayoutPage | LayoutNode | undefined = nodes?.current();
+        if (!layout) {
+          throw new Error('Unable to find current page/layout');
+        }
+
+        if (forComponentId) {
+          const foundNode = nodes?.findById(forComponentId);
+          if (!foundNode) {
+            throw new Error(`
+              Unable to find component with id:  
+              ${forComponentId}\n
+              Available components on the current page: 
+             ${layout?.flat(true).map((c) => c.item.id)}
+            `);
+          }
+          layout = foundNode;
+        }
+
+        const dataSources = dataSourcesFromState(state);
+        const out = evalExpr(expr as Expression, layout, dataSources, { config });
+        setOutput(out);
+        setIsError(false);
+      } catch (e) {
+        setOutput(e.message);
+        setIsError(true);
+      }
+    } else {
+      setOutput('');
+      setIsError(false);
+    }
+  }, [input, formData]);
+
+  return (
+    <div className={classes.container}>
+      <SplitView direction='column'>
+        <textarea
+          className={cn(classes.textbox, classes.input)}
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+        />
+        <textarea
+          style={{ color: isError ? 'red' : 'black' }}
+          className={cn(classes.textbox, classes.output)}
+          readOnly={true}
+          value={output}
+        />
+      </SplitView>
+    </div>
+  );
+};

--- a/src/features/devtools/components/ExpressionPlayground/ExpressionPlayground.tsx
+++ b/src/features/devtools/components/ExpressionPlayground/ExpressionPlayground.tsx
@@ -46,16 +46,16 @@ export const ExpressionPlayground = () => {
         const nodes = resolvedLayoutsFromState(state);
         let layout: LayoutPage | LayoutNode | undefined = nodes?.current();
         if (!layout) {
-          throw new Error('Unable to find current page/layout');
+          throw new Error('Fant ikke nåværende side/layout');
         }
 
         if (forComponentId) {
           const foundNode = nodes?.findById(forComponentId);
           if (!foundNode) {
             throw new Error(`
-              Unable to find component with id:  
+              Fant ingen komponent med id:
               ${forComponentId}\n
-              Available components on the current page: 
+              Tilgjengelige komponenter på nåværende side:
              ${layout?.flat(true).map((c) => c.item.id)}
             `);
           }

--- a/src/features/devtools/components/LayoutInspector/LayoutInspector.module.css
+++ b/src/features/devtools/components/LayoutInspector/LayoutInspector.module.css
@@ -44,12 +44,14 @@
   flex-direction: column;
   width: 100%;
   height: 100%;
+  background: white;
+  padding: 4px;
 }
 
 .properties > textarea {
+  background: transparent;
   font-family: monospace;
   line-height: 1.2;
-  background: transparent;
   flex: 1;
   resize: none;
   font-size: 0.8rem;


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

This is the basic expression playground I showed in today's demo. It currently only supports "global" expressions (you cannot select a component to run it from). My current thought is to be able to choose a component in the future, maybe adding a button to the layout inspector that will open the expression playground with that component selected, or maybe just add a dropdown. Even though this is missing in this first version, I think it still adds a lot of value for very little effort so I thought I may as well just release what I have now.

I don't expect a thorough review, but I mostly copied the code from the window.evalExpression, and just hardcoded the forComponentId to null, so it is quite trivial to add support for selecting a component later.