### PR TITLE
Wait for save before validating autoSaveBehavior="OnChangePage"

### DIFF
--- a/src/features/layout/update/updateFormLayoutSagas.ts
+++ b/src/features/layout/update/updateFormLayoutSagas.ts
@@ -62,6 +62,7 @@ export function* updateCurrentViewSaga({
       const visibleLayouts: string[] | null = yield select(selectLayoutOrder);
       if (visibleLayouts?.includes(uiConfig.currentView)) {
         yield put(FormDataActions.saveLatest({}));
+        yield take(FormDataActions.submitFulfilled);
       }
     } else {
       // When triggering navigation to the next page, we need to make sure there are no unsaved changes. The action to

--- a/test/e2e/integration/app-frontend/auto-save-behavior.ts
+++ b/test/e2e/integration/app-frontend/auto-save-behavior.ts
@@ -1,8 +1,11 @@
+import texts from 'test/e2e/fixtures/texts.json';
 import { AppFrontend } from 'test/e2e/pageobjects/app-frontend';
+import { Common } from 'test/e2e/pageobjects/common';
 
 import { Triggers } from 'src/types';
 
 const appFrontend = new AppFrontend();
+const mui = new Common();
 
 describe('Auto save behavior', () => {
   it('onChangeFormData: Should save form data when interacting with form element(checkbox) but not on navigation', () => {
@@ -99,5 +102,71 @@ describe('Auto save behavior', () => {
     // Both pages the 'repeating' and 'hide' pages are now hidden
     cy.get(appFrontend.navMenuCurrent).should('have.text', '2. summary');
     cy.get(appFrontend.navMenuButtons).should('have.length', 2);
+  });
+
+  [Triggers.ValidatePage, Triggers.ValidateAllPages].forEach((trigger) => {
+    it(`should run save before single field validation with navigation trigger ${trigger || 'undefined'}`, () => {
+      cy.interceptLayoutSetsUiSettings({ autoSaveBehavior: 'onChangePage' });
+      cy.interceptLayout('changename', (component) => {
+        if (component.type === 'NavigationButtons') {
+          component.triggers = trigger ? [trigger] : [];
+        }
+      });
+
+      cy.goto('changename');
+      let putFormDataCounter = 0;
+      cy.intercept('PUT', '**/data/**', () => {
+        putFormDataCounter++;
+      }).as('putFormData');
+
+      // The newFirstName field has a trigger for single field validation, and it should cause a very specific error
+      // message to appear if the field is set to 'test'. Regardless of the trigger on page navigation, if we're saving
+      // the data on page navigation, the error message should appear (because the field is set to trigger it).
+      cy.get(appFrontend.changeOfName.newFirstName).type('test');
+
+      cy.get(appFrontend.changeOfName.newMiddleName).type('Kråka');
+      cy.get(appFrontend.changeOfName.confirmChangeName).find('input').dsCheck();
+      cy.get(appFrontend.changeOfName.reasonRelationship).click();
+      cy.get(appFrontend.changeOfName.reasonRelationship).type('hello world');
+      cy.get(appFrontend.changeOfName.dateOfEffect).siblings().findByRole('button').click();
+      cy.get(mui.selectedDate).click();
+
+      cy.get(appFrontend.nextButton).clickAndGone();
+      cy.wait('@putFormData').then(() => {
+        expect(putFormDataCounter).to.be.eq(1);
+      });
+
+      // None of the triggers should cause the page to change, because all of them should be triggered validation
+      // and stopped by the error message.
+      cy.navPage('form').should('have.attr', 'aria-current', 'page');
+
+      let expectedErrors: string[] = [];
+      if (trigger == Triggers.ValidatePage) {
+        expectedErrors = ['Du må fylle ut nytt etternavn', texts.testIsNotValidValue];
+      } else if (trigger == Triggers.ValidateAllPages) {
+        expectedErrors = [
+          'Du må fylle ut nytt etternavn',
+          texts.testIsNotValidValue,
+          'Må summeres opp til 100%', // Validation on the future 'grid' page
+        ];
+      } else {
+        expectedErrors = [
+          // We don't validate the whole page, but the first name field has a trigger for single field validation,
+          // so that should be triggered when we're saving the data on page navigation.
+          texts.testIsNotValidValue,
+        ];
+      }
+
+      cy.get(appFrontend.errorReport).findAllByRole('listitem').should('have.length', expectedErrors.length);
+      for (const error of expectedErrors) {
+        cy.get(appFrontend.errorReport).should('contain.text', error);
+      }
+
+      cy.get(appFrontend.fieldValidation(appFrontend.changeOfName.newFirstName))
+        .should('have.text', texts.testIsNotValidValue)
+        .then((error) => {
+          cy.wrap(error).find('a[href="https://www.altinn.no/"]').should('exist');
+        });
+    });
   });
 });


### PR DESCRIPTION
## Description

This will fix two of the cases for triggers on the NavigationButton. When the trigger is undefined the user is naviagted to next page. This also happens for autoSaveBehavior="OnChangePage".

Single field validation still won't work.

## Related Issue(s)

- closes 2/3 #1257

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [ ] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
