### PR TITLE
fix(Alert): use body instead of description for alert textResourceBin…

### DIFF
--- a/src/layout/Alert/Alert.test.tsx
+++ b/src/layout/Alert/Alert.test.tsx
@@ -13,9 +13,9 @@ describe('Alert', () => {
     expect(screen.getByText(/title for alert/i)).toBeInTheDocument();
   });
 
-  it('should display description', () => {
-    render({ description: 'Description for alert' });
-    expect(screen.getByText(/description for alert/i)).toBeInTheDocument();
+  it('should display body', () => {
+    render({ body: 'Body for alert' });
+    expect(screen.getByText(/body for alert/i)).toBeInTheDocument();
   });
 
   it('should display as role="alert" when hidden is false', () => {
@@ -38,8 +38,8 @@ const render = ({
   severity = 'info',
   hidden,
   title,
-  description,
-}: Partial<ExprResolved<ILayoutCompAlert>> & { title?: string; description?: string } = {}) =>
+  body,
+}: Partial<ExprResolved<ILayoutCompAlert>> & { title?: string; body?: string } = {}) =>
   renderGenericComponentTest<'Alert'>({
     type: 'Alert',
     renderer: (props) => <Alert {...props} />,
@@ -47,7 +47,7 @@ const render = ({
       id: 'alert-box',
       textResourceBindings: {
         title,
-        description,
+        body,
       },
       severity,
       hidden,

--- a/src/layout/Alert/Alert.tsx
+++ b/src/layout/Alert/Alert.tsx
@@ -11,7 +11,7 @@ export const Alert = ({ node }: AlertProps) => {
   const { langAsString } = useLanguage();
 
   const title = textResourceBindings?.title && langAsString(textResourceBindings.title);
-  const description = textResourceBindings?.description && langAsString(textResourceBindings.description);
+  const body = textResourceBindings?.body && langAsString(textResourceBindings.body);
   const shouldAlertScreenReaders = hidden === false;
 
   return (
@@ -20,7 +20,7 @@ export const Alert = ({ node }: AlertProps) => {
       useAsAlert={shouldAlertScreenReaders}
       title={title}
     >
-      {description}
+      {body}
     </AlertBaseComponent>
   );
 };

--- a/src/layout/Alert/index.tsx
+++ b/src/layout/Alert/index.tsx
@@ -26,6 +26,6 @@ export type TypeConfig = {
   layout: ILayoutCompAlert;
   nodeItem: ExprResolved<ILayoutCompAlert>;
   nodeObj: LayoutNode;
-  validTextResourceBindings: 'title' | 'description';
+  validTextResourceBindings: 'title' | 'body';
   validDataModelBindings: undefined;
 };


### PR DESCRIPTION
## Description

Use `textResourceBindings.body` instead of `textResourceBindings.description` for the contents of `Alert`. 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [x] Has been added/updated - [PR added here](https://github.com/Altinn/altinn-studio-docs/pull/1037)
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
