### PR TITLE
Fixing sorting of active instance list

### DIFF
--- a/src/hooks/queries/useActiveInstancesQuery.ts
+++ b/src/hooks/queries/useActiveInstancesQuery.ts
@@ -17,6 +17,9 @@ export const useActiveInstancesQuery = (partyId?: string, enabled?: boolean): Us
   return useQuery([ServerStateCacheKey.GetActiveInstances], () => fetchActiveInstances(partyId || ''), {
     enabled,
     onSuccess: (instanceData) => {
+      // Sort array by last changed date
+      instanceData.sort((a, b) => new Date(a.lastChanged).getTime() - new Date(b.lastChanged).getTime());
+
       dispatch(InstanceDataActions.getFulfilled({ instanceData }));
     },
     onError: (error: HttpClientError) => {

--- a/test/e2e/integration/app-frontend/on-entry.ts
+++ b/test/e2e/integration/app-frontend/on-entry.ts
@@ -1,16 +1,28 @@
+import { v4 as uuidv4 } from 'uuid';
+
 import texts from 'test/e2e/fixtures/texts.json';
 import { AppFrontend } from 'test/e2e/pageobjects/app-frontend';
 
 const appFrontend = new AppFrontend();
 
 describe('On Entry', () => {
-  const instanceIdExample = '512345/58f1af2b-a90f-4828-8bf6-38fa24c51379';
+  const instanceIdExamples = [`512345/${uuidv4()}`, `512345/${uuidv4()}`, `512345/${uuidv4()}`];
   beforeEach(() => {
     cy.intercept('**/active', [
       {
-        id: instanceIdExample,
+        id: instanceIdExamples[0],
         lastChanged: '2021-04-06T14:11:02.6893987Z',
-        lastChangedBy: 'Ola Nordman',
+        lastChangedBy: 'Ola Nordmann',
+      },
+      {
+        id: instanceIdExamples[1],
+        lastChanged: '2022-04-06T14:11:02.6893987Z',
+        lastChangedBy: 'Foo Bar',
+      },
+      {
+        id: instanceIdExamples[2],
+        lastChanged: '2020-04-06T14:11:02.6893987Z',
+        lastChangedBy: 'Bar Baz',
       },
     ]);
   });
@@ -21,19 +33,21 @@ describe('On Entry', () => {
     cy.get(appFrontend.selectInstance.container).should('be.visible');
     cy.get(appFrontend.selectInstance.header).should('contain.text', texts.alreadyStartedForm);
     cy.get(appFrontend.selectInstance.description).should('contain.text', texts.continueOrStartNew);
-    cy.get(appFrontend.selectInstance.tableBody)
-      .find('tr')
-      .should('have.length', 1)
-      .first()
-      .then((activeInstance) => {
-        cy.wrap(activeInstance)
-          .find('td')
-          .eq(0)
-          .contains(/04\/06\/2021|06.04.2021/g);
-        cy.wrap(activeInstance).find('td').eq(1).should('have.text', 'Ola Nordman');
-        cy.wrap(activeInstance).find('td').eq(2).find('button').click();
-        cy.url().should('contain', instanceIdExample);
-      });
+    cy.get(appFrontend.selectInstance.tableBody).find('tr').should('have.length', instanceIdExamples.length);
+
+    // Verify order of rows (they should be sorted with the latest instance at the bottom)
+    cy.get(appFrontend.selectInstance.tableBody).find('tr').eq(0).should('contain.text', 'Bar Baz');
+    cy.get(appFrontend.selectInstance.tableBody).find('tr').eq(1).should('contain.text', 'Ola Nordmann');
+    cy.get(appFrontend.selectInstance.tableBody).find('tr').eq(2).should('contain.text', 'Foo Bar');
+
+    cy.get(appFrontend.selectInstance.tableBody).find('tr').eq(1).as('tableRow');
+    cy.get('@tableRow')
+      .find('td')
+      .eq(0)
+      .contains(/04\/06\/2021|06.04.2021/g);
+    cy.get('@tableRow').find('td').eq(1).should('have.text', 'Ola Nordmann');
+    cy.get('@tableRow').find('td').eq(2).find('button').click();
+    cy.url().should('contain', instanceIdExamples[0]);
   });
 
   it('is possible to create a new instance', () => {
@@ -43,6 +57,6 @@ describe('On Entry', () => {
     cy.intercept('POST', `/ttd/frontend-test/instances?instanceOwnerPartyId*`).as('createdInstance');
     cy.get(appFrontend.selectInstance.newInstance).click();
     cy.wait('@createdInstance').its('response.statusCode').should('eq', 201);
-    cy.url().should('not.contain', instanceIdExample);
+    cy.url().should('not.contain', instanceIdExamples[0]);
   });
 });


### PR DESCRIPTION
## Description
Sorting list of active instances before rendering instance selector (this was done before, but was probably missed during the query rewrite). Added regression test.

## Related Issue(s)

- https://altinn.slack.com/archives/C02ESDSGPN1/p1683879046181739

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
