### PR TITLE
Visual testing: Making screenshots less flaky (2)

### DIFF
--- a/test/e2e/integration/app-frontend/hide-row-in-group.ts
+++ b/test/e2e/integration/app-frontend/hide-row-in-group.ts
@@ -53,6 +53,10 @@ it('should be possible to hide rows when "Endre fra" is greater or equals to [..
   cy.get('@firstRow').eq(1).should('contain.text', 'Endre fra');
   cy.get('@firstRow').eq(2).should('contain.text', 'Endre til');
 
+  // Take a screenshot, but make sure the preselectedOptionIndex takes effect first
+  cy.get(appFrontend.group.overflowGroup).find('tr:nth(1) td:nth(0) input').should('have.value', 'Altinn');
+  cy.get(appFrontend.group.overflowGroup).find('tr:nth(2) td:nth(0) input').should('have.value', 'Altinn');
+  cy.get(appFrontend.group.overflowGroup).find('tr:nth(3) td:nth(0) input').should('have.value', 'Altinn');
   cy.snapshot('hide-row-in-group');
 
   // Adding a new row to the repeating group should automatically move it to the overflow group on the next page


### PR DESCRIPTION
## Description
More fixes. This time:
- Making sure the `preselectedOptionIndex` takes effect before taking the screenshot in `hide-row-in-group`

## Related Issue(s)

- #1264
- https://percy.io/700b0900/altinn-app-frontend-react/builds/28364684/changed/1576701856?browser=chrome&browser_ids=38&subcategories=unreviewed%2Cchanges_requested&viewLayout=overlay&viewMode=new&width=987&widths=987

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
