### PR TITLE
Compacting the number formatting configuration + schema tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -187,6 +187,7 @@
       "\\.(css|less|scss)$": "identity-obj-proxy",
       "\\./applicationMetadataMock.json": "<rootDir>/src/__mocks__/applicationMetadataMock.json",
       "^src/(.*)$": "<rootDir>/src/$1",
+      "^schemas/(.*)$": "<rootDir>/schemas/$1",
       "^uuid$": "<rootDir>/node_modules/uuid/dist/index.js"
     },
     "testRegex": "\\.test\\.(ts|tsx|js|jsx)$",

--- a/schemas/json/layout/expression.schema.v1.json
+++ b/schemas/json/layout/expression.schema.v1.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://altinncdn.no/schemas/json/layout/expression.schema.v1.json",
-  "$schema": "https://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Expression",
   "description": "Multi-purpose expression mini-language used to declare dynamic behaviour in Altinn 3 apps",
   "examples": [

--- a/schemas/json/layout/layout.schema.v1.json
+++ b/schemas/json/layout/layout.schema.v1.json
@@ -1098,43 +1098,39 @@
       ]
     },
     "inputFormatting": {
+      "type": "object",
+      "properties": {
         "currency": {
+          "type": "string",
           "title": "Language-sensitive number formatting based on currency",
-          "type": "object",
           "description": "Enables currency along with thousand and decimal separators to be language sensitive based on selected app language. They are configured in number property. Note: parts that already exist in number property are not overridden by this prop.",
-          "properties": {
-            "valuta": {
-              "type": "string",
-              "title": "Type of currency",
-              "description": "Type of currency that is set to be language-sensitive",
-              "enum": ["AED","AFN","ALL","AMD","ANG","AOA","ARS","AUD","AWG","AZN","BAM","BBD","BDT","BGN","BHD","BIF","BMD","BND","BOB","BOV","BRL","BSD","BTN","BWP","BYN","BZD","CAD","CDF","CHE","CHF","CHW","CLF","CLP","CNY","COP","COU","CRC","CUC","CUP","CVE","CZK","DJF","DKK","DOP","DZD","EGP","ERN","ETB","EUR","FJD","FKP","GBP","GEL","GHS","GIP","GMD","GNF","GTQ","GYD","HKD","HNL","HTG","HUF","IDR","ILS","INR","IQD","IRR","ISK","JMD","JOD","JPY","KES","KGS","KHR","KMF","KPW","KRW","KWD","KYD","KZT","LAK","LBP","LKR","LRD","LSL","LYD","MAD","MDL","MGA","MKD","MMK","MNT","MOP","MRU","MUR","MVR","MWK","MXN","MXV","MYR","MZN","NAD","NGN","NIO","NOK","NPR","NZD","OMR","PAB","PEN","PGK","PHP","PKR","PLN","PYG","QAR","RON","RSD","RUB","RWF","SAR","SBD","SCR","SDG","SEK","SGD","SHP","SLE","SLL","SOS","SRD","SSP","STN","SVC","SYP","SZL","THB","TJS","TMT","TND","TOP","TRY","TTD","TWD","TZS","UAH","UGX","USD","USN","UYI","UYU","UYW","UZS","VED","VES","VND","VUV","WST","XAF","XCD","XDR","XOF","XPF","XSU","XUA","YER","ZAR","ZMW","ZWL"]
-            },
-            "position": {
-              "type": "string",
-              "title": "Position of the unit",
-              "description": "Display the unit as prefix or suffix. Default is prefix",
-              "enum": ["prefix", "suffix"]
-            }
-          }
+          "enum": ["AED", "AFN", "ALL", "AMD", "ANG", "AOA", "ARS", "AUD", "AWG", "AZN", "BAM", "BBD", "BDT", "BGN",
+            "BHD", "BIF", "BMD", "BND", "BOB", "BOV", "BRL", "BSD", "BTN", "BWP", "BYN", "BZD", "CAD", "CDF", "CHE",
+            "CHF", "CHW", "CLF", "CLP", "CNY", "COP", "COU", "CRC", "CUC", "CUP", "CVE", "CZK", "DJF", "DKK", "DOP",
+            "DZD", "EGP", "ERN", "ETB", "EUR", "FJD", "FKP", "GBP", "GEL", "GHS", "GIP", "GMD", "GNF", "GTQ", "GYD",
+            "HKD", "HNL", "HTG", "HUF", "IDR", "ILS", "INR", "IQD", "IRR", "ISK", "JMD", "JOD", "JPY", "KES", "KGS",
+            "KHR", "KMF", "KPW", "KRW", "KWD", "KYD", "KZT", "LAK", "LBP", "LKR", "LRD", "LSL", "LYD", "MAD", "MDL",
+            "MGA", "MKD", "MMK", "MNT", "MOP", "MRU", "MUR", "MVR", "MWK", "MXN", "MXV", "MYR", "MZN", "NAD", "NGN",
+            "NIO", "NOK", "NPR", "NZD", "OMR", "PAB", "PEN", "PGK", "PHP", "PKR", "PLN", "PYG", "QAR", "RON", "RSD",
+            "RUB", "RWF", "SAR", "SBD", "SCR", "SDG", "SEK", "SGD", "SHP", "SLE", "SLL", "SOS", "SRD", "SSP", "STN",
+            "SVC", "SYP", "SZL", "THB", "TJS", "TMT", "TND", "TOP", "TRY", "TTD", "TWD", "TZS", "UAH", "UGX", "USD",
+            "USN", "UYI", "UYU", "UYW", "UZS", "VED", "VES", "VND", "VUV", "WST", "XAF", "XCD", "XDR", "XOF", "XPF",
+            "XSU", "XUA", "YER", "ZAR", "ZMW", "ZWL"
+          ]
         },
         "unit": {
           "title": "Language-sensitive number formatting based on unit",
-          "type": "object",
+          "type": "string",
           "description": "Enables unit along with thousand and decimal separators to be language sensitive based on selected app language. They are configured in number property. Note: parts that already exist in number property are not overridden by this prop.",
-          "properties": {
-            "unitType": {
-              "type": "string",
-              "title": "Type of unit",
-              "description": "Type of unit that is set to be language-sensitive",
-              "enum": ["celsius","centimeter","day","degree","foot","gram","hectare","hour","inch","kilogram","kilometer","liter","meter","milliliter","millimeter","millisecond","minute","month","percent","second","week","year"]
-            },
-            "position": {
-              "type": "string",
-              "title": "Position of the unit",
-              "description": "Display the unit as prefix or suffix. Default is suffix",
-              "enum": ["prefix", "suffix"]
-            }
-          }
+          "enum": ["celsius", "centimeter", "day", "degree", "foot", "gram", "hectare", "hour", "inch", "kilogram",
+            "kilometer", "liter", "meter", "milliliter", "millimeter", "millisecond", "minute", "month", "percent",
+            "second", "week", "year"]
+        },
+        "position": {
+          "type": "string",
+          "title": "Position of the currency/unit symbol (only when using currency or unit options)",
+          "description": "Display the unit as prefix or suffix. Default is prefix",
+          "enum": ["prefix", "suffix"]
         },
         "number": {
           "$ref": "https://altinncdn.no/schemas/json/component/number-format.schema.v1.json"
@@ -1319,4 +1315,4 @@
       ]
     }
   }
-
+}

--- a/src/hooks/useMapToReactNumberConfig.ts
+++ b/src/hooks/useMapToReactNumberConfig.ts
@@ -13,15 +13,15 @@ export const useMapToReactNumberConfig = (formatting: IInputFormatting, value = 
 
   const createOptions = (config: IInputFormatting) => {
     if (config.currency) {
-      return { style: 'currency', currency: config.currency.valuta } as CurrencyFormattingOptions;
+      return { style: 'currency', currency: config.currency } as CurrencyFormattingOptions;
     }
     if (config.unit) {
-      return { style: 'unit', unit: config.unit.unitType } as UnitFormattingOptions;
+      return { style: 'unit', unit: config.unit } as UnitFormattingOptions;
     }
     return undefined;
   };
-  // Check if position has been configured in dynamic formatting. Either prefix or suffix of currency/unit
-  const position: string | undefined = formatting?.currency?.position || formatting?.unit?.position || undefined;
+  // Check if position has been configured in dynamic formatting. Either prefix or suffix
+  const position = formatting?.position || undefined;
 
   const numberFormatResult = {
     ...formatNumber(value, appLanguage, createOptions(formatting), position),

--- a/src/layout/layout.d.ts
+++ b/src/layout/layout.d.ts
@@ -88,19 +88,17 @@ export interface IComponentRadioOrCheckbox<T extends Extract<ComponentTypes, 'Ra
 
 export type NumberFormatProps = Exclude<Parameters<typeof TextField>[0]['formatting'], undefined>['number'];
 
-export type CurrencyProps = {
-  valuta: string;
-  position?: string;
-};
-
-export type UnitProps = {
-  unitType: string;
-  position?: string;
-};
-
+/**
+ * Number formatting options. Will be reduced to react-number-format options:
+ * @see useMapToReactNumberConfig
+ */
 export interface IInputFormatting {
-  currency?: CurrencyProps;
-  unit?: UnitProps;
+  // Newer Intl.NumberFormat options
+  currency?: string;
+  unit?: string;
+  position?: 'prefix' | 'suffix';
+
+  // Older options based on react-number-format
   number?: NumberFormatProps;
   align?: 'right' | 'center' | 'left';
 }

--- a/src/utils/formattingUtils.test.ts
+++ b/src/utils/formattingUtils.test.ts
@@ -5,7 +5,7 @@ const value = '12000.20';
 let language = 'en';
 const currencyOptions: CurrencyFormattingOptions = { style: 'currency', currency: 'NOK' };
 const unitOptions: UnitFormattingOptions = { style: 'unit', unit: 'kilogram' };
-let position: string | undefined = 'prefix';
+let position: 'prefix' | 'suffix' | undefined = 'prefix';
 
 describe('dynamic number formatting', () => {
   it('returns with correct number config', () => {

--- a/src/utils/formattingUtils.ts
+++ b/src/utils/formattingUtils.ts
@@ -19,7 +19,7 @@ export const formatNumber = (
   number: string,
   locale: string | null,
   options: CurrencyFormattingOptions | UnitFormattingOptions | undefined,
-  position: string | undefined,
+  position: 'prefix' | 'suffix' | undefined,
 ): FormattingResult => {
   const defaultFormat: FormattingResult = {
     thousandSeparator: undefined,

--- a/src/utils/layout/getAllLayoutSets.ts
+++ b/src/utils/layout/getAllLayoutSets.ts
@@ -8,6 +8,7 @@ interface AppLayoutSet {
   appName: string;
   setName: string;
   layouts: ILayouts;
+  entireFiles: { [key: string]: unknown };
 }
 
 /**
@@ -47,6 +48,7 @@ export function getAllLayoutSets(dir: string): AppLayoutSet[] {
       }
 
       const layouts: ILayouts = {};
+      const entireFiles: { [key: string]: unknown } = {};
       for (const layoutFile of layoutFiles.filter((s) => !s.startsWith('.') && s.endsWith('.json'))) {
         const fileContent = fs.readFileSync(path.join(...setPath, layoutFile));
         let layoutContent;
@@ -57,12 +59,14 @@ export function getAllLayoutSets(dir: string): AppLayoutSet[] {
           continue;
         }
         layouts[layoutFile.replace('.json', '')] = layoutContent.data.layout;
+        entireFiles[layoutFile.replace('.json', '')] = layoutContent;
       }
 
       out.push({
         appName: app,
         setName: set.set,
         layouts,
+        entireFiles,
       });
     }
   }

--- a/src/utils/layout/schema.test.ts
+++ b/src/utils/layout/schema.test.ts
@@ -1,0 +1,83 @@
+import Ajv from 'ajv';
+import dotenv from 'dotenv';
+import fs from 'node:fs';
+import numberFormatSchema from 'schemas/json/component/number-format.schema.v1.json';
+import expressionSchema from 'schemas/json/layout/expression.schema.v1.json';
+import layoutSchema from 'schemas/json/layout/layout.schema.v1.json';
+import type { ErrorObject } from 'ajv';
+
+import { getAllLayoutSets } from 'src/utils/layout/getAllLayoutSets';
+
+describe('Layout schema', () => {
+  describe('All schemas should be valid', () => {
+    const recurse = (dir: string) => {
+      const files = fs.readdirSync(dir);
+      for (const file of files) {
+        if (fs.lstatSync(`${dir}/${file}`).isDirectory()) {
+          recurse(`${dir}/${file}`);
+          continue;
+        }
+
+        if (!file.endsWith('.json')) {
+          continue;
+        }
+
+        it(`${dir}/${file} should be parseable as JSON`, () => {
+          const content = fs.readFileSync(`${dir}/${file}`, 'utf-8');
+          expect(() => JSON.parse(content)).not.toThrow();
+
+          const schema = JSON.parse(content);
+          const ajv = new Ajv();
+          expect(ajv.validateSchema(schema)).toBeTruthy();
+        });
+      }
+    };
+
+    recurse('schemas');
+  });
+
+  describe('All known layout sets should validate against the layout schema', () => {
+    const env = dotenv.config();
+    const dir = env.parsed?.ALTINN_ALL_APPS_DIR;
+    if (!dir) {
+      it('did not find any apps', () => {
+        expect(true).toBeTruthy();
+      });
+      console.warn(
+        'ALTINN_ALL_APPS_DIR should be set, please create a .env file and point it to a directory containing all known apps',
+      );
+      return;
+    }
+
+    const ajv = new Ajv({
+      strict: false,
+      schemas: [expressionSchema, numberFormatSchema],
+    });
+    const validate = ajv.compile(layoutSchema);
+    const allLayoutSets = getAllLayoutSets(dir);
+
+    const ignoreSomeErrors = (errors: ErrorObject[] | null | undefined) =>
+      (errors || []).filter((error) => {
+        if (error.instancePath.endsWith('/id') && error.message?.startsWith('must match pattern')) {
+          // Ignore errors about id not matching pattern. This is common, and we don't care that much about it.
+          return false;
+        }
+        if (error.message?.startsWith("must have required property 'size'")) {
+          // Fairly common for Header components. Maybe we should make this one optional?
+          return false;
+        }
+
+        return true;
+      });
+
+    for (const { appName, setName, entireFiles } of allLayoutSets) {
+      for (const layoutName of Object.keys(entireFiles)) {
+        const layout = entireFiles[layoutName];
+        it(`${appName}/${setName}/${layoutName}`, () => {
+          validate(layout);
+          expect(ignoreSomeErrors(validate.errors)).toEqual([]);
+        });
+      }
+    }
+  });
+});

--- a/test/e2e/integration/app-frontend/formatting.ts
+++ b/test/e2e/integration/app-frontend/formatting.ts
@@ -1,5 +1,7 @@
 import { AppFrontend } from 'test/e2e/pageobjects/app-frontend';
 
+import type { IInputFormatting } from 'src/layout/layout';
+
 const appFrontend = new AppFrontend();
 
 describe('Formatting', () => {
@@ -26,86 +28,62 @@ describe('Formatting', () => {
     cy.get(appFrontend.group.newValue).should('not.contain.value', '-').and('have.css', 'text-align', 'right');
   });
 
-  [
-    { currency: { valuta: 'NOK' }, number: { prefix: 'SEK ' } },
-    { valuta: 'NOK', position: 'prefix' },
-    { valuta: 'NOK', position: 'suffix' },
-    { valuta: 'NOK' },
-    { unitType: 'kilogram', position: 'prefix' },
-    { unitType: 'kilogram' },
-  ].forEach((dynamicFormatting) => {
-    const init = () => {
-      cy.goto('group');
-      cy.get(appFrontend.nextButton).click();
-      cy.get(appFrontend.group.showGroupToContinue).should('be.visible');
-      cy.get(appFrontend.group.showGroupToContinue).find('input').dsCheck();
-      cy.get(appFrontend.group.addNewItem).click();
-    };
-    const changeToEnglishLang = () => {
-      cy.findByRole('combobox', { name: 'Språk' }).click();
-      cy.findByRole('option', { name: 'Engelsk' }).click();
-    };
-    it('Dynamic number formatting', () => {
-      cy.interceptLayout('group', (component) => {
-        if (component.type === 'Input' && component.formatting) {
-          delete component.formatting.number;
-          if (dynamicFormatting.valuta) {
-            component.formatting.currency = dynamicFormatting;
-          }
-          if (dynamicFormatting.unitType) {
-            component.formatting.unit = dynamicFormatting;
-          }
-          // Testing if config in number overrides dynamic formatting
-          if (dynamicFormatting.number) {
-            component.formatting.currency = dynamicFormatting.currency;
-            component.formatting.number = dynamicFormatting.number;
-          }
+  const changeToLang = (option: 'en' | 'nb') => {
+    cy.findByRole('combobox', { name: option === 'en' ? 'Språk' : 'Language' }).click();
+    cy.findByRole('option', { name: option === 'en' ? 'Engelsk' : 'Norwegian bokmål' }).click();
+  };
+
+  it('Dynamic number formatting', () => {
+    cy.goto('group');
+    cy.get(appFrontend.nextButton).click();
+    cy.get(appFrontend.group.showGroupToContinue).should('be.visible');
+    cy.get(appFrontend.group.showGroupToContinue).find('input').dsCheck();
+    cy.get(appFrontend.group.addNewItem).click();
+
+    cy.get(appFrontend.group.currentValue).numberFormatClear();
+    cy.get(appFrontend.group.currentValue).type('10000');
+
+    const alternatives: { format: IInputFormatting; expected: any }[] = [
+      {
+        format: { currency: 'NOK', number: { prefix: 'SEK ' } },
+        expected: { nb: 'SEK 10 000', en: 'SEK 10,000' },
+      },
+      {
+        format: { currency: 'NOK', position: 'prefix' },
+        expected: { nb: 'kr 10 000', en: 'NOK 10,000' },
+      },
+      {
+        format: { currency: 'NOK', position: 'suffix' },
+        expected: { nb: '10 000 kr', en: '10,000 NOK' },
+      },
+      {
+        format: { currency: 'NOK' },
+        expected: { nb: 'kr 10 000', en: 'NOK 10,000' },
+      },
+      {
+        format: { unit: 'kilogram', position: 'prefix' },
+        expected: { nb: 'kg 10 000', en: 'kg 10,000' },
+      },
+      {
+        format: { unit: 'kilogram' },
+        expected: { nb: '10 000 kg', en: '10,000 kg' },
+      },
+    ];
+
+    for (const { format, expected } of alternatives) {
+      cy.changeLayout((component) => {
+        if (component.type === 'Input' && component.formatting && component.id === 'currentValue') {
+          component.formatting = format;
         }
       });
-      init();
-      cy.get(appFrontend.group.currentValue).type('10000');
-      if (dynamicFormatting.valuta && dynamicFormatting.position === 'prefix') {
-        cy.get(appFrontend.group.currentValue).assertTextWithoutWhiteSpaces('kr 10 000');
-        changeToEnglishLang();
-        cy.get(appFrontend.group.currentValue).assertTextWithoutWhiteSpaces('NOK 10,000');
+
+      for (const lang of ['en', 'nb'] as const) {
+        changeToLang(lang);
+        cy.get(appFrontend.group.currentValue).assertTextWithoutWhiteSpaces(expected[lang]);
         cy.get(appFrontend.group.saveMainGroup).click();
-        cy.findByText('NOK 10,000');
+        cy.findByText(expected[lang]);
+        cy.get(appFrontend.group.edit).click();
       }
-      if (dynamicFormatting.valuta && dynamicFormatting.position === 'suffix') {
-        cy.get(appFrontend.group.currentValue).assertTextWithoutWhiteSpaces('10 000 kr');
-        changeToEnglishLang();
-        cy.get(appFrontend.group.currentValue).assertTextWithoutWhiteSpaces('10,000 NOK');
-        cy.get(appFrontend.group.saveMainGroup).click();
-        cy.findByText('10,000 NOK');
-      }
-      if (dynamicFormatting.valuta && !dynamicFormatting.position) {
-        cy.get(appFrontend.group.currentValue).assertTextWithoutWhiteSpaces('kr 10 000');
-        changeToEnglishLang();
-        cy.get(appFrontend.group.currentValue).assertTextWithoutWhiteSpaces('NOK 10,000');
-        cy.get(appFrontend.group.saveMainGroup).click();
-        cy.findByText('NOK 10,000');
-      }
-      if (dynamicFormatting.unitType && dynamicFormatting.position === 'prefix') {
-        cy.get(appFrontend.group.currentValue).assertTextWithoutWhiteSpaces('kg 10 000');
-        changeToEnglishLang();
-        cy.get(appFrontend.group.currentValue).assertTextWithoutWhiteSpaces('kg 10,000');
-        cy.get(appFrontend.group.saveMainGroup).click();
-        cy.findByText('kg 10,000');
-      }
-      if (dynamicFormatting.unitType && !dynamicFormatting.position) {
-        cy.get(appFrontend.group.currentValue).assertTextWithoutWhiteSpaces('10 000 kg');
-        changeToEnglishLang();
-        cy.get(appFrontend.group.currentValue).assertTextWithoutWhiteSpaces('10,000 kg');
-        cy.get(appFrontend.group.saveMainGroup).click();
-        cy.findByText('10,000 kg');
-      }
-      if (dynamicFormatting.number) {
-        cy.get(appFrontend.group.currentValue).assertTextWithoutWhiteSpaces('SEK 10 000');
-        changeToEnglishLang();
-        cy.get(appFrontend.group.currentValue).assertTextWithoutWhiteSpaces('SEK 10,000');
-        cy.get(appFrontend.group.saveMainGroup).click();
-        cy.findByText('SEK 10,000');
-      }
-    });
+    }
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,8 @@
     "forceConsistentCasingInFileNames": true,
     "paths": {
       "src/*": ["src/*"],
-      "test/*": ["test/*"]
+      "test/*": ["test/*"],
+      "schemas/*": ["schemas/*"]
     },
     "allowSyntheticDefaultImports": true,
     "exactOptionalPropertyTypes": false,


### PR DESCRIPTION
## Description

Compacting the number formatting configuration, so that we save one level of depth. This way you can configure a field to: `"formatting": { "currency": "NOK" }` instead of the more verbose `"formatting": { "currency": { "valuta": "NOK" }}`. I think we can get away with having a top-level `currency` and `unit` property here, and re-use the `position` property for both `currency` and `unit`.

Also:
- Refactored the cypress test so there's less duplication of code, and hopefully clearer which format leads to which expectations in the number formatted field.
- Updated the schema, fixing the syntax error in it
- Added a unit test to make sure the schema files are valid

## Related Issue(s)

- #1132
- #717

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [x] Has been added/updated
    - https://github.com/Altinn/altinn-studio-docs/pull/919
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [x] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [ ] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
