### PR TITLE
Validations: Hiding validations for hidden components (JsonSchema edition)

### DIFF
--- a/src/utils/validation/validation.ts
+++ b/src/utils/validation/validation.ts
@@ -771,6 +771,10 @@ function addErrorToValidations(
   }
 }
 
+/**
+ * @deprecated
+ * @see mapToComponentValidationsGivenNode
+ */
 function mapToComponentValidationsGivenComponent(
   layoutId: string,
   component: ExprUnresolved<ILayoutComponent | ILayoutGroup>,
@@ -799,7 +803,7 @@ export function mapToComponentValidationsGivenNode(
   onlyInRowIndex?: number,
 ) {
   let fieldKey: string | undefined = undefined;
-  const component = node.flat(true, onlyInRowIndex).find((item) => {
+  const foundNode = node.flat(true, onlyInRowIndex).find((item) => {
     if (item.item.dataModelBindings) {
       fieldKey = Object.keys(item.item.dataModelBindings).find(
         (key) =>
@@ -809,11 +813,11 @@ export function mapToComponentValidationsGivenNode(
     return !!fieldKey;
   });
 
-  if (!fieldKey || !component) {
+  if (!fieldKey || !foundNode || foundNode.isHidden()) {
     return;
   }
 
-  addErrorToValidations(validations, layoutId, component.item.id, fieldKey, errorMessage);
+  addErrorToValidations(validations, layoutId, foundNode.item.id, fieldKey, errorMessage);
 }
 
 /*

--- a/test/e2e/integration/app-frontend/group.ts
+++ b/test/e2e/integration/app-frontend/group.ts
@@ -124,22 +124,19 @@ describe('Group', () => {
     cy.get(appFrontend.group.addNewItem).click();
     cy.get(appFrontend.group.currentValue).type('1');
     cy.get(appFrontend.group.newValue).type('0');
-    cy.get(appFrontend.fieldValidationError.replace('field', 'newValue')).should('have.text', texts.zeroIsNotValid);
+    cy.get(appFrontend.fieldValidation('newValue')).should('have.text', texts.zeroIsNotValid);
     cy.get(appFrontend.group.newValue).clear();
     cy.get(appFrontend.group.newValue).type('1');
-    cy.get(appFrontend.fieldValidationError.replace('field', 'newValue')).should('not.exist');
+    cy.get(appFrontend.fieldValidation('newValue')).should('not.exist');
     cy.get(appFrontend.group.mainGroup).siblings(appFrontend.group.tableErrors).should('not.exist');
     cy.get(appFrontend.group.mainGroup).find(appFrontend.group.editContainer).find(appFrontend.group.next).click();
     cy.get(appFrontend.group.addNewItem).should('not.exist');
     cy.get(appFrontend.group.comments).type('test');
     cy.get(appFrontend.group.comments).blur();
-    cy.get(appFrontend.fieldValidationError.replace('field', 'comments')).should(
-      'have.text',
-      texts.testIsNotValidValue,
-    );
+    cy.get(appFrontend.fieldValidation('comments')).should('have.text', texts.testIsNotValidValue);
     cy.get(appFrontend.group.comments).clear();
     cy.get(appFrontend.group.comments).type('automation');
-    cy.get(appFrontend.fieldValidationError.replace('field', 'comments')).should('not.exist');
+    cy.get(appFrontend.fieldValidation('comments')).should('not.exist');
     cy.get(appFrontend.group.subGroup).siblings(appFrontend.group.tableErrors).should('not.exist');
     cy.get(appFrontend.group.mainGroup).siblings(appFrontend.group.tableErrors).should('not.exist');
     cy.get(appFrontend.group.saveSubGroup).clickAndGone();
@@ -303,18 +300,12 @@ describe('Group', () => {
 
     cy.get(appFrontend.group.saveMainGroup).click();
 
-    cy.get(appFrontend.fieldValidationError.replace('field', 'currentValue-0')).should(
-      'have.text',
-      texts.requiredFieldFromValue,
-    );
+    cy.get(appFrontend.fieldValidation('currentValue-0')).should('have.text', texts.requiredFieldFromValue);
 
     cy.findByLabelText(/1\. Endre fra/i).type('123');
     cy.get(appFrontend.group.saveMainGroup).click();
 
-    cy.get(appFrontend.fieldValidationError.replace('field', 'newValue-0')).should(
-      'have.text',
-      texts.requiredFieldToValue,
-    );
+    cy.get(appFrontend.fieldValidation('newValue-0')).should('have.text', texts.requiredFieldToValue);
 
     cy.get(appFrontend.group.mainGroup)
       .find(mui.tableBody)

--- a/test/e2e/integration/app-frontend/validation.ts
+++ b/test/e2e/integration/app-frontend/validation.ts
@@ -15,9 +15,10 @@ describe('Validation', () => {
     cy.get(appFrontend.changeOfName.newFirstName).type('Some value');
     cy.get(appFrontend.changeOfName.newFirstName).blur();
     cy.get(appFrontend.changeOfName.newFirstName).clear();
-    cy.get(
-      appFrontend.fieldValidationError.replace('field', appFrontend.changeOfName.newFirstName.substring(1)),
-    ).should('have.text', texts.requiredFieldFromBackend);
+    cy.get(appFrontend.fieldValidation(appFrontend.changeOfName.newFirstName)).should(
+      'have.text',
+      texts.requiredFieldFromBackend,
+    );
 
     // Doing the same for any other field (without server-side required validation) should not show an error
     cy.get(appFrontend.changeOfName.newMiddleName).type('Some value');
@@ -25,9 +26,7 @@ describe('Validation', () => {
     cy.get(appFrontend.changeOfName.newMiddleName).focus();
     cy.get(appFrontend.changeOfName.newMiddleName).clear();
     cy.get(appFrontend.changeOfName.newMiddleName).blur();
-    cy.get(
-      appFrontend.fieldValidationError.replace('field', appFrontend.changeOfName.newMiddleName.substring(1)),
-    ).should('not.exist');
+    cy.get(appFrontend.fieldValidation(appFrontend.changeOfName.newMiddleName)).should('not.exist');
 
     cy.get(appFrontend.changeOfName.newFirstName).type('Some first name');
     cy.get(appFrontend.changeOfName.newMiddleName).type('Some middle name');
@@ -39,15 +38,9 @@ describe('Validation', () => {
 
     cy.get(appFrontend.nextButton).click();
 
-    cy.get(
-      appFrontend.fieldValidationError.replace('field', appFrontend.changeOfName.newFirstName.substring(1)),
-    ).should('not.exist');
-
-    cy.get(
-      appFrontend.fieldValidationError.replace('field', appFrontend.changeOfName.newMiddleName.substring(1)),
-    ).should('not.exist');
-
-    cy.get(appFrontend.fieldValidationError.replace('field', appFrontend.changeOfName.newLastName.substring(1))).should(
+    cy.get(appFrontend.fieldValidation(appFrontend.changeOfName.newFirstName)).should('not.exist');
+    cy.get(appFrontend.fieldValidation(appFrontend.changeOfName.newMiddleName)).should('not.exist');
+    cy.get(appFrontend.fieldValidation(appFrontend.changeOfName.newLastName)).should(
       'have.text',
       texts.requiredFieldLastName,
     );
@@ -58,7 +51,7 @@ describe('Validation', () => {
     cy.intercept('GET', '**/validate').as('validateData');
     cy.get(appFrontend.changeOfName.newFirstName).type('test');
     cy.wait('@validateData');
-    cy.get(appFrontend.fieldValidationError.replace('field', appFrontend.changeOfName.newFirstName.substring(1)))
+    cy.get(appFrontend.fieldValidation(appFrontend.changeOfName.newFirstName))
       .should('have.text', texts.testIsNotValidValue)
       .then((error) => {
         cy.wrap(error).find('a[href="https://www.altinn.no/"]').should('exist');
@@ -70,9 +63,10 @@ describe('Validation', () => {
     cy.intercept('GET', '**/validate').as('validateData');
     cy.get(appFrontend.changeOfName.newMiddleName).type('test');
     cy.wait('@validateData');
-    cy.get(
-      appFrontend.fieldValidationWarning.replace('field', appFrontend.changeOfName.newMiddleName.substring(1)),
-    ).should('have.text', texts.testIsNotValidValue);
+    cy.get(appFrontend.fieldValidation(appFrontend.changeOfName.newMiddleName, 'warning')).should(
+      'have.text',
+      texts.testIsNotValidValue,
+    );
   });
 
   it('Soft validation - info', () => {
@@ -80,9 +74,10 @@ describe('Validation', () => {
     cy.intercept('GET', '**/validate').as('validateData');
     cy.get(appFrontend.changeOfName.newMiddleName).type('info');
     cy.wait('@validateData');
-    cy.get(
-      appFrontend.fieldValidationInfo.replace('field', appFrontend.changeOfName.newMiddleName.substring(1)),
-    ).should('have.text', texts.infoMessage);
+    cy.get(appFrontend.fieldValidation(appFrontend.changeOfName.newMiddleName, 'info')).should(
+      'have.text',
+      texts.infoMessage,
+    );
   });
 
   it('Soft validation - success', () => {
@@ -90,9 +85,10 @@ describe('Validation', () => {
     cy.intercept('GET', '**/validate').as('validateData');
     cy.get(appFrontend.changeOfName.newMiddleName).type('success');
     cy.wait('@validateData');
-    cy.get(
-      appFrontend.fieldValidationSuccess.replace('field', appFrontend.changeOfName.newMiddleName.substring(1)),
-    ).should('have.text', texts.successMessage);
+    cy.get(appFrontend.fieldValidation(appFrontend.changeOfName.newMiddleName, 'success')).should(
+      'have.text',
+      texts.successMessage,
+    );
   });
 
   it('Page validation on clicking next', () => {
@@ -119,10 +115,7 @@ describe('Validation', () => {
       .findAllByRole('button')
       .should('have.length', 4 + 3);
 
-    const lastNameError = appFrontend.fieldValidationError.replace(
-      'field',
-      appFrontend.changeOfName.newLastName.substring(1),
-    );
+    const lastNameError = appFrontend.fieldValidation(appFrontend.changeOfName.newLastName);
     cy.get(lastNameError).should('exist').should('not.be.inViewport');
     cy.get(appFrontend.changeOfName.newLastName).should('not.be.focused');
 
@@ -154,10 +147,7 @@ describe('Validation', () => {
   it('Validation on uploaded attachment type', () => {
     cy.goto('changename');
     cy.get(appFrontend.changeOfName.upload).selectFile('test/e2e/fixtures/test.png', { force: true });
-    cy.get(appFrontend.fieldValidationError.replace('field', appFrontend.changeOfName.upload.substring(1))).should(
-      'contain.text',
-      texts.attachmentError,
-    );
+    cy.get(appFrontend.fieldValidation(appFrontend.changeOfName.upload)).should('contain.text', texts.attachmentError);
   });
 
   it('Validation on uploaded attachment type with tag', () => {
@@ -175,10 +165,7 @@ describe('Validation', () => {
   it('Client side validation from json schema', () => {
     cy.goto('changename');
     cy.get(appFrontend.changeOfName.newLastName).type('client');
-    cy.get(appFrontend.fieldValidationError.replace('field', appFrontend.changeOfName.newLastName.substring(1))).should(
-      'have.text',
-      texts.clientSide,
-    );
+    cy.get(appFrontend.fieldValidation(appFrontend.changeOfName.newLastName)).should('have.text', texts.clientSide);
   });
 
   it('Task validation', () => {
@@ -208,16 +195,13 @@ describe('Validation', () => {
     // Create validation error
     cy.get(appFrontend.group.mainGroup).find(appFrontend.group.editContainer).find(appFrontend.group.next).click();
     cy.get(appFrontend.group.comments).type('test');
-    cy.get(appFrontend.fieldValidationError.replace('field', 'comments')).should(
-      'have.text',
-      texts.testIsNotValidValue,
-    );
+    cy.get(appFrontend.fieldValidation('comments')).should('have.text', texts.testIsNotValidValue);
     cy.get(appFrontend.errorReport).should('exist').should('be.visible');
 
     // Hide field that contains validation error and verify validation messages are gone
     cy.get(appFrontend.group.hideCommentField).find('input').dsCheck();
     cy.get(appFrontend.group.comments).should('not.exist');
-    cy.get(appFrontend.fieldValidationError.replace('field', 'comments')).should('not.exist');
+    cy.get(appFrontend.fieldValidation('comments')).should('not.exist');
     cy.get(appFrontend.errorReport).should('not.exist');
   });
 

--- a/test/e2e/integration/app-stateless-anonymous/validation.ts
+++ b/test/e2e/integration/app-stateless-anonymous/validation.ts
@@ -13,7 +13,7 @@ describe('Validation in anonymous stateless app', () => {
     cy.get(appFrontend.stateless.name).invoke('val').should('be.empty');
     cy.get(appFrontend.navButtons).contains('button', 'next').click();
 
-    const nameError = appFrontend.fieldValidationError.replace('field', appFrontend.stateless.name.substring(1));
+    const nameError = appFrontend.fieldValidation(appFrontend.stateless.name);
 
     cy.get(appFrontend.stateless.name).should('be.visible');
     cy.get(nameError).should('have.text', texts.requiredFieldName);

--- a/test/e2e/pageobjects/app-frontend.ts
+++ b/test/e2e/pageobjects/app-frontend.ts
@@ -115,11 +115,9 @@ export class AppFrontend {
 
   public feedback = '#FeedbackContainer';
 
-  //field is a placeholder which has to be replaced with the selector value of the field
-  public fieldValidationError = '[id^="error_field"]';
-  public fieldValidationWarning = '[id^="warning_field"]';
-  public fieldValidationInfo = '[id^="info_field"]';
-  public fieldValidationSuccess = '[id^="success_field"]';
+  public fieldValidation(field: string, errorType: 'error' | 'warning' | 'info' | 'success' = 'error') {
+    return `[id^="${errorType}_${field.replace(/^#/, '')}"]`;
+  }
 
   //selectors for ttd/frontend-test app
   //message - task_1


### PR DESCRIPTION
## Description
We already hide validation messages for components that are hidden, but there were validations that slipped through the cracks. In this case, JsonSchema validation for a component would still be included even if the component was hidden - this change fixes the problem.

I also took the liberty to refactor the field validation selectors we use in cypress tests - which adds a lot of changes to the PR.

## Related Issue(s)

- Mentioned during a meeting with `org/ssb` last week, with details and follow-up in a private Slack thread between me and @rvessb

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
