### PR TITLE
Fix doNotPromptForParty test locally

### DIFF
--- a/test/e2e/integration/app-frontend/reportee-selection.ts
+++ b/test/e2e/integration/app-frontend/reportee-selection.ts
@@ -35,7 +35,21 @@ describe('Reportee selection', () => {
   });
 });
 
-describe.only('doNotPromptForParty doNotPromptForPartyPreference', () => {
+const fakeParty = {
+  partyId: 12345678,
+  partyTypeName: 1,
+  orgNumber: '9879879876',
+  ssn: '12312312345',
+  unitType: null,
+  name: 'Fake Party',
+  isDeleted: false,
+  onlyHierarchyElementWithNoAccess: false,
+  person: null,
+  organization: null,
+  childParties: null,
+};
+
+describe('doNotPromptForParty doNotPromptForPartyPreference', () => {
   beforeEach(() => {
     // Enable feature toggle on the window object
     cy.on('window:before:load', (win) => {
@@ -56,6 +70,13 @@ describe.only('doNotPromptForParty doNotPromptForPartyPreference', () => {
       cy.intercept('GET', '**/api/v1/profile/user', (req) => {
         req.on('response', (res) => {
           res.body.profileSettingPreference.doNotPromptForParty = doNotPromptForParty;
+        });
+      });
+
+      // Intercept allowed parties
+      cy.intercept('GET', `**/api/v1/parties?allowedtoinstantiatefilter=true`, (req) => {
+        req.on('response', (res) => {
+          res.body.push(fakeParty);
         });
       });
 
@@ -107,21 +128,7 @@ describe.only('doNotPromptForParty doNotPromptForPartyPreference', () => {
 
       // Intercept allowed parties
       cy.intercept('GET', `**/api/v1/parties?allowedtoinstantiatefilter=true`, {
-        body: [
-          {
-            partyId: 50085642,
-            partyTypeName: 1,
-            orgNumber: '',
-            ssn: '23033600534',
-            unitType: null,
-            name: 'RISHAUG JULIUS',
-            isDeleted: false,
-            onlyHierarchyElementWithNoAccess: false,
-            person: null,
-            organization: null,
-            childParties: null,
-          },
-        ],
+        body: [fakeParty],
       });
 
       cy.startAppInstance(appFrontend.apps.frontendTest);


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

I noticed that the test for doNotPromptForParty failed locally, this is because the default user in localtest only has a single valid party. I Fixed this by adding a mock party to the list of valid parties.

It also turns out that I did an upsie and forgot to remove `describe.only()`, so the other reportee-selection test was not running since #1204 was merged.