### PR TITLE
Prevent opening group for editing when clicking validation messages in some cases

### DIFF
--- a/src/layout/Group/RepeatingGroupTableRow.tsx
+++ b/src/layout/Group/RepeatingGroupTableRow.tsx
@@ -299,11 +299,11 @@ export function shouldEditInTable(
   tableNode: LayoutNode,
   columnSettings: ILayoutGroup['tableColumns'],
 ) {
-  if (groupEdit?.mode === 'onlyTable') {
+  const column = columnSettings && columnSettings[tableNode.item.baseComponentId || tableNode.item.id];
+  if (groupEdit?.mode === 'onlyTable' && column?.editInTable !== false) {
     return tableNode.def.canRenderInTable();
   }
 
-  const column = columnSettings && columnSettings[tableNode.item.baseComponentId || tableNode.item.id];
   if (column && column.editInTable) {
     return tableNode.def.canRenderInTable();
   }

--- a/src/utils/layout/LayoutNode.ts
+++ b/src/utils/layout/LayoutNode.ts
@@ -165,9 +165,24 @@ export class LayoutNode<Item extends AnyItem = AnyItem, Type extends ComponentTy
       return true;
     }
 
-    if (this.parent.item.type === 'Group' && 'rows' in this.parent.item && typeof this.rowIndex === 'number') {
+    if (this.parent instanceof LayoutNode && this.parent.isRepGroup() && typeof this.rowIndex === 'number') {
       const isHiddenRow = this.parent.item.rows[this.rowIndex]?.groupExpressions?.hiddenRow;
       if (isHiddenRow) {
+        return true;
+      }
+
+      const myBaseId = this.item.baseComponentId || this.item.id;
+      const groupMode = this.parent.item.edit?.mode;
+      const tableColSetup = this.parent.item.tableColumns && this.parent.item.tableColumns[myBaseId];
+
+      // This specific configuration hides the component fully, without having set hidden=true on the component itself.
+      // It's most likely done by mistake, but we still need to respect it when checking if the component is hidden,
+      // because it doesn't make sense to validate a component that is hidden in the UI and the
+      // user cannot interact with.
+      const hiddenImplicitly =
+        tableColSetup?.showInExpandedEdit === false && !tableColSetup.editInTable && groupMode !== 'onlyTable';
+
+      if (hiddenImplicitly) {
         return true;
       }
     }

--- a/src/utils/layout/LayoutNode.ts
+++ b/src/utils/layout/LayoutNode.ts
@@ -179,8 +179,13 @@ export class LayoutNode<Item extends AnyItem = AnyItem, Type extends ComponentTy
       // It's most likely done by mistake, but we still need to respect it when checking if the component is hidden,
       // because it doesn't make sense to validate a component that is hidden in the UI and the
       // user cannot interact with.
-      const hiddenImplicitly =
-        tableColSetup?.showInExpandedEdit === false && !tableColSetup.editInTable && groupMode !== 'onlyTable';
+      let hiddenImplicitly =
+        tableColSetup?.showInExpandedEdit === false && !tableColSetup?.editInTable && groupMode !== 'onlyTable';
+
+      if (groupMode === 'onlyTable' && tableColSetup?.editInTable === false) {
+        // This is also a way to hide a component implicitly
+        hiddenImplicitly = true;
+      }
 
       if (hiddenImplicitly) {
         return true;

--- a/test/e2e/integration/app-frontend/validation.ts
+++ b/test/e2e/integration/app-frontend/validation.ts
@@ -422,12 +422,30 @@ describe('Validation', () => {
     cy.get(appFrontend.group.editContainer).should('not.exist');
 
     cy.changeLayout((component) => {
+      if (component.type === 'Group' && component.id === 'mainGroup' && component.tableColumns) {
+        // Components that are not editable in the table, when using the 'onlyTable' mode, are implicitly hidden
+        component.tableColumns.currentValue.editInTable = false;
+      }
+    });
+
+    cy.get(appFrontend.group.row(0).currentValue).should('not.exist');
+    cy.get(appFrontend.group.row(0).newValue).should('exist');
+    cy.get(appFrontend.group.mainGroupTableBody).find('tr').eq(1).find('td').eq(0).should('have.text', 'NOK 1 233');
+    cy.get(appFrontend.group.mainGroupTableBody).find('tr').eq(2).find('td').eq(0).should('have.text', '');
+    cy.get(appFrontend.group.row(2).currentValue).should('not.exist');
+    cy.get(appFrontend.nextButton).click();
+    cy.get(appFrontend.errorReport).findAllByRole('listitem').should('have.length', 1);
+    cy.get(appFrontend.errorReport).findByText('Du må fylle ut 2. endre verdi til').click();
+    cy.get(appFrontend.group.row(2).newValue).should('be.focused');
+
+    cy.changeLayout((component) => {
       if (component.type === 'Group' && component.id === 'mainGroup' && component.edit && component.tableColumns) {
         // In regular mode, if the edit button is hidden, we should not open the row in edit mode to focus a component
         // because this isn't a mode the user would be able to reach either.
         component.edit.mode = 'showTable';
         component.edit.editButton = false;
         component.tableColumns.newValue.editInTable = undefined;
+        component.tableColumns.currentValue.editInTable = undefined;
       }
     });
 

--- a/test/e2e/integration/app-frontend/validation.ts
+++ b/test/e2e/integration/app-frontend/validation.ts
@@ -2,6 +2,8 @@ import texts from 'test/e2e/fixtures/texts.json';
 import { AppFrontend } from 'test/e2e/pageobjects/app-frontend';
 import { Common } from 'test/e2e/pageobjects/common';
 
+import { Triggers } from 'src/types';
+
 const appFrontend = new AppFrontend();
 const mui = new Common();
 
@@ -269,7 +271,7 @@ describe('Validation', () => {
 
   it('Clicking the error report should focus the correct field', () => {
     cy.interceptLayout('group', (component) => {
-      if (component.id === 'comments') {
+      if (component.id === 'comments' || component.id === 'newValue' || component.id === 'currentValue') {
         component.required = true;
       }
     });
@@ -277,16 +279,41 @@ describe('Validation', () => {
 
     cy.get(appFrontend.group.prefill.liten).dsCheck();
     cy.get(appFrontend.group.prefill.stor).dsCheck();
-
     cy.get(appFrontend.nextButton).click();
 
     // Check that showGroupToContinue is focused
     cy.get(appFrontend.nextButton).click();
+    cy.get(appFrontend.errorReport).findAllByRole('listitem').should('have.length', 1);
     cy.get(appFrontend.errorReport).findByText(texts.requiredOpenRepGroup).click();
     cy.get(appFrontend.group.showGroupToContinue).find('input').should('be.focused');
 
-    // Check that nested group with multipage gets focus
+    // Check that clicking the error focuses a component inside a group
     cy.get(appFrontend.group.showGroupToContinue).find('input').dsCheck();
+    cy.get(appFrontend.group.addNewItem).click();
+    cy.get(appFrontend.group.editContainer).find(appFrontend.group.next).click();
+    cy.get(appFrontend.group.row(2).nestedGroup.row(0).comments).should('be.visible');
+    cy.get(appFrontend.group.saveMainGroup).click();
+    cy.get(appFrontend.group.editContainer).should('be.visible');
+    cy.get(appFrontend.errorReport).findAllByRole('listitem').should('have.length', 3);
+    cy.get(appFrontend.errorReport)
+      .findByText('Du må fylle ut 1.')
+      .should('have.text', 'Du må fylle ut 1. endre fra')
+      .click();
+    cy.get(appFrontend.group.row(2).currentValue).should('exist').and('be.focused');
+    cy.get(appFrontend.group.row(2).currentValue).type('123');
+
+    // At this point, even though we have filled out the required field, the validation message for the other
+    // field should still be there as it was.
+    cy.get(appFrontend.errorReport).findByText('Du må fylle ut 2. endre verdi til').click();
+    cy.get(appFrontend.group.row(2).newValue).should('exist').and('be.focused');
+    cy.get(appFrontend.group.saveMainGroup).click();
+    cy.get(appFrontend.errorReport).findAllByRole('listitem').should('have.length', 2);
+
+    // Validation message should now have changed, since we filled out currentValue and saved
+    cy.get(appFrontend.errorReport).findByText('Du må fylle ut 2. endre verdi 123 til').should('be.visible');
+    cy.get(appFrontend.group.row(2).deleteBtn).click();
+
+    // Check that nested group with multipage gets focus
     cy.get(appFrontend.group.row(0).editBtn).click();
     cy.get(appFrontend.group.editContainer).find(appFrontend.group.next).click();
     cy.get(appFrontend.group.row(0).nestedGroup.row(0).comments).type('comment');
@@ -305,8 +332,129 @@ describe('Validation', () => {
     cy.get(appFrontend.group.row(0).editBtn).click();
     cy.gotoNavPage('summary');
     cy.get(appFrontend.sendinButton).click();
+    cy.get(appFrontend.errorReport).findAllByRole('listitem').should('have.length', 1);
     cy.get(appFrontend.errorReport).findByText(texts.requiredSendersName).click();
     cy.get(appFrontend.group.sendersName).should('be.focused');
+    cy.get(appFrontend.group.sendersName).type('hello world');
+    cy.get(appFrontend.errorReport).should('not.exist');
+    cy.get(appFrontend.prevButton).click();
+
+    cy.changeLayout((component) => {
+      if (component.type === 'Group' && component.id === 'mainGroup' && component.tableColumns) {
+        // As the component is hidden in edit mode, and not shown in the table for editing, it should not be
+        // showing any validation messages.
+        component.tableColumns.currentValue.showInExpandedEdit = false;
+      }
+    });
+
+    // Attempting to save the group with one remaining required field should let us focus that field,
+    // but the field not shown in the expanded edit should not be focused
+    cy.get(appFrontend.group.addNewItem).click();
+    cy.get(appFrontend.group.saveMainGroup).click();
+
+    // The currentValue field is required, but as it's implicitly hidden in the expanded edit, it should not produce
+    // a validation message or be visible in the error report.
+    cy.get(appFrontend.errorReport).findAllByRole('listitem').should('have.length', 1);
+    cy.get(appFrontend.group.editContainer).should('be.visible');
+    cy.get(appFrontend.errorReport).findByText('Du må fylle ut 2. endre verdi til').click();
+    cy.get(appFrontend.group.row(2).newValue).should('exist').and('be.focused');
+    cy.get(appFrontend.group.row(2).currentValue).should('not.exist');
+
+    // Even though the currentValue field is hidden, the value should still be displayed in the table
+    cy.get(appFrontend.group.mainGroupTableBody).find('tr').eq(0).find('td').eq(0).should('have.text', 'NOK 1');
+    cy.get(appFrontend.group.mainGroupTableBody).find('tr').eq(1).find('td').eq(0).should('have.text', 'NOK 1 233');
+
+    // Filling out the remaining field should let us save the group and hide leftover errors
+    cy.get(appFrontend.group.row(2).newValue).type('456');
+    cy.get(appFrontend.group.saveMainGroup).click();
+    cy.get(appFrontend.group.editContainer).should('not.exist');
+    cy.get(appFrontend.errorReport).should('not.exist');
+
+    cy.changeLayout((component) => {
+      if (component.type === 'Group' && component.id === 'mainGroup' && component.edit) {
+        // In the 'onlyTable' mode, there is no option to edit a row, so we should not open the row in edit mode
+        // to focus a component either.
+        component.edit.mode = 'onlyTable';
+      }
+    });
+
+    // These components are not editable in the table yet, so even though the edit button
+    // is gone now, they're not to be found.
+    cy.get(appFrontend.group.edit).should('not.exist');
+    cy.get(appFrontend.group.row(0).currentValue).should('not.exist');
+    cy.get(appFrontend.group.row(2).currentValue).should('not.exist');
+    cy.get(appFrontend.group.row(0).newValue).should('not.exist');
+    cy.get(appFrontend.group.editContainer).should('not.exist');
+
+    cy.changeLayout((component) => {
+      if (component.type === 'Group' && component.id === 'mainGroup' && component.tableColumns) {
+        component.tableColumns.currentValue.editInTable = undefined;
+        component.tableColumns.newValue.editInTable = true;
+      }
+      if (component.type === 'NavigationButtons') {
+        // When components are visible in the table, the validation trigger on the group itself stops having an effect,
+        // as there is no way for the user to say they're 'done' editing a row.
+        component.triggers = [Triggers.ValidatePage];
+      }
+    });
+
+    // Components are now visible in the table
+    cy.get(appFrontend.group.row(0).currentValue).should('have.attr', 'readonly', 'readonly');
+    cy.get(appFrontend.group.row(2).currentValue).should('not.have.attr', 'readonly');
+    cy.get(appFrontend.group.row(0).newValue).should('have.attr', 'readonly', 'readonly');
+
+    // Delete the row, start over, and observe that the currentValue now exists as a field in the table and
+    // produces a validation message if not filled out. We need to use the 'next' button to trigger validation.
+    cy.get(appFrontend.group.row(2).deleteBtn).click();
+    cy.get(appFrontend.group.row(2).currentValue).should('not.exist');
+    cy.get(appFrontend.group.addNewItem).click();
+    cy.get(appFrontend.group.row(2).currentValue).should('exist');
+    cy.get(appFrontend.group.row(2).newValue).should('exist');
+    cy.get(appFrontend.group.editContainer).should('not.exist');
+    cy.get(appFrontend.errorReport).should('not.exist');
+    cy.get(appFrontend.nextButton).click();
+    cy.get(appFrontend.errorReport).findAllByRole('listitem').should('have.length', 2);
+    cy.get(appFrontend.errorReport).findByText('Du må fylle ut 1.').click();
+    cy.get(appFrontend.group.row(2).currentValue).should('be.focused');
+    cy.get(appFrontend.group.editContainer).should('not.exist');
+    cy.get(appFrontend.errorReport).findByText('Du må fylle ut 2. endre verdi til').click();
+    cy.get(appFrontend.group.row(2).newValue).should('be.focused');
+    cy.get(appFrontend.group.editContainer).should('not.exist');
+
+    cy.changeLayout((component) => {
+      if (component.type === 'Group' && component.id === 'mainGroup' && component.edit && component.tableColumns) {
+        // In regular mode, if the edit button is hidden, we should not open the row in edit mode to focus a component
+        // because this isn't a mode the user would be able to reach either.
+        component.edit.mode = 'showTable';
+        component.edit.editButton = false;
+        component.tableColumns.newValue.editInTable = undefined;
+      }
+    });
+
+    cy.get(appFrontend.errorReport).findAllByRole('listitem').should('have.length', 1);
+    cy.get(appFrontend.group.editContainer).should('not.exist');
+    cy.get(appFrontend.group.addNewItem).click();
+    cy.get(appFrontend.group.editContainer).should('be.visible');
+    cy.get(appFrontend.group.row(3).newValue).should('exist');
+    cy.get(appFrontend.group.row(3).currentValue).should('not.exist');
+    cy.get(appFrontend.group.saveMainGroup).click();
+    cy.get(appFrontend.errorReport).findAllByRole('listitem').should('have.length', 2);
+    cy.get(appFrontend.errorReport).findAllByText('Du må fylle ut 2. endre verdi til').eq(0).click();
+
+    // We have no way to focus this field, because this component is hidden when the edit container is no longer
+    // visible for this row. It's not technically a fully hidden component since it can still be edited when the
+    // edit container was first opened, but by removing the edit button, we've made it impossible to reach the
+    // component to focus it.
+    //
+    // Note that we're testing expected functionality here, but if you're actually implementing this in an app, you
+    // should trigger validation before saving and closing the group row, so that the user cannot reach this state
+    // (although they still could if refreshing the page, so it's not the best idea).
+    cy.focused().should('have.text', 'Du må fylle ut 2. endre verdi til');
+
+    // Clicking the next validation message should focus the component already open in editing mode
+    cy.get(appFrontend.group.editContainer).find(appFrontend.group.row(3).newValue).should('not.be.focused');
+    cy.get(appFrontend.errorReport).findAllByText('Du må fylle ut 2. endre verdi til').eq(1).click();
+    cy.get(appFrontend.group.editContainer).find(appFrontend.group.row(3).newValue).should('be.focused');
   });
 
   it('Validates mime type on attachment', () => {

--- a/test/e2e/pageobjects/app-frontend.ts
+++ b/test/e2e/pageobjects/app-frontend.ts
@@ -220,6 +220,8 @@ export class AppFrontend {
     hideCommentField: '[id^="hideComment"]',
     hiddenRowsInfoMsg: '[data-componentid="info-msg"]',
     row: (idx: number) => ({
+      currentValue: `#currentValue-${idx}`,
+      newValue: `#newValue-${idx}`,
       uploadSingle: makeUploaderSelectors('mainUploaderSingle', idx, 3, 'untagged'),
       uploadMulti: makeUploaderSelectors('mainUploaderMulti', idx, 4, 'untagged'),
       editBtn: `#group-mainGroup-table-body > tr:nth-child(${idx + 1}) [data-testid=edit-button]`,


### PR DESCRIPTION
## Description
Fixing a few bugs:
- When a component in a repeating group is set to `showInExpandedEdit: false` and is not editable in the table, it is implicitly hidden, so the user cannot fix any validation messages for it either. Marking this field as hidden, so that we also hide any validation messages for it. This is most likely an implementation mistake if hiding required fields (or fields with errors in them).
- Allowing an app developer to set `editInTable: false` even when using `mode: onlyTable` on a repeating group. This means that you can opt out of editing a component in the table if you want to. (These components are also implicitly hidden, but their values still appear in the table). Verified that no apps in tt02/prod currently use this setup, so this should not be breaking.
- Fixing multiple configurations that could lead to unexpected behaviour when clicking on validation messages in the bottom error report:
  - The repeating group could open in edit mode, even if it was set to `mode: onlyTable` (meaning it should have no edit mode)
  - The repeating group could open in edit mode, even if the edit button was hidden for the row (meaning the user could not have opened it for editing manually)
  - The component that should get focus was in the table instead of inside the edit container

## Related Issue(s)

- https://altinn.slack.com/archives/C02EVE4RU82/p1687355049376939

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
