### PR TITLE
Markdown/text formatting support in Grid cells + nesting fix

### DIFF
--- a/src/components/form/MessageBanner.tsx
+++ b/src/components/form/MessageBanner.tsx
@@ -4,12 +4,13 @@ import classNames from 'classnames';
 
 import classes from 'src/components/form/MessageBanner.module.css';
 import { getLanguageFromKey } from 'src/language/sharedLanguage';
+import type { ValidLanguageKey } from 'src/hooks/useLanguage';
 import type { ILanguage } from 'src/types/shared';
 
 interface IMessageBannerProps {
   language: ILanguage;
   error?: boolean;
-  messageKey: string;
+  messageKey: ValidLanguageKey;
 }
 
 export const MessageBanner = ({ language, error, messageKey }: IMessageBannerProps) => (

--- a/src/features/instantiate/containers/InstantiationErrorPage.tsx
+++ b/src/features/instantiate/containers/InstantiationErrorPage.tsx
@@ -7,7 +7,7 @@ import { AltinnError } from 'src/components/altinnError';
 import { InstantiationContainer } from 'src/features/instantiate/containers/InstantiationContainer';
 
 export type IInstantiationErrorPageProps = {
-  title: string | JSX.Element | JSX.Element[];
+  title: string | JSX.Element | JSX.Element[] | null;
   content: React.ReactNode;
   statusCode: string;
 } & RouteProps;

--- a/src/features/language/languageSlice.test.ts
+++ b/src/features/language/languageSlice.test.ts
@@ -17,7 +17,7 @@ describe('languageSlice', () => {
         },
       }),
     );
-    expect(nextState.language?.testKey).toEqual('test');
+    expect((nextState.language as any)?.testKey).toEqual('test');
     expect(nextState.error).toBeNull();
   });
 

--- a/src/hooks/useLanguage.ts
+++ b/src/hooks/useLanguage.ts
@@ -43,7 +43,7 @@ export function useLanguage(): IUseLanguage {
         return getParsedLanguageFromText(textResource);
       }
 
-      return getParsedLanguageFromKey(key, language, params, false);
+      return getParsedLanguageFromKey(key as ValidLanguageKey, language, params, false);
     },
     langAsString: (key, params) => {
       const textResource = getTextResourceByKey(key, textResources);
@@ -51,7 +51,7 @@ export function useLanguage(): IUseLanguage {
         return textResource;
       }
 
-      return getParsedLanguageFromKey(key, language, params, true);
+      return getParsedLanguageFromKey(key as ValidLanguageKey, language, params, true);
     },
   };
 }

--- a/src/hooks/useLanguage.ts
+++ b/src/hooks/useLanguage.ts
@@ -1,0 +1,57 @@
+import { useAppSelector } from 'src/hooks/useAppSelector';
+import { getParsedLanguageFromKey, getParsedLanguageFromText, getTextResourceByKey } from 'src/language/sharedLanguage';
+import type { FixedLanguageList } from 'src/language/languages';
+
+export interface IUseLanguage {
+  lang(key: ValidLanguageKey | string | undefined, params?: string[]): string | JSX.Element | JSX.Element[] | null;
+  langAsString(key: ValidLanguageKey | string | undefined, params?: string[]): string;
+}
+
+/**
+ * This type converts the language object into a dot notation union of valid language keys.
+ * Using this type helps us get suggestions for valid language keys in useLanguage() functions.
+ * Thanks to ChatGPT for refinements to make this work!
+ */
+type ObjectToDotNotation<T extends Record<string, any>, Prefix extends string = ''> = {
+  [K in keyof T]: K extends string
+    ? T[K] extends string | number | boolean | null | undefined
+      ? `${Prefix}${K}`
+      : K extends string
+      ? ObjectToDotNotation<T[K], `${Prefix}${K}.`>
+      : never
+    : never;
+}[keyof T];
+
+export type ValidLanguageKey = ObjectToDotNotation<FixedLanguageList>;
+
+/**
+ * Hook to resolve a key to a language string or React element (if the key is found and contains markdown or HTML).
+ * Prefer this over using the long-named language functions. When those are less used, we can refactor their
+ * functionality into this hook and remove them.
+ *
+ * You get two functions from this hook, and you can choose which one to use based on your needs:
+ * - lang(key, params) usually returns a React element
+ */
+export function useLanguage(): IUseLanguage {
+  const textResources = useAppSelector((state) => state.textResources.resources);
+  const language = useAppSelector((state) => state.language.language);
+
+  return {
+    lang: (key, params) => {
+      const textResource: string | undefined = getTextResourceByKey(key, textResources);
+      if (textResource !== key && textResource !== undefined) {
+        return getParsedLanguageFromText(textResource);
+      }
+
+      return getParsedLanguageFromKey(key, language, params, false);
+    },
+    langAsString: (key, params) => {
+      const textResource = getTextResourceByKey(key, textResources);
+      if (textResource !== key && textResource !== undefined) {
+        return textResource;
+      }
+
+      return getParsedLanguageFromKey(key, language, params, true);
+    },
+  };
+}

--- a/src/language/languages.ts
+++ b/src/language/languages.ts
@@ -2,6 +2,8 @@ import { en } from 'src/language/texts/en';
 import { nb } from 'src/language/texts/nb';
 import { nn } from 'src/language/texts/nn';
 
+export type FixedLanguageList = ReturnType<typeof en>;
+
 export function getLanguageFromCode(languageCode: string) {
   switch (languageCode) {
     case 'en':

--- a/src/language/sharedLanguage.ts
+++ b/src/language/sharedLanguage.ts
@@ -3,6 +3,7 @@ import parseHtmlToReact from 'html-react-parser';
 import { marked } from 'marked';
 import type { HTMLReactParserOptions } from 'html-react-parser';
 
+import type { ValidLanguageKey } from 'src/hooks/useLanguage';
 import type { IAltinnOrgs, IApplication, IDataSources, ILanguage, ITextResource } from 'src/types/shared';
 
 DOMPurify.addHook('afterSanitizeAttributes', (node) => {
@@ -27,37 +28,20 @@ DOMPurify.addHook('afterSanitizeAttributes', (node) => {
  * @deprecated Use lang() from useLanguage.ts instead
  * @see useLanguage
  */
-export function getLanguageFromKey<T extends string | undefined>(
-  key: T,
-  language: ILanguage | null,
-  allowObject: true,
-): string | T | ILanguage;
-export function getLanguageFromKey<T extends string | undefined>(key: T, language: ILanguage | null): string | T;
-export function getLanguageFromKey<T extends string | undefined>(
-  key: T,
-  language: ILanguage | null,
-  allowObject = false,
-) {
+export function getLanguageFromKey<T extends ValidLanguageKey | undefined>(key: T, language: ILanguage | null) {
   if (!key || !language) {
     return key;
   }
   const path = key.split('.');
-  const value = allowObject ? getNestedObject(language, path, true) : getNestedObject(language, path, false);
-  if (!value) {
+  const value = getNestedObject(language, path);
+  if (!value || typeof value === 'object') {
     return key;
   }
   return value;
 }
 
-function getNestedObject(nestedObj: ILanguage, pathArr: string[], allowObject: true): string | ILanguage;
-function getNestedObject(nestedObj: ILanguage, pathArr: string[], allowObject: false): string;
-function getNestedObject(nestedObj: ILanguage, pathArr: string[], allowObject = false) {
-  const out = pathArr.reduce((obj, key) => (obj && obj[key] !== 'undefined' ? obj[key] : undefined), nestedObj);
-  if (out && (allowObject || typeof out !== 'object')) {
-    return out;
-  }
-
-  return '';
+function getNestedObject(nestedObj: ILanguage, pathArr: string[]) {
+  return pathArr.reduce((obj, key) => (obj && obj[key] !== 'undefined' ? obj[key] : undefined), nestedObj);
 }
 
 export type LangParams = (string | undefined | number)[];
@@ -68,19 +52,19 @@ export type LangParams = (string | undefined | number)[];
  * @see useLanguage
  */
 export function getParsedLanguageFromKey(
-  key: string | undefined,
+  key: ValidLanguageKey | undefined,
   language: ILanguage | null,
   params?: LangParams,
   stringOutput?: false,
 ): JSX.Element | null;
 export function getParsedLanguageFromKey(
-  key: string | undefined,
+  key: ValidLanguageKey | undefined,
   language: ILanguage | null,
   params?: LangParams,
   stringOutput?: true,
 ): string;
 export function getParsedLanguageFromKey(
-  key: string | undefined,
+  key: ValidLanguageKey | undefined,
   language: ILanguage | null,
   params?: LangParams,
   stringOutput?: boolean,

--- a/src/language/sharedLanguage.ts
+++ b/src/language/sharedLanguage.ts
@@ -23,33 +23,48 @@ DOMPurify.addHook('afterSanitizeAttributes', (node) => {
   }
 });
 
-export function getLanguageFromKey(key: string | undefined, language: ILanguage) {
+/**
+ * @deprecated Use lang() from useLanguage.ts instead
+ * @see useLanguage
+ */
+export function getLanguageFromKey(key: string | undefined, language: ILanguage | null) {
   if (!key) {
     return key;
   }
-  const name = getNestedObject(language, key.split('.'));
+  const name = language ? getNestedObject(language, key.split('.')) : undefined;
   if (!name) {
     return key;
   }
   return name;
 }
 
-export function getNestedObject(nestedObj: any, pathArr: string[]) {
+function getNestedObject(nestedObj: any, pathArr: string[]) {
   return pathArr.reduce((obj, key) => (obj && obj[key] !== 'undefined' ? obj[key] : undefined), nestedObj);
 }
 
+export type LangParams = (string | undefined | number)[];
+
 // Example: {getParsedLanguageFromKey('marked.markdown', language, ['hei', 'sann'])}
+/**
+ * @deprecated Use lang() from useLanguage.ts instead
+ * @see useLanguage
+ */
 export function getParsedLanguageFromKey(
-  key: string,
-  language: ILanguage,
-  params?: any[],
+  key: string | undefined,
+  language: ILanguage | null,
+  params?: LangParams,
   stringOutput?: false,
-): JSX.Element;
-export function getParsedLanguageFromKey(key: string, language: ILanguage, params?: any[], stringOutput?: true): string;
+): JSX.Element | null;
 export function getParsedLanguageFromKey(
-  key: string,
-  language: ILanguage,
-  params?: any[],
+  key: string | undefined,
+  language: ILanguage | null,
+  params?: LangParams,
+  stringOutput?: true,
+): string;
+export function getParsedLanguageFromKey(
+  key: string | undefined,
+  language: ILanguage | null,
+  params?: LangParams,
   stringOutput?: boolean,
 ): any {
   const name = getLanguageFromKey(key, language);
@@ -103,17 +118,23 @@ const replaceRootTag = (domNode: any) => {
   }
 };
 
-const replaceParameters = (nameString: string | undefined, params: string[]) => {
+const replaceParameters = (nameString: string | undefined, params: LangParams) => {
   if (nameString === undefined) {
     return nameString;
   }
   let mutatingString = nameString;
-  params.forEach((param: string, index: number) => {
-    mutatingString = mutatingString.replaceAll(`{${index}}`, param);
+  params.forEach((param, index: number) => {
+    if (param !== undefined) {
+      mutatingString = mutatingString.replaceAll(`{${index}}`, `${param}`);
+    }
   });
   return mutatingString;
 };
 
+/**
+ * @deprecated Use lang() from useLanguage.ts instead
+ * @see useLanguage
+ */
 export function getTextResourceByKey<T extends string | undefined>(
   key: T,
   textResources: ITextResource[] | null,

--- a/src/language/texts/nb.ts
+++ b/src/language/texts/nb.ts
@@ -1,4 +1,6 @@
-export function nb() {
+import type { FixedLanguageList } from 'src/language/languages';
+
+export function nb(): FixedLanguageList {
   return {
     actions: {
       sign: 'Signer',

--- a/src/language/texts/nn.ts
+++ b/src/language/texts/nn.ts
@@ -1,4 +1,6 @@
-export function nn() {
+import type { FixedLanguageList } from 'src/language/languages';
+
+export function nn(): FixedLanguageList {
   return {
     actions: {
       sign: 'Signer',

--- a/src/layout/Address/AddressLabel.tsx
+++ b/src/layout/Address/AddressLabel.tsx
@@ -3,11 +3,12 @@ import React from 'react';
 import { OptionalIndicator } from 'src/components/form/OptionalIndicator';
 import { RequiredIndicator } from 'src/components/form/RequiredIndicator';
 import { getLanguageFromKey } from 'src/language/sharedLanguage';
+import type { ValidLanguageKey } from 'src/hooks/useLanguage';
 import type { ILabelSettings } from 'src/types';
 import type { ILanguage } from 'src/types/shared';
 
 interface IAddressLabel {
-  labelKey: string;
+  labelKey: ValidLanguageKey;
   id: string;
   language: ILanguage;
   required?: boolean;

--- a/src/layout/Grid/GridComponent.tsx
+++ b/src/layout/Grid/GridComponent.tsx
@@ -12,11 +12,11 @@ import { GenericComponent } from 'src/layout/GenericComponent';
 import css from 'src/layout/Grid/Grid.module.css';
 import { isGridRowHidden, nodesFromGrid } from 'src/layout/Grid/tools';
 import { getColumnStyles } from 'src/utils/formComponentUtils';
+import { LayoutNode } from 'src/utils/layout/LayoutNode';
 import { LayoutPage } from 'src/utils/layout/LayoutPage';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type { GridComponent, GridRow } from 'src/layout/Grid/types';
 import type { ITableColumnFormatting, ITableColumnProperties } from 'src/layout/layout';
-import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export function RenderGrid(props: PropsFromGenericComponent<'Grid'>) {
   const { node } = props;
@@ -24,6 +24,7 @@ export function RenderGrid(props: PropsFromGenericComponent<'Grid'>) {
   const shouldHaveFullWidth = node.parent instanceof LayoutPage;
   const columnSettings: ITableColumnFormatting = {};
   const isMobile = useMediaQuery('(max-width:768px)');
+  const isNested = node.parent instanceof LayoutNode;
 
   if (isMobile) {
     return <MobileGrid {...props} />;
@@ -39,6 +40,7 @@ export function RenderGrid(props: PropsFromGenericComponent<'Grid'>) {
           <GridRowRenderer
             key={rowIdx}
             row={row}
+            isNested={isNested}
             mutableColumnSettings={columnSettings}
           />
         ))}
@@ -49,10 +51,11 @@ export function RenderGrid(props: PropsFromGenericComponent<'Grid'>) {
 
 interface GridRowProps {
   row: GridRow<GridComponent>;
+  isNested: boolean;
   mutableColumnSettings: ITableColumnFormatting;
 }
 
-export function GridRowRenderer({ row, mutableColumnSettings }: GridRowProps) {
+export function GridRowRenderer({ row, isNested, mutableColumnSettings }: GridRowProps) {
   const { lang } = useLanguage();
 
   return isGridRowHidden(row) ? null : (
@@ -64,8 +67,8 @@ export function GridRowRenderer({ row, mutableColumnSettings }: GridRowProps) {
         const isFirst = cellIdx === 0;
         const isLast = cellIdx === row.cells.length - 1;
         const className = cn({
-          [css.fullWidthCellFirst]: isFirst,
-          [css.fullWidthCellLast]: isLast,
+          [css.fullWidthCellFirst]: isFirst && !isNested,
+          [css.fullWidthCellLast]: isLast && !isNested,
         });
 
         if (row.header && cell && 'columnOptions' in cell && cell.columnOptions) {

--- a/src/layout/Grid/GridComponent.tsx
+++ b/src/layout/Grid/GridComponent.tsx
@@ -7,8 +7,7 @@ import cn from 'classnames';
 
 import { ConditionalWrapper } from 'src/components/ConditionalWrapper';
 import { FullWidthWrapper } from 'src/components/form/FullWidthWrapper';
-import { useAppSelector } from 'src/hooks/useAppSelector';
-import { getTextResourceByKey } from 'src/language/sharedLanguage';
+import { useLanguage } from 'src/hooks/useLanguage';
 import { GenericComponent } from 'src/layout/GenericComponent';
 import css from 'src/layout/Grid/Grid.module.css';
 import { isGridRowHidden, nodesFromGrid } from 'src/layout/Grid/tools';
@@ -54,7 +53,7 @@ interface GridRowProps {
 }
 
 export function GridRowRenderer({ row, mutableColumnSettings }: GridRowProps) {
-  const textResources = useAppSelector((state) => state.textResources.resources);
+  const { lang } = useLanguage();
 
   return isGridRowHidden(row) ? null : (
     <InternalRow
@@ -85,7 +84,7 @@ export function GridRowRenderer({ row, mutableColumnSettings }: GridRowProps) {
               className={className}
               columnStyleOptions={textCellSettings}
             >
-              {getTextResourceByKey(cell.text, textResources)}
+              {lang(cell.text)}
             </CellWithText>
           );
         }

--- a/src/layout/Group/RepeatingGroupTable.tsx
+++ b/src/layout/Group/RepeatingGroupTable.tsx
@@ -189,6 +189,7 @@ export function RepeatingGroupTable({
             <GridRowRenderer
               key={`gridBefore-${index}`}
               row={{ ...row, cells: [...row.cells, ...extraCells] }}
+              isNested={isNested}
               mutableColumnSettings={columnSettings}
             />
           ))}
@@ -295,6 +296,7 @@ export function RepeatingGroupTable({
             <GridRowRenderer
               key={`gridAfter-${index}`}
               row={{ ...row, cells: [...row.cells, ...extraCells] }}
+              isNested={isNested}
               mutableColumnSettings={columnSettings}
             />
           ))}

--- a/src/layout/List/ListComponent.test.tsx
+++ b/src/layout/List/ListComponent.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { screen } from '@testing-library/react';
 
+import { nb } from 'src/language/texts/nb';
 import { ListComponent } from 'src/layout/List/ListComponent';
 import { renderGenericComponentTest } from 'src/testUtils';
 import type { RenderGenericComponentTestProps } from 'src/testUtils';
@@ -30,6 +31,7 @@ const render = ({ component, genericProps }: Partial<RenderGenericComponentTestP
     genericProps: {
       getTextResourceAsString: (value) => value,
       legend: () => <span>legend</span>,
+      language: nb(),
       ...genericProps,
     },
     manipulateState: (state) => {

--- a/src/layout/List/ListComponent.tsx
+++ b/src/layout/List/ListComponent.tsx
@@ -4,6 +4,7 @@ import { Pagination, ResponsiveTable, SortDirection } from '@altinn/altinn-desig
 import { FormControl, FormLabel } from '@material-ui/core';
 import cn from 'classnames';
 import type { ChangeProps, ResponsiveTableConfig, SortProps } from '@altinn/altinn-design-system';
+import type { DescriptionText } from '@altinn/altinn-design-system/dist/types/src/components/Pagination/Pagination';
 
 import { DataListsActions } from 'src/features/dataLists/dataListsSlice';
 import { useAppDispatch } from 'src/hooks/useAppDispatch';
@@ -109,7 +110,7 @@ export const ListComponent = ({
           onRowsPerPageChange={handleChangeRowsPerPage}
           currentPage={currentPage}
           setCurrentPage={handleChangeCurrentPage}
-          descriptionTexts={getLanguageFromKey('list_component', language)}
+          descriptionTexts={getLanguageFromKey('list_component', language, true) as unknown as DescriptionText}
         />
       );
     } else {

--- a/src/layout/List/ListComponent.tsx
+++ b/src/layout/List/ListComponent.tsx
@@ -10,7 +10,6 @@ import { DataListsActions } from 'src/features/dataLists/dataListsSlice';
 import { useAppDispatch } from 'src/hooks/useAppDispatch';
 import { useAppSelector } from 'src/hooks/useAppSelector';
 import { useGetDataList } from 'src/hooks/useGetDataList';
-import { getLanguageFromKey } from 'src/language/sharedLanguage';
 import { useRadioStyles } from 'src/layout/RadioButtons/radioButtonsUtils';
 import type { PropsFromGenericComponent } from 'src/layout';
 
@@ -110,7 +109,7 @@ export const ListComponent = ({
           onRowsPerPageChange={handleChangeRowsPerPage}
           currentPage={currentPage}
           setCurrentPage={handleChangeCurrentPage}
-          descriptionTexts={getLanguageFromKey('list_component', language, true) as unknown as DescriptionText}
+          descriptionTexts={language['list_component'] as DescriptionText}
         />
       );
     } else {

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -1,4 +1,5 @@
 import type { IProcessPermissions } from 'src/features/process';
+import type { FixedLanguageList } from 'src/language/languages';
 
 export interface IAltinnWindow extends Window {
   org: string;
@@ -121,9 +122,11 @@ export interface IInstanceState {
   isArchived: boolean;
 }
 // Language translations for altinn
-export interface ILanguage {
-  [key: string]: string | ILanguage;
-}
+export type ILanguage =
+  | FixedLanguageList
+  | {
+      [key: string]: string | ILanguage;
+    };
 // Language for the rendered alltinn app
 export interface IAppLanguage {
   language: string; // Language code

--- a/src/utils/textResource.ts
+++ b/src/utils/textResource.ts
@@ -2,6 +2,10 @@ import { getParsedLanguageFromKey, getParsedLanguageFromText, getTextResourceByK
 import type { ITextResource } from 'src/types';
 import type { ILanguage } from 'src/types/shared';
 
+/**
+ * @deprecated Use lang() or langAsString() from useLanguage.ts instead
+ * @see useLanguage
+ */
 export function getTextFromAppOrDefault(
   key: string,
   textResources: ITextResource[],

--- a/src/utils/textResource.ts
+++ b/src/utils/textResource.ts
@@ -1,4 +1,5 @@
 import { getParsedLanguageFromKey, getParsedLanguageFromText, getTextResourceByKey } from 'src/language/sharedLanguage';
+import type { ValidLanguageKey } from 'src/hooks/useLanguage';
 import type { ITextResource } from 'src/types';
 import type { ILanguage } from 'src/types/shared';
 
@@ -7,21 +8,21 @@ import type { ILanguage } from 'src/types/shared';
  * @see useLanguage
  */
 export function getTextFromAppOrDefault(
-  key: string,
+  key: string | ValidLanguageKey,
   textResources: ITextResource[],
   language: ILanguage,
   params?: string[],
   stringOutput?: false,
 ): JSX.Element | JSX.Element[];
 export function getTextFromAppOrDefault(
-  key: string,
+  key: string | ValidLanguageKey,
   textResources: ITextResource[],
   language: ILanguage,
   params?: string[],
   stringOutput?: true,
 ): string;
 export function getTextFromAppOrDefault(
-  key: string,
+  key: string | ValidLanguageKey,
   textResources: ITextResource[],
   language: ILanguage,
   params?: string[],
@@ -36,6 +37,6 @@ export function getTextFromAppOrDefault(
   }
 
   return stringOutput
-    ? getParsedLanguageFromKey(key, language, params, true)
-    : getParsedLanguageFromKey(key, language, params, false);
+    ? getParsedLanguageFromKey(key as ValidLanguageKey, language, params, true)
+    : getParsedLanguageFromKey(key as ValidLanguageKey, language, params, false);
 }

--- a/src/utils/validation/validation.ts
+++ b/src/utils/validation/validation.ts
@@ -19,6 +19,7 @@ import { ResolvedNodesSelector } from 'src/utils/layout/hierarchy';
 import type { IAttachment, IAttachments } from 'src/features/attachments';
 import type { ExprResolved, ExprUnresolved } from 'src/features/expressions/types';
 import type { IFormData } from 'src/features/formData';
+import type { ValidLanguageKey } from 'src/hooks/useLanguage';
 import type { ILayoutCompDatepicker } from 'src/layout/Datepicker/types';
 import type { ILayoutGroup } from 'src/layout/Group/types';
 import type {
@@ -553,7 +554,7 @@ export function validateComponentFormData(
           errorMessage = getTextResourceByKey(fieldSchema.errorMessage, textResources);
         } else {
           errorMessage = getParsedLanguageFromKey(
-            `validation_errors.${errorMessageKeys[error.keyword]?.textKey || error.keyword}`,
+            `validation_errors.${errorMessageKeys[error.keyword]?.textKey || error.keyword}` as ValidLanguageKey,
             language,
             [errorParams],
             true,
@@ -721,7 +722,7 @@ function validateFormDataForLayout(
       errorMessage = getTextResourceByKey(fieldSchema.errorMessage, textResources);
     } else {
       errorMessage = getParsedLanguageFromKey(
-        `validation_errors.${errorMessageKeys[error.keyword]?.textKey || error.keyword}`,
+        `validation_errors.${errorMessageKeys[error.keyword]?.textKey || error.keyword}` as ValidLanguageKey,
         language,
         [errorParams],
         true,

--- a/test/e2e/integration/app-frontend/grid.ts
+++ b/test/e2e/integration/app-frontend/grid.ts
@@ -48,6 +48,18 @@ describe('Grid component', () => {
     cy.get(appFrontend.errorReport).should('contain.text', 'Må summeres opp til 100%');
     cy.get(appFrontend.grid.totalPercent).parents('td').should('contain.text', 'Må summeres opp til 100%');
 
+    // Make sure markdown works in text cells
+    cy.get(appFrontend.grid.grid).find('tr').eq(1).find('td').eq(0).should('contain.text', 'Boliglån');
+    cy.changeLayout((component) => {
+      if (component.type === 'Grid') {
+        const cell = component.rows[1].cells[0];
+        if (cell && 'text' in cell) {
+          cell.text = 'Mitt **bolig**lån';
+        }
+      }
+    });
+    cy.get(appFrontend.grid.grid).find('tr').eq(1).find('td').eq(0).should('contain.text', 'Mitt boliglån');
+
     // Verify that the summary is correct
     cy.navPage('summary').click();
     cy.get(appFrontend.grid.summary).should('be.visible');


### PR DESCRIPTION
## Description

This fixes two issues with Grid (also when displaying Grid rows in the repeating group table):
1. Text cells can now contain markdown (either when used directly, or when referencing a text resource key)
2. When displaying a Grid (or a nested repeating group table), the first and last cells would mistakenly add the padding for full-width extension to the cell, causing the content to be compressed into one side of the cell)

In order to fix the markdown issue, I created a new `useLanguage` hook that should make it easier to work with language/text resources. This looks inside text resources first, then finds a language key if no text resource was found. It also provides auto-completion for language keys and keeps the number of parameters to a minimum, making for a better developer experience than existing language functions (which I have now deprecated).

## Related Issue(s)

- https://altinn.slack.com/archives/C02EVE4RU82/p1683622086153569 (markdown support)
- https://altinn.slack.com/archives/C02EVE4RU82/p1683811542418919 (compressed cells when displayed nested inside another component)

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
