### PR TITLE
Support description and help text in options from repeating groups

### DIFF
--- a/src/hooks/useOptionList.ts
+++ b/src/hooks/useOptionList.ts
@@ -20,12 +20,12 @@ export function useOptionList(component: ISelectionComponent): IOption[] {
     return options[key]?.options || [];
   }
   if (component.source) {
-    const relevantTextResource = textResources.find((e) => e.id === component.source?.label);
+    const relevantTextResourceLabel = textResources.find((e) => e.id === component.source?.label);
     const reduxOptions =
-      relevantTextResource &&
+      relevantTextResourceLabel &&
       setupSourceOptions({
         source: component.source,
-        relevantTextResource,
+        relevantTextResources: { label: relevantTextResourceLabel },
         relevantFormData: getRelevantFormDataForOptionSource(formData, component.source),
         repeatingGroups,
         dataSources: {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -101,6 +101,8 @@ export interface IOptionSource {
   group: string;
   label: string;
   value: string;
+  description?: string;
+  helpText?: string;
 }
 
 export interface IOptionsActualData {

--- a/src/utils/options.test.ts
+++ b/src/utils/options.test.ts
@@ -196,7 +196,7 @@ describe('utils > options', () => {
         label: 'dropdown.label',
         value: 'someGroup[{0}].fieldUsedAsValue',
       };
-      const relevantTextResource: ITextResource = {
+      const relevantTextResourceLabel: ITextResource = {
         id: 'dropdown.label',
         value: '{0}',
         unparsedValue: '{0}',
@@ -228,7 +228,7 @@ describe('utils > options', () => {
 
       const options = setupSourceOptions({
         source,
-        relevantTextResource,
+        relevantTextResources: { label: relevantTextResourceLabel },
         relevantFormData,
         repeatingGroups,
         dataSources,

--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -11,6 +11,7 @@ import {
   replaceIndexIndicatorsWithIndexes,
 } from 'src/utils/databindings';
 import type { IFormData } from 'src/features/formData';
+import type { IOptionResources } from 'src/hooks/useGetOptions';
 import type { ILayout } from 'src/layout/layout';
 import type {
   IMapping,
@@ -104,7 +105,7 @@ export function getRelevantFormDataForOptionSource(formData: IFormData, source: 
 
 interface ISetupSourceOptionsParams {
   source: IOptionSource;
-  relevantTextResource: ITextResource;
+  relevantTextResources: IOptionResources;
   relevantFormData: IFormData;
   repeatingGroups: IRepeatingGroups | null;
   dataSources: IDataSources;
@@ -115,12 +116,20 @@ interface ISetupSourceOptionsParams {
  */
 export function setupSourceOptions({
   source,
-  relevantTextResource,
+  relevantTextResources,
   relevantFormData,
   repeatingGroups,
   dataSources,
 }: ISetupSourceOptionsParams) {
-  const replacedOptionLabels = replaceTextResourceParams([relevantTextResource], dataSources, repeatingGroups);
+  const replacedOptionLabels = relevantTextResources.label
+    ? replaceTextResourceParams([relevantTextResources.label], dataSources, repeatingGroups)
+    : [];
+  const replacedOptionDescriptions = relevantTextResources.description
+    ? replaceTextResourceParams([relevantTextResources.description], dataSources, repeatingGroups)
+    : [];
+  const replacedOptionLabelsHelpTexts = relevantTextResources.helpText
+    ? replaceTextResourceParams([relevantTextResources.helpText], dataSources, repeatingGroups)
+    : [];
 
   const repGroup = Object.values(repeatingGroups || {}).find((group) => group.dataModelBinding === source.group);
 
@@ -132,8 +141,10 @@ export function setupSourceOptions({
   for (let i = 0; i <= repGroup.index; i++) {
     if (typeof replacedOptionLabels[i + 1]?.value !== 'undefined') {
       const option: IOption = {
-        label: replacedOptionLabels[i + 1].value,
         value: replaceOptionDataField(relevantFormData, source.value, i),
+        label: replacedOptionLabels[i + 1].value,
+        description: replacedOptionDescriptions[i + 1]?.value ?? undefined,
+        helpText: replacedOptionLabelsHelpTexts[i + 1]?.value ?? undefined,
       };
       options.push(option);
     }


### PR DESCRIPTION
## Description
Adds `helpText` and `description` to the `source` parameter used to get options from repeating groups.
<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [ ] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
