### PR TITLE
Added grouping indicator to non-repeating group

### DIFF
--- a/schemas/json/layout/layout.schema.v1.json
+++ b/schemas/json/layout/layout.schema.v1.json
@@ -567,6 +567,12 @@
           "description": "Alternatives for panel view of repeating group",
           "$ref": "#/definitions/groupPanelOptions"
         },
+        "showGroupingIndicator": {
+          "title": "Show grouping indicator",
+          "description": "Boolean to decide whether a vertical line indicating grouping of fields should be visible. Only relevant for non-repeating groups.",
+          "type": "boolean",
+          "default": false
+        },
         "maxCount": {
           "type": "integer",
           "title": "Maximum count",

--- a/src/features/pdf/PDFView.tsx
+++ b/src/features/pdf/PDFView.tsx
@@ -11,6 +11,7 @@ import { DisplayGroupContainer } from 'src/layout/Group/DisplayGroupContainer';
 import { ComponentType } from 'src/layout/LayoutComponent';
 import { SummaryComponent } from 'src/layout/Summary/SummaryComponent';
 import { useExprContext } from 'src/utils/layout/ExprContext';
+import type { HNonRepGroup } from 'src/utils/layout/hierarchy.types';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 interface PDFViewProps {
@@ -22,7 +23,7 @@ const PDFComponent = ({ node }: { node: LayoutNode }) => {
   if (node.isType('Group')) {
     return (
       <DisplayGroupContainer
-        groupNode={node}
+        groupNode={node as LayoutNode<HNonRepGroup, 'Group'>}
         renderLayoutNode={(child) => (
           <PDFComponent
             key={child.item.id}

--- a/src/features/pdf/PDFView.tsx
+++ b/src/features/pdf/PDFView.tsx
@@ -11,7 +11,6 @@ import { DisplayGroupContainer } from 'src/layout/Group/DisplayGroupContainer';
 import { ComponentType } from 'src/layout/LayoutComponent';
 import { SummaryComponent } from 'src/layout/Summary/SummaryComponent';
 import { useExprContext } from 'src/utils/layout/ExprContext';
-import type { HNonRepGroup } from 'src/utils/layout/hierarchy.types';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 interface PDFViewProps {
@@ -20,10 +19,10 @@ interface PDFViewProps {
 }
 
 const PDFComponent = ({ node }: { node: LayoutNode }) => {
-  if (node.isType('Group')) {
+  if (node.isNonRepGroup()) {
     return (
       <DisplayGroupContainer
-        groupNode={node as LayoutNode<HNonRepGroup, 'Group'>}
+        groupNode={node}
         renderLayoutNode={(child) => (
           <PDFComponent
             key={child.item.id}

--- a/src/features/pdf/data/generatePdfSagas.ts
+++ b/src/features/pdf/data/generatePdfSagas.ts
@@ -88,6 +88,7 @@ function generateAutomaticLayout(pdfFormat: IPdfFormat, uiConfig: IUiConfig, lay
           componentRef: component.id,
           pageRef,
           excludedChildren: pdfFormat?.excludedComponents,
+          largeGroup: component.type === 'Group' && (!component.maxCount || component.maxCount <= 1),
         } as ExprUnresolved<ILayoutCompSummary>;
       }
       return null;

--- a/src/layout/Group/DisplayGroupContainer.module.css
+++ b/src/layout/Group/DisplayGroupContainer.module.css
@@ -1,0 +1,21 @@
+.groupTitle {
+  font-weight: 700;
+  font-size: '1.5rem';
+  padding-bottom: 12px;
+}
+
+.groupBody {
+  padding-bottom: 12px;
+}
+
+.groupContainer {
+  padding-bottom: 38px !important;
+}
+
+.groupingIndicator {
+  border-left: 2px solid #949494;
+  margin-left: 12px !important;
+  margin-bottom: 0 !important;
+  padding-top: 0 !important;
+  padding-bottom: 0 !important;
+}

--- a/src/layout/Group/DisplayGroupContainer.module.css
+++ b/src/layout/Group/DisplayGroupContainer.module.css
@@ -1,11 +1,12 @@
 .groupTitle {
-  font-weight: 700;
-  font-size: '1.5rem';
-  padding-bottom: 12px;
+  font-weight: 500;
+  font-size: 1.25rem;
+  margin-bottom: 0;
 }
 
 .groupBody {
-  padding-bottom: 12px;
+  margin-top: 12px;
+  margin-bottom: 0;
 }
 
 .groupContainer {
@@ -15,7 +16,8 @@
 .groupingIndicator {
   border-left: 2px solid #949494;
   margin-left: 12px !important;
-  margin-bottom: 0 !important;
+  margin-bottom: 12px !important;
+  margin-top: 12px !important;
   padding-top: 0 !important;
   padding-bottom: 0 !important;
 }

--- a/src/layout/Group/DisplayGroupContainer.tsx
+++ b/src/layout/Group/DisplayGroupContainer.tsx
@@ -1,34 +1,25 @@
 import React from 'react';
 
-import { Grid, makeStyles, Typography } from '@material-ui/core';
+import { Grid, Typography } from '@material-ui/core';
 import cn from 'classnames';
 
+import { ConditionalWrapper } from 'src/components/ConditionalWrapper';
 import { useAppSelector } from 'src/hooks/useAppSelector';
-import { pageBreakStyles } from 'src/utils/formComponentUtils';
+import classes from 'src/layout/Group/DisplayGroupContainer.module.css';
+import { pageBreakStyles, selectComponentTexts } from 'src/utils/formComponentUtils';
 import { getTextFromAppOrDefault } from 'src/utils/textResource';
+import type { HNonRepGroup } from 'src/utils/layout/hierarchy.types';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export interface IDisplayGroupContainer {
-  groupNode: LayoutNode;
+  groupNode: LayoutNode<HNonRepGroup, 'Group'>;
   id?: string;
   onlyRowIndex?: number | undefined;
   renderLayoutNode: (node: LayoutNode) => JSX.Element | null;
 }
 
-const useStyles = makeStyles({
-  groupTitle: {
-    fontWeight: 700,
-    fontSize: '1.5rem',
-    paddingBottom: 12,
-  },
-  groupContainer: {
-    paddingBottom: 38,
-  },
-});
-
 export function DisplayGroupContainer({ groupNode, id, onlyRowIndex, renderLayoutNode }: IDisplayGroupContainer) {
   const container = groupNode.item;
-  const classes = useStyles();
   const title = useAppSelector((state) => {
     const titleKey = container.textResourceBindings?.title;
     if (titleKey && state.language.language) {
@@ -36,6 +27,10 @@ export function DisplayGroupContainer({ groupNode, id, onlyRowIndex, renderLayou
     }
     return undefined;
   });
+
+  const texts = useAppSelector((state) =>
+    selectComponentTexts(state.textResources.resources, container.textResourceBindings),
+  );
 
   if (groupNode.isHidden()) {
     return null;
@@ -52,20 +47,45 @@ export function DisplayGroupContainer({ groupNode, id, onlyRowIndex, renderLayou
       data-testid='display-group-container'
       data-componentid={container.id}
     >
-      {title && (
+      {(title || texts.body) && (
         <Grid
           item={true}
           xs={12}
         >
-          <Typography
-            className={classes.groupTitle}
-            variant='h2'
-          >
-            {title}
-          </Typography>
+          {title && (
+            <Typography
+              className={classes.groupTitle}
+              variant='h2'
+            >
+              {title}
+            </Typography>
+          )}
+          {texts.body && (
+            <Typography
+              className={classes.groupBody}
+              variant='body1'
+            >
+              {texts.body}
+            </Typography>
+          )}
         </Grid>
       )}
-      {groupNode.children(undefined, onlyRowIndex).map((n) => renderLayoutNode(n))}
+      <ConditionalWrapper
+        condition={!!container.showGroupingIndicator}
+        wrapper={(children) => (
+          <Grid
+            item={true}
+            container={true}
+            spacing={3}
+            alignItems='flex-start'
+            className={classes.groupingIndicator}
+          >
+            {children}
+          </Grid>
+        )}
+      >
+        <>{groupNode.children(undefined, onlyRowIndex).map((n) => renderLayoutNode(n))}</>
+      </ConditionalWrapper>
     </Grid>
   );
 }

--- a/src/layout/Group/DisplayGroupContainer.tsx
+++ b/src/layout/Group/DisplayGroupContainer.tsx
@@ -1,15 +1,35 @@
 import React from 'react';
 
-import { Grid, Typography } from '@material-ui/core';
+import { Grid } from '@material-ui/core';
 import cn from 'classnames';
 
 import { ConditionalWrapper } from 'src/components/ConditionalWrapper';
 import { useAppSelector } from 'src/hooks/useAppSelector';
 import classes from 'src/layout/Group/DisplayGroupContainer.module.css';
 import { pageBreakStyles, selectComponentTexts } from 'src/utils/formComponentUtils';
+import { LayoutNode } from 'src/utils/layout/LayoutNode';
 import { getTextFromAppOrDefault } from 'src/utils/textResource';
 import type { HGroups } from 'src/utils/layout/hierarchy.types';
-import type { LayoutNode } from 'src/utils/layout/LayoutNode';
+
+const H = ({ level, children, ...props }) => {
+  switch (level) {
+    case 1:
+      return <h1 {...props}>{children}</h1>;
+    case 2:
+      return <h2 {...props}>{children}</h2>;
+    case 3:
+      return <h3 {...props}>{children}</h3>;
+    case 4:
+      return <h4 {...props}>{children}</h4>;
+    case 5:
+      return <h5 {...props}>{children}</h5>;
+    case 6:
+      return <h6 {...props}>{children}</h6>;
+    default:
+      console.warn(`Heading level ${level} is not supported`);
+      return <h2 {...props}>{children}</h2>;
+  }
+};
 
 export interface IDisplayGroupContainer {
   groupNode: LayoutNode<HGroups, 'Group'>;
@@ -36,12 +56,18 @@ export function DisplayGroupContainer({ groupNode, id, onlyRowIndex, renderLayou
     return null;
   }
 
+  const isNested = groupNode.parent instanceof LayoutNode;
+  const headingLevel = Math.min(Math.max(groupNode.parents().length + 1, 2), 6);
+
   return (
     <Grid
       container={true}
       item={true}
       id={id || container.id}
-      className={cn(classes.groupContainer, pageBreakStyles(container.pageBreak))}
+      className={cn(pageBreakStyles(container.pageBreak), {
+        [classes.groupContainer]: !isNested,
+        [classes.groupingIndicator]: !!container.showGroupingIndicator && isNested,
+      })}
       spacing={3}
       alignItems='flex-start'
       data-testid='display-group-container'
@@ -53,25 +79,18 @@ export function DisplayGroupContainer({ groupNode, id, onlyRowIndex, renderLayou
           xs={12}
         >
           {title && (
-            <Typography
+            <H
+              level={headingLevel}
               className={classes.groupTitle}
-              variant='h2'
             >
               {title}
-            </Typography>
+            </H>
           )}
-          {texts.body && (
-            <Typography
-              className={classes.groupBody}
-              variant='body1'
-            >
-              {texts.body}
-            </Typography>
-          )}
+          {texts.body && <p className={classes.groupBody}>{texts.body}</p>}
         </Grid>
       )}
       <ConditionalWrapper
-        condition={!!container.showGroupingIndicator}
+        condition={!!container.showGroupingIndicator && !isNested}
         wrapper={(children) => (
           <Grid
             item={true}

--- a/src/layout/Group/DisplayGroupContainer.tsx
+++ b/src/layout/Group/DisplayGroupContainer.tsx
@@ -8,11 +8,11 @@ import { useAppSelector } from 'src/hooks/useAppSelector';
 import classes from 'src/layout/Group/DisplayGroupContainer.module.css';
 import { pageBreakStyles, selectComponentTexts } from 'src/utils/formComponentUtils';
 import { getTextFromAppOrDefault } from 'src/utils/textResource';
-import type { HNonRepGroup } from 'src/utils/layout/hierarchy.types';
+import type { HGroups } from 'src/utils/layout/hierarchy.types';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export interface IDisplayGroupContainer {
-  groupNode: LayoutNode<HNonRepGroup, 'Group'>;
+  groupNode: LayoutNode<HGroups, 'Group'>;
   id?: string;
   onlyRowIndex?: number | undefined;
   renderLayoutNode: (node: LayoutNode) => JSX.Element | null;

--- a/src/layout/Group/GroupRenderer.tsx
+++ b/src/layout/Group/GroupRenderer.tsx
@@ -7,6 +7,8 @@ import { RepeatingGroupsFocusProvider } from 'src/layout/Group/RepeatingGroupsFo
 import { PanelGroupContainer } from 'src/layout/Panel/PanelGroupContainer';
 import { PanelReferenceGroupContainer } from 'src/layout/Panel/PanelReferenceGroupContainer';
 import type { PropsFromGenericComponent } from 'src/layout';
+import type { HNonRepGroup } from 'src/utils/layout/hierarchy.types';
+import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export type GroupRendererProps = PropsFromGenericComponent<'Group'>;
 
@@ -47,7 +49,7 @@ export function GroupRenderer({ node }: GroupRendererProps) {
   return (
     <DisplayGroupContainer
       key={node.item.id}
-      groupNode={node}
+      groupNode={node as LayoutNode<HNonRepGroup, 'Group'>}
       renderLayoutNode={(n) => (
         <GenericComponent
           key={n.item.id}

--- a/src/layout/Group/GroupRenderer.tsx
+++ b/src/layout/Group/GroupRenderer.tsx
@@ -7,8 +7,6 @@ import { RepeatingGroupsFocusProvider } from 'src/layout/Group/RepeatingGroupsFo
 import { PanelGroupContainer } from 'src/layout/Panel/PanelGroupContainer';
 import { PanelReferenceGroupContainer } from 'src/layout/Panel/PanelReferenceGroupContainer';
 import type { PropsFromGenericComponent } from 'src/layout';
-import type { HNonRepGroup } from 'src/utils/layout/hierarchy.types';
-import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export type GroupRendererProps = PropsFromGenericComponent<'Group'>;
 
@@ -46,16 +44,22 @@ export function GroupRenderer({ node }: GroupRendererProps) {
   }
 
   // Treat as regular components
-  return (
-    <DisplayGroupContainer
-      key={node.item.id}
-      groupNode={node as LayoutNode<HNonRepGroup, 'Group'>}
-      renderLayoutNode={(n) => (
-        <GenericComponent
-          key={n.item.id}
-          node={n}
-        />
-      )}
-    />
-  );
+  if (node.isNonRepGroup()) {
+    return (
+      <DisplayGroupContainer
+        key={node.item.id}
+        groupNode={node}
+        renderLayoutNode={(n) => (
+          <GenericComponent
+            key={n.item.id}
+            node={n}
+          />
+        )}
+      />
+    );
+  }
+
+  // Invalid configuration
+  console.warn(`Group ${node.item.id} has an invalid configuration.`);
+  return null;
 }

--- a/src/layout/Group/SummaryGroupComponent.tsx
+++ b/src/layout/Group/SummaryGroupComponent.tsx
@@ -94,7 +94,7 @@ export function SummaryGroupComponent({
                       ...overrides,
                       targetNode: n,
                       grid: {},
-                      largeGroup: false,
+                      largeGroup: targetNode.isNonRepGroup(),
                     }}
                   />
                 );

--- a/src/layout/Group/SummaryGroupComponent.tsx
+++ b/src/layout/Group/SummaryGroupComponent.tsx
@@ -12,7 +12,7 @@ import { EditButton } from 'src/layout/Summary/EditButton';
 import { SummaryComponent } from 'src/layout/Summary/SummaryComponent';
 import { getTextFromAppOrDefault } from 'src/utils/textResource';
 import type { ISummaryComponent } from 'src/layout/Summary/SummaryComponent';
-import type { LayoutNodeFromType } from 'src/utils/layout/hierarchy.types';
+import type { HNonRepGroup, LayoutNodeFromType } from 'src/utils/layout/hierarchy.types';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export interface ISummaryGroupComponent {
@@ -79,7 +79,7 @@ export function SummaryGroupComponent({
             <DisplayGroupContainer
               key={`summary-${targetNode.item.id}-${idx}`}
               id={`summary-${targetNode.item.id}-${idx}`}
-              groupNode={targetNode}
+              groupNode={targetNode as LayoutNode<HNonRepGroup, 'Group'>}
               onlyRowIndex={idx}
               renderLayoutNode={(n) => {
                 if (inExcludedChildren(n) || n.isHidden()) {

--- a/src/layout/Group/SummaryGroupComponent.tsx
+++ b/src/layout/Group/SummaryGroupComponent.tsx
@@ -12,7 +12,7 @@ import { EditButton } from 'src/layout/Summary/EditButton';
 import { SummaryComponent } from 'src/layout/Summary/SummaryComponent';
 import { getTextFromAppOrDefault } from 'src/utils/textResource';
 import type { ISummaryComponent } from 'src/layout/Summary/SummaryComponent';
-import type { HNonRepGroup, LayoutNodeFromType } from 'src/utils/layout/hierarchy.types';
+import type { LayoutNodeFromType } from 'src/utils/layout/hierarchy.types';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export interface ISummaryGroupComponent {
@@ -79,7 +79,7 @@ export function SummaryGroupComponent({
             <DisplayGroupContainer
               key={`summary-${targetNode.item.id}-${idx}`}
               id={`summary-${targetNode.item.id}-${idx}`}
-              groupNode={targetNode as LayoutNode<HNonRepGroup, 'Group'>}
+              groupNode={targetNode}
               onlyRowIndex={idx}
               renderLayoutNode={(n) => {
                 if (inExcludedChildren(n) || n.isHidden()) {

--- a/src/layout/Group/types.d.ts
+++ b/src/layout/Group/types.d.ts
@@ -29,6 +29,7 @@ export interface ILayoutGroup extends ILayoutCompBase<'Group'> {
   tableColumns?: ITableColumnFormatting<IGroupColumnFormatting>;
   edit?: IGroupEditProperties;
   panel?: IGroupPanel;
+  showGroupingIndicator?: boolean;
   hiddenRow?: ExprVal.Boolean;
   rowsBefore?: GridRow[];
   rowsAfter?: GridRow[];

--- a/src/layout/Summary/SummaryComponent.tsx
+++ b/src/layout/Summary/SummaryComponent.tsx
@@ -96,7 +96,8 @@ export function SummaryComponent({ summaryNode, overrides }: ISummaryComponent) 
 
   const component = targetNode.def;
   const RenderSummary = 'renderSummary' in component ? component.renderSummary.bind(component) : null;
-  const shouldShowBorder = 'renderSummaryBoilerplate' in component && component?.renderSummaryBoilerplate();
+  const shouldShowBorder =
+    RenderSummary && 'renderSummaryBoilerplate' in component && component?.renderSummaryBoilerplate();
 
   return (
     <Grid

--- a/src/layout/Summary/SummaryComponent.tsx
+++ b/src/layout/Summary/SummaryComponent.tsx
@@ -96,6 +96,7 @@ export function SummaryComponent({ summaryNode, overrides }: ISummaryComponent) 
 
   const component = targetNode.def;
   const RenderSummary = 'renderSummary' in component ? component.renderSummary.bind(component) : null;
+  const shouldShowBorder = 'renderSummaryBoilerplate' in component && component?.renderSummaryBoilerplate();
 
   return (
     <Grid
@@ -112,7 +113,7 @@ export function SummaryComponent({ summaryNode, overrides }: ISummaryComponent) 
       <Grid
         container={true}
         className={cn({
-          [classes.border]: !display?.hideBottomBorder,
+          [classes.border]: !display?.hideBottomBorder && shouldShowBorder,
         })}
       >
         {RenderSummary && 'renderSummaryBoilerplate' in component ? (


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

Added optional groupingIndicator, line + indent, also added body text.

Anything about this that need unit/cypress testing?

I made some changes to how non-repeating groups are treated in summary to make it work a bit better. I made it so that largeGroup is true for nested non repeating groups, this will make it look more like how it does when filling out the form. I also made the bottomBorder not visible when not using summaryBoilerplate, this applies to group and grid, which have a custom rendering that makes it look better without it in my opinion. It looked very strange for non-repeating groups at least. TLDR; There were too many borders imo. 😅 

https://www.figma.com/file/Pvti3aRcOwH0k5Z7DrLznk/Arbeidsomr%C3%A5de%3A-Altinn-Studio-APPS?type=design&node-id=4745%3A110013&t=xrvnNTRiNxSh5H4u-1

The use of `!important` is due to #1000 i think, there are at least problems with overriding material-ui as well.

<img width="1059" alt="image" src="https://github.com/Altinn/app-frontend-react/assets/47412359/39b4f986-c570-4b81-8237-4400ad440bef">

## Related Issue(s)

- closes #436 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [x] Has been added/updated
    - https://github.com/Altinn/altinn-studio-docs/pull/944
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [x] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [ ] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
