### PR TITLE
Visual testing: Making screenshots less flaky (3)

### DIFF
--- a/src/layout/GenericComponent.tsx
+++ b/src/layout/GenericComponent.tsx
@@ -281,6 +281,7 @@ export function GenericComponent<Type extends ComponentTypes = ComponentTypes>({
     <FormComponentContext.Provider value={formComponentContext}>
       <Grid
         data-componentid={item.id}
+        data-componenttype={item.type}
         ref={gridRef}
         item={true}
         container={true}

--- a/src/layout/GenericComponent.tsx
+++ b/src/layout/GenericComponent.tsx
@@ -280,6 +280,7 @@ export function GenericComponent<Type extends ComponentTypes = ComponentTypes>({
   return (
     <FormComponentContext.Provider value={formComponentContext}>
       <Grid
+        data-componentbaseid={item.baseComponentId || item.id}
         data-componentid={item.id}
         data-componenttype={item.type}
         ref={gridRef}

--- a/src/layout/Likert/LikertComponent.tsx
+++ b/src/layout/Likert/LikertComponent.tsx
@@ -31,7 +31,7 @@ export const LikertComponent = (props: PropsFromGenericComponent<'Likert'>) => {
 
 const RadioGroupTableRow = (props: IControlledRadioGroupProps) => {
   const { node, componentValidations, legend, isValid } = props;
-  const { selected, handleChange, calculatedOptions, handleBlur } = useRadioButtons(props);
+  const { selected, handleChange, calculatedOptions, handleBlur, fetchingOptions } = useRadioButtons(props);
   const { lang, langAsString } = useLanguage();
 
   const id = node.item.id;
@@ -44,6 +44,7 @@ const RadioGroupTableRow = (props: IControlledRadioGroupProps) => {
     <TableRow
       aria-labelledby={rowLabelId}
       data-componentid={node.item.id}
+      data-is-loading={fetchingOptions ? 'true' : 'false'}
     >
       <th
         scope='row'

--- a/src/layout/layout.d.ts
+++ b/src/layout/layout.d.ts
@@ -157,8 +157,6 @@ export type ITextResourceBindings<T extends ComponentTypes = ComponentTypes> =
   | UnionToIntersection<TRBAsMap<T, string>>
   | undefined;
 
-type Test1 = ITextResourceBindings<'TextArea'>;
-
 export type TextBindingsForSummarizableComponents = 'summaryTitle' | 'summaryDescription' | 'summaryAccessibleTitle';
 export type TextBindingsForFormComponents = TextBindingsForSummarizableComponents | 'tableTitle' | 'shortName';
 export type TextBindingsForLabel = 'title' | 'description' | 'help';

--- a/test/e2e/integration/app-frontend/hide-row-in-group.ts
+++ b/test/e2e/integration/app-frontend/hide-row-in-group.ts
@@ -55,10 +55,8 @@ it('should be possible to hide rows when "Endre fra" is greater or equals to [..
   cy.get('@firstRow').eq(1).should('contain.text', 'Endre fra');
   cy.get('@firstRow').eq(2).should('contain.text', 'Endre til');
 
-  // Take a screenshot, but make sure the preselectedOptionIndex takes effect first
-  cy.get(appFrontend.group.overflowGroup).find('tr:nth(1) td:nth(0) input').should('have.value', 'Altinn');
-  cy.get(appFrontend.group.overflowGroup).find('tr:nth(2) td:nth(0) input').should('have.value', 'Altinn');
-  cy.get(appFrontend.group.overflowGroup).find('tr:nth(3) td:nth(0) input').should('have.value', 'Altinn');
+  // Take a screenshot, but make sure the preselectedOptionIndex in all Dropdowns take effect first
+  cy.get(appFrontend.group.overflowGroup).find('[data-componenttype=Dropdown] input').should('have.value', 'Altinn');
   cy.snapshot('hide-row-in-group');
 
   // Adding a new row to the repeating group should automatically move it to the overflow group on the next page

--- a/test/e2e/support/custom.ts
+++ b/test/e2e/support/custom.ts
@@ -163,7 +163,7 @@ const knownWcagViolations: KnownViolation[] = [
   },
 ];
 
-Cypress.Commands.add('snapshot', (name: string) => {
+Cypress.Commands.add('clearSelectionAndWait', (viewport) => {
   cy.get('#readyForPrint').should('exist');
 
   // Find focused element and blur it, to ensure that we don't get any focus outlines or styles in the snapshot.
@@ -177,6 +177,40 @@ Cypress.Commands.add('snapshot', (name: string) => {
 
   // Wait for elements marked as loading are not loading anymore
   cy.get('[data-is-loading=true]').should('not.exist');
+
+  if (viewport) {
+    cy.get(`html.viewport-is-${viewport}`).should('be.visible');
+  }
+
+  // Work around slow state updates in Dropdown (possibly in combination with preselectedOptionIndex)
+  cy.window().then((win) => {
+    cy.waitUntil(() => {
+      const allDropdowns = win.document.querySelectorAll('[data-componenttype="Dropdown"]');
+      const asArray = Array.from(allDropdowns);
+      for (const dropdown of asArray) {
+        const inputInside = dropdown.querySelector('input');
+        if (!inputInside) {
+          return false;
+        }
+        const activeDescendant = dropdown.getAttribute('aria-activedescendant');
+        if (!activeDescendant) {
+          return true;
+        }
+        const activeDescendantElement = win.document.getElementById(activeDescendant);
+        if ((activeDescendant && !inputInside.value) || !activeDescendantElement) {
+          // Dropdown has selected value, but this has not yet been reflected in the input field value.
+          // We should wait until this has happened.
+          return false;
+        }
+      }
+
+      return true;
+    });
+  });
+});
+
+Cypress.Commands.add('snapshot', (name: string) => {
+  cy.clearSelectionAndWait();
 
   // Running wcag tests before taking snapshot, because the resizing of the viewport can cause some elements to
   // re-render and go slightly out of sync with the proper state of the application. One example is the Dropdown
@@ -197,7 +231,7 @@ Cypress.Commands.add('snapshot', (name: string) => {
       };
       for (const [viewport, { width, height }] of Object.entries(viewportSizes)) {
         cy.viewport(width, height);
-        cy.get(`html.viewport-is-${viewport}`).should('be.visible');
+        cy.clearSelectionAndWait(viewport as keyof typeof viewportSizes);
         cy.percySnapshot(`${name} (${viewport})`, { percyCSS, widths: [width] });
       }
 
@@ -208,6 +242,8 @@ Cypress.Commands.add('snapshot', (name: string) => {
       cy.get(`html.viewport-is-${targetViewport}`).should('be.visible');
     });
   });
+
+  cy.clearSelectionAndWait();
 });
 
 Cypress.Commands.add('testWcag', () => {

--- a/test/e2e/support/custom.ts
+++ b/test/e2e/support/custom.ts
@@ -184,6 +184,7 @@ Cypress.Commands.add('clearSelectionAndWait', (viewport) => {
 
   // Work around slow state updates in Dropdown (possibly in combination with preselectedOptionIndex)
   cy.window().then((win) => {
+    const state = win.reduxStore.getState();
     cy.waitUntil(() => {
       const allDropdowns = win.document.querySelectorAll('[data-componenttype="Dropdown"]');
       const asArray = Array.from(allDropdowns);
@@ -192,6 +193,21 @@ Cypress.Commands.add('clearSelectionAndWait', (viewport) => {
         if (!inputInside) {
           return false;
         }
+        const baseId = dropdown.getAttribute('data-componentbaseid');
+        const currentPageName = state.formLayout.uiConfig.currentView;
+        const currentPage = state.formLayout.layouts && state.formLayout.layouts[currentPageName];
+        const componentDef = currentPage?.find((c) => c.id === baseId);
+        if (!componentDef) {
+          throw new Error(`Could not find component definition for dropdown with id ${baseId}`);
+        }
+        if (
+          componentDef.type === 'Dropdown' &&
+          componentDef.preselectedOptionIndex !== undefined &&
+          !inputInside.value
+        ) {
+          return false;
+        }
+
         const activeDescendant = dropdown.getAttribute('aria-activedescendant');
         if (!activeDescendant) {
           return true;

--- a/test/e2e/support/global.d.ts
+++ b/test/e2e/support/global.d.ts
@@ -189,6 +189,11 @@ declare global {
        * Runs the wcag tests on the app and notifies us of any violations (using axe/ally)
        */
       testWcag(): Chainable<null>;
+
+      /**
+       * Useful when taking snapshots; clear all selections and wait for the app to finish loading and stabilizing.
+       */
+      clearSelectionAndWait(viewport?: 'desktop' | 'tablet' | 'mobile'): Chainable<null>;
     }
   }
 }


### PR DESCRIPTION
## Description
This should make sure to wait for all Dropdown components to show their values before taking a snapshot.

## Related Issue(s)
- #1266 
- #1264

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
