### PR TITLE
Allowing Custom components to be rendered in table, ButtonGroup

### DIFF
--- a/src/layout/Custom/index.tsx
+++ b/src/layout/Custom/index.tsx
@@ -28,6 +28,14 @@ export class Custom extends FormComponent<'Custom'> {
     const displayData = this.useDisplayData(targetNode);
     return <SummaryItemSimple formDataAsString={displayData} />;
   }
+
+  canRenderInButtonGroup(): boolean {
+    return true;
+  }
+
+  canRenderInTable(): boolean {
+    return true;
+  }
 }
 
 export const Config = {

--- a/src/utils/formLayout.ts
+++ b/src/utils/formLayout.ts
@@ -377,7 +377,8 @@ export function extractBottomButtons(page: LayoutPage) {
   const toMainLayout: LayoutNode[] = [];
   const toErrorReport: LayoutNode[] = [];
   for (const node of all.reverse()) {
-    if ((node.isType('ButtonGroup') || node.def.canRenderInButtonGroup()) && toMainLayout.length === 0) {
+    const isButtonLike = node.isType('ButtonGroup') || (node.def.canRenderInButtonGroup() && !node.isType('Custom'));
+    if (isButtonLike && toMainLayout.length === 0) {
       toErrorReport.push(node);
     } else {
       toMainLayout.push(node);


### PR DESCRIPTION
## Description
This should allow Custom components to be rendered inside a ButtonGroup and a table (aka. `Grid` and repeating `Group`). We sadly don't have any tests for custom components currently.

## Related Issue(s)

- closes #1256

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
