### PR TITLE
fix(Accordion): bug with titles in Accordions. They did not use useLa…

### DIFF
--- a/src/__mocks__/initialStateMock.ts
+++ b/src/__mocks__/initialStateMock.ts
@@ -167,6 +167,10 @@ export function getInitialStateMock(customStates?: Partial<IRuntimeState>): IRun
             },
           ],
         },
+        {
+          id: 'accordion.title',
+          value: 'This is a title',
+        },
       ],
       error: null,
       language: 'nb',

--- a/src/layout/Accordion/Accordion.test.tsx
+++ b/src/layout/Accordion/Accordion.test.tsx
@@ -12,6 +12,12 @@ describe('Accordion', () => {
 
     expect(await screen.findByRole('heading', { name: /accordion title/i })).toBeInTheDocument();
   });
+
+  it('should display text from textResourceBindings if an ID to a text resource is used as title', async () => {
+    render({ title: 'accordion.title' });
+
+    expect(await screen.findByRole('heading', { name: /this is a title/i })).toBeInTheDocument();
+  });
 });
 
 const render = ({ title }: Partial<ILayoutAccordion> & { title?: string } = {}) =>

--- a/src/layout/Accordion/Accordion.tsx
+++ b/src/layout/Accordion/Accordion.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Accordion as DesignSystemAccordion } from '@digdir/design-system-react';
 import { Grid } from '@material-ui/core';
 
+import { useLanguage } from 'src/hooks/useLanguage';
 import { AccordionItem } from 'src/layout/Accordion/AccordionItem';
 import { GenericComponent } from 'src/layout/GenericComponent';
 import type { PropsFromGenericComponent } from 'src/layout';
@@ -11,7 +12,9 @@ type IAccordionProps = PropsFromGenericComponent<'Accordion'>;
 
 export const Accordion = ({ node }: IAccordionProps) => {
   const { textResourceBindings, renderAsAccordionItem } = node.item;
-  const title = textResourceBindings?.title ?? '';
+  const { langAsString } = useLanguage();
+
+  const title = langAsString(textResourceBindings?.title ?? '');
 
   if (renderAsAccordionItem) {
     return (


### PR DESCRIPTION
## Description

Title for `Accordion` did not use `langAsString` from `useLanguage` to resolve the title. This led to titles that referred to ids specified in `resource`-files would not resolve to correct text. 

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes #1353 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [x] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [x] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
