### PR TITLE
Fix `smartLowerCaseFirst()` crashing

### DIFF
--- a/src/utils/formComponentUtils.test.ts
+++ b/src/utils/formComponentUtils.test.ts
@@ -256,6 +256,8 @@ describe('formComponentUtils', () => {
       { input: 'SaaB', expected: 'SaaB' },
       { input: 'S.a.a.B', expected: 'S.a.a.B' },
       { input: '¿Cómo te llamas?', expected: '¿cómo te llamas?' },
+      { input: undefined, expected: undefined },
+      { input: '', expected: '' },
     ])('Should convert $input to $expected', ({ input, expected }) => {
       expect(smartLowerCaseFirst(input)).toEqual(expected);
     });

--- a/src/utils/formComponentUtils.ts
+++ b/src/utils/formComponentUtils.ts
@@ -168,6 +168,9 @@ export function getFieldName(
  * Un-uppercase the first letter of a string
  */
 export function lowerCaseFirst(text: string, firstLetterIndex = 0): string {
+  if (text.length <= firstLetterIndex) {
+    return text;
+  }
   if (firstLetterIndex > 0) {
     return (
       text.substring(0, firstLetterIndex) + text[firstLetterIndex].toLowerCase() + text.substring(firstLetterIndex + 1)
@@ -183,6 +186,10 @@ export function lowerCaseFirst(text: string, firstLetterIndex = 0): string {
 export function smartLowerCaseFirst(text: string | undefined): string | undefined {
   if (text === undefined) {
     return undefined;
+  }
+
+  if (text.length === 0) {
+    return text;
   }
 
   const uc = text.toUpperCase();


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

If you pass an empty string as the field key for validation the `smartLowerCaseFirst()` function crashes as this edge case was not handled. This fixes the edge case and adds a test case for it.

## Related Issue(s)

- https://altinn.slack.com/archives/C02ESDSC929/p1683185354761459

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
