### PR TITLE
Fixing flaky a11y/wcag error

### DIFF
--- a/src/layout/Button/WrappedButton.module.css
+++ b/src/layout/Button/WrappedButton.module.css
@@ -1,3 +1,0 @@
-.loading {
-  opacity: 0.8;
-}

--- a/src/layout/Button/WrappedButton.tsx
+++ b/src/layout/Button/WrappedButton.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { Button, ButtonColor, ButtonVariant } from '@digdir/design-system-react';
 
 import { ButtonLoader } from 'src/layout/Button/ButtonLoader';
-import classes from 'src/layout/Button/WrappedButton.module.css';
 
 export interface BaseButtonProps {
   onClick: (...args) => void;
@@ -39,12 +38,12 @@ export const WrappedButton = ({
   };
   return (
     <Button
-      className={thisIsLoading ? classes.loading : undefined}
+      data-is-loading={thisIsLoading ? 'true' : 'false'}
       variant={variant}
       color={color}
       onClick={handleClick}
       id={id}
-      disabled={disabled}
+      disabled={disabled || thisIsLoading}
     >
       {children}
       {thisIsLoading && <ButtonLoader />}

--- a/test/e2e/integration/app-frontend/hide-row-in-group.ts
+++ b/test/e2e/integration/app-frontend/hide-row-in-group.ts
@@ -4,8 +4,10 @@ const appFrontend = new AppFrontend();
 
 it('should be possible to hide rows when "Endre fra" is greater or equals to [...]', () => {
   cy.goto('group');
+  cy.intercept('PUT', '**/data/**').as('putFormData');
   for (const prefill of Object.values(appFrontend.group.prefill)) {
     cy.get(prefill).dsCheck();
+    cy.wait('@putFormData');
   }
   const headerRow = 1;
 

--- a/test/e2e/integration/app-frontend/validation.ts
+++ b/test/e2e/integration/app-frontend/validation.ts
@@ -279,10 +279,13 @@ describe('Validation', () => {
 
     cy.get(appFrontend.group.prefill.liten).dsCheck();
     cy.get(appFrontend.group.prefill.stor).dsCheck();
-    cy.get(appFrontend.nextButton).click();
+    cy.get(appFrontend.nextButton).clickAndGone();
+    cy.navPage('repeating').should('have.attr', 'aria-current', 'page');
 
-    // Check that showGroupToContinue is focused
+    // Check that showGroupToContinue can be focused when clicked
     cy.get(appFrontend.nextButton).click();
+    cy.navPage('repeating').should('have.attr', 'aria-current', 'page');
+
     cy.get(appFrontend.errorReport).findAllByRole('listitem').should('have.length', 1);
     cy.get(appFrontend.errorReport).findByText(texts.requiredOpenRepGroup).click();
     cy.get(appFrontend.group.showGroupToContinue).find('input').should('be.focused');
@@ -413,6 +416,7 @@ describe('Validation', () => {
     cy.get(appFrontend.group.editContainer).should('not.exist');
     cy.get(appFrontend.errorReport).should('not.exist');
     cy.get(appFrontend.nextButton).click();
+    cy.navPage('repeating').should('have.attr', 'aria-current', 'page');
     cy.get(appFrontend.errorReport).findAllByRole('listitem').should('have.length', 2);
     cy.get(appFrontend.errorReport).findByText('Du må fylle ut 1.').click();
     cy.get(appFrontend.group.row(2).currentValue).should('be.focused');
@@ -434,6 +438,7 @@ describe('Validation', () => {
     cy.get(appFrontend.group.mainGroupTableBody).find('tr').eq(2).find('td').eq(0).should('have.text', '');
     cy.get(appFrontend.group.row(2).currentValue).should('not.exist');
     cy.get(appFrontend.nextButton).click();
+    cy.navPage('repeating').should('have.attr', 'aria-current', 'page');
     cy.get(appFrontend.errorReport).findAllByRole('listitem').should('have.length', 1);
     cy.get(appFrontend.errorReport).findByText('Du må fylle ut 2. endre verdi til').click();
     cy.get(appFrontend.group.row(2).newValue).should('be.focused');

--- a/test/e2e/support/custom.ts
+++ b/test/e2e/support/custom.ts
@@ -128,12 +128,6 @@ const knownWcagViolations: KnownViolation[] = [
   {
     spec: 'app-frontend/hide-row-in-group.ts',
     test: 'should be possible to hide rows when "Endre fra" is greater or equals to [...]',
-    id: 'aria-valid-attr-value',
-    nodeLength: 3,
-  },
-  {
-    spec: 'app-frontend/hide-row-in-group.ts',
-    test: 'should be possible to hide rows when "Endre fra" is greater or equals to [...]',
     id: 'heading-order',
     nodeLength: 1,
   },
@@ -172,6 +166,11 @@ const knownWcagViolations: KnownViolation[] = [
 Cypress.Commands.add('snapshot', (name: string) => {
   cy.get('#readyForPrint').should('exist');
 
+  // Running wcag tests before taking snapshot, because the resizing of the viewport can cause some elements to
+  // re-render and go slightly out of sync with the proper state of the application. One example is the Dropdown
+  // component, which can sometimes render without all the options (and selected value) a short time after resizing.
+  cy.testWcag();
+
   cy.window().then((win) => {
     // Find focused element and blur it, to ensure that we don't get any focus outlines or styles in the snapshot.
     const focused = win.document.activeElement;
@@ -203,8 +202,6 @@ Cypress.Commands.add('snapshot', (name: string) => {
       cy.get(`html.viewport-is-${targetViewport}`).should('be.visible');
     });
   });
-
-  cy.testWcag();
 });
 
 Cypress.Commands.add('testWcag', () => {

--- a/test/e2e/support/custom.ts
+++ b/test/e2e/support/custom.ts
@@ -166,18 +166,24 @@ const knownWcagViolations: KnownViolation[] = [
 Cypress.Commands.add('snapshot', (name: string) => {
   cy.get('#readyForPrint').should('exist');
 
+  // Find focused element and blur it, to ensure that we don't get any focus outlines or styles in the snapshot.
+  cy.window().then((win) => {
+    const focused = win.document.activeElement;
+    if (focused && 'blur' in focused && typeof focused.blur === 'function') {
+      focused.blur();
+    }
+  });
+  cy.focused().should('not.exist');
+
+  // Wait for elements marked as loading are not loading anymore
+  cy.get('[data-is-loading=true]').should('not.exist');
+
   // Running wcag tests before taking snapshot, because the resizing of the viewport can cause some elements to
   // re-render and go slightly out of sync with the proper state of the application. One example is the Dropdown
   // component, which can sometimes render without all the options (and selected value) a short time after resizing.
   cy.testWcag();
 
   cy.window().then((win) => {
-    // Find focused element and blur it, to ensure that we don't get any focus outlines or styles in the snapshot.
-    const focused = win.document.activeElement;
-    if (focused && 'blur' in focused && typeof focused.blur === 'function') {
-      focused.blur();
-    }
-
     const { innerWidth, innerHeight } = win;
     cy.readFile('test/percy.css').then((percyCSS) => {
       cy.log(`Taking snapshot with Percy: ${name}`);


### PR DESCRIPTION
## Description
Performing axe/a11y testing before running Percy, as Percy resizes the viewport in order to make snapshots of different screen sizes, which apparently also disrupts some components in the design system, making the dropdown not show its value after resizing a little while.

This will probably also cause flakiness in Percy testing, but we'll cross that bridge with a more generically fitting solution if it becomes necessary.

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [x] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
