### PR TITLE
Support `renderAsSummary` components in PDF

### DIFF
--- a/src/features/pdf/PDFView.tsx
+++ b/src/features/pdf/PDFView.tsx
@@ -11,6 +11,7 @@ import { DisplayGroupContainer } from 'src/layout/Group/DisplayGroupContainer';
 import { ComponentType } from 'src/layout/LayoutComponent';
 import { SummaryComponent } from 'src/layout/Summary/SummaryComponent';
 import { useExprContext } from 'src/utils/layout/ExprContext';
+import type { LayoutNodeFromType } from 'src/utils/layout/hierarchy.types';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 interface PDFViewProps {
@@ -19,7 +20,17 @@ interface PDFViewProps {
 }
 
 const PDFComponent = ({ node }: { node: LayoutNode }) => {
-  if (node.isNonRepGroup()) {
+  if (node.isType('Summary') || node.item.renderAsSummary) {
+    return (
+      <SummaryComponent
+        summaryNode={node as LayoutNodeFromType<'Summary'>}
+        overrides={{
+          grid: { xs: 12 },
+          display: { hideChangeButton: true, hideValidationMessages: true },
+        }}
+      />
+    );
+  } else if (node.isNonRepGroup()) {
     return (
       <DisplayGroupContainer
         groupNode={node}
@@ -29,16 +40,6 @@ const PDFComponent = ({ node }: { node: LayoutNode }) => {
             node={child}
           />
         )}
-      />
-    );
-  } else if (node.isType('Summary')) {
-    return (
-      <SummaryComponent
-        summaryNode={node}
-        overrides={{
-          grid: { xs: 12 },
-          display: { hideChangeButton: true, hideValidationMessages: true },
-        }}
       />
     );
   } else if (node.isComponentType(ComponentType.Presentation)) {

--- a/src/features/pdf/data/generatePdfSagas.ts
+++ b/src/features/pdf/data/generatePdfSagas.ts
@@ -24,8 +24,7 @@ import type { IApplicationMetadata } from 'src/features/applicationMetadata';
 import type { ExprUnresolved } from 'src/features/expressions/types';
 import type { IPdfFormat, IPdfMethod } from 'src/features/pdf/data/types';
 import type { ILayoutCompInstanceInformation } from 'src/layout/InstanceInformation/types';
-import type { ILayout, ILayoutComponentOrGroup, ILayouts } from 'src/layout/layout';
-import type { ILayoutCompSummary } from 'src/layout/Summary/types.d';
+import type { ILayout, ILayouts } from 'src/layout/layout';
 import type { ILayoutSets, IRuntimeState, IUiConfig } from 'src/types';
 import type { IInstance } from 'src/types/shared';
 
@@ -69,17 +68,15 @@ function generateAutomaticLayout(pdfFormat: IPdfFormat, uiConfig: IUiConfig, lay
       pageRef,
       topLevelComponents(layout ?? []).filter((component) => !excludedComponents.has(component.id)),
     ])
-    .flatMap(
-      ([pageRef, components]: [string, ILayout]) =>
-        components?.map((component) => [pageRef, component]) as [string, ILayoutComponentOrGroup][],
-    )
+    .flatMap(([pageRef, components]: [string, ILayout]) => components?.map((component) => [pageRef, component]))
     .map(([pageRef, component]) => {
       const layoutComponent = getLayoutComponentObject(component.type);
 
       if (
-        component.type === 'Group' ||
-        layoutComponent.type === ComponentType.Form ||
-        layoutComponent.type === ComponentType.Presentation
+        !component.renderAsSummary &&
+        (component.type === 'Group' ||
+          layoutComponent.type === ComponentType.Form ||
+          layoutComponent.type === ComponentType.Presentation)
       ) {
         return {
           id: `__pdf__${component.id}`,
@@ -88,7 +85,7 @@ function generateAutomaticLayout(pdfFormat: IPdfFormat, uiConfig: IUiConfig, lay
           pageRef,
           excludedChildren: pdfFormat?.excludedComponents,
           largeGroup: component.type === 'Group' && (!component.maxCount || component.maxCount <= 1),
-        } as ExprUnresolved<ILayoutCompSummary>;
+        };
       }
       return null;
     })

--- a/src/utils/layout/LayoutNode.ts
+++ b/src/utils/layout/LayoutNode.ts
@@ -49,7 +49,7 @@ export class LayoutNode<Item extends AnyItem = AnyItem, Type extends ComponentTy
   }
 
   public isType<T extends ComponentTypes>(type: T): this is LayoutNodeFromType<T> {
-    return this.item.type === type;
+    return this.item.type === type || (!!this.item.renderAsSummary && type === 'Summary');
   }
 
   public isComponentType<T extends ComponentType>(type: T): this is LayoutNodeFromComponentType<T> {

--- a/src/utils/layout/LayoutNode.ts
+++ b/src/utils/layout/LayoutNode.ts
@@ -49,7 +49,7 @@ export class LayoutNode<Item extends AnyItem = AnyItem, Type extends ComponentTy
   }
 
   public isType<T extends ComponentTypes>(type: T): this is LayoutNodeFromType<T> {
-    return this.item.type === type || (!!this.item.renderAsSummary && type === 'Summary');
+    return this.item.type === type;
   }
 
   public isComponentType<T extends ComponentType>(type: T): this is LayoutNodeFromComponentType<T> {


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

This makes components with `renderAsSummary: true` behave like actual `Summary` components for PDF generation, giving more flexibility when using a custom PDF layout.

Removed some type assertions as well since `LayoutComponentOrGroup` resolves to `any` and therefore makes no difference.

## Related Issue(s)

- https://altinndevops.slack.com/archives/C05FCB9738R/p1688979831492709?thread_ts=1688388588.706849&cid=C05FCB9738R

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [x] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
