### PR TITLE
Quickfix: Panel in PDF

### DIFF
--- a/src/components/form/FullWidthWrapper.module.css
+++ b/src/components/form/FullWidthWrapper.module.css
@@ -1,13 +1,15 @@
-.fullWidth {
-  margin-left: calc(var(--modal-padding-x) * -1);
-  margin-right: calc(var(--modal-padding-x) * -1);
-  width: calc(100% + 2 * var(--modal-padding-x));
-}
+@media only screen {
+  .fullWidth {
+    margin-left: calc(var(--modal-padding-x) * -1);
+    margin-right: calc(var(--modal-padding-x) * -1);
+    width: calc(100% + 2 * var(--modal-padding-x));
+  }
 
-.consumeBottomPadding {
-  margin-bottom: calc(var(--modal-padding-y) * -1);
-}
+  .consumeBottomPadding {
+    margin-bottom: calc(var(--modal-padding-y) * -1);
+  }
 
-.consumeTopPadding {
-  margin-top: calc(var(--modal-padding-y) * -1);
+  .consumeTopPadding {
+    margin-top: calc(var(--modal-padding-y) * -1);
+  }
 }


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->
This makes the fullWidthWrapper css only apply to screen and not print.

Previously it would have a negative margin to the sides, and if it was on the bottom/top of its page it would also comsume bottom/top padding making it overlap with other things.

Before:
![image](https://github.com/Altinn/app-frontend-react/assets/47412359/8aa8442e-3218-4201-a870-f283c50dc5e3)

After:
![image](https://github.com/Altinn/app-frontend-react/assets/47412359/61a2ad6c-39d7-4601-b429-7ff8507a1600)


