### PR TITLE
Fix `Checkboxes` to use `lang` instead of `langAsString`

### DIFF
--- a/src/layout/Checkboxes/CheckboxesContainerComponent.tsx
+++ b/src/layout/Checkboxes/CheckboxesContainerComponent.tsx
@@ -114,7 +114,7 @@ export const CheckboxContainerComponent = ({
         disabled={readOnly}
         onChange={(values) => handleChange(values)}
         legend={overrideDisplay?.renderLegend === false ? null : labelText}
-        description={textResourceBindings?.description && langAsString(textResourceBindings.description)}
+        description={textResourceBindings?.description && lang(textResourceBindings.description)}
         error={!isValid}
         fieldSetProps={{
           'aria-label': overrideDisplay?.renderedInTable ? langAsString(textResourceBindings?.title) : undefined,
@@ -134,8 +134,8 @@ export const CheckboxContainerComponent = ({
           checked: selected.includes(option.value),
           hideLabel,
           label: langAsString(option.label),
-          description: langAsString(option.description),
-          helpText: option.helpText && langAsString(option.helpText),
+          description: lang(option.description),
+          helpText: option.helpText && lang(option.helpText),
         }))}
       />
     </div>


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

On the `Checkboxes` component, `langAsString` was used for description and help text instead of `lang`, which is what `RadioButtons` uses. I let `label` still use `langAsString` on both checkbox and radio. The reason for this is twofold: 1. If the label is not of type string, then the help text button will [not get an accessible name](https://github.com/digdir/designsystem/blob/main/packages/react/src/components/_CheckboxRadioTemplate/CheckboxRadioTemplate.tsx#L119-L124). This is a design system issue. 2. useDisplayData expects to return a string, and if formatting is used on the label then this will not look good in summary. Is it possible to still get a pure string representation from raw markdown? 

## Related Issue(s)

- https://altinn.slack.com/archives/C02FK32FBR6/p1691395951702349

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
