### PR TITLE
fix(RadioButtons): add disabled property to FieldSet when readOnly is true

### DIFF
--- a/src/components/form/RadioGroup.tsx
+++ b/src/components/form/RadioGroup.tsx
@@ -13,6 +13,7 @@ export interface IRadioGroupProps {
   error?: React.ReactNode;
   children: React.ReactElement<typeof RadioButton> | React.ReactElement<typeof RadioButton>[];
   shouldDisplayHorizontally?: boolean;
+  disabled?: boolean;
 }
 
 export const RadioGroup = ({
@@ -22,12 +23,14 @@ export const RadioGroup = ({
   children,
   error,
   shouldDisplayHorizontally,
+  disabled = false,
 }: IRadioGroupProps) => (
   <FieldSet
     legend={legend}
     description={description}
     helpText={helpText}
     error={error}
+    disabled={disabled}
   >
     <div
       role='radiogroup'

--- a/src/layout/RadioButtons/ControlledRadioGroup.tsx
+++ b/src/layout/RadioButtons/ControlledRadioGroup.tsx
@@ -45,6 +45,7 @@ export const ControlledRadioGroup = (props: IControlledRadioGroupProps) => {
             description={textResourceBindings?.description && lang(textResourceBindings.description)}
             helpText={textResourceBindings?.help && lang(textResourceBindings.help)}
             error={!isValid}
+            disabled={readOnly}
             shouldDisplayHorizontally={shouldUseRowLayout({
               layout,
               optionsCount: calculatedOptions.length,


### PR DESCRIPTION
## Description

This PR fixes a bug that was reported on [slack](https://altinndevops.slack.com/archives/C045EB3JA9X/p1688553637421089)
The new `RadioButtons` component did not pass along the disabled prop to `FieldSet` when `readOnly` was set to `true`.

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes #1310 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [x] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
