### PR TITLE
Prevent crash on save invalid decimal value

### DIFF
--- a/src/hooks/useMapToReactNumberConfig.ts
+++ b/src/hooks/useMapToReactNumberConfig.ts
@@ -4,20 +4,20 @@ import type { IUseLanguage } from 'src/hooks/useLanguage';
 import type { IInputFormatting } from 'src/layout/layout';
 import type { CurrencyFormattingOptions, UnitFormattingOptions } from 'src/utils/formattingUtils';
 
-export const useMapToReactNumberConfig = (formatting: IInputFormatting, value = ''): IInputFormatting => {
+export const useMapToReactNumberConfig = (formatting: IInputFormatting | undefined, value = ''): IInputFormatting => {
   const langTools = useLanguage();
   return getMapToReactNumberConfig(formatting, value, langTools);
 };
 
 export const getMapToReactNumberConfig = (
-  formatting: IInputFormatting,
+  formatting: IInputFormatting | undefined,
   value = '',
   langTools: IUseLanguage,
 ): IInputFormatting => {
   const { selectedLanguage } = langTools;
 
   if (!formatting?.currency && !formatting?.unit) {
-    return formatting;
+    return formatting ?? {};
   }
 
   const createOptions = (config: IInputFormatting) => {

--- a/src/hooks/useReload.ts
+++ b/src/hooks/useReload.ts
@@ -1,0 +1,7 @@
+import { useCallback, useState } from 'react';
+
+export function useReload(key: string): [string, () => void] {
+  const [reloadKey, setReloadKey] = useState(0);
+  const reload = useCallback(() => setReloadKey((k) => k + 1), []);
+  return [`${key}-${reloadKey}`, reload];
+}

--- a/src/hooks/useReload.ts
+++ b/src/hooks/useReload.ts
@@ -1,7 +1,12 @@
 import { useCallback, useState } from 'react';
 
-export function useReload(key: string): [string, () => void] {
-  const [reloadKey, setReloadKey] = useState(0);
-  const reload = useCallback(() => setReloadKey((k) => k + 1), []);
-  return [`${key}-${reloadKey}`, reload];
+/**
+ * Hook used to force a rerender of a component. It works by updating the key whenever you call rerender().
+ * @param baseKey - The base key to use.
+ * @returns A tuple containing the key to set in the component's key prop, and the rerender function.
+ */
+export function useRerender(baseKey: string): [string, () => void] {
+  const [number, setNumber] = useState(0);
+  const rerender = useCallback(() => setNumber((k) => k + 1), []);
+  return [`${baseKey}-${number}`, rerender];
 }

--- a/src/layout/Input/InputComponent.tsx
+++ b/src/layout/Input/InputComponent.tsx
@@ -6,6 +6,7 @@ import { TextField } from '@digdir/design-system-react';
 import { useDelayedSavedState } from 'src/hooks/useDelayedSavedState';
 import { useLanguage } from 'src/hooks/useLanguage';
 import { useMapToReactNumberConfig } from 'src/hooks/useMapToReactNumberConfig';
+import { useReload } from 'src/hooks/useReload';
 import { canBeParsedToDecimal } from 'src/utils/formattingUtils';
 import { createCharacterLimit } from 'src/utils/inputUtils';
 import type { PropsFromGenericComponent } from 'src/layout';
@@ -32,10 +33,18 @@ export function InputComponent({ node, isValid, formData, handleDataChange, over
   );
   const { lang, langAsString } = useLanguage();
   const reactNumberFormatConfig = useMapToReactNumberConfig(formatting as IInputFormatting | undefined, value);
+  const [inputKey, reloadInput] = useReload('input');
 
   function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
     if (!reactNumberFormatConfig.number || canBeParsedToDecimal(e.target.value)) {
       setValue(e.target.value);
+    }
+  }
+
+  function onBlur() {
+    saveValue();
+    if (reactNumberFormatConfig.number) {
+      reloadInput();
     }
   }
 
@@ -56,8 +65,9 @@ export function InputComponent({ node, isValid, formData, handleDataChange, over
         ></SearchField>
       ) : (
         <TextField
+          key={inputKey}
           id={id}
-          onBlur={saveValue}
+          onBlur={onBlur}
           onChange={handleChange}
           onPaste={onPaste}
           characterLimit={!readOnly && maxLength !== undefined ? createCharacterLimit(maxLength, lang) : undefined}

--- a/src/layout/Input/InputComponent.tsx
+++ b/src/layout/Input/InputComponent.tsx
@@ -31,7 +31,7 @@ export function InputComponent({ node, isValid, formData, handleDataChange, over
     saveWhileTyping,
   );
   const { lang, langAsString } = useLanguage();
-  const reactNumberFormatConfig = useMapToReactNumberConfig(formatting as IInputFormatting, value);
+  const reactNumberFormatConfig = useMapToReactNumberConfig(formatting as IInputFormatting | undefined, value);
 
   function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
     if (!reactNumberFormatConfig.number || canBeParsedToDecimal(e.target.value)) {

--- a/src/layout/Input/InputComponent.tsx
+++ b/src/layout/Input/InputComponent.tsx
@@ -6,7 +6,7 @@ import { TextField } from '@digdir/design-system-react';
 import { useDelayedSavedState } from 'src/hooks/useDelayedSavedState';
 import { useLanguage } from 'src/hooks/useLanguage';
 import { useMapToReactNumberConfig } from 'src/hooks/useMapToReactNumberConfig';
-import { useReload } from 'src/hooks/useReload';
+import { useRerender } from 'src/hooks/useReload';
 import { canBeParsedToDecimal } from 'src/utils/formattingUtils';
 import { createCharacterLimit } from 'src/utils/inputUtils';
 import type { PropsFromGenericComponent } from 'src/layout';
@@ -33,7 +33,7 @@ export function InputComponent({ node, isValid, formData, handleDataChange, over
   );
   const { lang, langAsString } = useLanguage();
   const reactNumberFormatConfig = useMapToReactNumberConfig(formatting as IInputFormatting | undefined, value);
-  const [inputKey, reloadInput] = useReload('input');
+  const [inputKey, rerenderInput] = useRerender('input');
 
   function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
     if (!reactNumberFormatConfig.number || canBeParsedToDecimal(e.target.value)) {
@@ -44,7 +44,7 @@ export function InputComponent({ node, isValid, formData, handleDataChange, over
   function onBlur() {
     saveValue();
     if (reactNumberFormatConfig.number) {
-      reloadInput();
+      rerenderInput();
     }
   }
 

--- a/src/layout/Input/InputComponent.tsx
+++ b/src/layout/Input/InputComponent.tsx
@@ -6,6 +6,7 @@ import { TextField } from '@digdir/design-system-react';
 import { useDelayedSavedState } from 'src/hooks/useDelayedSavedState';
 import { useLanguage } from 'src/hooks/useLanguage';
 import { useMapToReactNumberConfig } from 'src/hooks/useMapToReactNumberConfig';
+import { canBeParsedToDecimal } from 'src/utils/formattingUtils';
 import { createCharacterLimit } from 'src/utils/inputUtils';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type { IInputFormatting } from 'src/layout/layout';
@@ -31,7 +32,12 @@ export function InputComponent({ node, isValid, formData, handleDataChange, over
   );
   const { lang, langAsString } = useLanguage();
   const reactNumberFormatConfig = useMapToReactNumberConfig(formatting as IInputFormatting, value);
-  const handleChange = (e) => setValue(e.target.value);
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    if (!reactNumberFormatConfig.number || canBeParsedToDecimal(e.target.value)) {
+      setValue(e.target.value);
+    }
+  }
 
   const ariaLabel = overrideDisplay?.renderedInTable === true ? langAsString(textResourceBindings?.title) : undefined;
 

--- a/src/layout/Input/index.tsx
+++ b/src/layout/Input/index.tsx
@@ -26,7 +26,11 @@ export class Input extends FormComponent<'Input'> {
 
     const text = formData[node.item.dataModelBindings.simpleBinding] || '';
 
-    const numberFormatting = getMapToReactNumberConfig(node.item.formatting as IInputFormatting, text, langTools);
+    const numberFormatting = getMapToReactNumberConfig(
+      node.item.formatting as IInputFormatting | undefined,
+      text,
+      langTools,
+    );
 
     if (numberFormatting?.number) {
       return formatNumericText(text, numberFormatting.number);

--- a/src/utils/formattingUtils.test.ts
+++ b/src/utils/formattingUtils.test.ts
@@ -1,4 +1,4 @@
-import { formatNumber } from 'src/utils/formattingUtils';
+import { canBeParsedToDecimal, formatNumber } from 'src/utils/formattingUtils';
 import type { CurrencyFormattingOptions, UnitFormattingOptions } from 'src/utils/formattingUtils';
 
 const value = '12000.20';
@@ -39,5 +39,31 @@ describe('dynamic number formatting', () => {
     language = 'nb';
     position = 'suffix';
     expect(' kr').toEqual(formatNumber(value, language, currencyOptions, position).suffix);
+  });
+});
+
+describe('canBeParsedToDecimal', () => {
+  const testCases: [string, boolean][] = [
+    ['', true],
+    ['1', true],
+    ['1.1', true],
+    ['1.1e1', true],
+    ['1.1e-1', true],
+    ['1.1e+1', true],
+    ['-1', true],
+    ['-1.1', true],
+    ['-1.1e1', true],
+    ['-1.1e-1', true],
+    ['-1.1e+1', true],
+    ['8e28', false],
+    ['-8e28', false],
+    ['-', false],
+    ['.', false],
+    ['0.1', true],
+    ['.1', true],
+  ];
+
+  it.each(testCases)('should return %s as %s', (value, expected) => {
+    expect(canBeParsedToDecimal(value)).toEqual(expected);
   });
 });

--- a/src/utils/formattingUtils.ts
+++ b/src/utils/formattingUtils.ts
@@ -51,3 +51,18 @@ export const formatNumber = (
   });
   return intlResult;
 };
+
+/**
+ * Checks if a string can be parsed to a decimal in C#.
+ * 1. Empty string is valid. This will get removed from the datamodel before save.
+ * 2. Value must be parsable as float in javascript.
+ * 3. Value must be between +- 7.9e28
+ * @see https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/floating-point-numeric-types
+ */
+export function canBeParsedToDecimal(value: string): boolean {
+  if (!value.length) {
+    return true;
+  }
+  const parsedValue = parseFloat(value);
+  return isFinite(parsedValue) && parsedValue < 7.92e28 && parsedValue > -7.92e28;
+}


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

If the form data we save to the backend cannot be parsed into the strong types of the data model class, the save fails with 400 bad request and due to our handling of such errors, the app "crashes" with "unknown error". Since we use `decimal` as our preferred number type when generating the data model classes in studio (even if you select integer it seems), we should probably make sure that our `Input` component with number formatting is "safe" to use with numeric data types in the data model.

This change will check whether the number can be parsed into the `decimal` type before saving the data when using number formatting. The `react-number-format` already restricts what you can type into the box, but there are a few edge cases that this deals with. For example, you need to be able to type the characters `-` and `.` to support negative and floating point values; but these characters by themselves are not valid numbers and will cause a crash.

There is also a size restriction on `decimal` that will also cause a crash if not respected. So this also prevents a crash if you type a number that is too big. ~~A potential issue is that you do not get any feedback that the data you typed was not saved, this cannot easily be done with validation, since that requires the data to be saved first.~~

**EDIT**: I may have found a solution which is not too hacky. I am now forcing a rerender onBlur if the component has number formatting. Before, it would still show the entire number you typed even though it did not get saved, now you at least see the data you are actually going to submit.

https://github.com/Altinn/app-frontend-react/assets/47412359/a484e4e3-1898-4937-b159-a660edaae20e




## Related Issue(s)

- closes #1354 
- somewhat mitigates https://github.com/Altinn/app-lib-dotnet/issues/197 but only for `decimal` values which is default. It will still crash when used with `int`. 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
