### PR TITLE
Bugfixed undesirable jumping to the first field in a repeating group

### DIFF
--- a/src/layout/Group/GroupContainer.tsx
+++ b/src/layout/Group/GroupContainer.tsx
@@ -74,8 +74,8 @@ export function GroupContainer({ node }: IGroupProps): JSX.Element | null {
   const AddButton = (): JSX.Element => (
     <Button
       id={`add-button-${id}`}
-      onClick={onClickAdd}
-      onKeyUp={onKeypressAdd}
+      onClick={handleOnAddButtonClick}
+      onKeyUp={handleOnAddKeypress}
       variant={ButtonVariant.Outline}
       size={ButtonSize.Medium}
       icon={<AddIcon aria-hidden='true' />}
@@ -97,10 +97,11 @@ export function GroupContainer({ node }: IGroupProps): JSX.Element | null {
     </Button>
   );
 
-  const onClickAdd = useCallback(() => {
+  const addNewRowToGroup = useCallback((): void => {
     if (!edit?.alwaysShowAddButton || edit?.mode === 'showAll') {
       dispatch(FormLayoutActions.updateRepeatingGroups({ layoutElementId: id }));
     }
+
     if (edit?.mode !== 'showAll' && edit?.mode !== 'onlyTable') {
       dispatch(
         FormLayoutActions.updateRepeatingGroupsEditIndex({
@@ -112,30 +113,35 @@ export function GroupContainer({ node }: IGroupProps): JSX.Element | null {
       );
       setMultiPageIndex(0);
     }
+  }, [dispatch, edit?.alwaysShowAddButton, edit?.mode, id, node, repeatingGroupIndex, setMultiPageIndex]);
 
+  const handleOnAddButtonClick = (): void => {
+    addNewRowToGroup();
     triggerFocus(repeatingGroupIndex + 1);
-  }, [dispatch, id, edit?.mode, edit?.alwaysShowAddButton, node, repeatingGroupIndex, setMultiPageIndex, triggerFocus]);
+  };
 
-  useEffect(() => {
+  // Add new row if openByDefault is true and no rows exist
+  useEffect((): void => {
     if (edit?.openByDefault && repeatingGroupIndex === -1) {
-      onClickAdd();
+      addNewRowToGroup();
     }
-  }, [edit?.openByDefault, onClickAdd, repeatingGroupIndex]);
+  }, [addNewRowToGroup, edit?.openByDefault, repeatingGroupIndex]);
 
-  useEffect(() => {
+  useEffect((): void => {
     if (edit?.multiPage && multiPageIndex < 0) {
       setMultiPageIndex(0);
     }
   }, [edit?.multiPage, multiPageIndex, setMultiPageIndex]);
 
-  const onKeypressAdd = (event: React.KeyboardEvent<HTMLButtonElement>): void => {
+  const handleOnAddKeypress = (event: React.KeyboardEvent<HTMLButtonElement>): void => {
     const allowedKeys = ['enter', ' ', 'spacebar'];
     if (allowedKeys.includes(event.key.toLowerCase())) {
-      onClickAdd();
+      addNewRowToGroup();
+      triggerFocus(repeatingGroupIndex + 1);
     }
   };
 
-  const onClickRemove = (groupIndex: number): void => {
+  const handleOnRemoveClick = (groupIndex: number): void => {
     dispatch(
       FormLayoutActions.updateRepeatingGroups({
         layoutElementId: id,
@@ -190,7 +196,7 @@ export function GroupContainer({ node }: IGroupProps): JSX.Element | null {
           repeatingGroupIndex={repeatingGroupIndex}
           deleting={deletingIndexes.includes(repeatingGroupIndex)}
           setEditIndex={setEditIndex}
-          onClickRemove={onClickRemove}
+          onClickRemove={handleOnRemoveClick}
           setMultiPageIndex={setMultiPageIndex}
           multiPageIndex={multiPageIndex}
           filteredIndexes={filteredIndexList}
@@ -235,7 +241,7 @@ export function GroupContainer({ node }: IGroupProps): JSX.Element | null {
                       id={id}
                       deleting={deletingIndexes.includes(index)}
                       setEditIndex={setEditIndex}
-                      onClickRemove={onClickRemove}
+                      onClickRemove={handleOnRemoveClick}
                       forceHideSaveButton={true}
                     />
                   </div>


### PR DESCRIPTION
## Description
Bugfixed undesirable jumping to the first field in a repeating group by doing some code-splitting to avoid "side-effects" that are focusing on the first focusable element, when a row is added initially with a useEffect-hook.


<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes #1089

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [x] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
