### PR TITLE
DevTools: Fixing data model schema lookups

### DIFF
--- a/src/hooks/useDataModelSchema.tsx
+++ b/src/hooks/useDataModelSchema.tsx
@@ -20,7 +20,6 @@ function useDraft(enabled: boolean) {
     dataModels && currentDataModelName && currentDataModelName in dataModels && dataModels[currentDataModelName];
 
   if (!currentModel) {
-    console.warn('Unable to read current data model schema');
     return undefined;
   }
 
@@ -31,12 +30,12 @@ function useDraft(enabled: boolean) {
   // The library does not seem to support 2019-09 and 2020-12 versions yet, and for all others it seems the
   // schema version is not usually specified. Also, ajv seems to default to Draft07, so we'll do that too.
   const rootPath = getRootElementPath(currentModel);
-  const modelCopy = JSON.parse(JSON.stringify(currentModel));
+  const modelCopy = structuredClone(currentModel);
   if (rootPath) {
     modelCopy.$ref = rootPath;
   }
 
-  return new Draft07(currentModel);
+  return new Draft07(modelCopy);
 }
 
 const Context = React.createContext<Draft07 | undefined>(undefined);


### PR DESCRIPTION
## Description
Well, this is embarrassing.. The reason some apps did not look up the data model path correctly, was that I forgot to use a variable I had prepared, and instead I used the raw model with no references to the start node. This should fix the issue. Tested on `bjosttveit/newcomer-sogndal`, which @bjosttveit reported to not be working.

Also removed the misleading `console.warn`, because it also complained when the app state was loading.

## Related Issue(s)

- #990

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
