### PR TITLE
Ensure to use the profile or selectedAppLanguage when format the dates

### DIFF
--- a/src/features/formData/update/updateFormDataSagas.ts
+++ b/src/features/formData/update/updateFormDataSagas.ts
@@ -90,7 +90,14 @@ function* runValidations(field: string, data: any, componentId: string | undefin
   );
 
   const componentValidations = validationResult?.validations[layoutId][componentId];
-  const componentSpecificValidations = validateComponentSpecificValidations(data, component, state.language.language);
+
+  const profileLanguage = state.profile.selectedAppLanguage || state.profile.profile.profileSettingPreference.language;
+  const componentSpecificValidations = validateComponentSpecificValidations(
+    data,
+    component,
+    state.language.language,
+    profileLanguage,
+  );
   const mergedValidations = mergeComponentValidations(componentValidations ?? {}, componentSpecificValidations);
 
   const invalidDataComponents = state.formValidations.invalidDataTypes || [];

--- a/src/layout/Datepicker/DatepickerComponent.tsx
+++ b/src/layout/Datepicker/DatepickerComponent.tsx
@@ -6,6 +6,7 @@ import { KeyboardDatePicker, MuiPickersUtilsProvider } from '@material-ui/picker
 import moment from 'moment';
 import type { MaterialUiPickersDate } from '@material-ui/pickers/typings/date';
 
+import { useAppSelector } from 'src/hooks/useAppSelector';
 import { useDelayedSavedState } from 'src/hooks/useDelayedSavedState';
 import { getLanguageFromKey } from 'src/language/sharedLanguage';
 import { getDateConstraint, getDateFormat, getDateString } from 'src/utils/dateHelpers';
@@ -113,12 +114,14 @@ export function DatepickerComponent({
   getTextResourceAsString,
 }: IDatepickerProps) {
   const classes = useStyles();
+  const profile = useAppSelector((state) => state.profile);
+  const languageLocale = profile.selectedAppLanguage || profile.profile.profileSettingPreference.language;
   const { minDate, maxDate, format, timeStamp = true, readOnly, required, id, textResourceBindings } = node.item;
 
   const calculatedMinDate = getDateConstraint(minDate, 'min');
   const calculatedMaxDate = getDateConstraint(maxDate, 'max');
 
-  const calculatedFormat = getDateFormat(format);
+  const calculatedFormat = getDateFormat(format, languageLocale);
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 

--- a/src/layout/Datepicker/index.tsx
+++ b/src/layout/Datepicker/index.tsx
@@ -4,6 +4,7 @@ import { useAppSelector } from 'src/hooks/useAppSelector';
 import { DatepickerComponent } from 'src/layout/Datepicker/DatepickerComponent';
 import { FormComponent } from 'src/layout/LayoutComponent';
 import { SummaryItemSimple } from 'src/layout/Summary/SummaryItemSimple';
+import { appLanguageStateSelector } from 'src/selectors/appLanguageStateSelector';
 import { getDateFormat } from 'src/utils/dateHelpers';
 import { formatISOString } from 'src/utils/formatDate';
 import type { PropsFromGenericComponent } from 'src/layout';
@@ -17,9 +18,7 @@ export class Datepicker extends FormComponent<'Datepicker'> {
 
   useDisplayData(node: LayoutNodeFromType<'Datepicker'>): string {
     const formData = useAppSelector((state) => state.formData.formData);
-    const language = useAppSelector(
-      (state) => state.profile.selectedAppLanguage || state.profile.profile.profileSettingPreference.language,
-    );
+    const language = useAppSelector(appLanguageStateSelector);
     if (!node.item.dataModelBindings?.simpleBinding) {
       return '';
     }

--- a/src/layout/Datepicker/index.tsx
+++ b/src/layout/Datepicker/index.tsx
@@ -17,11 +17,14 @@ export class Datepicker extends FormComponent<'Datepicker'> {
 
   useDisplayData(node: LayoutNodeFromType<'Datepicker'>): string {
     const formData = useAppSelector((state) => state.formData.formData);
+    const language = useAppSelector(
+      (state) => state.profile.selectedAppLanguage || state.profile.profile.profileSettingPreference.language,
+    );
     if (!node.item.dataModelBindings?.simpleBinding) {
       return '';
     }
 
-    const dateFormat = getDateFormat(node.item.format);
+    const dateFormat = getDateFormat(node.item.format, language);
     const data = formData[node.item.dataModelBindings?.simpleBinding] || '';
     return formatISOString(data, dateFormat) ?? data;
   }

--- a/src/layout/InstanceInformation/InstanceInformationComponent.tsx
+++ b/src/layout/InstanceInformation/InstanceInformationComponent.tsx
@@ -51,12 +51,16 @@ export function InstanceInformationComponent({ node }: PropsFromGenericComponent
   const instance: IInstance | null = useAppSelector((state: IRuntimeState) => state.instanceData.instance);
   const parties: IParty[] | null = useAppSelector((state: IRuntimeState) => state.party.parties);
   const language: ILanguage | null = useAppSelector((state) => state.language.language);
+  const profileLanguage = useAppSelector(
+    (state) => state.profile.selectedAppLanguage || state.profile.profile.profileSettingPreference.language,
+  );
   const appReceiver = useAppSelector(selectAppReceiver);
 
   const instanceOwnerParty =
     instance && parties?.find((party: IParty) => party.partyId.toString() === instance.instanceOwner.partyId);
 
-  const instanceDateSent = dateSent !== false && Moment(instance?.lastChanged).format(getDateFormat());
+  const instanceDateSent =
+    dateSent !== false && Moment(instance?.lastChanged).format(getDateFormat(undefined, profileLanguage));
 
   const instanceSender =
     sender !== false &&

--- a/src/layout/InstanceInformation/InstanceInformationComponent.tsx
+++ b/src/layout/InstanceInformation/InstanceInformationComponent.tsx
@@ -8,6 +8,7 @@ import type { PropsFromGenericComponent } from '..';
 import { AltinnSummaryTable } from 'src/components/table/AltinnSummaryTable';
 import { useAppSelector } from 'src/hooks/useAppSelector';
 import { getLanguageFromKey } from 'src/language/sharedLanguage';
+import { appLanguageStateSelector } from 'src/selectors/appLanguageStateSelector';
 import { selectAppReceiver } from 'src/selectors/language';
 import { getDateFormat } from 'src/utils/dateHelpers';
 import type { IRuntimeState } from 'src/types';
@@ -51,9 +52,7 @@ export function InstanceInformationComponent({ node }: PropsFromGenericComponent
   const instance: IInstance | null = useAppSelector((state: IRuntimeState) => state.instanceData.instance);
   const parties: IParty[] | null = useAppSelector((state: IRuntimeState) => state.party.parties);
   const language: ILanguage | null = useAppSelector((state) => state.language.language);
-  const profileLanguage = useAppSelector(
-    (state) => state.profile.selectedAppLanguage || state.profile.profile.profileSettingPreference.language,
-  );
+  const profileLanguage = useAppSelector(appLanguageStateSelector);
   const appReceiver = useAppSelector(selectAppReceiver);
 
   const instanceOwnerParty =

--- a/src/utils/dateHelpers.test.ts
+++ b/src/utils/dateHelpers.test.ts
@@ -5,6 +5,7 @@ import {
   DatepickerMaxDateDefault,
   DatepickerMinDateDefault,
   getDateConstraint,
+  getDateFormat,
   getDateString,
   getISOString,
 } from 'src/utils/dateHelpers';
@@ -33,6 +34,29 @@ describe('dateHelpers', () => {
       expect(moment(result).isSame(validISOString, 'day')).toEqual(true);
     });
   });
+
+  describe('getDateFormat', () => {
+    it('should return format if format is provided', () => {
+      const result = getDateFormat('YYYY-MM-DD');
+      expect(result).toEqual('YYYY-MM-DD');
+    });
+
+    it('should return english format', () => {
+      const result = getDateFormat(undefined, 'en');
+      expect(result).toEqual('MM/DD/YYYY');
+    });
+
+    it('should return norwegian format', () => {
+      const result = getDateFormat(undefined, 'nb');
+      expect(result).toEqual('DD.MM.YYYY');
+    });
+
+    it('should return norwegian format as default', () => {
+      const result = getDateFormat(undefined, undefined);
+      expect(result).toEqual('DD.MM.YYYY');
+    });
+  });
+
   describe('getDateString', () => {
     it.each([true, false])('should return a string that can be parsed as ISO_8601', (timestamp) => {
       const date = moment();

--- a/src/utils/dateHelpers.ts
+++ b/src/utils/dateHelpers.ts
@@ -21,8 +21,11 @@ export function getISOString(potentialDate: string | undefined): string | undefi
 const locale = window.navigator?.language || (window.navigator as any)?.userLanguage || 'nb';
 moment.locale(locale);
 
-export function getDateFormat(format?: string): string {
-  return moment.localeData().longDateFormat('L') || format || DatepickerFormatDefault;
+export function getDateFormat(format?: string, selectedLanguage = 'nb'): string {
+  if (format) {
+    return format;
+  }
+  return moment.localeData(selectedLanguage).longDateFormat('L') || DatepickerFormatDefault;
 }
 
 export function getDateString(date: moment.Moment | null, timestamp: boolean) {

--- a/src/utils/validation/runClientSideValidation.ts
+++ b/src/utils/validation/runClientSideValidation.ts
@@ -61,6 +61,7 @@ export function runClientSideValidation(state: IRuntimeState): ValidationResult 
     layouts,
     layoutOrder,
     state.language.language,
+    state.profile.selectedAppLanguage || state.profile.profile.profileSettingPreference.language,
   );
   out.emptyFieldsValidations = validateEmptyFields(
     state.formData.formData,

--- a/src/utils/validation/validation.test.ts
+++ b/src/utils/validation/validation.test.ts
@@ -760,6 +760,7 @@ describe('utils > validation', () => {
         toCollection(mockLayout),
         Object.keys(mockLayoutState.layouts),
         mockLanguage.language,
+        'nb',
       );
 
       const mockResult = {
@@ -785,6 +786,7 @@ describe('utils > validation', () => {
         toCollection(mockLayout),
         Object.keys(mockLayoutState.layouts),
         mockLanguage.language,
+        'nb',
       );
 
       const mockResult = {
@@ -818,6 +820,7 @@ describe('utils > validation', () => {
         toCollection(mockLayout),
         Object.keys(mockLayout),
         mockLanguage.language,
+        'nb',
       );
 
       const mockResult = {
@@ -844,6 +847,7 @@ describe('utils > validation', () => {
         toCollection(mockLayout, {}, new Set(['componentId_4'])),
         Object.keys(mockLayout),
         mockLanguage.language,
+        'nb',
       );
 
       const mockResult = {
@@ -870,6 +874,7 @@ describe('utils > validation', () => {
         toCollection(mockLayout),
         [],
         mockLanguage.language,
+        'nb',
       );
 
       expect(componentSpecificValidations).toEqual({});
@@ -2500,6 +2505,7 @@ describe('utils > validation', () => {
           format: 'DD.MM.YYYY',
         } as ExprUnresolved<ILayoutCompDatepicker>,
         mockLanguage.language,
+        'nb',
       );
 
       expect(validations.simpleBinding).toEqual({
@@ -2516,6 +2522,7 @@ describe('utils > validation', () => {
           format: 'DD.MM.YYYY',
         } as ExprUnresolved<ILayoutCompDatepicker>,
         mockLanguage.language,
+        'nb',
       );
 
       expect(validations.simpleBinding).toEqual({
@@ -2532,6 +2539,7 @@ describe('utils > validation', () => {
           format: 'DD.MM.YYYY',
         } as ExprUnresolved<ILayoutCompDatepicker>,
         mockLanguage.language,
+        'nb',
       );
 
       expect(validations.simpleBinding).toEqual({
@@ -2548,6 +2556,7 @@ describe('utils > validation', () => {
           format: 'DD.MM.YYYY',
         } as ExprUnresolved<ILayoutCompDatepicker>,
         mockLanguage.language,
+        'nb',
       );
 
       expect(validations.simpleBinding).toEqual({
@@ -2564,6 +2573,7 @@ describe('utils > validation', () => {
           format: 'DD.MM.YYYY',
         } as ExprUnresolved<ILayoutCompDatepicker>,
         mockLanguage.language,
+        'nb',
       );
 
       expect(validations.simpleBinding).toEqual({
@@ -2580,6 +2590,7 @@ describe('utils > validation', () => {
           format: 'DD.MM.YYYY',
         } as ExprUnresolved<ILayoutCompDatepicker>,
         mockLanguage.language,
+        'nb',
       );
 
       expect(validations.simpleBinding).toEqual({
@@ -2596,6 +2607,7 @@ describe('utils > validation', () => {
           format: 'DD.MM.YYYY',
         } as ExprUnresolved<ILayoutCompDatepicker>,
         mockLanguage.language,
+        'nb',
       );
 
       expect(validations.simpleBinding).toEqual({
@@ -2612,6 +2624,7 @@ describe('utils > validation', () => {
           format: 'DD.MM.YYYY',
         } as ExprUnresolved<ILayoutCompDatepicker>,
         mockLanguage.language,
+        'nb',
       );
 
       expect(validations.simpleBinding).toEqual({


### PR DESCRIPTION
## Description

Using the user's profile or the selected app language to format dates accurately. Using the appropriate language setting is crucial to ensure that dates are displayed correctly in the user's desired format.

![image](https://user-images.githubusercontent.com/46874830/235133549-cec69100-8710-473a-92cc-cf53c35a167a.png)
<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

The PR itself.

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
