### PR TITLE
Enable DevTools button in Studio preview

### DIFF
--- a/src/features/devtools/DevTools.tsx
+++ b/src/features/devtools/DevTools.tsx
@@ -4,7 +4,8 @@ import type { ReactNode } from 'react';
 import { OpenDevToolsButton } from 'src/features/devtools/components/OpenDevToolsButton/OpenDevToolsButton';
 import { DevToolsPanel } from 'src/features/devtools/DevToolsPanel';
 
-const localEnv = window.location.hostname === 'local.altinn.cloud';
+const devHostNames = ['local.altinn.cloud', 'dev.altinn.studio', 'altinn.studio', 'studio.localhost'];
+const shouldShowButton = devHostNames.includes(window.location.hostname);
 
 interface IDevToolsProps {
   children: ReactNode;
@@ -26,7 +27,7 @@ export const DevTools = ({ children }: IDevToolsProps) => {
 
   return (
     <>
-      {localEnv && (
+      {shouldShowButton && (
         <OpenDevToolsButton
           isHidden={panelOpen}
           onClick={() => setPanelOpen(true)}


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

This adds Altinn Studio to the list of hostnames that should display the devtools button in addition to `local.altinn.cloud`. Tested by @standeren .
