### PR TITLE
Grid/`rowsBefore`/`rowsAfter`: Resolving text resource bindings inside repeating groups

### DIFF
--- a/src/layout/Grid/hierarchy.ts
+++ b/src/layout/Grid/hierarchy.ts
@@ -1,6 +1,7 @@
 import { nodesFromGrid } from 'src/layout/Grid/tools';
 import { ComponentHierarchyGenerator } from 'src/utils/layout/HierarchyGenerator';
 import type { GridComponent, GridRow } from 'src/layout/Grid/types';
+import type { ITextResource } from 'src/types';
 import type { LayoutNodeFromType } from 'src/utils/layout/hierarchy.types';
 import type {
   ChildFactory,
@@ -76,5 +77,24 @@ export class GridHierarchyGenerator extends ComponentHierarchyGenerator<'Grid'> 
 
   childrenFromNode(node: LayoutNodeFromType<'Grid'>): LayoutNode[] {
     return nodesFromGrid(node);
+  }
+
+  rewriteTextBindingsForRows(node: LayoutNode, rows: GridRow<GridComponent>[], textResources: ITextResource[]) {
+    if (node.rowIndex === undefined) {
+      return;
+    }
+
+    for (const row of rows) {
+      for (const cell of row.cells) {
+        if (cell && 'text' in cell && this.textResourceHasRepeatingGroupVariable(cell.text, textResources)) {
+          cell.text = `${cell.text}-${node.rowIndex}`;
+        }
+      }
+    }
+  }
+
+  rewriteTextBindings(node: LayoutNodeFromType<'Grid'>, textResources: ITextResource[]) {
+    super.rewriteTextBindings(node, textResources);
+    this.rewriteTextBindingsForRows(node, node.item.rows, textResources);
   }
 }

--- a/src/layout/Group/hierarchy.ts
+++ b/src/layout/Group/hierarchy.ts
@@ -2,6 +2,7 @@ import { GridHierarchyGenerator } from 'src/layout/Grid/hierarchy';
 import { nodesFromGridRow } from 'src/layout/Grid/tools';
 import { getRepeatingGroupStartStopIndex } from 'src/utils/formLayout';
 import { ComponentHierarchyGenerator } from 'src/utils/layout/HierarchyGenerator';
+import type { ITextResource } from 'src/types';
 import type { HRepGroupChild, HRepGroupRow, LayoutNodeFromType } from 'src/utils/layout/hierarchy.types';
 import type {
   ChildFactory,
@@ -105,6 +106,16 @@ export class GroupHierarchyGenerator extends ComponentHierarchyGenerator<'Group'
     }
 
     return list;
+  }
+
+  rewriteTextBindings(node: LayoutNodeFromType<'Group'>, textResources: ITextResource[]) {
+    super.rewriteTextBindings(node, textResources);
+    if (node.item?.rowsBefore) {
+      this.innerGrid.rewriteTextBindingsForRows(node, node.item.rowsBefore, textResources);
+    }
+    if (node.item?.rowsAfter) {
+      this.innerGrid.rewriteTextBindingsForRows(node, node.item.rowsAfter, textResources);
+    }
   }
 
   /**

--- a/src/utils/layout/hierarchy.ts
+++ b/src/utils/layout/hierarchy.ts
@@ -6,7 +6,6 @@ import { getLayoutComponentObject } from 'src/layout';
 import { buildAuthContext } from 'src/utils/authContext';
 import { buildInstanceContext } from 'src/utils/instanceContext';
 import { generateEntireHierarchy } from 'src/utils/layout/HierarchyGenerator';
-import { LayoutPage } from 'src/utils/layout/LayoutPage';
 import type { ILayouts } from 'src/layout/layout';
 import type { IRepeatingGroups, IRuntimeState, ITextResource } from 'src/types';
 import type { AnyItem, HierarchyDataSources } from 'src/utils/layout/hierarchy.types';
@@ -100,31 +99,7 @@ function resolvedNodesInLayouts(
 function rewriteTextResourceBindings(collection: LayoutPages, textResources: ITextResource[]) {
   for (const layout of Object.values(collection.all())) {
     for (const node of layout.flat(true)) {
-      if (!node.item.textResourceBindings || node.rowIndex === undefined) {
-        continue;
-      }
-
-      if (node.parent instanceof LayoutPage || !(node.parent.parent instanceof LayoutPage)) {
-        // This only works in row items on the first level (not for nested repeating groups)
-        continue;
-      }
-
-      const rewrittenItems = { ...node.item.textResourceBindings };
-      if (textResources && node.item.textResourceBindings) {
-        const bindingsWithVariablesForRepeatingGroups = Object.keys(rewrittenItems).filter((key) => {
-          const textKey = rewrittenItems[key];
-          const textResource = textResources.find((text) => text.id === textKey);
-          return (
-            textResource && textResource.variables && textResource.variables.find((v) => v.key.indexOf('[{0}]') > -1)
-          );
-        });
-
-        bindingsWithVariablesForRepeatingGroups.forEach((key) => {
-          rewrittenItems[key] = `${rewrittenItems[key]}-${node.rowIndex}`;
-        });
-      }
-
-      node.item.textResourceBindings = { ...rewrittenItems };
+      node.def.hierarchyGenerator().rewriteTextBindings(node as any, textResources);
     }
   }
 }

--- a/test/e2e/integration/app-frontend/grid.ts
+++ b/test/e2e/integration/app-frontend/grid.ts
@@ -109,4 +109,16 @@ describe('Grid component', () => {
     cy.get(appFrontend.grid.kredittkort.percentComponent).should('not.exist');
     cy.get(appFrontend.grid.kredittkort.verifiedComponent).should('not.exist');
   });
+
+  it('should resolve text resources when Grid rows are shown in nested repeating groups', () => {
+    cy.goto('group');
+    cy.get(appFrontend.group.prefill.liten).dsCheck();
+    cy.navPage('repeating').click();
+    cy.get(appFrontend.group.showGroupToContinue).find('input').dsCheck();
+    cy.get(appFrontend.group.row(0).editBtn).click();
+    cy.get(appFrontend.group.editContainer).find(appFrontend.group.next).click();
+    cy.get(appFrontend.group.row(0).nestedGroup.groupContainer)
+      .find('table tr:last-child td:first-child')
+      .should('contain.text', 'Foreldreraden er prefill: true');
+  });
 });


### PR DESCRIPTION
## Description

Implementing proper text resource rewriting for `Grid` component rows, as it uses a non-standard way of referencing text resources (in cells, not in `textResourceBindings`). This fixes a problem reported on Slack.

## Related Issue(s)

- https://altinn.slack.com/archives/C02EVE4RU82/p1684823161039679

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
