### PR TITLE
Update @digdir/design-system-react to 0.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "@altinn/altinn-design-system": "0.27.8",
     "@babel/polyfill": "7.12.1",
     "@date-io/moment": "1.3.13",
-    "@digdir/design-system-react": "0.13.0",
+    "@digdir/design-system-react": "0.14.0",
     "@material-ui/core": "4.12.4",
     "@material-ui/icons": "4.11.3",
     "@material-ui/pickers": "3.3.10",

--- a/src/features/devtools/DevTools.module.css
+++ b/src/features/devtools/DevTools.module.css
@@ -9,7 +9,7 @@
 
 .panel {
   background-color: #efefef;
-  z-index: 10000;
+  z-index: 1000;
   position: fixed;
   bottom: 0;
   width: 100%;
@@ -47,7 +47,7 @@
   position: absolute;
   top: 10px;
   right: 0;
-  z-index: 10001;
+  z-index: 1001;
 }
 
 .tabs {

--- a/src/features/devtools/components/LayoutInspector/LayoutInspector.module.css
+++ b/src/features/devtools/components/LayoutInspector/LayoutInspector.module.css
@@ -93,7 +93,7 @@
   position: absolute;
   top: 32px;
   right: 0;
-  z-index: 10001;
+  z-index: 1001;
 }
 
 .headerLink {

--- a/src/features/devtools/components/OpenDevToolsButton/OpenDevToolsButton.module.css
+++ b/src/features/devtools/components/OpenDevToolsButton/OpenDevToolsButton.module.css
@@ -1,5 +1,5 @@
 .devToolsButton {
-  z-index: 10000;
+  z-index: 1000;
   position: fixed;
   padding: 10px 0 10px 10px;
   bottom: 20px;

--- a/src/index.css
+++ b/src/index.css
@@ -50,13 +50,6 @@
   }
 }
 
-/* TODO: remove when https://github.com/digdir/designsystem/issues/497 is resolved 
- * This is a workaround to avoid the dropdown list from being hidden behind the dev tools panel
- */
-* {
-  --option_list-z_index: 10002 !important;
-}
-
 /* Custom CSS for all app */
 
 /* Workaround to avoid (PDF) postfix from Altinn designsystem */

--- a/yarn.lock
+++ b/yarn.lock
@@ -2805,12 +2805,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@digdir/design-system-react@npm:0.13.0":
-  version: 0.13.0
-  resolution: "@digdir/design-system-react@npm:0.13.0"
+"@digdir/design-system-react@npm:0.14.0":
+  version: 0.14.0
+  resolution: "@digdir/design-system-react@npm:0.14.0"
   dependencies:
     "@altinn/figma-design-tokens": ^6.0.1
-    "@digdir/design-system-tokens": ^0.1.2
+    "@digdir/design-system-tokens": ^0.1.3
     "@floating-ui/react": 0.24.1
     "@navikt/aksel-icons": ^3.2.4
     "@navikt/ds-icons": ^2.3.0
@@ -2818,14 +2818,14 @@ __metadata:
   peerDependencies:
     react: ">=16.8"
     react-dom: ">=16.8"
-  checksum: 4f532f8f5515fa621bdba807bdf5299bfa682c34c4f7d657389ec27045170cbf6b1e84c7fb7ae9fe24132cd3cb4b1b82bf127655b0ae8176996480b45851486b
+  checksum: 3d6e7ac6cbd4631578a68c55e469fcce1032383d79dac7e2face874b9e338af8c13a476346ca9a9f11c6d3b1ffead425132872689328c47e8d88ec35352b05bc
   languageName: node
   linkType: hard
 
-"@digdir/design-system-tokens@npm:^0.1.2":
-  version: 0.1.2
-  resolution: "@digdir/design-system-tokens@npm:0.1.2"
-  checksum: 7701afc7c8c410038f859a67f1b5b0648107c8ab4c202755f6a5c05c8c8ff8fdbd3eec49654f44baf5fb059caf3cca3c938dc2eb683faef7ea73ddf3407411dc
+"@digdir/design-system-tokens@npm:^0.1.3":
+  version: 0.1.3
+  resolution: "@digdir/design-system-tokens@npm:0.1.3"
+  checksum: 17d5905880971d4863b5cda6cd3c7bf03ebfce4f0e1899db9788254abd23bb9e0091f0be6a5d51d1f23ac3f3c5c9bca244faeeb9f1cf91858b2eac8a59d802f2
   languageName: node
   linkType: hard
 
@@ -5604,7 +5604,7 @@ __metadata:
     "@babel/runtime": ^7.21.0
     "@babel/runtime-corejs3": ^7.21.0
     "@date-io/moment": 1.3.13
-    "@digdir/design-system-react": 0.13.0
+    "@digdir/design-system-react": 0.14.0
     "@material-ui/core": 4.12.4
     "@material-ui/icons": 4.11.3
     "@material-ui/pickers": 3.3.10


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

Only other change is removing the z-index workaround for dev-tools and adjusting the z-index of the dev tools panel. It is still not possible to set the z-index for select, but I now get the same results as before without the workaround.