### PR TITLE
fix font-size in errorReport + material-ui to css-modules

### DIFF
--- a/src/components/message/ErrorReport.module.css
+++ b/src/components/message/ErrorReport.module.css
@@ -1,0 +1,28 @@
+.errorList {
+  list-style-position: outside;
+  margin-left: 24px;
+}
+
+.errorList li {
+  margin-bottom: 8px;
+}
+.errorList span {
+  font-size: 1rem;
+}
+.errorList button {
+  text-align: left;
+  border-bottom: 2px solid transparent;
+}
+
+.errorList button:hover {
+  border-bottom: 2px solid black;
+}
+
+.buttonAsInvisibleLink {
+  display: inline;
+  margin: 0;
+  padding: 0;
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+}

--- a/src/components/message/ErrorReport.tsx
+++ b/src/components/message/ErrorReport.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 
 import { Panel, PanelVariant } from '@altinn/altinn-design-system';
-import { Grid, makeStyles } from '@material-ui/core';
+import { Grid } from '@material-ui/core';
 
 import { FullWidthWrapper } from 'src/components/form/FullWidthWrapper';
+import classes from 'src/components/message/ErrorReport.module.css';
 import { FormLayoutActions } from 'src/features/layout/formLayoutSlice';
 import { useAppDispatch } from 'src/hooks/useAppDispatch';
 import { useAppSelector } from 'src/hooks/useAppSelector';
@@ -19,40 +20,12 @@ export interface IErrorReportProps {
   nodes: LayoutNode[];
 }
 
-const iconSize = 16;
-const ArrowForwardIcon = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="${iconSize}" style="position: relative; top: 2px">
-  <path d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"></path>
+const ArrowForwardSvg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16px" style="position: relative; top: 2px">
+<path d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"></path>
 </svg>`;
-
-const useStyles = makeStyles((theme) => ({
-  errorList: {
-    listStylePosition: 'outside',
-    marginLeft: iconSize + theme.spacing(1),
-    listStyleImage: `url("data:image/svg+xml,${encodeURIComponent(ArrowForwardIcon)}")`,
-    '& > li': {
-      marginBottom: theme.spacing(1),
-    },
-    '& > li > button': {
-      textAlign: 'left',
-      borderBottom: '2px solid transparent',
-    },
-    '& > li > button:hover': {
-      borderBottom: `2px solid black`,
-    },
-  },
-  buttonAsInvisibleLink: {
-    backgroundColor: 'transparent',
-    border: 'none',
-    cursor: 'pointer',
-    textDecoration: 'none',
-    display: 'inline',
-    margin: 0,
-    padding: 0,
-  },
-}));
+const listStyleImg = `url("data:image/svg+xml,${encodeURIComponent(ArrowForwardSvg)}")`;
 
 export const ErrorReport = ({ nodes }: IErrorReportProps) => {
-  const classes = useStyles();
   const dispatch = useAppDispatch();
   const currentView = useAppSelector((state) => state.formLayout.uiConfig.currentView);
   const [errorsMapped, errorsUnmapped] = useAppSelector((state) => [
@@ -142,14 +115,20 @@ export const ErrorReport = ({ nodes }: IErrorReportProps) => {
             >
               <ul className={classes.errorList}>
                 {errorsUnmapped.map((error: string) => (
-                  <li key={`unmapped-${error}`}>
+                  <li
+                    key={`unmapped-${error}`}
+                    style={{ listStyleImage: listStyleImg }}
+                  >
                     {getParsedLanguageFromText(error, {
                       disallowedTags: ['a'],
                     })}
                   </li>
                 ))}
                 {errorsMapped.map((error) => (
-                  <li key={`mapped-${error.componentId}-${error.message}`}>
+                  <li
+                    key={`mapped-${error.componentId}-${error.message}`}
+                    style={{ listStyleImage: listStyleImg }}
+                  >
                     <button
                       className={classes.buttonAsInvisibleLink}
                       onClick={handleErrorClick(error)}


### PR DESCRIPTION
## Description
Resized font in list-items in error report - were too small. Also moved some material-ui to css-modules.


<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
