### PR TITLE
Visual testing: Making screenshots less flaky

### DIFF
--- a/src/components/ThemeWrapper.tsx
+++ b/src/components/ThemeWrapper.tsx
@@ -23,7 +23,10 @@ export const ThemeWrapper = ({ children }: ThemeWrapperProps) => {
   document.documentElement.lang = language;
   document.documentElement.dir = direction;
 
-  React.useEffect(() => {
+  // Using a layout effect to make sure the whole app is re-rendered as we want it before taking screenshots
+  // for visual testing. This is needed because the visual testing library takes screenshots as soon as the viewport
+  // is resized and these classes are set.
+  React.useLayoutEffect(() => {
     const documentClasses = {
       'viewport-is-mobile': isMobile,
       'viewport-is-tablet': isTablet && !isMobile,

--- a/src/layout/Datepicker/DatepickerComponent.tsx
+++ b/src/layout/Datepicker/DatepickerComponent.tsx
@@ -195,6 +195,7 @@ export function DatepickerComponent({
               }),
             }}
             inputProps={{
+              className: 'no-visual-testing',
               'aria-label': overrideDisplay?.renderedInTable
                 ? getTextResourceAsString(textResourceBindings?.title)
                 : undefined,

--- a/src/layout/Datepicker/index.tsx
+++ b/src/layout/Datepicker/index.tsx
@@ -33,7 +33,12 @@ export class Datepicker extends FormComponent<'Datepicker'> {
 
   renderSummary({ targetNode }: SummaryRendererProps<'Datepicker'>): JSX.Element | null {
     const displayData = this.useDisplayData(targetNode);
-    return <SummaryItemSimple formDataAsString={displayData} />;
+    return (
+      <SummaryItemSimple
+        formDataAsString={displayData}
+        hideFromVisualTesting={true}
+      />
+    );
   }
 }
 

--- a/src/layout/FileUpload/shared/summary.ts
+++ b/src/layout/FileUpload/shared/summary.ts
@@ -46,8 +46,15 @@ export function useUploaderSummaryData(node: LayoutNodeFromType<'FileUpload' | '
   const listBinding = node.item.dataModelBindings?.list;
   if (listBinding) {
     const values = extractListFromBinding(formData, listBinding);
-    return attachmentsFromUuids(node.item.id, values, attachments);
+    return attachmentsFromUuids(node.item.id, values, attachments).sort(sortAttachmentsByName);
   }
 
-  return attachmentsFromComponentId(node.item.id, attachments);
+  return attachmentsFromComponentId(node.item.id, attachments).sort(sortAttachmentsByName);
+}
+
+function sortAttachmentsByName(a: IAttachment, b: IAttachment) {
+  if (a.name && b.name) {
+    return a.name.localeCompare(b.name);
+  }
+  return 0;
 }

--- a/src/layout/Summary/SummaryItemSimple.tsx
+++ b/src/layout/Summary/SummaryItemSimple.tsx
@@ -1,19 +1,22 @@
 import React from 'react';
 
+import cn from 'classnames';
+
 import { useAppSelector } from 'src/hooks/useAppSelector';
 import { getLanguageFromKey } from 'src/language/sharedLanguage';
 import classes from 'src/layout/Summary/SummaryItemSimple.module.css';
 
 export interface ISummaryItemSimple {
   formDataAsString: string | undefined;
+  hideFromVisualTesting?: boolean;
 }
 
-export function SummaryItemSimple({ formDataAsString }: ISummaryItemSimple) {
+export function SummaryItemSimple({ formDataAsString, hideFromVisualTesting = false }: ISummaryItemSimple) {
   const language = useAppSelector((state) => state.language.language);
   return (
     <div data-testid={'summary-item-simple'}>
       {formDataAsString ? (
-        <span className={classes.data}>{formDataAsString}</span>
+        <span className={cn(classes.data, { 'no-visual-testing': hideFromVisualTesting })}>{formDataAsString}</span>
       ) : (
         <span className={classes.emptyField}>{getLanguageFromKey('general.empty_summary', language || {})}</span>
       )}

--- a/test/e2e/integration/app-frontend/components.ts
+++ b/test/e2e/integration/app-frontend/components.ts
@@ -268,6 +268,13 @@ describe('UI Components', () => {
     cy.get('#form-content-newFirstName').contains('Du har 0 tegn igjen');
     cy.get(appFrontend.changeOfName.newFirstName).type('r');
     cy.get('#form-content-newFirstName').contains('Du har overskredet maks antall tegn med 1');
+
+    // This field triggers validation, but the countdown error is not yet visible in the error report, because this
+    // countdown circumvents the normal validation flow and is not affected by triggers.
+    // @see https://github.com/Altinn/app-frontend-react/issues/1263
+    cy.get(appFrontend.errorReport).should('be.visible');
+    cy.get(appFrontend.errorReport).should('contain.text', 'Må summeres opp til 100%');
+    cy.get(appFrontend.errorReport).should('not.contain.text', 'Du har overskredet maks antall tegn med 1');
     cy.snapshot('components:text-countdown');
   });
 });

--- a/test/e2e/support/custom.ts
+++ b/test/e2e/support/custom.ts
@@ -83,6 +83,12 @@ Cypress.Commands.add('snapshot', (name: string) => {
   cy.get('#readyForPrint').should('exist');
 
   cy.window().then((win) => {
+    // Find focused element and blur it, to ensure that we don't get any focus outlines or styles in the snapshot.
+    const focused = win.document.activeElement;
+    if (focused && 'blur' in focused && typeof focused.blur === 'function') {
+      focused.blur();
+    }
+
     const { innerWidth, innerHeight } = win;
     cy.readFile('test/percy.css').then((percyCSS) => {
       cy.log('Taking snapshot with Percy');


### PR DESCRIPTION
## Description
- Hiding dates from the date picker in tests (these change all the time! _duh_)
- Sorting attachments shown in Summary by name (avoids randomness, improves user experience)
- Delaying setting `viewport-is-(mobile|tablet|desktop)` classes to hopefully fix some issues where the layout was not entirely rendered yet when we took a screenshot
- Making sure the error report is visible when taking a screenshot in `components:text-countdown`. This was sometimes captured, sometimes not. Changing the field should trigger validation, and should display the error report.
- Preventing focus on the submit button to sometimes change the background color for it in screenshots, giving us slight color diffs for things we didn't change

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
