### PR TITLE
feat(Alert): add Alert component which uses @digdir/design-system-react

### DIFF
--- a/schemas/json/layout/layout.schema.v1.json
+++ b/schemas/json/layout/layout.schema.v1.json
@@ -167,12 +167,6 @@
           "description": "The severity of the alert.",
           "type": "string",
           "enum": ["success", "warning", "danger", "info"]
-        },
-        "useAsAlert": {
-          "title": "Use as alert",
-          "description": "Boolean value indicating if the alert should be used as an alert. Setting to true will make screen readers read the alert when it is rendered.",
-          "type": "boolean",
-          "default": false
         }
       },
       "required": ["severity"]

--- a/schemas/json/layout/layout.schema.v1.json
+++ b/schemas/json/layout/layout.schema.v1.json
@@ -42,7 +42,7 @@
           "type": "string",
           "title": "Type",
           "description": "The component type.",
-          "enum": ["ActionButton", "AddressComponent", "AttachmentList", "Button", "ButtonGroup", "Checkboxes", "Custom", "Datepicker", "Dropdown", "FileUpload", "FileUploadWithTag", "Grid", "Group", "Header", "Image", "Input", "InstanceInformation", "InstantiationButton", "IFrame", "Likert","Link", "List", "MultipleSelect", "NavigationButtons", "NavigationBar", "Panel", "Paragraph", "PrintButton", "RadioButtons", "Summary", "TextArea"]
+          "enum": ["Alert","ActionButton", "AddressComponent", "AttachmentList", "Button", "ButtonGroup", "Checkboxes", "Custom", "Datepicker", "Dropdown", "FileUpload", "FileUploadWithTag", "Grid", "Group", "Header", "Image", "Input", "InstanceInformation", "InstantiationButton", "IFrame", "Likert","Link", "List", "MultipleSelect", "NavigationButtons", "NavigationBar", "Panel", "Paragraph", "PrintButton", "RadioButtons", "Summary", "TextArea"]
         },
         "required": {
           "title": "Required",
@@ -128,6 +128,7 @@
       },
       "required": ["id", "type"],
       "allOf": [
+        { "if": {"properties": {"type": { "const": "Alert"}}}, "then": {"$ref": "#/definitions/alertComponent"}},
         { "if": {"properties": {"type": { "const": "ActionButton"}}}, "then": {"$ref": "#/definitions/actionButtonComponent"}},
         { "if": {"properties": {"type": { "const": "AddressComponent"}}}, "then": { "$ref": "#/definitions/addressComponent"}},
         { "if": {"properties": {"type": { "const": "AttachmentList"}}}, "then": { "$ref": "#/definitions/attachmentListComponent"}},
@@ -158,6 +159,23 @@
         { "if": {"properties": {"type": { "const": "List"}}}, "then": {"$ref": "#/definitions/listComponent"}},
         { "if": { "properties": { "type": { "const": "MapComponent" } } }, "then": { "$ref": "#/definitions/mapComponent" }}
       ]
+    },
+    "alertComponent": {
+      "properties": {
+        "severity": {
+          "title": "Severity",
+          "description": "The severity of the alert.",
+          "type": "string",
+          "enum": ["success", "warning", "danger", "info"]
+        },
+        "useAsAlert": {
+          "title": "Use as alert",
+          "description": "Boolean value indicating if the alert should be used as an alert. Setting to true will make screen readers read the alert when it is rendered.",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "required": ["severity"]
     },
     "headerComponent": {
       "properties": {

--- a/src/components/form/SoftValidations.test.tsx
+++ b/src/components/form/SoftValidations.test.tsx
@@ -3,8 +3,7 @@ import React from 'react';
 import { screen } from '@testing-library/react';
 
 import { getInitialStateMock } from 'src/__mocks__/initialStateMock';
-import { getPanelTitle, SoftValidations } from 'src/components/form/SoftValidations';
-import { staticUseLanguageForTests } from 'src/hooks/useLanguage';
+import { SoftValidations } from 'src/components/form/SoftValidations';
 import { FormComponentContext } from 'src/layout';
 import { renderWithProviders } from 'src/testUtils';
 import type { ISoftValidationProps, SoftValidationVariant } from 'src/components/form/SoftValidations';
@@ -18,11 +17,7 @@ const render = (
 ) => {
   const allProps: ISoftValidationProps = {
     variant: 'info',
-    children: (
-      <ol>
-        <li>Some message</li>
-      </ol>
-    ),
+    errorMessages: ['Some message'],
     ...props,
   };
 
@@ -41,34 +36,12 @@ const render = (
 
 describe('SoftValidations', () => {
   it.each(['info', 'warning', 'success'])(
-    'for variant %p it should render the message with correct title',
+    'for variant %p it should render the message',
     (variant: SoftValidationVariant) => {
-      const langTools = staticUseLanguageForTests();
       render({ variant });
 
       const message = screen.getByText('Some message');
       expect(message).toBeInTheDocument();
-
-      const title = screen.getByText(getPanelTitle({ variant, langTools }));
-      expect(title).toBeInTheDocument();
-    },
-  );
-
-  it.each(['info', 'warning', 'success'])(
-    'for variant %p it should render the message with overridden title if supplied by app',
-    (variant: SoftValidationVariant) => {
-      const expectedTitle = {
-        info: 'Lurt å tenke på',
-        warning: 'OBS',
-        success: 'Så flott!',
-      };
-      render({ variant });
-
-      const message = screen.getByText('Some message');
-      expect(message).toBeInTheDocument();
-
-      const title = screen.getByText(expectedTitle[variant]);
-      expect(title).toBeInTheDocument();
     },
   );
 });

--- a/src/components/form/SoftValidations.tsx
+++ b/src/components/form/SoftValidations.tsx
@@ -1,44 +1,36 @@
 import React from 'react';
 
-import { Panel } from 'src/components/form/Panel';
 import { useLanguage } from 'src/hooks/useLanguage';
-import type { IUseLanguage } from 'src/hooks/useLanguage';
+import { getParsedLanguageFromText } from 'src/language/sharedLanguage';
+import { AlertBaseComponent } from 'src/layout/Alert/AlertBaseComponent';
 
 export interface ISoftValidationProps {
-  children: React.ReactNode;
   variant: SoftValidationVariant;
+  errorMessages: string[];
 }
 
 export type SoftValidationVariant = 'warning' | 'info' | 'success';
 
-interface IGetPanelTitleProps {
-  variant: SoftValidationVariant;
-  langTools: IUseLanguage;
-}
+export const validationMessagesToList = (message: string, index: number) => (
+  <li key={`validationMessage-${index}`}>{getParsedLanguageFromText(message)}</li>
+);
 
-export const getPanelTitle = ({ variant, langTools }: IGetPanelTitleProps) => {
-  const { langAsString } = langTools;
-  switch (variant) {
-    case 'warning':
-      return langAsString('soft_validation.warning_title');
-    case 'info':
-      return langAsString('soft_validation.info_title');
-    case 'success':
-      return langAsString('soft_validation.success_title');
-  }
-};
+export function SoftValidations({ variant, errorMessages }: ISoftValidationProps) {
+  const { langAsString } = useLanguage();
 
-export function SoftValidations({ variant, children }: ISoftValidationProps) {
-  const langTools = useLanguage();
+  /**
+   * Rendering the error messages as an ordered
+   * list with each error message as a list item.
+   */
+  const ariaLabel = langAsString(errorMessages.join());
 
   return (
-    <Panel
-      variant={variant}
-      showPointer={true}
-      showIcon={true}
-      title={getPanelTitle({ variant, langTools })}
+    <AlertBaseComponent
+      severity={variant}
+      useAsAlert={true}
+      ariaLabel={ariaLabel}
     >
-      {children}
-    </Panel>
+      <ol style={{ paddingLeft: 0 }}>{errorMessages.map(validationMessagesToList)}</ol>
+    </AlertBaseComponent>
   );
 }

--- a/src/layout/Alert/Alert.module.css
+++ b/src/layout/Alert/Alert.module.css
@@ -3,6 +3,6 @@
   font-size: 1.25rem;
 }
 
-.description {
+.body {
   margin: 0;
 }

--- a/src/layout/Alert/Alert.module.css
+++ b/src/layout/Alert/Alert.module.css
@@ -1,0 +1,8 @@
+.title {
+  font-weight: 500;
+  font-size: 1.25rem;
+}
+
+.description {
+  margin: 0;
+}

--- a/src/layout/Alert/Alert.test.tsx
+++ b/src/layout/Alert/Alert.test.tsx
@@ -4,7 +4,8 @@ import { screen } from '@testing-library/react';
 
 import { Alert } from 'src/layout/Alert/Alert';
 import { renderGenericComponentTest } from 'src/testUtils';
-import type { ILayoutCompAlertBase } from 'src/layout/Alert/types';
+import type { ExprResolved } from 'src/features/expressions/types';
+import type { ILayoutCompAlert } from 'src/layout/Alert/types';
 
 describe('Alert', () => {
   it('should display title', () => {
@@ -17,24 +18,29 @@ describe('Alert', () => {
     expect(screen.getByText(/description for alert/i)).toBeInTheDocument();
   });
 
-  it('should display as role="alert" when useAsAlert is true', () => {
-    render({ title: 'title for alert', useAsAlert: true });
+  it('should display as role="alert" when hidden is false', () => {
+    render({ title: 'title for alert', hidden: false });
     expect(screen.getByRole('alert', { name: /title for alert/i })).toBeInTheDocument();
   });
 
-  it('should not display as role="alert" when useAsAlert is false', () => {
-    render({ title: 'title for alert', useAsAlert: false });
+  it('should not display as role="alert" when hidden is true', () => {
+    render({ title: 'title for alert', hidden: true });
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('should not display as role="alert" when hidden is undefined', () => {
+    render({ title: 'title for alert', hidden: undefined });
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   });
 });
 
 const render = ({
   severity,
-  useAsAlert,
+  hidden,
   title,
   description,
-}: Partial<ILayoutCompAlertBase> & { title?: string; description?: string } = {}) =>
-  renderGenericComponentTest({
+}: Partial<ExprResolved<ILayoutCompAlert>> & { title?: string; description?: string } = {}) =>
+  renderGenericComponentTest<'Alert'>({
     type: 'Alert',
     renderer: (props) => <Alert {...props} />,
     component: {
@@ -44,6 +50,6 @@ const render = ({
         description,
       },
       severity,
-      useAsAlert,
+      hidden,
     },
   });

--- a/src/layout/Alert/Alert.test.tsx
+++ b/src/layout/Alert/Alert.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+
+import { screen } from '@testing-library/react';
+
+import { Alert } from 'src/layout/Alert/Alert';
+import { renderGenericComponentTest } from 'src/testUtils';
+import type { ILayoutCompAlertBase } from 'src/layout/Alert/types';
+
+describe('Alert', () => {
+  it('should display title', () => {
+    render({ title: 'Title for alert' });
+    expect(screen.getByText(/title for alert/i)).toBeInTheDocument();
+  });
+
+  it('should display description', () => {
+    render({ description: 'Description for alert' });
+    expect(screen.getByText(/description for alert/i)).toBeInTheDocument();
+  });
+
+  it('should display as role="alert" when useAsAlert is true', () => {
+    render({ title: 'title for alert', useAsAlert: true });
+    expect(screen.getByRole('alert', { name: /title for alert/i })).toBeInTheDocument();
+  });
+
+  it('should not display as role="alert" when useAsAlert is false', () => {
+    render({ title: 'title for alert', useAsAlert: false });
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+});
+
+const render = ({
+  severity,
+  useAsAlert,
+  title,
+  description,
+}: Partial<ILayoutCompAlertBase> & { title?: string; description?: string } = {}) =>
+  renderGenericComponentTest({
+    type: 'Alert',
+    renderer: (props) => <Alert {...props} />,
+    component: {
+      id: 'alert-box',
+      textResourceBindings: {
+        title,
+        description,
+      },
+      severity,
+      useAsAlert,
+    },
+  });

--- a/src/layout/Alert/Alert.test.tsx
+++ b/src/layout/Alert/Alert.test.tsx
@@ -35,7 +35,7 @@ describe('Alert', () => {
 });
 
 const render = ({
-  severity,
+  severity = 'info',
   hidden,
   title,
   description,

--- a/src/layout/Alert/Alert.tsx
+++ b/src/layout/Alert/Alert.tsx
@@ -1,21 +1,10 @@
 import React from 'react';
 
-import { Alert as AlertDesignSystem } from '@digdir/design-system-react';
-
 import { useLanguage } from 'src/hooks/useLanguage';
+import { AlertBaseComponent } from 'src/layout/Alert/AlertBaseComponent';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export type AlertProps = PropsFromGenericComponent<'Alert'>;
-
-import styles from 'src/layout/Alert/Alert.module.css';
-import type { AlertSeverity } from 'src/layout/Alert/types';
-
-function calculateAriaLive(severity: AlertSeverity): 'polite' | 'assertive' {
-  if (severity === 'warning' || severity === 'danger') {
-    return 'assertive';
-  }
-  return 'polite';
-}
 
 export const Alert = ({ node }: AlertProps) => {
   const { severity, textResourceBindings, hidden } = node.item;
@@ -26,14 +15,12 @@ export const Alert = ({ node }: AlertProps) => {
   const shouldAlertScreenReaders = hidden === false;
 
   return (
-    <AlertDesignSystem
+    <AlertBaseComponent
       severity={severity}
-      role={shouldAlertScreenReaders ? 'alert' : undefined}
-      aria-live={shouldAlertScreenReaders ? calculateAriaLive(severity) : undefined}
-      aria-label={shouldAlertScreenReaders ? title : undefined}
+      useAsAlert={shouldAlertScreenReaders}
+      title={title}
     >
-      <span className={styles.title}>{title}</span>
-      <p className={styles.description}>{description}</p>
-    </AlertDesignSystem>
+      {description}
+    </AlertBaseComponent>
   );
 };

--- a/src/layout/Alert/Alert.tsx
+++ b/src/layout/Alert/Alert.tsx
@@ -8,6 +8,14 @@ import type { PropsFromGenericComponent } from 'src/layout';
 export type AlertProps = PropsFromGenericComponent<'Alert'>;
 
 import styles from 'src/layout/Alert/Alert.module.css';
+import type { AlertSeverity } from 'src/layout/Alert/types';
+
+function calculateAriaLive(severity: AlertSeverity): 'polite' | 'assertive' {
+  if (severity === 'warning' || severity === 'danger') {
+    return 'assertive';
+  }
+  return 'polite';
+}
 
 export const Alert = ({ node }: AlertProps) => {
   const { severity, useAsAlert, textResourceBindings } = node.item;
@@ -20,7 +28,7 @@ export const Alert = ({ node }: AlertProps) => {
     <AlertDesignSystem
       severity={severity}
       role={useAsAlert ? 'alert' : undefined}
-      aria-live={useAsAlert ? 'polite' : undefined}
+      aria-live={useAsAlert ? calculateAriaLive(severity) : undefined}
       aria-label={useAsAlert ? title : undefined}
     >
       <span className={styles.title}>{title}</span>

--- a/src/layout/Alert/Alert.tsx
+++ b/src/layout/Alert/Alert.tsx
@@ -18,18 +18,19 @@ function calculateAriaLive(severity: AlertSeverity): 'polite' | 'assertive' {
 }
 
 export const Alert = ({ node }: AlertProps) => {
-  const { severity, useAsAlert, textResourceBindings } = node.item;
+  const { severity, textResourceBindings, hidden } = node.item;
   const { langAsString } = useLanguage();
 
   const title = textResourceBindings?.title && langAsString(textResourceBindings.title);
   const description = textResourceBindings?.description && langAsString(textResourceBindings.description);
+  const shouldAlertScreenReaders = hidden === false;
 
   return (
     <AlertDesignSystem
       severity={severity}
-      role={useAsAlert ? 'alert' : undefined}
-      aria-live={useAsAlert ? calculateAriaLive(severity) : undefined}
-      aria-label={useAsAlert ? title : undefined}
+      role={shouldAlertScreenReaders ? 'alert' : undefined}
+      aria-live={shouldAlertScreenReaders ? calculateAriaLive(severity) : undefined}
+      aria-label={shouldAlertScreenReaders ? title : undefined}
     >
       <span className={styles.title}>{title}</span>
       <p className={styles.description}>{description}</p>

--- a/src/layout/Alert/Alert.tsx
+++ b/src/layout/Alert/Alert.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+import { Alert as AlertDesignSystem } from '@digdir/design-system-react';
+
+import { useLanguage } from 'src/hooks/useLanguage';
+import type { PropsFromGenericComponent } from 'src/layout';
+
+export type AlertProps = PropsFromGenericComponent<'Alert'>;
+
+import styles from 'src/layout/Alert/Alert.module.css';
+
+export const Alert = ({ node }: AlertProps) => {
+  const { severity, useAsAlert, textResourceBindings } = node.item;
+  const { langAsString } = useLanguage();
+
+  const title = textResourceBindings?.title && langAsString(textResourceBindings.title);
+  const description = textResourceBindings?.description && langAsString(textResourceBindings.description);
+
+  return (
+    <AlertDesignSystem
+      severity={severity}
+      role={useAsAlert ? 'alert' : undefined}
+      aria-live={useAsAlert ? 'polite' : undefined}
+      aria-label={useAsAlert ? title : undefined}
+    >
+      <span className={styles.title}>{title}</span>
+      <p className={styles.description}>{description}</p>
+    </AlertDesignSystem>
+  );
+};

--- a/src/layout/Alert/AlertBaseComponent.test.tsx
+++ b/src/layout/Alert/AlertBaseComponent.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+import { render as rtlRender, screen } from '@testing-library/react';
+
+import { AlertBaseComponent } from 'src/layout/Alert/AlertBaseComponent';
+import type { AlertBaseComponentProps } from 'src/layout/Alert/AlertBaseComponent';
+
+const defaultProps: AlertBaseComponentProps = {
+  severity: 'info',
+};
+
+const render = (props: Partial<AlertBaseComponentProps> = {}) =>
+  rtlRender(
+    <AlertBaseComponent
+      {...defaultProps}
+      {...props}
+    />,
+  );
+
+describe('Alert', () => {
+  it('should display title', () => {
+    render({ title: 'Title for alert' });
+    expect(screen.getByText(/title for alert/i)).toBeInTheDocument();
+  });
+
+  it('should display children', () => {
+    render({ children: 'Description for alert' });
+    expect(screen.getByText(/description for alert/i)).toBeInTheDocument();
+  });
+});

--- a/src/layout/Alert/AlertBaseComponent.tsx
+++ b/src/layout/Alert/AlertBaseComponent.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+import { Alert as AlertDesignSystem } from '@digdir/design-system-react';
+
+import styles from 'src/layout/Alert/Alert.module.css';
+import type { AlertSeverity } from 'src/layout/Alert/types';
+
+function calculateAriaLive(severity: AlertSeverity): 'polite' | 'assertive' {
+  if (severity === 'warning' || severity === 'danger') {
+    return 'assertive';
+  }
+  return 'polite';
+}
+
+export type AlertBaseComponentProps = {
+  title?: string;
+  children?: React.ReactNode;
+  useAsAlert?: boolean;
+  severity: AlertSeverity;
+  ariaLabel?: string;
+};
+
+export const AlertBaseComponent = ({ title, children, useAsAlert, severity, ariaLabel }: AlertBaseComponentProps) => (
+  <AlertDesignSystem
+    severity={severity}
+    role={useAsAlert ? 'alert' : undefined}
+    aria-live={useAsAlert ? calculateAriaLive(severity) : undefined}
+    aria-label={useAsAlert ? ariaLabel ?? title : undefined}
+  >
+    <span className={styles.title}>{title}</span>
+    <div className={styles.body}>{children}</div>
+  </AlertDesignSystem>
+);

--- a/src/layout/Alert/index.tsx
+++ b/src/layout/Alert/index.tsx
@@ -12,10 +12,6 @@ export class Alert extends PresentationComponent<'Alert'> {
     return <AlertComponent {...props} />;
   }
 
-  renderWithLabel(): boolean {
-    return false;
-  }
-
   canRenderInTable(): boolean {
     return false;
   }
@@ -23,10 +19,13 @@ export class Alert extends PresentationComponent<'Alert'> {
 
 export const Config = {
   def: new Alert(),
+  rendersWithLabel: false as const,
 };
 
 export type TypeConfig = {
   layout: ILayoutCompAlert;
   nodeItem: ExprResolved<ILayoutCompAlert>;
   nodeObj: LayoutNode;
+  validTextResourceBindings: 'title' | 'description';
+  validDataModelBindings: undefined;
 };

--- a/src/layout/Alert/index.tsx
+++ b/src/layout/Alert/index.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+import { Alert as AlertComponent } from 'src/layout/Alert/Alert';
+import { PresentationComponent } from 'src/layout/LayoutComponent';
+import type { ExprResolved } from 'src/features/expressions/types';
+import type { PropsFromGenericComponent } from 'src/layout';
+import type { ILayoutCompAlert } from 'src/layout/Alert/types';
+import type { LayoutNode } from 'src/utils/layout/LayoutNode';
+
+export class Alert extends PresentationComponent<'Alert'> {
+  render(props: PropsFromGenericComponent<'Alert'>): JSX.Element | null {
+    return <AlertComponent {...props} />;
+  }
+
+  renderWithLabel(): boolean {
+    return false;
+  }
+
+  canRenderInTable(): boolean {
+    return false;
+  }
+}
+
+export const Config = {
+  def: new Alert(),
+};
+
+export type TypeConfig = {
+  layout: ILayoutCompAlert;
+  nodeItem: ExprResolved<ILayoutCompAlert>;
+  nodeObj: LayoutNode;
+};

--- a/src/layout/Alert/types.d.ts
+++ b/src/layout/Alert/types.d.ts
@@ -1,7 +1,9 @@
 import type { ILayoutCompBase } from 'src/layout/layout';
 
+export type AlertSeverity = 'success' | 'warning' | 'danger' | 'info';
+
 export interface ILayoutCompAlertBase {
-  severity: 'success' | 'warning' | 'danger' | 'info';
+  severity: AlertSeverity;
   useAsAlert?: boolean;
 }
 

--- a/src/layout/Alert/types.d.ts
+++ b/src/layout/Alert/types.d.ts
@@ -4,7 +4,6 @@ export type AlertSeverity = 'success' | 'warning' | 'danger' | 'info';
 
 export interface ILayoutCompAlertBase {
   severity: AlertSeverity;
-  useAsAlert?: boolean;
 }
 
 export type ILayoutCompAlert = ILayoutCompBase<'Alert'> & ILayoutCompAlertBase;

--- a/src/layout/Alert/types.d.ts
+++ b/src/layout/Alert/types.d.ts
@@ -1,0 +1,8 @@
+import type { ILayoutCompBase } from 'src/layout/layout';
+
+export interface ILayoutCompAlertBase {
+  severity: 'success' | 'warning' | 'danger' | 'info';
+  useAsAlert?: boolean;
+}
+
+export type ILayoutCompAlert = ILayoutCompBase<'Alert'> & ILayoutCompAlertBase;

--- a/src/utils/render.tsx
+++ b/src/utils/render.tsx
@@ -40,17 +40,13 @@ export function renderValidationMessages(
 ) {
   if (variant !== 'error') {
     return (
-      <SoftValidations
-        variant={variant}
-        key={id}
-      >
-        <ol
-          style={{ paddingLeft: 0 }}
-          id={id}
-        >
-          {messages.map(validationMessagesToList)}
-        </ol>
-      </SoftValidations>
+      <div style={{ paddingTop: 'var(--fds-spacing-2)' }}>
+        <SoftValidations
+          variant={variant}
+          key={id}
+          errorMessages={messages}
+        />
+      </div>
     );
   }
 
@@ -63,7 +59,7 @@ export function renderValidationMessages(
         size='small'
         id={id}
       >
-        <ol style={{ paddingLeft: 0 }}>{messages.map(validationMessagesToList)}</ol>
+        <ol>{messages.map(validationMessagesToList)}</ol>
       </ErrorMessage>
     </div>
   );

--- a/test/e2e/integration/app-frontend/validation.ts
+++ b/test/e2e/integration/app-frontend/validation.ts
@@ -79,13 +79,12 @@ describe('Validation', () => {
       const field = appFrontend.changeOfName.newMiddleName;
       cy.get(field).clear();
       cy.get(field).type(value);
-      cy.get(appFrontend.fieldValidation(field, realType)).should('have.text', message);
+      cy.get(`#form-content-newMiddleName`).findByRole('alert', { name: message }).should('exist');
 
       // Should not have any other messages
-      for (const otherType of Object.keys(validationTypeMap)) {
-        const realOtherType = otherType as keyof typeof validationTypeMap;
-        if (realOtherType !== realType) {
-          cy.get(appFrontend.fieldValidation(field, realOtherType)).should('not.exist');
+      for (const [otherType, { message: otherMessage }] of Object.entries(validationTypeMap)) {
+        if (otherType !== realType) {
+          cy.findByRole('alert', { name: otherMessage }).should('not.exist');
         }
       }
     }


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

Added a new `Alert` component, with options for 
- `severity` - sets the style of the alert, and has four valid values `"success" | "info" | "danger" | "warning"`.  
- `title` - sets the title via `textResourceBindings`.
- `description` - sets the description via `textResourceBindings`.
- ~~`useAsAlert` - A boolean which specifies whether the component should have `role="alert"` or not. It should not have this for static elements displaying information, but should have it for dynamic elements that appear after a certain user input. I currently implemented the `aria-live` attribute with `polite`, but I think maybe this should be configurable. Or maybe it should be based on severity label. if `useAsAlert` is set, and `severity` is >= `warning`, `aria-live` should be set to `assertive`.~~ This option is removed and rather determined automatically based on the `hidden` property of `GenericComponent`. If `hidden` is explicitly set to `false` we append `role="alert"` to the `Alert` component. There is however one problem with this. If an element is hidden with an expression, but the expression evaluates to `false` on page load, `role="alert"` will be appended to the `Alert` component on load. The same problem would exist for the old API, where the app developers used a `useAsAlert` flag. 

Screenshot: 
![image](https://github.com/Altinn/app-frontend-react/assets/26043795/44794c0f-a38b-4fd5-9eb5-d4262dcc3b32)


## Related Issue(s)

- closes #1284 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated - I have added some alerts to frontend-tests so that the alert is tested with percy. I also updated some failing cypress tests for Soft validations. Stopped using the custom id-based selector, and used `@testing-library/cypress` selectors for testing the content of alert messages instead. 
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [x] I have tested with a screen reader/keyboard navigation/automated wcag validator - Tested with wave and orca screen reader. The screen reader reads alerts twice for some reason, but I think this is an orca issue. Could somebody test with VoiceOver on Mac?
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [x] Has been added/updated - [Have submitted a PR with documentation here](https://github.com/Altinn/altinn-studio-docs/pull/1008)
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [x] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [ ] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
