### PR TITLE
Removing autosave functionality (not in use)

### DIFF
--- a/src/__mocks__/formDataStateMock.ts
+++ b/src/__mocks__/formDataStateMock.ts
@@ -13,7 +13,6 @@ export function getFormDataStateMock(customState?: Partial<IFormDataState>) {
       'referencedGroup[2].inputField': 'Value from input field [2]',
     },
     lastSavedFormData: {},
-    savingId: '',
     submittingId: '',
     unsavedChanges: false,
     saving: false,

--- a/src/__mocks__/uiConfigStateMock.ts
+++ b/src/__mocks__/uiConfigStateMock.ts
@@ -1,7 +1,6 @@
 import type { IUiConfig } from 'src/types';
 
 export const getUiConfigStateMock = (customStates?: Partial<IUiConfig>): IUiConfig => ({
-  autoSave: true,
   focus: null,
   tracks: {
     hidden: [],

--- a/src/features/formData/formDataSlice.ts
+++ b/src/features/formData/formDataSlice.ts
@@ -71,17 +71,6 @@ export const formDataSlice = () => {
           state.submittingId = componentId;
         },
       }),
-      savingStarted: mkAction<void>({
-        reducer: (state) => {
-          state.saving = true;
-        },
-      }),
-      savingEnded: mkAction<{ model: IFormData }>({
-        reducer: (state, action) => {
-          state.saving = false;
-          state.lastSavedFormData = action.payload.model;
-        },
-      }),
       submitFulfilled: mkAction<void>({
         reducer: (state) => {
           state.unsavedChanges = false;
@@ -92,6 +81,17 @@ export const formDataSlice = () => {
           const { error } = action.payload;
           state.error = error;
           state.submittingId = '';
+        },
+      }),
+      savingStarted: mkAction<void>({
+        reducer: (state) => {
+          state.saving = true;
+        },
+      }),
+      savingEnded: mkAction<{ model: IFormData }>({
+        reducer: (state, action) => {
+          state.saving = false;
+          state.lastSavedFormData = action.payload.model;
         },
       }),
       update: mkAction<IUpdateFormData>({

--- a/src/features/formData/formDataSlice.ts
+++ b/src/features/formData/formDataSlice.ts
@@ -27,7 +27,6 @@ export const initialState: IFormDataState = {
   unsavedChanges: false,
   saving: false,
   submittingId: '',
-  savingId: '',
   error: null,
 };
 
@@ -68,9 +67,8 @@ export const formDataSlice = () => {
       submit: mkAction<ISubmitDataAction>({
         takeEvery: submitFormSaga,
         reducer: (state, action) => {
-          const { apiMode, componentId } = action.payload;
-          state.savingId = apiMode !== 'Complete' ? componentId : state.savingId;
-          state.submittingId = apiMode === 'Complete' ? componentId : state.submittingId;
+          const { componentId } = action.payload;
+          state.submittingId = componentId;
         },
       }),
       savingStarted: mkAction<void>({
@@ -86,7 +84,6 @@ export const formDataSlice = () => {
       }),
       submitFulfilled: mkAction<void>({
         reducer: (state) => {
-          state.savingId = '';
           state.unsavedChanges = false;
         },
       }),
@@ -95,7 +92,6 @@ export const formDataSlice = () => {
           const { error } = action.payload;
           state.error = error;
           state.submittingId = '';
-          state.savingId = '';
         },
       }),
       update: mkAction<IUpdateFormData>({

--- a/src/features/formData/formDataTypes.ts
+++ b/src/features/formData/formDataTypes.ts
@@ -14,8 +14,6 @@ export interface IFormDataRejected {
 
 export interface ISubmitDataAction {
   url?: string;
-  apiMode?: string;
-  stopWithWarnings?: boolean;
   componentId: string;
 }
 

--- a/src/features/formData/index.d.ts
+++ b/src/features/formData/index.d.ts
@@ -17,9 +17,8 @@ export interface IFormDataState {
   unsavedChanges: boolean;
   saving: boolean;
 
-  // The component IDs which triggered submitting/saving last time
+  // The component IDs which triggered a submit (saving the form data in order to move to the next step)
   submittingId: string;
-  savingId: string;
 
   error: Error | null;
 }

--- a/src/features/formData/submit/submitFormDataSagas.ts
+++ b/src/features/formData/submit/submitFormDataSagas.ts
@@ -32,6 +32,10 @@ import type { IRuntimeState, IRuntimeStore, IValidationIssue } from 'src/types';
 const LayoutSelector: (store: IRuntimeStore) => ILayoutState = (store: IRuntimeStore) => store.formLayout;
 const getApplicationMetaData = (store: IRuntimeState) => store.applicationMetadata?.applicationMetadata;
 
+/**
+ * Saga that submits the form data to the backend, and moves the process forward.
+ * @see autoSaveSaga
+ */
 export function* submitFormSaga(): SagaIterator {
   try {
     const state: IRuntimeState = yield select();
@@ -138,6 +142,17 @@ function* waitForSaving() {
   yield put(FormDataActions.savingStarted());
 }
 
+/**
+ * This is the saving logic that is used for both autosaving and when the form is
+ * submitted at the end (moving the process forward).
+ *
+ * Strangely, this only performs the autosave logic for regular apps, but stateless apps have their own logic for this.
+ * However, when the form is submitted at the end, this is used for both regular and stateless apps.
+ *
+ * @see submitFormSaga
+ * @see autoSaveSaga
+ * @see postStatelessData
+ */
 export function* putFormData({ field, componentId }: SaveDataParams) {
   const defaultDataElementGuid: string | undefined = yield select((state) =>
     getCurrentTaskDataElementId(
@@ -227,6 +242,13 @@ function getModelToSave(state: IRuntimeState) {
   );
 }
 
+/**
+ * Saves the form data to the backend, called from the auto-save saga. This calls the methods that actually perform
+ * the save operation, but this is NOT the saving logic that happens on _submit_ (when the form is submitted, and
+ * the process moves forward).
+ * @see autoSaveSaga
+ * @see submitFormSaga
+ */
 export function* saveFormDataSaga({
   payload: { field, componentId, singleFieldValidation },
 }: PayloadAction<IUpdateFormDataFulfilled>): SagaIterator {
@@ -236,7 +258,7 @@ export function* saveFormDataSaga({
     const application = state.applicationMetadata.applicationMetadata;
 
     if (isStatelessApp(application)) {
-      yield call(saveStatelessData, { field, componentId });
+      yield call(postStatelessData, { field, componentId });
     } else {
       // app with instance
       yield call(putFormData, { field, componentId });
@@ -264,7 +286,13 @@ interface SaveDataParams {
   componentId?: string;
 }
 
-export function* saveStatelessData({ field, componentId }: SaveDataParams) {
+/**
+ * Innermost POST request that is called for stateless apps. This is only called during auto-save, and not when the
+ * form is submitted.
+ * @see saveFormDataSaga
+ * @see autoSaveSaga
+ */
+export function* postStatelessData({ field, componentId }: SaveDataParams) {
   const state: IRuntimeState = yield select();
   const model = getModelToSave(state);
   const allowAnonymous = yield select(makeGetAllowAnonymousSelector());
@@ -313,6 +341,10 @@ export function* saveStatelessData({ field, componentId }: SaveDataParams) {
   yield put(FormDataActions.savingEnded({ model: state.formData.formData }));
 }
 
+/**
+ * Auto-saves the form data when the user has made changes to the form. This is done very often.
+ * @see submitFormSaga
+ */
 export function* autoSaveSaga({
   payload: { skipAutoSave, field, componentId, singleFieldValidation },
 }: PayloadAction<IUpdateFormDataFulfilled>): SagaIterator {

--- a/src/features/formData/submit/submitFormDataSagas.ts
+++ b/src/features/formData/submit/submitFormDataSagas.ts
@@ -27,10 +27,9 @@ import type { IApplicationMetadata } from 'src/features/applicationMetadata';
 import type { IFormData } from 'src/features/formData';
 import type { ISubmitDataAction, IUpdateFormDataFulfilled } from 'src/features/formData/formDataTypes';
 import type { ILayoutState } from 'src/features/layout/formLayoutSlice';
-import type { IRuntimeState, IRuntimeStore, IUiConfig, IValidationIssue } from 'src/types';
+import type { IRuntimeState, IRuntimeStore, IValidationIssue } from 'src/types';
 
 const LayoutSelector: (store: IRuntimeStore) => ILayoutState = (store: IRuntimeStore) => store.formLayout;
-const UIConfigSelector: (store: IRuntimeStore) => IUiConfig = (store: IRuntimeStore) => store.formLayout.uiConfig;
 const getApplicationMetaData = (store: IRuntimeState) => store.applicationMetadata?.applicationMetadata;
 
 export function* submitFormSaga({
@@ -326,17 +325,11 @@ export function* autoSaveSaga({
     return;
   }
 
-  const uiConfig: IUiConfig = yield select(UIConfigSelector);
   const applicationMetadata: IApplicationMetadata = yield select(getApplicationMetaData);
 
-  // undefined should default to auto save
-  const shouldAutoSave = uiConfig.autoSave !== false;
-
-  if (shouldAutoSave) {
-    if (isStatelessApp(applicationMetadata)) {
-      yield put(FormDataActions.saveLatest({ field, componentId, singleFieldValidation }));
-    } else {
-      yield put(FormDataActions.saveEvery({ field, componentId, singleFieldValidation }));
-    }
+  if (isStatelessApp(applicationMetadata)) {
+    yield put(FormDataActions.saveLatest({ field, componentId, singleFieldValidation }));
+  } else {
+    yield put(FormDataActions.saveEvery({ field, componentId, singleFieldValidation }));
   }
 }

--- a/src/features/layout/fetch/fetchFormLayoutSagas.test.ts
+++ b/src/features/layout/fetch/fetchFormLayoutSagas.test.ts
@@ -94,7 +94,6 @@ describe('fetchFormLayoutSagas', () => {
             hiddenLayoutsExpressions: { ...hiddenExprPage1 },
           }),
         )
-        .put(FormLayoutActions.updateAutoSave({ autoSave: undefined }))
         .put(
           FormLayoutActions.updateCurrentView({
             newView: 'page1',
@@ -120,7 +119,6 @@ describe('fetchFormLayoutSagas', () => {
             hiddenLayoutsExpressions: { FormLayout: hiddenExprPage1['page1'] },
           }),
         )
-        .put(FormLayoutActions.updateAutoSave({ autoSave: undefined }))
         .put(
           FormLayoutActions.updateCurrentView({
             newView: 'FormLayout',
@@ -169,7 +167,6 @@ describe('fetchFormLayoutSagas', () => {
             },
           }),
         )
-        .put(FormLayoutActions.updateAutoSave({ autoSave: undefined }))
         .put(
           FormLayoutActions.updateCurrentView({
             newView: 'page2',
@@ -201,7 +198,6 @@ describe('fetchFormLayoutSagas', () => {
             },
           }),
         )
-        .put(FormLayoutActions.updateAutoSave({ autoSave: undefined }))
         .put(
           FormLayoutActions.updateCurrentView({
             newView: 'page1',
@@ -227,7 +223,6 @@ describe('fetchFormLayoutSagas', () => {
             hiddenLayoutsExpressions: { ...hiddenExprPage1 },
           }),
         )
-        .put(FormLayoutActions.updateAutoSave({ autoSave: undefined }))
         .put(
           FormLayoutActions.updateCurrentView({
             newView: 'page1',
@@ -253,7 +248,6 @@ describe('fetchFormLayoutSagas', () => {
             hiddenLayoutsExpressions: { ...hiddenExprPage1 },
           }),
         )
-        .put(FormLayoutActions.updateAutoSave({ autoSave: undefined }))
         .put(
           FormLayoutActions.updateCurrentView({
             newView: 'page1',

--- a/src/features/layout/fetch/fetchFormLayoutSagas.ts
+++ b/src/features/layout/fetch/fetchFormLayoutSagas.ts
@@ -54,13 +54,11 @@ export function* fetchLayoutSaga(): SagaIterator {
     const layouts: ILayouts = {};
     const navigationConfig: any = {};
     const hiddenLayoutsExpressions: ExprUnresolved<IHiddenLayoutsExpressions> = {};
-    let autoSave: boolean | undefined;
     let firstLayoutKey: string;
     if (layoutResponse.data?.layout) {
       layouts.FormLayout = layoutResponse.data.layout;
       hiddenLayoutsExpressions.FormLayout = layoutResponse.data.hidden;
       firstLayoutKey = 'FormLayout';
-      autoSave = layoutResponse.data.autoSave;
     } else {
       const orderedLayoutKeys = Object.keys(layoutResponse).sort();
 
@@ -79,7 +77,6 @@ export function* fetchLayoutSaga(): SagaIterator {
         layouts[key] = cleanLayout(layoutResponse[key].data.layout);
         hiddenLayoutsExpressions[key] = layoutResponse[key].data.hidden;
         navigationConfig[key] = layoutResponse[key].data.navigation;
-        autoSave = layoutResponse[key].data.autoSave;
       });
     }
 
@@ -102,7 +99,6 @@ export function* fetchLayoutSaga(): SagaIterator {
         hiddenLayoutsExpressions,
       }),
     );
-    yield put(FormLayoutActions.updateAutoSave({ autoSave }));
     yield put(
       FormLayoutActions.updateCurrentView({
         newView: firstLayoutKey,

--- a/src/features/layout/formLayoutSlice.ts
+++ b/src/features/layout/formLayoutSlice.ts
@@ -42,7 +42,6 @@ export const initialState: ILayoutState = {
   uiConfig: {
     focus: null,
     hiddenFields: [],
-    autoSave: null,
     repeatingGroups: null,
     fileUploadersWithTag: {},
     receiptLayoutName: undefined,
@@ -160,12 +159,6 @@ export const formLayoutSlice = () => {
           reducer: (state, action) => {
             const { key } = action.payload;
             state.uiConfig.currentViewCacheKey = key;
-          },
-        }),
-        updateAutoSave: mkAction<LayoutTypes.IUpdateAutoSave>({
-          reducer: (state, action) => {
-            const { autoSave } = action.payload;
-            state.uiConfig.autoSave = autoSave;
           },
         }),
         updateCurrentView: mkAction<LayoutTypes.IUpdateCurrentView>({

--- a/src/features/layout/formLayoutTypes.ts
+++ b/src/features/layout/formLayoutTypes.ts
@@ -35,10 +35,6 @@ export interface ISetCurrentViewCacheKey {
   key: string | undefined;
 }
 
-export interface IUpdateAutoSave {
-  autoSave: boolean | undefined;
-}
-
 export interface IUpdateCurrentView {
   newView: string;
   returnToView?: string;

--- a/src/features/layout/repGroups/updateRepeatingGroupEditIndexSaga.ts
+++ b/src/features/layout/repGroups/updateRepeatingGroupEditIndexSaga.ts
@@ -101,7 +101,7 @@ export function* updateRepeatingGroupEditIndexSaga({
       yield put(ValidationActions.updateValidations({ validations: newValidations }));
       const rowValidations = filterValidationsByRow(resolvedNodes, combinedValidations, group, rowIndex);
 
-      if (canFormBeSaved({ validations: rowValidations, invalidDataTypes: false }, 'Complete')) {
+      if (canFormBeSaved({ validations: rowValidations, invalidDataTypes: false })) {
         if (shouldAddRow) {
           yield put(FormLayoutActions.repGroupAddRow({ groupId: group }));
         }

--- a/src/features/layout/update/updateFormLayoutSagas.ts
+++ b/src/features/layout/update/updateFormLayoutSagas.ts
@@ -136,13 +136,10 @@ export function* updateCurrentViewSaga({
           }),
         );
       } else if (
-        !canFormBeSaved(
-          {
-            validations: { [currentView]: validations[currentView] },
-            invalidDataTypes: false,
-          },
-          'Complete',
-        )
+        !canFormBeSaved({
+          validations: { [currentView]: validations[currentView] },
+          invalidDataTypes: false,
+        })
       ) {
         yield put(
           FormLayoutActions.updateCurrentViewRejected({

--- a/src/layout/Button/ButtonComponent.test.tsx
+++ b/src/layout/Button/ButtonComponent.test.tsx
@@ -37,7 +37,6 @@ const render = (submittingId: string) => {
     },
     manipulateState: (state) => {
       state.formData.submittingId = submittingId;
-      state.formLayout.uiConfig.autoSave = true;
     },
   });
 };

--- a/src/layout/Button/ButtonComponent.tsx
+++ b/src/layout/Button/ButtonComponent.tsx
@@ -23,7 +23,6 @@ export const ButtonComponent = ({ node, ...componentProps }: IButtonReceivedProp
 
   const dispatch = useAppDispatch();
   const submittingId = useAppSelector((state) => state.formData.submittingId);
-  const savingId = useAppSelector((state) => state.formData.savingId);
   const confirmingId = useAppSelector((state) => state.process.completingId);
   const currentTaskType = useAppSelector((state) => state.instanceData.instance?.process?.currentTask?.altinnTaskType);
   const processActionsFeature = useAppSelector(
@@ -60,8 +59,6 @@ export const ButtonComponent = ({ node, ...componentProps }: IButtonReceivedProp
         dispatch(
           FormDataActions.submit({
             url: `${window.location.origin}/${org}/${app}/api/${instanceId}`,
-            apiMode: 'Complete',
-            stopWithWarnings: false,
             componentId,
           }),
         );
@@ -72,7 +69,7 @@ export const ButtonComponent = ({ node, ...componentProps }: IButtonReceivedProp
       }
     }
   };
-  const busyWithId = savingId || submittingId || confirmingId || '';
+  const busyWithId = submittingId || confirmingId || '';
   return (
     <div
       className={classes.container}

--- a/src/layout/Button/ButtonComponent.tsx
+++ b/src/layout/Button/ButtonComponent.tsx
@@ -4,10 +4,8 @@ import { FormDataActions } from 'src/features/formData/formDataSlice';
 import { ProcessActions } from 'src/features/process/processSlice';
 import { useAppDispatch } from 'src/hooks/useAppDispatch';
 import { useAppSelector } from 'src/hooks/useAppSelector';
-import { getLanguageFromKey } from 'src/language/sharedLanguage';
 import classes from 'src/layout/Button/ButtonComponent.module.css';
 import { getComponentFromMode } from 'src/layout/Button/getComponentFromMode';
-import { SaveButton } from 'src/layout/Button/SaveButton';
 import { SubmitButton } from 'src/layout/Button/SubmitButton';
 import { LayoutPage } from 'src/utils/layout/LayoutPage';
 import type { PropsFromGenericComponent } from 'src/layout';
@@ -24,7 +22,6 @@ export const ButtonComponent = ({ node, ...componentProps }: IButtonReceivedProp
   const props: IButtonProvidedProps = { ...componentProps, ...node.item, node };
 
   const dispatch = useAppDispatch();
-  const autoSave = useAppSelector((state) => state.formLayout.uiConfig.autoSave);
   const submittingId = useAppSelector((state) => state.formData.submittingId);
   const savingId = useAppSelector((state) => state.formData.savingId);
   const confirmingId = useAppSelector((state) => state.process.completingId);
@@ -55,9 +52,6 @@ export const ButtonComponent = ({ node, ...componentProps }: IButtonReceivedProp
       </div>
     );
   }
-  const saveFormData = () => {
-    dispatch(FormDataActions.submit({ componentId: 'saveBtn' }));
-  };
 
   const submitTask = ({ componentId }: { componentId: string }) => {
     if (!disabled) {
@@ -84,17 +78,6 @@ export const ButtonComponent = ({ node, ...componentProps }: IButtonReceivedProp
       className={classes.container}
       style={{ marginTop: parentIsPage ? 'var(--button-margin-top)' : undefined }}
     >
-      {autoSave === false && ( // can this be removed from the component?
-        <SaveButton
-          onClick={saveFormData}
-          id='saveBtn'
-          busyWithId={busyWithId}
-          language={props.language}
-          disabled={disabled}
-        >
-          {getLanguageFromKey('general.save', props.language)}
-        </SaveButton>
-      )}
       <SubmitButton
         onClick={() => submitTask({ componentId: id })}
         id={id}

--- a/src/layout/Group/RepeatingGroupsTable.test.tsx
+++ b/src/layout/Group/RepeatingGroupsTable.test.tsx
@@ -40,7 +40,6 @@ const getLayout = (
           index: 3,
         },
       },
-      autoSave: false,
       currentView: 'FormLayout',
       focus: undefined,
       tracks: {

--- a/src/layout/Group/SummaryGroupComponent.test.tsx
+++ b/src/layout/Group/SummaryGroupComponent.test.tsx
@@ -70,7 +70,6 @@ describe('SummaryGroupComponent', () => {
         ],
       },
       uiConfig: {
-        autoSave: true,
         focus: null,
         hiddenFields: [],
         repeatingGroups: {

--- a/src/layout/Likert/GroupContainerLikertTestUtils.tsx
+++ b/src/layout/Likert/GroupContainerLikertTestUtils.tsx
@@ -127,7 +127,6 @@ const createLayout = (
     },
     currentView: 'FormLayout',
     focus: null,
-    autoSave: null,
     fileUploadersWithTag: {},
     navigationConfig: {},
     tracks: {

--- a/src/layout/Likert/GroupContainerLikertTestUtils.tsx
+++ b/src/layout/Likert/GroupContainerLikertTestUtils.tsx
@@ -211,7 +211,6 @@ export const render = ({
     lastSavedFormData: {},
     error: null,
     submittingId: '',
-    savingId: '',
     unsavedChanges: false,
     saving: false,
   };

--- a/src/layout/NavigationBar/NavigationBarComponent.test.tsx
+++ b/src/layout/NavigationBar/NavigationBarComponent.test.tsx
@@ -33,7 +33,6 @@ const render = ({ dispatch = jest.fn() }: Props = {}) => {
             hidden: [],
           },
           currentView: 'page1',
-          autoSave: false,
           focus: 'focus',
           hiddenFields: [],
           repeatingGroups: {},

--- a/src/layout/NavigationButtons/NavigationButtonsComponent.test.tsx
+++ b/src/layout/NavigationButtons/NavigationButtonsComponent.test.tsx
@@ -57,7 +57,6 @@ describe('NavigationButton', () => {
     },
     uiConfig: {
       currentView: 'layout1',
-      autoSave: true,
       focus: null,
       hiddenFields: [],
       repeatingGroups: {},

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -176,7 +176,6 @@ export interface IHiddenLayoutsExpressions {
 }
 
 export interface IUiConfig {
-  autoSave: boolean | null | undefined;
   receiptLayoutName?: string;
   currentView: string;
   currentViewCacheKey?: string;

--- a/src/utils/validation/validation.test.ts
+++ b/src/utils/validation/validation.test.ts
@@ -738,15 +738,12 @@ describe('utils > validation', () => {
 
   describe('canFormBeSaved', () => {
     it('should validate correctly', () => {
-      const apiModeComplete = 'Complete';
-      const falseResult = validation.canFormBeSaved(mockFormValidationResult, apiModeComplete);
+      const falseResult = validation.canFormBeSaved(mockFormValidationResult);
       const falseResult2 = validation.canFormBeSaved(mockInvalidTypes);
       const trueResult2 = validation.canFormBeSaved(null);
-      const trueResult3 = validation.canFormBeSaved(mockFormValidationResult);
       expect(falseResult).toBeFalsy();
       expect(falseResult2).toBeFalsy();
       expect(trueResult2).toBeTruthy();
-      expect(trueResult3).toBeTruthy();
     });
   });
 

--- a/src/utils/validation/validation.ts
+++ b/src/utils/validation/validation.ts
@@ -820,16 +820,16 @@ export function mapToComponentValidationsGivenNode(
   addErrorToValidations(validations, layoutId, foundNode.item.id, fieldKey, errorMessage);
 }
 
-/*
+/**
  * Checks if form can be saved. If it contains anything other than valid error messages it returns false
  */
-export function canFormBeSaved(validationResult: IValidationResult | null, apiMode?: string): boolean {
+export function canFormBeSaved(validationResult: IValidationResult | null): boolean {
   if (validationResult && validationResult.invalidDataTypes) {
     return false;
   }
 
   const validations = validationResult?.validations;
-  if (!validations || apiMode !== 'Complete') {
+  if (!validations) {
     return true;
   }
   return Object.keys(validations).every((layoutId: string) =>


### PR DESCRIPTION
## Description

Removing the `autoSave` toggle. My reasons for this is:
- You have to know what you're doing to toggle it off, because it isn't documented anywhere (you had to read our code to find it).
- Nobody is using this setting, as far as I can tell (and I've downloaded every app currently in production and every app I could get a hold of that's on tt02).
- Server-side calculations stop being responsive if you toggle it off.
- There's been a notice in our code for a while asking if that setting is used at all, and everyone had to code around it hoping other changes to form saving didn't break this unknown feature.
- If you try to enable it, you might find that we only respect the setting from the _last layout file we processed_, so it would've been best to set it on every single layout file if you really wanted it. Or just never change the page order.
- We have no tests for it, so nobody knows if it works in conjunction with other features (such as triggers for components, seem to just not be working at all).
- Nobody seem to have requested it (it was implemented in https://github.com/Altinn/altinn-studio/pull/4953, which links to two issues that never describes anything about enabling/disabling auto-saving). Either that, or this is leftovers from the past, if no autosaving used to be the default until this _was_ introduced.
- I don't want to support it in #1175.

A recording of it action, for posterity. Notice how server-side calculations are not updated until you manually trigger a save.

https://github.com/Altinn/app-frontend-react/assets/700139/df61113b-67b6-4354-84d1-013c7bb3a514

## Related Issue(s)

- #1175

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [x] Has been added/updated
    - https://github.com/Altinn/altinn-studio-docs/pull/955
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
