### PR TITLE
Refac: use dataSources instead of AltinnWindow

### DIFF
--- a/src/__mocks__/hierarchyMock.ts
+++ b/src/__mocks__/hierarchyMock.ts
@@ -1,4 +1,5 @@
 import { getInitialStateMock } from 'src/__mocks__/initialStateMock';
+import type { IProfileState } from 'src/features/profile';
 import type { HierarchyDataSources } from 'src/utils/layout/hierarchy.types';
 
 export function getHierarchyDataSourcesMock(): HierarchyDataSources {
@@ -10,5 +11,7 @@ export function getHierarchyDataSourcesMock(): HierarchyDataSources {
     authContext: null,
     validations: {},
     devTools: getInitialStateMock().devTools,
+    textResources: [],
+    profile: {} as IProfileState,
   };
 }

--- a/src/features/expressions/ExprContext.ts
+++ b/src/features/expressions/ExprContext.ts
@@ -4,7 +4,8 @@ import { ExprRuntimeError, NodeNotFound, NodeNotFoundWithoutContext } from 'src/
 import { prettyErrors, prettyErrorsToConsole } from 'src/features/expressions/prettyErrors';
 import type { ExprConfig, Expression } from 'src/features/expressions/types';
 import type { IFormData } from 'src/features/formData';
-import type { IApplicationSettings, IAuthContext, IInstanceContext } from 'src/types/shared';
+import type { IProfileState } from 'src/features/profile';
+import type { IApplicationSettings, IAuthContext, IInstanceContext, ITextResource } from 'src/types/shared';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 import type { LayoutPage } from 'src/utils/layout/LayoutPage';
 
@@ -14,6 +15,8 @@ export interface ContextDataSources {
   formData: IFormData;
   authContext: Partial<IAuthContext> | null;
   hiddenFields: Set<string>;
+  textResources: ITextResource[];
+  profile: IProfileState;
 }
 
 export interface PrettyErrorsOptions {

--- a/src/features/expressions/index.ts
+++ b/src/features/expressions/index.ts
@@ -45,8 +45,6 @@ export interface EvalExprInObjArgs<T> {
   deleteNonExpressions?: boolean;
 }
 
-const altinnWindow = window as unknown as IAltinnWindow;
-
 /**
  * Magic key used to indicate a config value for all possible values in an object
  */
@@ -533,16 +531,19 @@ export const ExprFunctions = {
       if (key === null) {
         throw new LookupNotFound(this, `"Key" parameter cannot be null.`);
       }
-      const state = altinnWindow.reduxStore.getState();
-      return getTextResourceByKey(key, state.textResources.resources);
+
+      return getTextResourceByKey(key, this.dataSources.textResources);
     },
     args: [ExprVal.String] as const,
     returns: ExprVal.String,
   }),
   language: defineFunc({
-    impl(): string {
-      const state = altinnWindow.reduxStore.getState();
-      return state.profile.selectedAppLanguage || state.profile.profile.profileSettingPreference.language;
+    impl(): string | null {
+      const selectedLanguage =
+        this.dataSources.profile?.selectedAppLanguage ||
+        this.dataSources.profile?.profile?.profileSettingPreference?.language;
+
+      return selectedLanguage || null;
     },
     args: [] as const,
     returns: ExprVal.String,

--- a/src/features/expressions/shared-tests/functions/language/should-return-profile-settings-preference.json
+++ b/src/features/expressions/shared-tests/functions/language/should-return-profile-settings-preference.json
@@ -1,13 +1,13 @@
 {
-  "name": "Should return profile selectedAppLanguage",
+  "name": "Should return profileSettingPreference",
   "expression": ["language"],
-  "expects": "nb",
+  "expects": "en",
   "profile": {
     "profile": {
       "profileSettingPreference": {
         "language": "en"
       }
     },
-    "selectedAppLanguage": "nb"
+    "selectedAppLanguage": null
   }
 }

--- a/src/features/expressions/shared.test.ts
+++ b/src/features/expressions/shared.test.ts
@@ -13,6 +13,7 @@ import { _private } from 'src/utils/layout/hierarchy';
 import { generateEntireHierarchy, generateHierarchy } from 'src/utils/layout/HierarchyGenerator';
 import type { FunctionTest, SharedTestContext, SharedTestContextList } from 'src/features/expressions/shared';
 import type { Expression } from 'src/features/expressions/types';
+import type { IProfileState } from 'src/features/profile';
 import type { IRepeatingGroups } from 'src/types';
 import type { IApplicationSettings } from 'src/types/shared';
 import type { HierarchyDataSources } from 'src/utils/layout/hierarchy.types';
@@ -61,6 +62,8 @@ describe('Expressions shared function tests', () => {
         instance,
         permissions,
         frontendSettings,
+        textResources,
+        profile,
       }) => {
         const dataSources: HierarchyDataSources = {
           ...getHierarchyDataSourcesMock(),
@@ -68,6 +71,8 @@ describe('Expressions shared function tests', () => {
           instanceContext: buildInstanceContext(instance),
           applicationSettings: frontendSettings || ({} as IApplicationSettings),
           authContext: buildAuthContext(permissions),
+          textResources: textResources || [],
+          profile: profile || ({} as IProfileState),
         };
 
         const _layouts = convertLayouts(layouts);

--- a/src/features/expressions/shared.ts
+++ b/src/features/expressions/shared.ts
@@ -2,7 +2,9 @@ import fs from 'node:fs';
 
 import type { Expression } from 'src/features/expressions/types';
 import type { IProcessPermissions } from 'src/features/process';
+import type { IProfileState } from 'src/features/profile';
 import type { ILayout, ILayouts } from 'src/layout/layout';
+import type { ITextResource } from 'src/types';
 import type { IApplicationSettings, IInstance } from 'src/types/shared';
 
 export interface Layouts {
@@ -22,6 +24,8 @@ export interface SharedTest {
   instance?: IInstance;
   permissions?: IProcessPermissions;
   frontendSettings?: IApplicationSettings;
+  textResources?: ITextResource[];
+  profile?: IProfileState;
 }
 
 export interface SharedTestContext {

--- a/src/layout/Group/DisplayGroupContainer.tsx
+++ b/src/layout/Group/DisplayGroupContainer.tsx
@@ -9,7 +9,7 @@ import classes from 'src/layout/Group/DisplayGroupContainer.module.css';
 import { pageBreakStyles, selectComponentTexts } from 'src/utils/formComponentUtils';
 import { LayoutNode } from 'src/utils/layout/LayoutNode';
 import { getTextFromAppOrDefault } from 'src/utils/textResource';
-import type { HGroups } from 'src/utils/layout/hierarchy.types';
+import type { HGroups } from 'src/layout/Group/types';
 
 const H = ({ level, children, ...props }) => {
   switch (level) {

--- a/src/utils/layout/hierarchy.ts
+++ b/src/utils/layout/hierarchy.ts
@@ -113,6 +113,8 @@ export function dataSourcesFromState(state: IRuntimeState): HierarchyDataSources
     authContext: buildAuthContext(state.process),
     validations: state.formValidations.validations,
     devTools: state.devTools,
+    textResources: state.textResources.resources,
+    profile: state.profile,
   };
 }
 
@@ -170,8 +172,20 @@ function useResolvedExpressions() {
       hiddenFields: new Set(hiddenFields),
       validations,
       devTools,
+      textResources,
+      profile: state.profile,
     }),
-    [formData, applicationSettings, instance, process, hiddenFields, validations, devTools],
+    [
+      formData,
+      applicationSettings,
+      instance,
+      process,
+      hiddenFields,
+      validations,
+      devTools,
+      textResources,
+      state.profile,
+    ],
   );
 
   return useMemo(


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

Small refactoring to improve the code by using **dataSources** instead of **AltinnWindow**.

## Related Issue(s)

- closes #1176 
## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
