### PR TITLE
Reintroduce panel body to panel groups that use children

### DIFF
--- a/src/layout/Panel/Panel.module.css
+++ b/src/layout/Panel/Panel.module.css
@@ -1,3 +1,7 @@
 .panelPadding > div {
   --panel-x-padding: var(--modal-padding-x) !important;
 }
+
+.panelBodyText {
+  padding: 12px;
+}

--- a/src/layout/Panel/PanelGroupContainer.test.tsx
+++ b/src/layout/Panel/PanelGroupContainer.test.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+
+import { screen } from '@testing-library/react';
+
+import { getInitialStateMock } from 'src/__mocks__/initialStateMock';
+import { PanelReferenceGroupContainer } from 'src/layout/Panel/PanelReferenceGroupContainer';
+import { renderWithProviders } from 'src/testUtils';
+import type { ExprUnresolved } from 'src/features/expressions/types';
+import type { ILayoutState } from 'src/features/layout/formLayoutSlice';
+import type { ILayoutGroup } from 'src/layout/Group/types';
+import type { ILayout } from 'src/layout/layout';
+import type { RootState } from 'src/redux/store';
+
+describe('PanelGroupContainer', () => {
+  const initialState = getInitialStateMock();
+  const container: ExprUnresolved<ILayoutGroup> = {
+    id: 'group',
+    type: 'Group',
+    children: ['input1', 'input2'],
+    textResourceBindings: {
+      title: 'Title for PanelGoup',
+      body: 'Body for PanelGroup',
+    },
+    panel: {
+      variant: 'info',
+    },
+  };
+
+  const groupComponents: ILayout = [
+    {
+      id: 'input1',
+      type: 'Input',
+      dataModelBindings: {
+        simpleBinding: 'something',
+      },
+      textResourceBindings: {
+        title: 'Title for first input',
+      },
+      readOnly: false,
+      required: false,
+      disabled: false,
+    },
+    {
+      id: 'input2',
+      type: 'Input',
+      dataModelBindings: {
+        simpleBinding: 'something.else',
+      },
+      textResourceBindings: {
+        title: 'Title for second input',
+      },
+      readOnly: false,
+      required: false,
+      disabled: false,
+    },
+  ];
+
+  const state: ILayoutState = {
+    layouts: {
+      FormLayout: [],
+    },
+    uiConfig: {
+      ...initialState.formLayout.uiConfig,
+      hiddenFields: [],
+      currentView: 'FormLayout',
+    },
+    error: null,
+    layoutsets: null,
+  };
+
+  it('should display panel with group children', async () => {
+    render({
+      container,
+      components: groupComponents,
+      customState: {
+        formLayout: state,
+      },
+    });
+
+    const customIcon = screen.queryByTestId('panel-group-container');
+    expect(customIcon).toBeInTheDocument();
+
+    const firstInputTitle = screen.queryByText('Title for first input');
+    expect(firstInputTitle).toBeInTheDocument();
+
+    const secondInputTitle = screen.queryByText('Title for second input');
+    expect(secondInputTitle).toBeInTheDocument();
+  });
+
+  it('should display title and body', async () => {
+    render({
+      container,
+      components: groupComponents,
+      customState: {
+        formLayout: state,
+      },
+    });
+
+    const title = screen.queryByText('Title for PanelGoup');
+    expect(title).toBeInTheDocument();
+
+    const body = screen.queryByText('Body for PanelGroup');
+    expect(body).toBeInTheDocument();
+  });
+});
+
+interface TestProps {
+  container: ExprUnresolved<ILayoutGroup>;
+  components?: ILayout | undefined;
+  customState?: Partial<RootState>;
+}
+
+const render = ({ container, components, customState }: TestProps) => {
+  let preloadedState = getInitialStateMock() as RootState;
+  preloadedState = {
+    ...preloadedState,
+    ...customState,
+  };
+  const formLayout = preloadedState.formLayout.layouts && preloadedState.formLayout.layouts['FormLayout'];
+  container && formLayout?.push(container);
+  formLayout?.push(...(components || []));
+
+  renderWithProviders(<PanelReferenceGroupContainer id={'group'} />, { preloadedState });
+};

--- a/src/layout/Panel/PanelGroupContainer.tsx
+++ b/src/layout/Panel/PanelGroupContainer.tsx
@@ -66,7 +66,7 @@ export const PanelGroupContainer = ({ node }: PanelGroupConatinerProps) => {
             spacing={3}
             data-testid='panel-group-container'
           >
-            <span className={classes.panelBodyText}>{texts.body}</span>
+            {texts.body && <span className={classes.panelBodyText}>{texts.body}</span>}
             {node.children().map((child) => (
               <GenericComponent
                 key={node.item.id}

--- a/src/layout/Panel/PanelGroupContainer.tsx
+++ b/src/layout/Panel/PanelGroupContainer.tsx
@@ -13,6 +13,7 @@ import classes from 'src/layout/Panel/Panel.module.css';
 import { selectComponentTexts } from 'src/utils/formComponentUtils';
 import { LayoutPage } from 'src/utils/layout/LayoutPage';
 import type { LayoutNodeFromType } from 'src/utils/layout/hierarchy.types';
+
 interface PanelGroupConatinerProps {
   node: LayoutNodeFromType<'Group'>;
 }
@@ -65,6 +66,7 @@ export const PanelGroupContainer = ({ node }: PanelGroupConatinerProps) => {
             spacing={3}
             data-testid='panel-group-container'
           >
+            <span className={classes.panelBodyText}>{texts.body}</span>
             {node.children().map((child) => (
               <GenericComponent
                 key={node.item.id}


### PR DESCRIPTION
## Description
The use of the body textresource was omitted after updating panelgroup component to better suit the signing case. 

This PR reintroduces the use of the optional textresource in order to allow setting a body in the panelgroup when using children to specify the groups components instead of groupReference.

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes https://github.com/Altinn/app-frontend-react/issues/1153

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [x] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
