### PR TITLE
Fixing text resource bindings set to empty strings in repeating groups

### DIFF
--- a/src/layout/Group/RepeatingGroupTableRow.tsx
+++ b/src/layout/Group/RepeatingGroupTableRow.tsx
@@ -45,8 +45,12 @@ function getEditButtonText(
   textResourceBindings: ITextResourceBindings | undefined,
 ) {
   const buttonTextKey = isEditing
-    ? textResourceBindings?.edit_button_close ?? 'general.save_and_close'
-    : textResourceBindings?.edit_button_open ?? 'general.edit_alt';
+    ? textResourceBindings?.edit_button_close
+      ? textResourceBindings?.edit_button_close
+      : 'general.save_and_close'
+    : textResourceBindings?.edit_button_open
+    ? textResourceBindings?.edit_button_open
+    : 'general.edit_alt';
   return langTools.langAsString(buttonTextKey);
 }
 

--- a/src/layout/Group/RepeatingGroupsEditContainer.tsx
+++ b/src/layout/Group/RepeatingGroupsEditContainer.tsx
@@ -260,7 +260,7 @@ function RepeatingGroupsEditContainerInternal({
                   variant={ButtonVariant.Filled}
                   color={ButtonColor.Primary}
                 >
-                  {lang(texts?.save_and_next_button ?? 'general.save_and_next')}
+                  {lang(texts?.save_and_next_button ? texts?.save_and_next_button : 'general.save_and_next')}
                 </Button>
               </Grid>
             )}
@@ -272,7 +272,7 @@ function RepeatingGroupsEditContainerInternal({
                   variant={saveAndNextButtonVisible ? ButtonVariant.Outline : ButtonVariant.Filled}
                   color={ButtonColor.Primary}
                 >
-                  {lang(texts?.save_button ?? 'general.save_and_close')}
+                  {lang(texts?.save_button ? texts?.save_button : 'general.save_and_close')}
                 </Button>
               </Grid>
             )}

--- a/test/e2e/integration/app-frontend/components.ts
+++ b/test/e2e/integration/app-frontend/components.ts
@@ -167,11 +167,26 @@ describe('UI Components', () => {
 
   it('address component fetches post place from zip code', () => {
     cy.goto('changename');
+
+    // Mock zip code API, so that we don't rely on external services for our tests
+    cy.intercept('GET', 'https://api.bring.com/shippingguide/api/postalCode.json**', (req) => {
+      req.reply((res) => {
+        res.send({
+          body: {
+            postalCodeType: 'NORMAL',
+            result: 'KARDEMOMME BY', // Intentionally wrong, to test that our mock is used
+            valid: true,
+          },
+        });
+      });
+    }).as('zipCodeApi');
+
     cy.get(appFrontend.changeOfName.address.street_name).type('Sesame Street 1A');
     cy.get(appFrontend.changeOfName.address.street_name).blur();
-    cy.get(appFrontend.changeOfName.address.zip_code).type('0174');
+    cy.get(appFrontend.changeOfName.address.zip_code).type('0123');
     cy.get(appFrontend.changeOfName.address.zip_code).blur();
-    cy.get(appFrontend.changeOfName.address.post_place).should('have.value', 'OSLO');
+    cy.get(appFrontend.changeOfName.address.post_place).should('have.value', 'KARDEMOMME BY');
+    cy.get('@zipCodeApi').its('request.url').should('include', '0123');
   });
 
   it('radios, checkboxes and other components can be readOnly', () => {


### PR DESCRIPTION
## Description
This should fix an edge-case where text resource bindings for edit/delete/etc buttons in repeating groups were set to empty strings. See the linked discussion for details.

## Related Issue(s)

- https://altinn.slack.com/archives/C02EVE4RU82/p1687858029037189
- #1255

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
