### PR TITLE
WCAG: Party selection buttons

### DIFF
--- a/src/components/altinnParty.tsx
+++ b/src/components/altinnParty.tsx
@@ -196,6 +196,7 @@ export function AltinnParty({ party, onSelectParty, showSubUnits }: IAltinnParty
           >
             <Grid
               key={index}
+              role='button'
               className={classes.subUnit}
               container={true}
               direction='column'
@@ -226,6 +227,7 @@ export function AltinnParty({ party, onSelectParty, showSubUnits }: IAltinnParty
     <Paper className={party.onlyHierarchyElementWithNoAccess ? classes.partyPaperDisabled : classes.partyPaper}>
       <Grid
         id={`party-${party.partyId}`}
+        role='button'
         data-testid='AltinnParty-PartyWrapper'
         container={true}
         direction='row'

--- a/src/layout/Group/DisplayGroupContainer.tsx
+++ b/src/layout/Group/DisplayGroupContainer.tsx
@@ -9,7 +9,7 @@ import classes from 'src/layout/Group/DisplayGroupContainer.module.css';
 import { pageBreakStyles, selectComponentTexts } from 'src/utils/formComponentUtils';
 import { LayoutNode } from 'src/utils/layout/LayoutNode';
 import { getTextFromAppOrDefault } from 'src/utils/textResource';
-import type { HGroups } from 'src/utils/layout/hierarchy.types';
+import type { HGroups } from 'src/layout/Group/types';
 
 const H = ({ level, children, ...props }) => {
   switch (level) {


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

This is a quick fix that adds `role=button` to the party selection items, these ones:

<img width="487" alt="image" src="https://github.com/Altinn/app-frontend-react/assets/47412359/58d4d17a-2179-4b8e-ba34-0972b18c8bfc">

 This has annoyed me for a while since i use [vimium](https://chrome.google.com/webstore/detail/vimium/dbepggeogbaibhgnhhndojpepiihcmeb) to navigate in the browser and it could not detect these as clickable since it was just a div with no role. It was likely not great to use with screen readers either.
