### PR TITLE
Urgent: Fixing state overwrite in Dropdown

### DIFF
--- a/src/layout/Dropdown/DropdownComponent.tsx
+++ b/src/layout/Dropdown/DropdownComponent.tsx
@@ -25,7 +25,7 @@ export function DropdownComponent({ node, formData, handleDataChange, isValid, o
     textResourceBindings,
   } = node.item;
   const { langAsString } = useLanguage();
-  const options = (useGetOptions({ optionsId, mapping, source }) || staticOptions || []).filter(duplicateOptionFilter);
+  const options = (useGetOptions({ optionsId, mapping, source }) || staticOptions)?.filter(duplicateOptionFilter);
   const lookupKey = optionsId && getOptionLookupKey({ id: optionsId, mapping });
   const fetchingOptions = useAppSelector((state) => lookupKey && state.optionState.options[lookupKey]?.loading);
   const hasSelectedInitial = React.useRef(false);

--- a/test/e2e/integration/app-frontend/components.ts
+++ b/test/e2e/integration/app-frontend/components.ts
@@ -325,4 +325,27 @@ describe('UI Components', () => {
     cy.get(appFrontend.errorReport).should('not.contain.text', 'Du har overskredet maks antall tegn med 1');
     cy.snapshot('components:text-countdown');
   });
+
+  it('should remember values after refreshing', () => {
+    cy.goto('changename');
+    cy.get(appFrontend.changeOfName.dateOfEffect).should('have.value', '');
+    cy.fillOut('changename');
+    cy.gotoNavPage('form');
+
+    cy.get(appFrontend.changeOfName.sources).dsSelect('Digitaliseringsdirektoratet');
+    cy.get(appFrontend.changeOfName.reference).dsSelect('Sophie Salt');
+    cy.get(appFrontend.changeOfName.reference2).dsSelect('Dole');
+    cy.reloadAndWait();
+
+    cy.get(appFrontend.changeOfName.newFirstName).should('have.value', 'a');
+    cy.get(appFrontend.changeOfName.newLastName).should('have.value', 'a');
+    cy.get(appFrontend.changeOfName.confirmChangeName).find('input').should('be.checked');
+    cy.get(appFrontend.changeOfName.reasonRelationship).should('have.value', 'test');
+    cy.get(appFrontend.changeOfName.dateOfEffect).should('not.have.value', '');
+    cy.get('#form-content-fileUpload-changename').find('td').first().should('contain.text', 'test.pdf');
+
+    cy.get(appFrontend.changeOfName.sources).should('have.value', 'Digitaliseringsdirektoratet');
+    cy.get(appFrontend.changeOfName.reference).should('have.value', 'Sophie Salt');
+    cy.get(appFrontend.changeOfName.reference2).should('have.value', 'Dole');
+  });
 });


### PR DESCRIPTION
## Description
Fixes values in Dropdown sometimes being overwritten/set to empty value. The Dropdown component relied on `options` being `undefined` until set to something, causing it to overwrite values previously set in the form data/prefill if you refreshed the page or loaded an existing instance. 

## Related Issue(s)

- https://altinn.slack.com/archives/CCQEQKGJD/p1688032374868919?thread_ts=1688030638.433839&cid=CCQEQKGJD

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
