### PR TITLE
Cleanup: Multiple minor changes

### DIFF
--- a/src/components/wrappers/ProcessWrapper.tsx
+++ b/src/components/wrappers/ProcessWrapper.tsx
@@ -34,7 +34,7 @@ export const ProcessWrapper = () => {
 
   const instanceId = useAppSelector((state) => state.instantiation.instanceId);
   const instanceIdFromUrl = useInstanceIdParams()?.instanceId;
-  window['instanceId'] = instanceIdFromUrl;
+  window.instanceId = instanceIdFromUrl;
 
   const { pdfPreview } = useAppSelector((state) => state.devTools);
   const [searchParams] = useSearchParams();

--- a/src/features/confirm/components/ConfirmButton.tsx
+++ b/src/features/confirm/components/ConfirmButton.tsx
@@ -26,7 +26,7 @@ export const ConfirmButton = (props: Omit<BaseButtonProps, 'onClick'> & { id: st
   const { instanceId } = window;
 
   const handleConfirmClick = () => {
-    if (!disabled) {
+    if (!disabled && instanceId) {
       setValidateId(props.id);
       httpGet(getValidationUrl(instanceId))
         .then((data: any) => {

--- a/src/features/confirm/components/ConfirmButton.tsx
+++ b/src/features/confirm/components/ConfirmButton.tsx
@@ -10,7 +10,6 @@ import { getTextFromAppOrDefault } from 'src/utils/textResource';
 import { getValidationUrl } from 'src/utils/urls/appUrlHelper';
 import { mapDataElementValidationToRedux } from 'src/utils/validation/validation';
 import type { BaseButtonProps } from 'src/layout/Button/WrappedButton';
-import type { IAltinnWindow } from 'src/types';
 import type { ILanguage } from 'src/types/shared';
 
 export const ConfirmButton = (props: Omit<BaseButtonProps, 'onClick'> & { id: string; language: ILanguage }) => {
@@ -24,7 +23,7 @@ export const ConfirmButton = (props: Omit<BaseButtonProps, 'onClick'> & { id: st
   const disabled = processActionsFeature && !actions?.confirm;
 
   const dispatch = useAppDispatch();
-  const { instanceId } = window as Window as IAltinnWindow;
+  const { instanceId } = window;
 
   const handleConfirmClick = () => {
     if (!disabled) {

--- a/src/features/confirm/containers/ConfirmPage.test.tsx
+++ b/src/features/confirm/containers/ConfirmPage.test.tsx
@@ -60,6 +60,7 @@ describe('ConfirmPage', () => {
 
   it('should show loading when clicking submit', async () => {
     const user = userEvent.setup();
+    window.instanceId = state.instance?.id;
     const { store } = renderWithProviders(
       <MemoryRouter>
         <ConfirmPage {...props} />

--- a/src/features/dataLists/fetchDataListsSaga.ts
+++ b/src/features/dataLists/fetchDataListsSaga.ts
@@ -17,7 +17,7 @@ import type {
   IFetchSpecificDataListSaga,
 } from 'src/features/dataLists/index';
 import type { IFormData } from 'src/features/formData';
-import type { IUpdateFormDataFulfilled } from 'src/features/formData/formDataTypes';
+import type { IUpdateFormData } from 'src/features/formData/formDataTypes';
 import type { ILayouts } from 'src/layout/layout';
 import type { IRepeatingGroups, IRuntimeState } from 'src/types';
 
@@ -152,7 +152,7 @@ export function* fetchSpecificDataListSaga({
 
 export function* checkIfDataListShouldRefetchSaga({
   payload: { field },
-}: PayloadAction<IUpdateFormDataFulfilled>): SagaIterator {
+}: PayloadAction<IUpdateFormData>): SagaIterator {
   const dataList: IDataList = yield select(dataListsSelector);
   let foundInExistingDataList = false;
   for (const dataListKey of Object.keys(dataList)) {

--- a/src/features/devtools/components/ExpressionPlayground/ExpressionPlayground.tsx
+++ b/src/features/devtools/components/ExpressionPlayground/ExpressionPlayground.tsx
@@ -98,7 +98,7 @@ export const ExpressionPlayground = () => {
             style={{ color: isError ? 'red' : 'black' }}
             className={cn(classes.textbox, classes.output)}
             readOnly={true}
-            value={output}
+            value={JSON.stringify(output)}
             placeholder={'Resultatet av uttrykket vises her'}
           />
         </SplitView>

--- a/src/features/expressions/index.ts
+++ b/src/features/expressions/index.ts
@@ -12,7 +12,6 @@ import { ExprContext } from 'src/features/expressions/ExprContext';
 import { ExprVal } from 'src/features/expressions/types';
 import { addError, asExpression, canBeExpression } from 'src/features/expressions/validation';
 import { getTextResourceByKey } from 'src/language/sharedLanguage';
-import { dataSourcesFromState, resolvedLayoutsFromState } from 'src/utils/layout/hierarchy';
 import { LayoutNode } from 'src/utils/layout/LayoutNode';
 import { LayoutPage } from 'src/utils/layout/LayoutPage';
 import type { ContextDataSources } from 'src/features/expressions/ExprContext';
@@ -27,7 +26,6 @@ import type {
 } from 'src/features/expressions/types';
 import type { ILayoutGroup } from 'src/layout/Group/types';
 import type { ILayoutComponent } from 'src/layout/layout';
-import type { IAltinnWindow } from 'src/types';
 import type { IAuthContext, IInstanceContext } from 'src/types/shared';
 
 export interface EvalExprOptions {
@@ -730,41 +728,11 @@ export const ExprTypes: {
  *
  * @see resolvedNodesInLayouts
  */
-(window as unknown as IAltinnWindow).evalExpression = (maybeExpression: any, forComponentId?: string) => {
-  const config: ExprConfig<ExprVal.Any> = {
-    returnType: ExprVal.Any,
-    defaultValue: null,
-    resolvePerRow: false,
-  };
-
-  const expr = asExpression(maybeExpression, config);
-  if (!expr) {
-    return null;
-  }
-
-  const state = (window as unknown as IAltinnWindow).reduxStore.getState();
-  const nodes = resolvedLayoutsFromState(state);
-  let layout: LayoutPage | LayoutNode | undefined = nodes?.current();
-  if (!layout) {
-    console.error('Unable to find current page/layout');
-    return;
-  }
-
-  if (forComponentId) {
-    const foundNode = nodes?.findById(forComponentId);
-    if (!foundNode) {
-      console.error('Unable to find component with id', forComponentId);
-      console.error(
-        'Available components on the current page:',
-        layout?.flat(true).map((c) => c.item.id),
-      );
-      return;
-    }
-    layout = foundNode;
-  }
-
-  const dataSources = dataSourcesFromState(state);
-  return evalExpr(expr as Expression, layout, dataSources, { config });
+window.evalExpression = () => {
+  throw new Error(
+    'evalExpression() utgår. Du kan nå evaluere og teste uttrykk i utviklerverktøyene i stedet. Trykk Ctrl+Shift+K ' +
+      'for å åpne utviklerverktøyene, og naviger til fanen som heter "Uttrykk".',
+  );
 };
 
 export const ExprConfigForComponent: ExprObjConfig<ILayoutComponent> = {

--- a/src/features/formData/formDataSlice.ts
+++ b/src/features/formData/formDataSlice.ts
@@ -16,7 +16,6 @@ import type {
   ISaveAction,
   ISubmitDataAction,
   IUpdateFormData,
-  IUpdateFormDataFulfilled,
 } from 'src/features/formData/formDataTypes';
 import type { IFormData, IFormDataState } from 'src/features/formData/index';
 import type { ActionsFromSlice, MkActionType } from 'src/redux/sagaSlice';
@@ -97,7 +96,7 @@ export const formDataSlice = () => {
       update: mkAction<IUpdateFormData>({
         takeEvery: updateFormDataSaga,
       }),
-      updateFulfilled: mkAction<IUpdateFormDataFulfilled>({
+      updateFulfilled: mkAction<IUpdateFormData>({
         takeLatest: [checkIfRuleShouldRunSaga, autoSaveSaga],
         takeEvery: [checkIfOptionsShouldRefetchSaga, checkIfDataListShouldRefetchSaga],
         reducer: (state, action) => {

--- a/src/features/formData/formDataTypes.ts
+++ b/src/features/formData/formDataTypes.ts
@@ -28,21 +28,12 @@ export interface ISaveAction {
   singleFieldValidation?: ISingleFieldValidation;
 }
 
-export interface IUpdateFormDataProps {
+export interface IUpdateFormData {
   skipValidation?: boolean;
   skipAutoSave?: boolean;
   singleFieldValidation?: ISingleFieldValidation;
-}
-
-export interface IUpdateFormData extends IUpdateFormDataProps {
-  field: string;
-  data: any;
   componentId?: string;
-}
-
-export interface IUpdateFormDataFulfilled extends IUpdateFormDataProps {
   field: string;
-  componentId?: string;
   data: any;
 }
 

--- a/src/features/formData/submit/submitFormDataSagas.ts
+++ b/src/features/formData/submit/submitFormDataSagas.ts
@@ -25,7 +25,7 @@ import {
 } from 'src/utils/validation/validation';
 import type { IApplicationMetadata } from 'src/features/applicationMetadata';
 import type { IFormData } from 'src/features/formData';
-import type { IUpdateFormDataFulfilled } from 'src/features/formData/formDataTypes';
+import type { IUpdateFormData } from 'src/features/formData/formDataTypes';
 import type { ILayoutState } from 'src/features/layout/formLayoutSlice';
 import type { IRuntimeState, IRuntimeStore, IValidationIssue } from 'src/types';
 
@@ -251,7 +251,7 @@ function getModelToSave(state: IRuntimeState) {
  */
 export function* saveFormDataSaga({
   payload: { field, componentId, singleFieldValidation },
-}: PayloadAction<IUpdateFormDataFulfilled>): SagaIterator {
+}: PayloadAction<IUpdateFormData>): SagaIterator {
   try {
     const state: IRuntimeState = yield select();
     // updates the default data element
@@ -347,7 +347,7 @@ export function* postStatelessData({ field, componentId }: SaveDataParams) {
  */
 export function* autoSaveSaga({
   payload: { skipAutoSave, field, componentId, singleFieldValidation },
-}: PayloadAction<IUpdateFormDataFulfilled>): SagaIterator {
+}: PayloadAction<IUpdateFormData>): SagaIterator {
   if (skipAutoSave) {
     return;
   }

--- a/src/features/formRules/checkRulesSagas.ts
+++ b/src/features/formRules/checkRulesSagas.ts
@@ -6,7 +6,7 @@ import { FormDataActions } from 'src/features/formData/formDataSlice';
 import { checkIfRuleShouldRun } from 'src/utils/rules';
 import type { IRuleConnections } from 'src/features/dynamics';
 import type { IFormDataState } from 'src/features/formData';
-import type { IUpdateFormDataFulfilled } from 'src/features/formData/formDataTypes';
+import type { IUpdateFormData } from 'src/features/formData/formDataTypes';
 import type { ILayoutState } from 'src/features/layout/formLayoutSlice';
 import type { IRuntimeState } from 'src/types';
 
@@ -23,7 +23,7 @@ export interface IResponse {
 
 export function* checkIfRuleShouldRunSaga({
   payload: { field, skipAutoSave, skipValidation, singleFieldValidation },
-}: PayloadAction<IUpdateFormDataFulfilled>): SagaIterator {
+}: PayloadAction<IUpdateFormData>): SagaIterator {
   try {
     const ruleConnectionState: IRuleConnections | null = yield select(selectRuleConnection);
     const formDataState: IFormDataState = yield select(selectFormDataConnection);

--- a/src/features/options/fetch/fetchOptionsSagas.ts
+++ b/src/features/options/fetch/fetchOptionsSagas.ts
@@ -15,7 +15,7 @@ import { getOptionLookupKey, getOptionLookupKeys } from 'src/utils/options';
 import { selectNotNull } from 'src/utils/sagas';
 import { getOptionsUrl } from 'src/utils/urls/appUrlHelper';
 import type { IFormData } from 'src/features/formData';
-import type { IUpdateFormDataFulfilled } from 'src/features/formData/formDataTypes';
+import type { IUpdateFormData } from 'src/features/formData/formDataTypes';
 import type { ILayouts, ISelectionComponentProps } from 'src/layout/layout';
 import type {
   IFetchSpecificOptionSaga,
@@ -131,9 +131,7 @@ export function* fetchSpecificOptionSaga({ optionsId, dataMapping, secure }: IFe
   }
 }
 
-export function* checkIfOptionsShouldRefetchSaga({
-  payload: { field },
-}: PayloadAction<IUpdateFormDataFulfilled>): SagaIterator {
+export function* checkIfOptionsShouldRefetchSaga({ payload: { field } }: PayloadAction<IUpdateFormData>): SagaIterator {
   const options: IOptions = yield select(optionsSelector);
   const optionsWithIndexIndicators = yield select(optionsWithIndexIndicatorsSelector);
   let foundInExistingOptions = false;

--- a/src/features/profile/profileSlice.ts
+++ b/src/features/profile/profileSlice.ts
@@ -5,15 +5,13 @@ import { createSagaSlice } from 'src/redux/sagaSlice';
 import { getLanguageQueryParam } from 'src/utils/party';
 import type { IFetchProfileFulfilled, IFetchProfileRejected, IProfileState } from 'src/features/profile/index';
 import type { ActionsFromSlice, MkActionType } from 'src/redux/sagaSlice';
-import type { IAltinnWindow } from 'src/types';
 import type { IProfile } from 'src/types/shared';
 
 export interface IUpdateSelectedAppLanguage {
   selected: string;
 }
 
-const altinnWindow = window as Window as IAltinnWindow;
-const getLanguageStorageKey = (userId: number | undefined) => `selectedAppLanguage${altinnWindow.app}${userId ?? ''}`;
+const getLanguageStorageKey = (userId: number | undefined) => `selectedAppLanguage${window.app}${userId ?? ''}`;
 
 export const initialState: IProfileState = {
   profile: {

--- a/src/features/toggles.ts
+++ b/src/features/toggles.ts
@@ -1,12 +1,8 @@
-import type { IAltinnWindow } from 'src/types';
-
 type FeatureToggle = 'doNotPromptForPartyPreference';
 export type IFeatureToggles = { [key in FeatureToggle]?: boolean };
 
-const altinnWindow = window as Window as IAltinnWindow;
-
 const featureToggles: IFeatureToggles = {
-  doNotPromptForPartyPreference: altinnWindow.featureToggles?.doNotPromptForPartyPreference ?? false,
+  doNotPromptForPartyPreference: window.featureToggles?.doNotPromptForPartyPreference ?? false,
 };
 
-altinnWindow.featureToggles = featureToggles;
+window.featureToggles = featureToggles;

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,7 +1,7 @@
 import type { ToolkitStore } from '@reduxjs/toolkit/src/configureStore';
 
 import type { IFeatureToggles } from 'src/features/toggles';
-import type { IRules, IRuntimeState } from 'src/types';
+import type { IRuleObject, IRules, IRuntimeState } from 'src/types';
 
 declare global {
   interface Window {
@@ -14,9 +14,9 @@ declare global {
     reduxActionLog: any[];
     featureToggles: IFeatureToggles;
 
-    conditionalRuleHandlerObject: any;
+    conditionalRuleHandlerObject: IRuleObject;
     conditionalRuleHandlerHelper: IRules;
-    ruleHandlerObject: any;
+    ruleHandlerObject: IRuleObject;
     ruleHandlerHelper: IRules;
   }
 }

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,5 +1,6 @@
 import type { ToolkitStore } from '@reduxjs/toolkit/src/configureStore';
 
+import type { IFeatureToggles } from 'src/features/toggles';
 import type { IRules, IRuntimeState } from 'src/types';
 
 declare global {
@@ -12,5 +13,6 @@ declare global {
     evalExpression: () => any;
     reduxStore: ToolkitStore<IRuntimeState>;
     reduxActionLog: any[];
+    featureToggles: IFeatureToggles;
   }
 }

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -7,7 +7,7 @@ declare global {
   interface Window {
     app: string;
     conditionalRuleHandlerHelper: IRules;
-    instanceId: string;
+    instanceId: string | undefined;
     org: string;
     reportee: string;
     evalExpression: () => any;

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -6,7 +6,6 @@ import type { IRules, IRuntimeState } from 'src/types';
 declare global {
   interface Window {
     app: string;
-    conditionalRuleHandlerHelper: IRules;
     instanceId: string | undefined;
     org: string;
     reportee: string;
@@ -14,5 +13,10 @@ declare global {
     reduxStore: ToolkitStore<IRuntimeState>;
     reduxActionLog: any[];
     featureToggles: IFeatureToggles;
+
+    conditionalRuleHandlerObject: any;
+    conditionalRuleHandlerHelper: IRules;
+    ruleHandlerObject: any;
+    ruleHandlerHelper: IRules;
   }
 }

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,7 +1,16 @@
-declare module '*.png';
+import type { ToolkitStore } from '@reduxjs/toolkit/src/configureStore';
 
-declare module '*.module.css' {
-  const styles: { [className: string]: string };
-  // eslint-disable-next-line import/no-default-export
-  export default styles;
+import type { IRules, IRuntimeState } from 'src/types';
+
+declare global {
+  interface Window {
+    app: string;
+    conditionalRuleHandlerHelper: IRules;
+    instanceId: string;
+    org: string;
+    reportee: string;
+    evalExpression: () => any;
+    reduxStore: ToolkitStore<IRuntimeState>;
+    reduxActionLog: any[];
+  }
 }

--- a/src/hooks/useAlwaysPromptForParty.ts
+++ b/src/hooks/useAlwaysPromptForParty.ts
@@ -1,19 +1,17 @@
 import { useAppSelector } from 'src/hooks/useAppSelector';
 import { useInstanceIdParams } from 'src/hooks/useInstanceIdParams';
-import type { IAltinnWindow } from 'src/types';
 
 export function useAlwaysPromptForParty(): boolean | null {
   const { partyId: partyIdFromUrl } = useInstanceIdParams();
   const applicationMetadata = useAppSelector((state) => state.applicationMetadata.applicationMetadata);
   const profile = useAppSelector((state) => state.profile.profile);
   const parties = useAppSelector((state) => state.party.parties);
-  const altinnWindow = window as Window as IAltinnWindow;
 
   if (!profile.partyId || parties === null) {
     return null;
   }
 
-  if (!altinnWindow.featureToggles.doNotPromptForPartyPreference) {
+  if (!window.featureToggles.doNotPromptForPartyPreference) {
     return false;
   }
 

--- a/src/layout/Button/ButtonComponent.tsx
+++ b/src/layout/Button/ButtonComponent.tsx
@@ -9,7 +9,6 @@ import { getComponentFromMode } from 'src/layout/Button/getComponentFromMode';
 import { SubmitButton } from 'src/layout/Button/SubmitButton';
 import { LayoutPage } from 'src/utils/layout/LayoutPage';
 import type { PropsFromGenericComponent } from 'src/layout';
-import type { IAltinnWindow } from 'src/types';
 import type { HComponent } from 'src/utils/layout/hierarchy.types';
 
 export type IButtonReceivedProps = PropsFromGenericComponent<'Button'>;
@@ -54,7 +53,7 @@ export const ButtonComponent = ({ node, ...componentProps }: IButtonReceivedProp
 
   const submitTask = ({ componentId }: { componentId: string }) => {
     if (!disabled) {
-      const { org, app, instanceId } = window as Window as IAltinnWindow;
+      const { org, app, instanceId } = window;
       if (currentTaskType === 'data') {
         dispatch(
           FormDataActions.submit({

--- a/src/layout/Image/ImageComponent.tsx
+++ b/src/layout/Image/ImageComponent.tsx
@@ -5,7 +5,6 @@ import { Grid, makeStyles } from '@material-ui/core';
 import { HelpTextContainer } from 'src/components/form/HelpTextContainer';
 import { useAppSelector } from 'src/hooks/useAppSelector';
 import type { PropsFromGenericComponent } from 'src/layout';
-import type { IAltinnWindow } from 'src/types';
 
 export type IImageProps = PropsFromGenericComponent<'Image'>;
 
@@ -25,10 +24,7 @@ export function ImageComponent({ node, language, getTextResourceAsString, getTex
 
   let imgSrc = image?.src[languageKey] || image?.src.nb || '';
   if (imgSrc.startsWith('wwwroot')) {
-    imgSrc = imgSrc.replace(
-      'wwwroot',
-      `/${(window as Window as IAltinnWindow).org}/${(window as Window as IAltinnWindow).app}`,
-    );
+    imgSrc = imgSrc.replace('wwwroot', `/${window.org}/${window.app}`);
   }
 
   const imgType = imgSrc.slice(-3);

--- a/src/modules.d.ts
+++ b/src/modules.d.ts
@@ -1,0 +1,7 @@
+declare module '*.png';
+
+declare module '*.module.css' {
+  const styles: { [className: string]: string };
+  // eslint-disable-next-line import/no-default-export
+  export default styles;
+}

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -6,7 +6,6 @@ import type { SagaMiddleware } from 'redux-saga';
 
 import { combinedReducers } from 'src/redux/reducers';
 import { appApi } from 'src/services/AppApi';
-import type { IAltinnWindow } from 'src/types';
 
 export const setupStore = (preloadedState?: PreloadedState<RootState>) => {
   const sagaMiddleware: SagaMiddleware<any> = createSagaMiddleware();
@@ -39,12 +38,12 @@ export const setupStore = (preloadedState?: PreloadedState<RootState>) => {
   //    and inject actions when we need to. Testing the state directly might expose problems not easily/visibly testable
   //    in the app itself.
   // 2. Allows the window.evalExpression() test-function to get the current state for testing expressions.
-  (window as unknown as IAltinnWindow).reduxStore = store;
+  window.reduxStore = store;
 
   if (process.env.NODE_ENV === 'development') {
     // Expose a log containing all dispatched actions. This is useful when Cypress tests fail, so that we can gather
     // the logged actions to re-construct the redux state history using the redux devtools.
-    (window as unknown as IAltinnWindow).reduxActionLog = actionLog;
+    window.reduxActionLog = actionLog;
   }
 
   return { store, sagaMiddleware };

--- a/src/services/AppApi.tsx
+++ b/src/services/AppApi.tsx
@@ -3,11 +3,8 @@ import axios from 'axios';
 import type { BaseQueryFn } from '@reduxjs/toolkit/query/react';
 import type { AxiosError, AxiosRequestConfig } from 'axios';
 
-import type { IAltinnWindow } from 'src/types';
-
-const altinnWindow = window as Window as IAltinnWindow;
-const { org, app } = altinnWindow;
-const origin = altinnWindow.location.origin;
+const { org, app } = window;
+const origin = window.location.origin;
 
 const axiosBaseQuery =
   (

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -4,8 +4,6 @@ import 'core-js/stable/structured-clone'; // https://github.com/jsdom/jsdom/issu
 
 import { TextDecoder, TextEncoder } from 'util';
 
-import type { IAltinnWindow } from 'src/types';
-
 // https://jestjs.io/docs/manual-mocks#mocking-methods-which-are-not-implemented-in-jsdom
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
@@ -26,10 +24,9 @@ Object.defineProperty(document, 'fonts', {
 });
 
 // org and app is assigned to window object, so to avoid 'undefined' in tests, they need to be set
-const altinnWindow = window as Window as IAltinnWindow;
-altinnWindow.org = 'ttd';
-altinnWindow.app = 'test';
-altinnWindow.featureToggles = {};
+window.org = 'ttd';
+window.app = 'test';
+window.featureToggles = {};
 jest.setTimeout(10000);
 
 jest.mock('axios');

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -121,7 +121,13 @@ export interface IRepeatingGroups {
 }
 
 export interface IRules {
-  [id: string]: any;
+  [id: string]: () => Record<string, string>;
+}
+
+export type RuleFunc<T extends Record<string, any>> = (argObject: T) => T;
+
+export interface IRuleObject {
+  [id: string]: RuleFunc<any>;
 }
 
 export type IRuntimeState = RootState;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,23 +1,9 @@
-import type { ToolkitStore } from '@reduxjs/toolkit/src/configureStore';
 import type Ajv from 'ajv/dist/core';
 
 import type { ExprUnresolved, ExprVal } from 'src/features/expressions/types';
 import type { IFormData } from 'src/features/formData';
 import type { IKeepComponentScrollPos } from 'src/features/layout/formLayoutTypes';
-import type { IFeatureToggles } from 'src/features/toggles';
 import type { RootState } from 'src/redux/store';
-
-export interface IAltinnWindow extends Window {
-  app: string;
-  conditionalRuleHandlerHelper: IRules;
-  instanceId: string;
-  org: string;
-  reportee: string;
-  evalExpression: (maybeExpression: any, forComponentId?: string) => any;
-  reduxStore: ToolkitStore<IRuntimeState>;
-  reduxActionLog: any[];
-  featureToggles: IFeatureToggles;
-}
 
 export interface IComponentBindingValidation {
   errors?: string[];

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -1,11 +1,6 @@
 import type { IProcessPermissions } from 'src/features/process';
 import type { FixedLanguageList } from 'src/language/languages';
 
-export interface IAltinnWindow extends Window {
-  org: string;
-  app: string;
-}
-
 export interface IApplication {
   createdBy: string;
   created: string;

--- a/src/utils/conditionalRendering.test.ts
+++ b/src/utils/conditionalRendering.test.ts
@@ -65,8 +65,8 @@ describe('conditionalRendering', () => {
       mockField: '4',
     };
 
-    (window as any).conditionalRuleHandlerHelper = mockRuleHandlerHelper;
-    (window as any).conditionalRuleHandlerObject = mockRuleHandler;
+    window.conditionalRuleHandlerHelper = mockRuleHandlerHelper;
+    window.conditionalRuleHandlerObject = mockRuleHandler;
   });
 
   it('should HIDE element when rule is set to HIDE and condition is TRUE', () => {

--- a/src/utils/conditionalRendering.ts
+++ b/src/utils/conditionalRendering.ts
@@ -117,7 +117,7 @@ function runConditionalRenderingRule(
     return acc;
   }, {});
 
-  const result = (window as any).conditionalRuleHandlerObject[functionToRun](newObj);
+  const result = window.conditionalRuleHandlerObject[functionToRun](newObj);
   const action = rule.selectedAction;
   const hide = (action === 'Show' && !result) || (action === 'Hide' && result);
   Object.keys(rule.selectedFields).forEach((elementToPerformActionOn) => {

--- a/src/utils/conditionalRendering.ts
+++ b/src/utils/conditionalRendering.ts
@@ -5,7 +5,7 @@ import type {
   ISelectedFields,
 } from 'src/features/dynamics';
 import type { IFormData } from 'src/features/formData';
-import type { IAltinnWindow, IRepeatingGroup, IRepeatingGroups } from 'src/types';
+import type { IRepeatingGroup, IRepeatingGroups } from 'src/types';
 
 /*
  * Runs conditional rendering rules, returns array of affected layout elements
@@ -16,7 +16,7 @@ export function runConditionalRenderingRules(
   repeatingGroups?: IRepeatingGroups,
 ): Set<string> {
   const componentsToHide = new Set<string>();
-  if (!(window as Window as IAltinnWindow).conditionalRuleHandlerHelper) {
+  if (!window.conditionalRuleHandlerHelper) {
     // rules have not been initialized
     return componentsToHide;
   }
@@ -108,7 +108,7 @@ function runConditionalRenderingRule(
   hiddenFields: Set<string>,
 ) {
   const functionToRun = rule.selectedFunction;
-  const objectToUpdate = (window as Window as IAltinnWindow).conditionalRuleHandlerHelper[functionToRun]();
+  const objectToUpdate = window.conditionalRuleHandlerHelper[functionToRun]();
 
   // Map input object structure to input object defined in the conditional rendering rule connection
   const newObj = Object.keys(objectToUpdate).reduce((acc: any, elem: any) => {

--- a/src/utils/rules/index.ts
+++ b/src/utils/rules/index.ts
@@ -38,7 +38,7 @@ export function checkIfRuleShouldRun(
     });
 
     if (shouldRunFunction) {
-      const objectToUpdate = (window as any).ruleHandlerHelper[functionToRun]();
+      const objectToUpdate = window.ruleHandlerHelper[functionToRun]();
       if (Object.keys(objectToUpdate).length >= 1) {
         const newObj = Object.keys(objectToUpdate).reduce((acc: any, elem: any) => {
           const inputParamBinding = connectionDef.inputParams[elem];
@@ -46,7 +46,7 @@ export function checkIfRuleShouldRun(
           acc[elem] = formDataState.formData && formDataState.formData[inputParamBinding];
           return acc;
         }, {});
-        const result = (window as any).ruleHandlerObject[functionToRun](newObj);
+        const result = window.ruleHandlerObject[functionToRun](newObj);
         const updatedDataBinding = connectionDef.outParams.outParam0;
         let updatedComponent: string | undefined = undefined;
         Object.keys(layouts || {}).forEach((id) => {
@@ -90,24 +90,23 @@ export function checkIfRuleShouldRun(
 
 export function getRuleModelFields() {
   const ruleModelFields: IRuleModelFieldElement[] = [];
-  const windowObj = window as any;
-  if (!windowObj.ruleHandlerObject || !windowObj.conditionalRuleHandlerObject) {
+  if (!window.ruleHandlerObject || !window.conditionalRuleHandlerObject) {
     return ruleModelFields;
   }
 
-  Object.keys(windowObj.ruleHandlerObject).forEach((functionName) => {
+  Object.keys(window.ruleHandlerObject).forEach((functionName) => {
     const innerFuncObj = {
       name: functionName,
-      inputs: (window as any).ruleHandlerHelper[functionName](),
+      inputs: window.ruleHandlerHelper[functionName](),
       type: 'rule',
     };
     ruleModelFields.push(innerFuncObj);
   });
 
-  Object.keys(windowObj.conditionalRuleHandlerObject).forEach((functionName) => {
+  Object.keys(window.conditionalRuleHandlerObject).forEach((functionName) => {
     const innerFuncObj = {
       name: functionName,
-      inputs: (window as any).conditionalRuleHandlerHelper[functionName](),
+      inputs: window.conditionalRuleHandlerHelper[functionName](),
       type: 'condition',
     };
     ruleModelFields.push(innerFuncObj);

--- a/src/utils/rules/rules.test.tsx
+++ b/src/utils/rules/rules.test.tsx
@@ -89,8 +89,8 @@ describe('rules checkIfRuleShouldRun', () => {
       layouts: mockLayout,
     };
     mockLastUpdatedDataBinding = 'mockDataModelBinding2';
-    (window as any).ruleHandlerHelper = mockRuleHandlerHelper;
-    (window as any).ruleHandlerObject = mockRuleHandlerObject;
+    window.ruleHandlerHelper = mockRuleHandlerHelper;
+    window.ruleHandlerObject = mockRuleHandlerObject;
   });
 
   it('should return true if rule should be triggered', () => {
@@ -283,12 +283,12 @@ describe('rules getRuleModelFields', () => {
       'var conditionalRuleHandlerHelper = { biggerThan10: () => { return { number: "number" }; }, smallerThan10:' +
       ' () => { return { number: "number" } }, lengthBiggerThan4: () => { return { value: "value" } } }';
 
-    const scriptEle = (window as any).document.createElement('script');
+    const scriptEle = window.document.createElement('script');
     scriptEle.innerHTML = mockRuleScript;
-    (window as any).ruleHandlerHelper = mockRuleHandlerHelper;
-    (window as any).conditionalRuleHandlerHelper = mockConditionalRuleHandlerHelper;
-    (window as any).conditionalRuleHandlerObject = mockConditionalRuleHandlerObject;
-    (window as any).ruleHandlerObject = mockRuleHandlerObject;
+    window.ruleHandlerHelper = mockRuleHandlerHelper;
+    window.conditionalRuleHandlerHelper = mockConditionalRuleHandlerHelper;
+    window.conditionalRuleHandlerObject = mockConditionalRuleHandlerObject;
+    window.ruleHandlerObject = mockRuleHandlerObject;
   });
 
   it('should return an array ', () => {

--- a/src/utils/urls/appUrlHelper.test.ts
+++ b/src/utils/urls/appUrlHelper.test.ts
@@ -28,7 +28,7 @@ import {
 } from 'src/utils/urls/appUrlHelper';
 
 describe('Frontend urlHelper.ts', () => {
-  window['instanceId'] = '12345/instanceId-1234';
+  window.instanceId = '12345/instanceId-1234';
   describe('constants', () => {
     it('should return the expected url for validPartiesUrl', () => {
       expect(validPartiesUrl).toBe(

--- a/src/utils/urls/appUrlHelper.ts
+++ b/src/utils/urls/appUrlHelper.ts
@@ -3,10 +3,9 @@ import type { SortDirection } from '@altinn/altinn-design-system';
 import { mapFormData } from 'src/utils/databindings';
 import { getQueryStringFromObject } from 'src/utils/urls/urlHelper';
 import type { IFormData } from 'src/features/formData';
-import type { IAltinnWindow, IMapping } from 'src/types';
+import type { IMapping } from 'src/types';
 
-const altinnWindow = window as Window as IAltinnWindow;
-const { org, app } = altinnWindow;
+const { org, app } = window;
 const origin = window.location.origin;
 
 export const appPath = `${origin}/${org}/${app}`;
@@ -25,13 +24,13 @@ export const updateCookieUrl = (partyId: string) => `${appPath}/api/v1/parties/$
 export const textResourcesUrl = (language: string) => `${origin}/${org}/${app}/api/v1/texts/${language}`;
 
 export const fileUploadUrl = (attachmentType: string) =>
-  `${appPath}/instances/${altinnWindow.instanceId}/data?dataType=${attachmentType}`;
+  `${appPath}/instances/${window.instanceId}/data?dataType=${attachmentType}`;
 
-export const fileTagUrl = (dataGuid: string) => `${appPath}/instances/${altinnWindow.instanceId}/data/${dataGuid}/tags`;
+export const fileTagUrl = (dataGuid: string) => `${appPath}/instances/${window.instanceId}/data/${dataGuid}/tags`;
 
-export const dataElementUrl = (dataGuid: string) => `${appPath}/instances/${altinnWindow.instanceId}/data/${dataGuid}`;
+export const dataElementUrl = (dataGuid: string) => `${appPath}/instances/${window.instanceId}/data/${dataGuid}`;
 
-export const getProcessStateUrl = () => `${appPath}/instances/${altinnWindow.instanceId}/process`;
+export const getProcessStateUrl = () => `${appPath}/instances/${window.instanceId}/process`;
 
 export const getCreateInstancesUrl = (partyId: string) => `${appPath}/instances?instanceOwnerPartyId=${partyId}`;
 
@@ -49,7 +48,7 @@ export const getProcessNextUrl = (taskId?: string | null, language?: string | nu
     lang: language,
   });
 
-  return `${appPath}/instances/${altinnWindow.instanceId}/process/next${queryString}`;
+  return `${appPath}/instances/${window.instanceId}/process/next${queryString}`;
 };
 
 export const getRedirectUrl = (returnUrl: string) => `${appPath}/api/v1/redirect?url=${encodeURIComponent(returnUrl)}`;
@@ -156,7 +155,7 @@ export const getCalculatePageOrderUrl = (stateless: boolean) => {
   if (stateless) {
     return `${appPath}/v1/pages/order`;
   } else {
-    return `${appPath}/instances/${altinnWindow.instanceId}/pages/order`;
+    return `${appPath}/instances/${window.instanceId}/pages/order`;
   }
 };
 

--- a/test/e2e/integration/app-frontend/reportee-selection.ts
+++ b/test/e2e/integration/app-frontend/reportee-selection.ts
@@ -1,8 +1,6 @@
 import texts from 'test/e2e/fixtures/texts.json';
 import { AppFrontend } from 'test/e2e/pageobjects/app-frontend';
 
-import type { IAltinnWindow } from 'src/types';
-
 const appFrontend = new AppFrontend();
 
 describe('Reportee selection', () => {
@@ -40,7 +38,7 @@ describe('Reportee selection', () => {
 describe.only('doNotPromptForParty doNotPromptForPartyPreference', () => {
   beforeEach(() => {
     // Enable feature toggle on the window object
-    cy.on('window:before:load', (win: IAltinnWindow) => {
+    cy.on('window:before:load', (win) => {
       win.featureToggles = {
         doNotPromptForPartyPreference: true,
       };

--- a/test/e2e/support/app-frontend.ts
+++ b/test/e2e/support/app-frontend.ts
@@ -1,7 +1,6 @@
 import { AppFrontend } from 'test/e2e/pageobjects/app-frontend';
 
 import type { ILayouts } from 'src/layout/layout';
-import type { IAltinnWindow } from 'src/types';
 
 const appFrontend = new AppFrontend();
 
@@ -83,8 +82,7 @@ Cypress.Commands.add('interceptLayout', (taskName, mutator, wholeLayoutMutator) 
 
 Cypress.Commands.add('changeLayout', (mutator, wholeLayoutMutator) => {
   cy.window().then((win) => {
-    const aWin = win as unknown as IAltinnWindow;
-    const state = aWin.reduxStore.getState();
+    const state = win.reduxStore.getState();
     const layouts: ILayouts = structuredClone(state.formLayout.layouts || {});
     if (mutator && layouts) {
       for (const layout of Object.values(layouts)) {
@@ -96,7 +94,7 @@ Cypress.Commands.add('changeLayout', (mutator, wholeLayoutMutator) => {
     if (wholeLayoutMutator) {
       wholeLayoutMutator(layouts);
     }
-    aWin.reduxStore.dispatch({
+    win.reduxStore.dispatch({
       type: 'formLayout/updateLayouts',
       payload: layouts,
     });

--- a/test/e2e/support/index.ts
+++ b/test/e2e/support/index.ts
@@ -11,8 +11,6 @@ import 'test/e2e/support/auth';
 import { chaiExtensions } from 'test/e2e/support/chai-extensions';
 import { resetNavigation } from 'test/e2e/support/navigation';
 
-import type { IAltinnWindow } from 'src/types';
-
 before(() => {
   chai.use(chaiExtensions);
 });
@@ -36,13 +34,12 @@ afterEach(function () {
     const fileName = `redux-${specBaseName}-${title}-${attempt}.json`;
 
     cy.window().then((win) => {
-      const aWin = win as unknown as IAltinnWindow;
-      if (aWin.reduxActionLog && aWin.reduxStore) {
+      if (win.reduxActionLog && win.reduxStore) {
         // This object does approximately what the export function from redux-devtools does:
         // https://github.com/reduxjs/redux-devtools/blob/b82de745928211cd9b7daa7a61b197ad9e11ec36/extension/src/browser/extension/inject/pageScript.ts#L220-L226
         const history = {
-          payload: JSON.stringify(aWin.reduxActionLog),
-          preloadedState: JSON.stringify(aWin.reduxStore.getState()),
+          payload: JSON.stringify(win.reduxActionLog),
+          preloadedState: JSON.stringify(win.reduxStore.getState()),
         };
         cy.writeFile(`test/redux-history/${fileName}`, JSON.stringify(history, null, 2));
       }

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "types": ["node", "cypress", "@testing-library/cypress"]
   },
-  "include": ["./**/*.ts", "../src/global.d.ts"],
+  "include": ["./**/*.ts", "../src/modules.d.ts"],
   "exclude": ["../node_modules"]
 }

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "types": ["node", "cypress", "@testing-library/cypress"]
   },
-  "include": ["./**/*.ts", "../src/modules.d.ts"],
+  "include": ["./**/*.ts", "../src/modules.d.ts", "../src/global.d.ts"],
   "exclude": ["../node_modules"]
 }


### PR DESCRIPTION
## Description
Extracted from the branch I'm working on: https://github.com/Altinn/app-frontend-react/tree/experiment/new-form-data-storage2

- Converting the `IAltinnWindow` to a global type, so that we don't have to cast `Window` objects to it in order to access our own properties
- The `instanceId` on the Window object can now be undefined, as stateless apps don't have instance Ids. This confused the `ConfirmButton` component.
- The `IUpdateFormData` and `IUpdateFormDataFulfilled` types were identical, and inherited from a common root. Merged these two types to avoid the clutter.
- Adding a bit stricter type definitions for rules (`IRules` and `IRuleObject`)
- Deprecating and throwing an error when `evalExpression()` is called, where I make sure to tell developers to use the developer tools instead.
- In the expression playground in the developer tools, the result is now JSON encoded. This fixes a problem where an expression that used to return a string (or some value) that now suddenly returns `null` would not update its value in the preview pane (probably because passing a `null` to a `textarea` makes it uncontrolled and causes it to keep and display its last value).

## Related Issue(s)


## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [x] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
    - https://github.com/Altinn/altinn-studio-docs/pull/955
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
