### PR TITLE
Removed mocks from signing tests

### DIFF
--- a/test/e2e/integration/signing/double-signing.ts
+++ b/test/e2e/integration/signing/double-signing.ts
@@ -1,77 +1,58 @@
 import { AppFrontend } from 'test/e2e/pageobjects/app-frontend';
 
-import type { IBackendFeaturesState } from 'src/features/applicationMetadata';
-
 const appFrontend = new AppFrontend();
 
 describe('Double signing', () => {
   beforeEach(() => {
     cy.intercept('**/active', []).as('noActiveInstances');
     cy.intercept('POST', `**/instances?instanceOwnerPartyId*`).as('createInstance');
-    cy.intercept('GET', '**/applicationmetadata', (req) => {
-      req.on('response', (res) => {
-        res.body.features = {
-          processActions: true,
-        } as IBackendFeaturesState;
-      });
-    });
-    cy.interceptPermissions();
   });
 
   it('accountant -> manager -> auditor', () => {
-    cy.setPermissions('rw');
     cy.startAppInstance(appFrontend.apps.signingTest, 'accountant');
     cy.assertUser('accountant');
 
     cy.get(appFrontend.signingTest.incomeField).type('4567');
 
-    cy.setPermissions('r');
     cy.get(appFrontend.signingTest.submitButton).should('not.be.disabled').click();
     cy.get(appFrontend.signingTest.noAccessPanel).should('exist').and('be.visible');
 
-    cy.setPermissions('rsj');
     cy.switchUser('manager');
     cy.assertUser('manager');
 
     cy.get(appFrontend.signingTest.managerConfirmPanel).should('exist').and('be.visible');
-    cy.get(appFrontend.signingTest.incomeField).should('contain.value', '4 567 000 NOK');
+    cy.get(appFrontend.signingTest.incomeSummary).should('contain.text', '4 567 000 NOK');
 
-    cy.setPermissions('r');
     cy.get(appFrontend.signingTest.signingButton).should('not.be.disabled').click();
     cy.get(appFrontend.signingTest.sentToAuditor).should('exist').and('be.visible');
 
-    cy.setPermissions('rsj');
     cy.switchUser('auditor');
     cy.assertUser('auditor');
 
     cy.get(appFrontend.signingTest.auditorConfirmPanel).should('exist').and('be.visible');
-    cy.get(appFrontend.signingTest.incomeField).should('contain.value', '4 567 000 NOK');
+    cy.get(appFrontend.signingTest.incomeSummary).should('contain.text', '4 567 000 NOK');
     cy.get(appFrontend.signingTest.signingButton).should('not.be.disabled').click();
     cy.get(appFrontend.receipt.container).should('exist').and('be.visible');
   });
 
   it('manager -> manager -> auditor', () => {
-    cy.setPermissions('rw');
     cy.startAppInstance(appFrontend.apps.signingTest, 'manager');
     cy.assertUser('manager');
 
     cy.get(appFrontend.signingTest.incomeField).type('4567');
 
-    cy.setPermissions('rsj');
     cy.get(appFrontend.signingTest.submitButton).should('not.be.disabled').click();
     cy.get(appFrontend.signingTest.managerConfirmPanel).should('exist').and('be.visible');
-    cy.get(appFrontend.signingTest.incomeField).should('contain.value', '4 567 000 NOK');
+    cy.get(appFrontend.signingTest.incomeSummary).should('contain.text', '4 567 000 NOK');
 
-    cy.setPermissions('r');
     cy.get(appFrontend.signingTest.signingButton).should('not.be.disabled').click();
     cy.get(appFrontend.signingTest.sentToAuditor).should('exist').and('be.visible');
 
-    cy.setPermissions('rsj');
     cy.switchUser('auditor');
     cy.assertUser('auditor');
 
     cy.get(appFrontend.signingTest.auditorConfirmPanel).should('exist').and('be.visible');
-    cy.get(appFrontend.signingTest.incomeField).should('contain.value', '4 567 000 NOK');
+    cy.get(appFrontend.signingTest.incomeSummary).should('contain.text', '4 567 000 NOK');
     cy.get(appFrontend.signingTest.signingButton).should('not.be.disabled').click();
     cy.get(appFrontend.receipt.container).should('exist').and('be.visible');
   });

--- a/test/e2e/pageobjects/app-frontend.ts
+++ b/test/e2e/pageobjects/app-frontend.ts
@@ -271,6 +271,7 @@ export class AppFrontend {
 
   public signingTest = {
     incomeField: '#Input-income',
+    incomeSummary: '[data-testid="summary-Input-income"]',
     submitButton: '#Button-submit',
     signingButton: '#action-button-SigningButton',
     managerConfirmPanel: '#form-content-Panel-confirm1',


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

The `signing-test` app has been upgraded to v8-preview, and therefore, the mocks in the cypress tests are no longer needed. Another change is the use of `renderAsSummary` instead of `readOnly` fields for the signing steps.

## Related Issue(s)

- #1003 

