### PR TITLE
Feat/1116 support iframe to render html

### DIFF
--- a/schemas/json/layout/layout.schema.v1.json
+++ b/schemas/json/layout/layout.schema.v1.json
@@ -145,7 +145,6 @@
         { "if": {"properties": {"type": { "const": "TextArea"}}}, "then": { "$ref": "#/definitions/textAreaComponent"}},
         { "if": {"properties": {"type": { "const": "InstanceInformation"}}}, "then": { "$ref": "#/definitions/instanceInformationComponent"}},
         { "if": {"properties": {"type": { "const": "InstantiationButton"}}}, "then": { "$ref": "#/definitions/instantiationButtonComponent"}},
-        { "if": {"properties": {"type": { "const": "IFrame"}}}, "then": { "$ref": "#/definitions/iFrameComponent"}},
         { "if": {"properties": {"type": { "const": "Likert"}}}, "then": { "$ref": "#/definitions/radioAndCheckboxComponents"}},
         { "if": {"properties": {"type": { "const": "MultipleSelect"}}}, "then": { "$ref": "#/definitions/selectionComponents"}},
         { "if": {"properties": {"type": { "const": "NavigationButtons"}}}, "then": { "$ref": "#/definitions/navigationButtonsComponent"}},

--- a/schemas/json/layout/layout.schema.v1.json
+++ b/schemas/json/layout/layout.schema.v1.json
@@ -42,7 +42,7 @@
           "type": "string",
           "title": "Type",
           "description": "The component type.",
-          "enum": ["ActionButton", "AddressComponent", "AttachmentList", "Button", "ButtonGroup", "Checkboxes", "Custom", "Datepicker", "Dropdown", "FileUpload", "FileUploadWithTag", "Grid", "Group", "Header", "Image", "Input", "InstanceInformation", "InstantiationButton", "Likert","List", "MultipleSelect", "NavigationButtons", "NavigationBar", "Panel", "Paragraph", "PrintButton", "RadioButtons", "Summary", "TextArea"]
+          "enum": ["ActionButton", "AddressComponent", "AttachmentList", "Button", "ButtonGroup", "Checkboxes", "Custom", "Datepicker", "Dropdown", "FileUpload", "FileUploadWithTag", "Grid", "Group", "Header", "Image", "Input", "InstanceInformation", "InstantiationButton", "IFrame", "Likert","List", "MultipleSelect", "NavigationButtons", "NavigationBar", "Panel", "Paragraph", "PrintButton", "RadioButtons", "Summary", "TextArea"]
         },
         "required": {
           "title": "Required",
@@ -145,6 +145,7 @@
         { "if": {"properties": {"type": { "const": "TextArea"}}}, "then": { "$ref": "#/definitions/textAreaComponent"}},
         { "if": {"properties": {"type": { "const": "InstanceInformation"}}}, "then": { "$ref": "#/definitions/instanceInformationComponent"}},
         { "if": {"properties": {"type": { "const": "InstantiationButton"}}}, "then": { "$ref": "#/definitions/instantiationButtonComponent"}},
+        { "if": {"properties": {"type": { "const": "IFrame"}}}, "then": { "$ref": "#/definitions/iFrameComponent"}},
         { "if": {"properties": {"type": { "const": "Likert"}}}, "then": { "$ref": "#/definitions/radioAndCheckboxComponents"}},
         { "if": {"properties": {"type": { "const": "MultipleSelect"}}}, "then": { "$ref": "#/definitions/selectionComponents"}},
         { "if": {"properties": {"type": { "const": "NavigationButtons"}}}, "then": { "$ref": "#/definitions/navigationButtonsComponent"}},

--- a/src/language/texts/en.ts
+++ b/src/language/texts/en.ts
@@ -151,6 +151,11 @@ export function en() {
       row_popover_delete_message: 'Are you sure you want to delete this row?',
       row_popover_delete_button_confirm: 'Yes, delete the row',
     },
+    iframe_component: {
+      unsupported_browser_title: 'Your browser is unsupported',
+      unsupported_browser:
+        'Your browser does not support iframes that use srcdoc. This may result in not being able to see all the content intended to be displayed here. We recommend trying a different browser.',
+    },
     instance_selection: {
       changed_by: 'Changed by',
       continue: 'Continue here',

--- a/src/language/texts/nb.ts
+++ b/src/language/texts/nb.ts
@@ -153,6 +153,11 @@ export function nb(): FixedLanguageList {
       row_popover_delete_message: 'Er du sikker på at du vil slette denne raden?',
       row_popover_delete_button_confirm: 'Ja, slett raden',
     },
+    iframe_component: {
+      unsupported_browser_title: 'Nettleseren din støttes ikke',
+      unsupported_browser:
+        'Nettleseren du bruker støtter ikke iframes som benytter seg av srcdoc. Dette kan føre til at du ikke ser all innholdet som er ment å vises her. Vi anbefaler deg å prøve en annen nettleser.',
+    },
     instance_selection: {
       changed_by: 'Endret av',
       continue: 'Fortsett her',

--- a/src/language/texts/nn.ts
+++ b/src/language/texts/nn.ts
@@ -153,6 +153,11 @@ export function nn(): FixedLanguageList {
       row_popover_delete_message: 'Er du sikker på at du vil sletta denne rada?',
       row_popover_delete_button_confirm: 'Ja, slett rada',
     },
+    iframe_component: {
+      unsupported_browser_title: 'Nettlesaren din støttas ikkje',
+      unsupported_browser:
+        'Nettlesaren di støttar ikkje iframes som brukar srcdoc. Dette kan føre til at du ikkje ser all innhaldet som er meint å visast her. Vi anbefalar deg å prøve ein annan nettlesar.',
+    },
     instance_selection: {
       changed_by: 'Endra av',
       continue: 'Hald fram her',

--- a/src/layout/Iframe/IFrameComponent.tsx
+++ b/src/layout/Iframe/IFrameComponent.tsx
@@ -7,8 +7,8 @@ export type IFrameComponentProps = PropsFromGenericComponent<'IFrame'>;
 export const IFrameComponent = ({ node, getTextResourceAsString }: IFrameComponentProps): JSX.Element => {
   const { textResourceBindings } = node.item;
 
-  const HTMLString = getTextResourceAsString(textResourceBindings?.title) ?? '';
-  const iFrameTitle = getTextResourceAsString(textResourceBindings?.iFrameTitle) ?? '';
+  const iFrameTitle = textResourceBindings?.title;
+  const HTMLString = iFrameTitle ? getTextResourceAsString(iFrameTitle) : '';
 
   // Resize the iframe to fit the content thats loaded inside it
   const adjustIFrameSize = (iframe: React.BaseSyntheticEvent): void => {

--- a/src/layout/Iframe/IFrameComponent.tsx
+++ b/src/layout/Iframe/IFrameComponent.tsx
@@ -1,12 +1,29 @@
 import React from 'react';
 
+import { Panel, PanelVariant } from '@altinn/altinn-design-system';
+
+import { useLanguage } from 'src/hooks/useLanguage';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export type IFrameComponentProps = PropsFromGenericComponent<'IFrame'>;
 
 export const IFrameComponent = ({ node, getTextResourceAsString }: IFrameComponentProps): JSX.Element => {
-  const { textResourceBindings } = node.item;
+  const { lang } = useLanguage();
 
+  const isSrcDocUnsupported = !('srcdoc' in document.createElement('iframe'));
+
+  if (isSrcDocUnsupported) {
+    return (
+      <Panel
+        variant={PanelVariant.Error}
+        title={lang('iframe_component.unsupported_browser_title')}
+      >
+        <p>{lang('iframe_component.unsupported_browser')}</p>
+      </Panel>
+    );
+  }
+
+  const { textResourceBindings } = node.item;
   const iFrameTitle = textResourceBindings?.title;
   const HTMLString = iFrameTitle ? getTextResourceAsString(iFrameTitle) : '';
 
@@ -18,6 +35,7 @@ export const IFrameComponent = ({ node, getTextResourceAsString }: IFrameCompone
   return (
     <iframe
       scrolling='no'
+      frameBorder={0}
       width='100%'
       srcDoc={HTMLString}
       title={iFrameTitle}

--- a/src/layout/Iframe/IFrameComponent.tsx
+++ b/src/layout/Iframe/IFrameComponent.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+import type { PropsFromGenericComponent } from 'src/layout';
+
+export type IFrameComponentProps = PropsFromGenericComponent<'IFrame'>;
+
+export const IFrameComponent = ({ node, getTextResourceAsString }: IFrameComponentProps): JSX.Element => {
+  const { textResourceBindings } = node.item;
+
+  const HTMLString = getTextResourceAsString(textResourceBindings?.title) ?? '';
+  const iFrameTitle = getTextResourceAsString(textResourceBindings?.iFrameTitle) ?? '';
+
+  // Resize the iframe to fit the content thats loaded inside it
+  const adjustIFrameSize = (iframe: React.BaseSyntheticEvent): void => {
+    iframe.target.style.height = `${iframe.target.contentWindow.document.documentElement.scrollHeight}px`;
+  };
+
+  return (
+    <iframe
+      scrolling='no'
+      width='100%'
+      srcDoc={HTMLString}
+      title={iFrameTitle}
+      onLoad={adjustIFrameSize}
+      sandbox='allow-same-origin'
+    />
+  );
+};

--- a/src/layout/Iframe/index.tsx
+++ b/src/layout/Iframe/index.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import { IFrameComponent } from 'src/layout/Iframe/IFrameComponent';
+import { PresentationComponent } from 'src/layout/LayoutComponent';
+import type { IFrameComponentProps } from 'src/layout/Iframe/IFrameComponent';
+
+export class IFrame extends PresentationComponent<'IFrame'> {
+  render(props: IFrameComponentProps): JSX.Element | null {
+    return <IFrameComponent {...props} />;
+  }
+
+  renderWithLabel(): boolean {
+    return false;
+  }
+}

--- a/src/layout/Iframe/types.d.ts
+++ b/src/layout/Iframe/types.d.ts
@@ -1,0 +1,3 @@
+import type { ILayoutCompBase } from 'src/layout/layout';
+
+export type ILayoutCompIFrame = ILayoutCompBase<'IFrame'>;

--- a/src/layout/index.ts
+++ b/src/layout/index.ts
@@ -15,6 +15,7 @@ import { FileUploadWithTag } from 'src/layout/FileUploadWithTag/index';
 import { Grid } from 'src/layout/Grid';
 import { Group } from 'src/layout/Group';
 import { Header } from 'src/layout/Header/index';
+import { IFrame } from 'src/layout/Iframe';
 import { Image } from 'src/layout/Image/index';
 import { Input } from 'src/layout/Input/index';
 import { InstanceInformation } from 'src/layout/InstanceInformation/index';
@@ -70,6 +71,7 @@ export const components = {
   List: new List(),
   Group: new Group(),
   Summary: new Summary(),
+  IFrame: new IFrame(),
 };
 
 export type ComponentClassMap = typeof components;

--- a/src/layout/layout.d.ts
+++ b/src/layout/layout.d.ts
@@ -16,6 +16,7 @@ import type { ILayoutCompFileUploadWithTag } from 'src/layout/FileUploadWithTag/
 import type { ILayoutCompGrid } from 'src/layout/Grid/types';
 import type { IDataModelBindingsForGroup, ILayoutGroup } from 'src/layout/Group/types';
 import type { ILayoutCompHeader } from 'src/layout/Header/types';
+import type { ILayoutCompIFrame } from 'src/layout/Iframe/types';
 import type { ILayoutCompImage } from 'src/layout/Image/types';
 import type { ILayoutCompInput } from 'src/layout/Input/types';
 import type { ILayoutCompInstanceInformation } from 'src/layout/InstanceInformation/types';
@@ -136,6 +137,7 @@ interface Map {
   Grid: ILayoutCompGrid;
   Group: ILayoutGroup;
   Header: ILayoutCompHeader;
+  IFrame: ILayoutCompIFrame;
   Image: ILayoutCompImage;
   Input: ILayoutCompInput;
   InstantiationButton: ILayoutCompInstantiationButton;

--- a/test/e2e/integration/app-stateless-anonymous/anonymous.ts
+++ b/test/e2e/integration/app-stateless-anonymous/anonymous.ts
@@ -37,4 +37,18 @@ describe('Anonymous (stateless)', () => {
     cy.get('label:contains("mann")').click();
     cy.get('@console.warn').should('have.been.calledWith', 'Request aborted due to saga cancellation');
   });
+
+  it('should render iframe with srcdoc and the heading text should be "The red title is rendered within an iframe"', () => {
+    cy.get('iframe').should('exist');
+    cy.get('iframe').should('have.attr', 'srcdoc');
+
+    // access the content of the iframe
+    cy.get('iframe')
+      .its('0.contentDocument.body')
+      .should('not.be.empty')
+      .then(cy.wrap)
+      .within(() => {
+        cy.get('h1').contains('The red title is rendered within an iframe');
+      });
+  });
 });


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->
Valgdirektoratet wants to show the election card as HTML in an iframe rather than today's solution where the raw HTML is fetched and embedded into the app. Valgdirektoratet wants to have full control over the HTML and the CSS, hence we have now created support to render this HTML within an iframe.

### First preview of the documentation

The documentation is not done, but added the "preview" to give some more context to the reviewer. :)

![image](https://github.com/Altinn/app-frontend-react/assets/46874830/e10cb331-d334-4c77-a4d9-b8df648fd992)


## Related Issue(s)

- closes #1116 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [x] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [x] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [x] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [ ] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
