### PR TITLE
Quickfix: summary title formatting

### DIFF
--- a/src/layout/Summary/SummaryComponent.tsx
+++ b/src/layout/Summary/SummaryComponent.tsx
@@ -45,7 +45,7 @@ export function SummaryComponent({ summaryNode, overrides }: ISummaryComponent) 
         true,
       ),
   );
-  const { langAsString } = useLanguage();
+  const { lang } = useLanguage();
   const summaryItem = summaryNode.item;
   const targetNode = useResolvedNode(overrides?.targetNode || summaryNode.item.componentRef || summaryNode.item.id);
   const targetItem = targetNode?.item;
@@ -113,7 +113,7 @@ export function SummaryComponent({ summaryNode, overrides }: ISummaryComponent) 
           <SummaryContent
             onChangeClick={onChangeClick}
             changeText={changeText}
-            label={langAsString(titleKey)}
+            label={lang(titleKey)}
             summaryNode={summaryNode}
             targetNode={targetNode}
             overrides={overrides}


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

This quickfix fixes the formatting that broke for summary titles. 

![image](https://github.com/Altinn/app-frontend-react/assets/47412359/80b86ad2-e669-485d-9fdc-a32987602c47)

## Related Issue(s)

- https://github.com/Altinn/app-frontend-react/pull/1234

