### PR TITLE
Option select styling with and without description

### DIFF
--- a/src/components/form/SelectOptionItem.module.css
+++ b/src/components/form/SelectOptionItem.module.css
@@ -1,0 +1,3 @@
+.optionLabelSemiBold {
+  font-weight: 600;
+}

--- a/src/components/form/SelectOptionItem.tsx
+++ b/src/components/form/SelectOptionItem.tsx
@@ -13,7 +13,7 @@ export function SelectOptionItem({ option, listHasDescription }: ISelectOptionIt
   if (option.description) {
     return (
       <>
-        <b>{langAsString(option.label ?? option.value)}</b>
+        <span className={classes.optionLabelSemiBold}>{langAsString(option.label ?? option.value)}</span>
         <br />
         <span>{langAsString(option.description)}</span>
       </>

--- a/src/components/form/SelectOptionItem.tsx
+++ b/src/components/form/SelectOptionItem.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+import classes from 'src/components/form/SelectOptionItem.module.css';
+import { useLanguage } from 'src/hooks/useLanguage';
+import type { IOption } from 'src/types';
+type ISelectOptionItemProps = {
+  option: IOption;
+  listHasDescription: boolean;
+};
+
+export function SelectOptionItem({ option, listHasDescription }: ISelectOptionItemProps) {
+  const { langAsString } = useLanguage();
+  if (option.description) {
+    return (
+      <>
+        <b>{langAsString(option.label ?? option.value)}</b>
+        <br />
+        <span>{langAsString(option.description)}</span>
+      </>
+    );
+  } else {
+    return (
+      <span className={listHasDescription ? classes.optionLabelSemiBold : ''}>
+        {langAsString(option.label ?? option.value)}
+      </span>
+    );
+  }
+}

--- a/src/layout/Dropdown/DropdownComponent.tsx
+++ b/src/layout/Dropdown/DropdownComponent.tsx
@@ -32,6 +32,7 @@ export function DropdownComponent({ node, formData, handleDataChange, isValid, o
   const optionsHasChanged = useHasChangedIgnoreUndefined(options);
 
   const { value, setValue, saveValue } = useDelayedSavedState(handleDataChange, formData?.simpleBinding, 200);
+  const hasDescription = (options || staticOptions)?.some((option) => option.description);
 
   React.useEffect(() => {
     const shouldSelectOptionAutomatically =
@@ -60,10 +61,10 @@ export function DropdownComponent({ node, formData, handleDataChange, isValid, o
     () =>
       options?.map((option) => ({
         label: langAsString(option.label ?? option.value),
-        formattedLabel: formatLabelForSelect(option, langAsString),
+        formattedLabel: formatLabelForSelect(option, langAsString, hasDescription),
         value: option.value,
       })) || [],
-    [langAsString, options],
+    [langAsString, options, hasDescription],
   );
 
   return (

--- a/src/layout/Dropdown/DropdownComponent.tsx
+++ b/src/layout/Dropdown/DropdownComponent.tsx
@@ -32,7 +32,7 @@ export function DropdownComponent({ node, formData, handleDataChange, isValid, o
   const optionsHasChanged = useHasChangedIgnoreUndefined(options);
 
   const { value, setValue, saveValue } = useDelayedSavedState(handleDataChange, formData?.simpleBinding, 200);
-  const hasDescription = (options || staticOptions)?.some((option) => option.description);
+  const listHasDescription = (options || staticOptions)?.some((option) => option.description) || false;
 
   React.useEffect(() => {
     const shouldSelectOptionAutomatically =
@@ -61,10 +61,10 @@ export function DropdownComponent({ node, formData, handleDataChange, isValid, o
     () =>
       options?.map((option) => ({
         label: langAsString(option.label ?? option.value),
-        formattedLabel: formatLabelForSelect(option, langAsString, hasDescription),
+        formattedLabel: formatLabelForSelect(option, langAsString, listHasDescription),
         value: option.value,
       })) || [],
-    [langAsString, options, hasDescription],
+    [langAsString, options, listHasDescription],
   );
 
   return (

--- a/src/layout/Dropdown/DropdownComponent.tsx
+++ b/src/layout/Dropdown/DropdownComponent.tsx
@@ -3,12 +3,13 @@ import React from 'react';
 import { Select } from '@digdir/design-system-react';
 
 import { AltinnSpinner } from 'src/components/AltinnSpinner';
+import { SelectOptionItem } from 'src/components/form/SelectOptionItem';
 import { useAppSelector } from 'src/hooks/useAppSelector';
 import { useDelayedSavedState } from 'src/hooks/useDelayedSavedState';
 import { useGetOptions } from 'src/hooks/useGetOptions';
 import { useHasChangedIgnoreUndefined } from 'src/hooks/useHasChangedIgnoreUndefined';
 import { useLanguage } from 'src/hooks/useLanguage';
-import { duplicateOptionFilter, formatLabelForSelect, getOptionLookupKey } from 'src/utils/options';
+import { duplicateOptionFilter, getOptionLookupKey } from 'src/utils/options';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export type IDropdownProps = PropsFromGenericComponent<'Dropdown'>;
@@ -61,7 +62,12 @@ export function DropdownComponent({ node, formData, handleDataChange, isValid, o
     () =>
       options?.map((option) => ({
         label: langAsString(option.label ?? option.value),
-        formattedLabel: formatLabelForSelect(option, langAsString, listHasDescription),
+        formattedLabel: (
+          <SelectOptionItem
+            option={option}
+            listHasDescription={listHasDescription}
+          />
+        ),
         value: option.value,
       })) || [],
     [langAsString, options, listHasDescription],

--- a/src/layout/MultipleSelect/MultipleSelectComponent.tsx
+++ b/src/layout/MultipleSelect/MultipleSelectComponent.tsx
@@ -3,10 +3,11 @@ import React, { useMemo } from 'react';
 import { Select } from '@digdir/design-system-react';
 import type { MultiSelectOption } from '@digdir/design-system-react';
 
+import { SelectOptionItem } from 'src/components/form/SelectOptionItem';
 import { useDelayedSavedState } from 'src/hooks/useDelayedSavedState';
 import { useGetOptions } from 'src/hooks/useGetOptions';
 import { useLanguage } from 'src/hooks/useLanguage';
-import { duplicateOptionFilter, formatLabelForSelect } from 'src/utils/options';
+import { duplicateOptionFilter } from 'src/utils/options';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 import 'src/layout/MultipleSelect/MultipleSelect.css';
@@ -34,7 +35,12 @@ export function MultipleSelectComponent({
 
         return {
           label,
-          formattedLabel: formatLabelForSelect(option, langAsString, listHasDescription),
+          formattedLabel: (
+            <SelectOptionItem
+              option={option}
+              listHasDescription={listHasDescription}
+            />
+          ),
           value: option.value,
           deleteButtonLabel: `${langAsString('general.delete')} ${label}`,
         };

--- a/src/layout/MultipleSelect/MultipleSelectComponent.tsx
+++ b/src/layout/MultipleSelect/MultipleSelectComponent.tsx
@@ -25,7 +25,7 @@ export function MultipleSelectComponent({
   const { value, setValue, saveValue } = useDelayedSavedState(handleDataChange, formData?.simpleBinding);
   const { langAsString } = useLanguage();
 
-  const hasDescription = (apiOptions || options)?.some((option) => option.label);
+  const listHasDescription = (apiOptions || options)?.some((option) => option.description) || false;
 
   const calculatedOptions: MultiSelectOption[] = useMemo(
     () =>
@@ -34,12 +34,12 @@ export function MultipleSelectComponent({
 
         return {
           label,
-          formattedLabel: formatLabelForSelect(option, langAsString, hasDescription),
+          formattedLabel: formatLabelForSelect(option, langAsString, listHasDescription),
           value: option.value,
           deleteButtonLabel: `${langAsString('general.delete')} ${label}`,
         };
       }) || [],
-    [apiOptions, langAsString, options, hasDescription],
+    [apiOptions, langAsString, options, listHasDescription],
   );
 
   const handleChange = (values: string[]) => {

--- a/src/layout/MultipleSelect/MultipleSelectComponent.tsx
+++ b/src/layout/MultipleSelect/MultipleSelectComponent.tsx
@@ -25,18 +25,21 @@ export function MultipleSelectComponent({
   const { value, setValue, saveValue } = useDelayedSavedState(handleDataChange, formData?.simpleBinding);
   const { langAsString } = useLanguage();
 
+  const hasDescription = (apiOptions || options)?.some((option) => option.label);
+
   const calculatedOptions: MultiSelectOption[] = useMemo(
     () =>
       (apiOptions || options)?.filter(duplicateOptionFilter).map((option) => {
         const label = langAsString(option.label ?? option.value);
+
         return {
           label,
-          formattedLabel: formatLabelForSelect(option, langAsString),
+          formattedLabel: formatLabelForSelect(option, langAsString, hasDescription),
           value: option.value,
           deleteButtonLabel: `${langAsString('general.delete')} ${label}`,
         };
       }) || [],
-    [apiOptions, langAsString, options],
+    [apiOptions, langAsString, options, hasDescription],
   );
 
   const handleChange = (values: string[]) => {

--- a/src/utils/options.module.css
+++ b/src/utils/options.module.css
@@ -1,0 +1,3 @@
+.hasDescription {
+  font-weight: 600 !important;
+}

--- a/src/utils/options.module.css
+++ b/src/utils/options.module.css
@@ -1,3 +1,0 @@
-.hasDescription {
-  font-weight: 600 !important;
-}

--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -1,4 +1,4 @@
-import { getParsedLanguageFromText, replaceTextResourceParams } from 'src/language/sharedLanguage';
+import { replaceTextResourceParams } from 'src/language/sharedLanguage';
 import {
   getBaseGroupDataModelBindingFromKeyWithIndexIndicators,
   getGroupDataModelBinding,
@@ -8,7 +8,6 @@ import {
 } from 'src/utils/databindings';
 import type { IFormData } from 'src/features/formData';
 import type { IOptionResources } from 'src/hooks/useGetOptions';
-import type { IUseLanguage } from 'src/hooks/useLanguage';
 import type { ILayout } from 'src/layout/layout';
 import type { IMapping, IOption, IOptions, IOptionsMetaData, IOptionSource, IRepeatingGroups } from 'src/types';
 import type { IDataSources } from 'src/types/shared';
@@ -214,20 +213,4 @@ export function duplicateOptionFilter(currentOption: IOption, currentIndex: numb
     }
   }
   return true;
-}
-
-export function formatLabelForSelect(
-  option: IOption,
-  langAsString: IUseLanguage['langAsString'],
-  listHasDescription: boolean,
-): React.ReactNode {
-  if (option.description) {
-    return getParsedLanguageFromText(
-      `<b>${langAsString(option.label ?? option.value)}</b><br><span>${langAsString(option.description)}</span>`,
-    );
-  } else {
-    return getParsedLanguageFromText(
-      `<span style="${listHasDescription && 'font-weight:600'}">${langAsString(option.label ?? option.value)}</span>`,
-    );
-  }
 }

--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -219,7 +219,7 @@ export function duplicateOptionFilter(currentOption: IOption, currentIndex: numb
 export function formatLabelForSelect(
   option: IOption,
   langAsString: IUseLanguage['langAsString'],
-  hasDescription: boolean | undefined,
+  listHasDescription: boolean,
 ): React.ReactNode {
   if (option.description) {
     return getParsedLanguageFromText(
@@ -227,7 +227,7 @@ export function formatLabelForSelect(
     );
   } else {
     return getParsedLanguageFromText(
-      `<span style="${hasDescription ? 'font-weight: 600' : ''}">${langAsString(option.label ?? option.value)}</span>`,
+      `<span style="${listHasDescription && 'font-weight:600'}">${langAsString(option.label ?? option.value)}</span>`,
     );
   }
 }

--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -12,7 +12,6 @@ import type { IUseLanguage } from 'src/hooks/useLanguage';
 import type { ILayout } from 'src/layout/layout';
 import type { IMapping, IOption, IOptions, IOptionsMetaData, IOptionSource, IRepeatingGroups } from 'src/types';
 import type { IDataSources } from 'src/types/shared';
-
 export function getOptionLookupKey({ id, mapping }: IOptionsMetaData) {
   if (!mapping) {
     return id;
@@ -217,12 +216,18 @@ export function duplicateOptionFilter(currentOption: IOption, currentIndex: numb
   return true;
 }
 
-export function formatLabelForSelect(option: IOption, langAsString: IUseLanguage['langAsString']): React.ReactNode {
+export function formatLabelForSelect(
+  option: IOption,
+  langAsString: IUseLanguage['langAsString'],
+  hasDescription: boolean | undefined,
+): React.ReactNode {
   if (option.description) {
     return getParsedLanguageFromText(
       `<b>${langAsString(option.label ?? option.value)}</b><br><span>${langAsString(option.description)}</span>`,
     );
   } else {
-    return getParsedLanguageFromText(`<span>${langAsString(option.label ?? option.value)}</span>`);
+    return getParsedLanguageFromText(
+      `<span style="${hasDescription ? 'font-weight: 600' : ''}">${langAsString(option.label ?? option.value)}</span>`,
+    );
   }
 }


### PR DESCRIPTION
## Description
To improve the visual appearance, the font-weight is adjusted based on whether the option list contains descriptions in any of the options. If some or all options have descriptions, the labels/titles will be styled with semibold font-weight. If no options have descriptions, the labels/titles will be styled with regular font-weight.

I wasn't sure about the specific numeric value for semibold, but according to [the documentation here](https://drafts.csswg.org/css-fonts/#font-weight-numeric-values) it is recommended to use 600. Let me know if this value is wrong to use. 

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes #https://github.com/Altinn/app-frontend-react/issues/1169

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [x] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
