### PR TITLE
Static query parameters for options

### DIFF
--- a/schemas/json/layout/layout.schema.v1.json
+++ b/schemas/json/layout/layout.schema.v1.json
@@ -1372,9 +1372,6 @@
         "mapping": {
           "$ref": "#/definitions/mapping",
           "description": "(Optional) Used to map data model paths to query parameters when fetching list data."
-        },
-        "queryParameters": {
-          "$ref": "#/definitions/queryParameters"
         }
       },
       "required": [

--- a/schemas/json/layout/layout.schema.v1.json
+++ b/schemas/json/layout/layout.schema.v1.json
@@ -295,6 +295,9 @@
         "mapping": {
           "$ref": "#/definitions/mapping",
           "description": "Optionally used to map options"
+        },
+        "queryParameters": {
+          "$ref": "#/definitions/queryParameters"
         }
       },
       "required": ["optionsId"]
@@ -387,6 +390,9 @@
         "mapping": {
           "$ref": "#/definitions/mapping",
           "description": "Creates a new app instance with data collected from a stateless part of the app."
+        },
+        "queryParameters": {
+          "$ref": "#/definitions/queryParameters"
         }
       }
     },
@@ -968,6 +974,9 @@
           "$ref": "#/definitions/mapping",
           "description": "Optionally used to map options"
         },
+        "queryParameters": {
+          "$ref": "#/definitions/queryParameters"
+        },
         "autocomplete": {
           "$ref": "#/definitions/autocomplete"
         }
@@ -1266,6 +1275,22 @@
         "type": "string"
       }
     },
+    "queryParameters": {
+      "type": "object",
+      "title": "Query parameters",
+      "description": "Fixed query parameters to add to the url.",
+      "patternProperties": {
+        "^.+$": {
+          "type": "string",
+          "title": "Query parameter value"
+        }
+      },
+      "examples": [
+        {
+          "level": "1"
+        }
+      ]
+    },
     "iframeComponent": {
       "type": "object",
       "properties": {
@@ -1347,6 +1372,9 @@
         "mapping": {
           "$ref": "#/definitions/mapping",
           "description": "(Optional) Used to map data model paths to query parameters when fetching list data."
+        },
+        "queryParameters": {
+          "$ref": "#/definitions/queryParameters"
         }
       },
       "required": [

--- a/src/features/options/fetch/fetchOptionsSagas.test.ts
+++ b/src/features/options/fetch/fetchOptionsSagas.test.ts
@@ -281,6 +281,79 @@ describe('fetchOptionsSagas', () => {
         })
         .run();
     });
+
+    it('should include static query parameters in url', () => {
+      jest.spyOn(networking, 'httpGet').mockResolvedValue([]);
+
+      const formData = {
+        'FlytteTil.Fylke': 'Oslo',
+      };
+
+      return expectSaga(fetchSpecificOptionSaga, {
+        optionsId: 'kommune',
+        dataMapping: undefined,
+        fixedQueryParameters: { level: '1' },
+        secure: undefined,
+      })
+        .provide([
+          [select(formDataSelector), formData],
+          [select(staticUseLanguageFromState), { selectedLanguage: 'nb' }],
+          [select(instanceIdSelector), 'someId'],
+        ])
+        .call(networking.httpGet, 'https://local.altinn.cloud/ttd/test/api/options/kommune?language=nb&level=1')
+        .run();
+    });
+
+    it('should include mapping in url', () => {
+      jest.spyOn(networking, 'httpGet').mockResolvedValue([]);
+
+      const formData = {
+        'FlytteTil.Fylke': 'Oslo',
+      };
+
+      return expectSaga(fetchSpecificOptionSaga, {
+        optionsId: 'kommune',
+        dataMapping: {
+          'FlytteTil.Fylke': 'fylke',
+        },
+        fixedQueryParameters: undefined,
+        secure: undefined,
+      })
+        .provide([
+          [select(formDataSelector), formData],
+          [select(staticUseLanguageFromState), { selectedLanguage: 'nb' }],
+          [select(instanceIdSelector), 'someId'],
+        ])
+        .call(networking.httpGet, 'https://local.altinn.cloud/ttd/test/api/options/kommune?language=nb&fylke=Oslo')
+        .run();
+    });
+
+    it('should include static query parameters and mapping in request url', () => {
+      jest.spyOn(networking, 'httpGet').mockResolvedValue([]);
+
+      const formData = {
+        'FlytteTil.Fylke': 'Oslo',
+      };
+
+      return expectSaga(fetchSpecificOptionSaga, {
+        optionsId: 'kommune',
+        dataMapping: {
+          'FlytteTil.Fylke': 'fylke',
+        },
+        fixedQueryParameters: { level: '1' },
+        secure: undefined,
+      })
+        .provide([
+          [select(formDataSelector), formData],
+          [select(staticUseLanguageFromState), { selectedLanguage: 'nb' }],
+          [select(instanceIdSelector), 'someId'],
+        ])
+        .call(
+          networking.httpGet,
+          'https://local.altinn.cloud/ttd/test/api/options/kommune?language=nb&level=1&fylke=Oslo',
+        )
+        .run();
+    });
   });
 
   describe('instanceIdSelector', () => {

--- a/src/features/options/fetch/fetchOptionsSagas.test.ts
+++ b/src/features/options/fetch/fetchOptionsSagas.test.ts
@@ -218,6 +218,71 @@ describe('fetchOptionsSagas', () => {
     });
   });
 
+  describe('Fixed query parameters', () => {
+    it('should include static query parameters and mapping', () => {
+      jest.spyOn(networking, 'httpGet').mockResolvedValue([]);
+      const formLayout: ILayouts = {
+        formLayout: [
+          {
+            id: 'fylke',
+            type: 'Dropdown',
+            textResourceBindings: {
+              title: 'fylke',
+            },
+            dataModelBindings: {
+              simpleBinding: 'FlytteFra.Fylke',
+            },
+            optionsId: 'fylke',
+            required: true,
+            queryParameters: {
+              level: '1',
+            },
+          },
+          {
+            id: 'kommune',
+            type: 'Dropdown',
+            textResourceBindings: {
+              title: 'kommune',
+            },
+            dataModelBindings: {
+              simpleBinding: 'FlytteTil.Kommune',
+            },
+            optionsId: 'kommune',
+            required: true,
+            mapping: {
+              'FlytteTil.Fylke': 'fylke',
+            },
+            queryParameters: {
+              level: '2',
+            },
+          },
+        ],
+      };
+
+      return expectSaga(fetchOptionsSaga)
+        .provide([
+          [selectNotNull(formLayoutSelector), formLayout],
+          [selectNotNull(repeatingGroupsSelector), {}],
+          [select(instanceIdSelector), 'someId'],
+        ])
+        .fork(fetchSpecificOptionSaga, {
+          optionsId: 'fylke',
+          dataMapping: undefined,
+          fixedQueryParameters: { level: '1' },
+          secure: undefined,
+        })
+        .fork(fetchSpecificOptionSaga, {
+          optionsId: 'kommune',
+          dataMapping: {
+            'FlytteTil.Fylke': 'fylke',
+          },
+          fixedQueryParameters: { level: '2' },
+          secure: undefined,
+        })
+        .run();
+    });
+  });
+
   describe('instanceIdSelector', () => {
     it('should return instance id if present', () => {
       const state = {

--- a/src/features/options/fetch/fetchOptionsSagas.test.ts
+++ b/src/features/options/fetch/fetchOptionsSagas.test.ts
@@ -58,6 +58,7 @@ describe('fetchOptionsSagas', () => {
           dataMapping: {
             some_field: 'some_url_parm',
           },
+          fixedQueryParameters: undefined,
           secure: undefined,
         })
         .run();
@@ -140,6 +141,7 @@ describe('fetchOptionsSagas', () => {
         .fork(fetchSpecificOptionSaga, {
           optionsId: 'fylke',
           dataMapping: undefined,
+          fixedQueryParameters: undefined,
           secure: undefined,
         })
         .fork(fetchSpecificOptionSaga, {
@@ -147,6 +149,7 @@ describe('fetchOptionsSagas', () => {
           dataMapping: {
             'FlytteFra.Fylke': 'fylke',
           },
+          fixedQueryParameters: undefined,
           secure: undefined,
         })
         .run();
@@ -200,6 +203,7 @@ describe('fetchOptionsSagas', () => {
           dataMapping: {
             'FlytteFra.Fylke': 'fylke',
           },
+          fixedQueryParameters: undefined,
           secure: undefined,
         })
         .fork(fetchSpecificOptionSaga, {
@@ -207,6 +211,7 @@ describe('fetchOptionsSagas', () => {
           dataMapping: {
             'FlytteTil.Fylke': 'fylke',
           },
+          fixedQueryParameters: undefined,
           secure: undefined,
         })
         .run();

--- a/src/features/options/fetch/fetchOptionsSagas.ts
+++ b/src/features/options/fetch/fetchOptionsSagas.ts
@@ -67,6 +67,7 @@ export function* fetchOptionsSaga(): SagaIterator {
           getOptionLookupKeys({
             id: optionsId,
             mapping,
+            fixedQueryParameters: queryParameters,
             secure,
             repeatingGroups,
           })) ||
@@ -77,21 +78,12 @@ export function* fetchOptionsSaga(): SagaIterator {
       }
 
       if (!keys?.length) {
-        const lookupKey = optionsId ? getOptionLookupKey({ id: optionsId, fixedQueryParameters: queryParameters }) : '';
-        if (optionsId && !fetchedOptions.includes(lookupKey)) {
-          yield fork(fetchSpecificOptionSaga, {
-            optionsId,
-            fixedQueryParameters: queryParameters,
-            secure,
-          });
-          fetchedOptions.push(lookupKey);
-        }
         continue;
       }
 
       for (const optionObject of keys) {
-        const { id, mapping, secure } = optionObject;
-        const lookupKey = getOptionLookupKey({ id, mapping, fixedQueryParameters: queryParameters });
+        const { id, mapping, fixedQueryParameters, secure } = optionObject;
+        const lookupKey = getOptionLookupKey({ id, mapping, fixedQueryParameters });
         if (optionsId && !fetchedOptions.includes(lookupKey)) {
           yield fork(fetchSpecificOptionSaga, {
             optionsId,

--- a/src/hooks/useGetOptions.ts
+++ b/src/hooks/useGetOptions.ts
@@ -10,6 +10,7 @@ import type { IDataSources } from 'src/types/shared';
 interface IUseGetOptionsParams {
   optionsId: string | undefined;
   mapping?: IMapping;
+  queryParameters?: Record<string, string>;
   source?: IOptionSource;
 }
 
@@ -19,7 +20,7 @@ export interface IOptionResources {
   helpText?: ITextResource;
 }
 
-export const useGetOptions = ({ optionsId, mapping, source }: IUseGetOptionsParams) => {
+export const useGetOptions = ({ optionsId, mapping, queryParameters, source }: IUseGetOptionsParams) => {
   const relevantFormData = useAppSelector(
     (state) => (source && getRelevantFormDataForOptionSource(state.formData.formData, source)) || {},
     shallowEqual,
@@ -42,7 +43,7 @@ export const useGetOptions = ({ optionsId, mapping, source }: IUseGetOptionsPara
 
   useEffect(() => {
     if (optionsId) {
-      const key = getOptionLookupKey({ id: optionsId, mapping });
+      const key = getOptionLookupKey({ id: optionsId, mapping, fixedQueryParameters: queryParameters });
       setOptions(optionState[key]?.options);
     }
 
@@ -83,6 +84,7 @@ export const useGetOptions = ({ optionsId, mapping, source }: IUseGetOptionsPara
     relevantTextResources.label,
     relevantTextResources.description,
     relevantTextResources.helpText,
+    queryParameters,
   ]);
 
   return options;

--- a/src/layout/Checkboxes/CheckboxesContainerComponent.tsx
+++ b/src/layout/Checkboxes/CheckboxesContainerComponent.tsx
@@ -35,12 +35,13 @@ export const CheckboxContainerComponent = ({
     layout,
     readOnly,
     mapping,
+    queryParameters,
     source,
     textResourceBindings,
     required,
     labelSettings,
   } = node.item;
-  const apiOptions = useGetOptions({ optionsId, mapping, source });
+  const apiOptions = useGetOptions({ optionsId, mapping, queryParameters, source });
   const calculatedOptions = apiOptions || options || defaultOptions;
   const hasSelectedInitial = React.useRef(false);
   const optionsHasChanged = useHasChangedIgnoreUndefined(apiOptions);

--- a/src/layout/Dropdown/DropdownComponent.tsx
+++ b/src/layout/Dropdown/DropdownComponent.tsx
@@ -22,11 +22,14 @@ export function DropdownComponent({ node, formData, handleDataChange, isValid, o
     id,
     readOnly,
     mapping,
+    queryParameters,
     source,
     textResourceBindings,
   } = node.item;
   const { langAsString } = useLanguage();
-  const options = (useGetOptions({ optionsId, mapping, source }) || staticOptions)?.filter(duplicateOptionFilter);
+  const options = (useGetOptions({ optionsId, mapping, queryParameters, source }) || staticOptions)?.filter(
+    duplicateOptionFilter,
+  );
   const lookupKey = optionsId && getOptionLookupKey({ id: optionsId, mapping });
   const fetchingOptions = useAppSelector((state) => lookupKey && state.optionState.options[lookupKey]?.loading);
   const hasSelectedInitial = React.useRef(false);

--- a/src/layout/Likert/RepeatingGroupsLikertContainer.tsx
+++ b/src/layout/Likert/RepeatingGroupsLikertContainer.tsx
@@ -21,9 +21,9 @@ type RepeatingGroupsLikertContainerProps = {
 
 export const RepeatingGroupsLikertContainer = ({ node }: RepeatingGroupsLikertContainerProps) => {
   const firstLikertChild = node?.children((item) => item.type === 'Likert') as LayoutNodeFromType<'Likert'> | undefined;
-  const { optionsId, mapping, source, options } = firstLikertChild?.item || {};
+  const { optionsId, mapping, queryParameters, source, options } = firstLikertChild?.item || {};
   const mobileView = useIsMobileOrTablet();
-  const apiOptions = useGetOptions({ optionsId, mapping, source });
+  const apiOptions = useGetOptions({ optionsId, mapping, queryParameters, source });
   const calculatedOptions = apiOptions || options || [];
   const lookupKey = optionsId && getOptionLookupKey({ id: optionsId, mapping });
   const fetchingOptions = useAppSelector((state) => lookupKey && state.optionState.options[lookupKey]?.loading);

--- a/src/layout/MultipleSelect/MultipleSelectComponent.tsx
+++ b/src/layout/MultipleSelect/MultipleSelectComponent.tsx
@@ -19,8 +19,8 @@ export function MultipleSelectComponent({
   isValid,
   overrideDisplay,
 }: IMultipleSelectProps) {
-  const { options, optionsId, mapping, source, id, readOnly, textResourceBindings } = node.item;
-  const apiOptions = useGetOptions({ optionsId, mapping, source });
+  const { options, optionsId, mapping, queryParameters, source, id, readOnly, textResourceBindings } = node.item;
+  const apiOptions = useGetOptions({ optionsId, mapping, queryParameters, source });
   const { value, setValue, saveValue } = useDelayedSavedState(handleDataChange, formData?.simpleBinding);
   const { langAsString } = useLanguage();
 

--- a/src/layout/RadioButtons/radioButtonsUtils.ts
+++ b/src/layout/RadioButtons/radioButtonsUtils.ts
@@ -24,8 +24,8 @@ export const useRadioStyles = makeStyles(() => ({
 }));
 
 export const useRadioButtons = ({ node, handleDataChange, formData }: IRadioButtonsContainerProps) => {
-  const { optionsId, options, preselectedOptionIndex, mapping, source } = node.item;
-  const apiOptions = useGetOptions({ optionsId, mapping, source });
+  const { optionsId, options, preselectedOptionIndex, mapping, queryParameters, source } = node.item;
+  const apiOptions = useGetOptions({ optionsId, mapping, queryParameters, source });
   const _calculatedOptions = useMemo(() => apiOptions || options, [apiOptions, options]);
   const calculatedOptions = _calculatedOptions || [];
   const optionsHasChanged = useHasChangedIgnoreUndefined(apiOptions);

--- a/src/layout/layout.d.ts
+++ b/src/layout/layout.d.ts
@@ -43,6 +43,7 @@ interface ISelectionComponent {
   options?: IOption[];
   optionsId?: string;
   mapping?: IMapping;
+  queryParameters?: Record<string, string>;
   secure?: boolean;
   source?: IOptionSource;
   preselectedOptionIndex?: number;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -84,6 +84,7 @@ export interface IOptionsActualData {
 export interface IOptionsMetaData {
   id: string;
   mapping?: IMapping;
+  fixedQueryParameters?: Record<string, string>;
   loading?: boolean;
   secure?: boolean;
 }
@@ -271,6 +272,7 @@ export interface IFetchSpecificOptionSaga {
   formData?: IFormData;
   language?: string;
   dataMapping?: IMapping;
+  fixedQueryParameters?: Record<string, string>;
   secure?: boolean;
   instanceId?: string;
 }

--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -11,12 +11,20 @@ import type { IOptionResources } from 'src/hooks/useGetOptions';
 import type { ILayout } from 'src/layout/layout';
 import type { IMapping, IOption, IOptions, IOptionsMetaData, IOptionSource, IRepeatingGroups } from 'src/types';
 import type { IDataSources } from 'src/types/shared';
-export function getOptionLookupKey({ id, mapping }: IOptionsMetaData) {
-  if (!mapping) {
+
+export function getOptionLookupKey({ id, mapping, fixedQueryParameters }: IOptionsMetaData) {
+  if (!mapping && !fixedQueryParameters) {
     return id;
   }
 
-  return JSON.stringify({ id, mapping });
+  const keyObject: any = { id };
+  if (mapping) {
+    keyObject.mapping = mapping;
+  }
+  if (fixedQueryParameters) {
+    keyObject.fixedQueryParameters = fixedQueryParameters;
+  }
+  return JSON.stringify(keyObject);
 }
 
 interface IGetOptionLookupKeysParam extends IOptionsMetaData {

--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -39,6 +39,7 @@ interface IOptionLookupKeys {
 export function getOptionLookupKeys({
   id,
   mapping,
+  fixedQueryParameters,
   secure,
   repeatingGroups,
 }: IGetOptionLookupKeysParam): IOptionLookupKeys {
@@ -58,17 +59,17 @@ export function getOptionLookupKeys({
         };
         delete newMapping[mappingKey];
         newMapping[newMappingKey] = mapping[mappingKey];
-        lookupKeys.push({ id, mapping: newMapping, secure });
+        lookupKeys.push({ id, mapping: newMapping, fixedQueryParameters, secure });
       }
     });
 
     return {
       keys: lookupKeys,
-      keyWithIndexIndicator: { id, mapping, secure },
+      keyWithIndexIndicator: { id, mapping, fixedQueryParameters, secure },
     };
   }
 
-  lookupKeys.push({ id, mapping, secure });
+  lookupKeys.push({ id, mapping, fixedQueryParameters, secure });
   return {
     keys: lookupKeys,
   };

--- a/src/utils/urls/appUrlHelper.test.ts
+++ b/src/utils/urls/appUrlHelper.test.ts
@@ -252,6 +252,23 @@ describe('Frontend urlHelper.ts', () => {
       expect(result).toEqual('https://local.altinn.cloud/ttd/test/api/options/country?selectedCountry=Norway');
     });
 
+    it('should return correct url when fixed query parameters is provided', () => {
+      const result = getOptionsUrl({
+        optionsId: 'country',
+        formData: {
+          country: 'Norway',
+        },
+        dataMapping: {
+          country: 'selectedCountry',
+        },
+        fixedQueryParameters: {
+          level: '1',
+        },
+      });
+
+      expect(result).toEqual('https://local.altinn.cloud/ttd/test/api/options/country?level=1&selectedCountry=Norway');
+    });
+
     it('should return correct url when both language is passed and formData/dataMapping is provided', () => {
       const result = getOptionsUrl({
         optionsId: 'country',

--- a/src/utils/urls/appUrlHelper.test.ts
+++ b/src/utils/urls/appUrlHelper.test.ts
@@ -258,6 +258,21 @@ describe('Frontend urlHelper.ts', () => {
         formData: {
           country: 'Norway',
         },
+        dataMapping: undefined,
+        fixedQueryParameters: {
+          level: '1',
+        },
+      });
+
+      expect(result).toEqual('https://local.altinn.cloud/ttd/test/api/options/country?level=1');
+    });
+
+    it('should return correct url when fixed query parameters and dataMapping is provided', () => {
+      const result = getOptionsUrl({
+        optionsId: 'country',
+        formData: {
+          country: 'Norway',
+        },
         dataMapping: {
           country: 'selectedCountry',
         },

--- a/src/utils/urls/appUrlHelper.ts
+++ b/src/utils/urls/appUrlHelper.ts
@@ -193,19 +193,18 @@ export const getOptionsUrl = ({
   } else {
     url = new URL(`${appPath}/api/options/${optionsId}`);
   }
-  let params: Record<string, string> = {};
+
+  const params: Record<string, string> = {};
 
   if (language) {
     params.language = language;
   }
+  if (fixedQueryParameters) {
+    Object.assign(params, fixedQueryParameters);
+  }
   if (formData && dataMapping) {
     const mapped = mapFormData(formData, dataMapping);
-
-    params = {
-      ...params,
-      ...fixedQueryParameters,
-      ...mapped,
-    };
+    Object.assign(params, mapped);
   }
 
   url.search = new URLSearchParams(params).toString();

--- a/src/utils/urls/appUrlHelper.ts
+++ b/src/utils/urls/appUrlHelper.ts
@@ -171,6 +171,7 @@ export const frontendVersionsCDN = `${appFrontendCDNPath}/index.json`;
 export interface IGetOptionsUrlParams {
   optionsId: string;
   dataMapping?: IMapping;
+  fixedQueryParameters?: Record<string, string>;
   formData?: IFormData;
   language?: string;
   secure?: boolean;
@@ -180,6 +181,7 @@ export interface IGetOptionsUrlParams {
 export const getOptionsUrl = ({
   optionsId,
   dataMapping,
+  fixedQueryParameters,
   formData,
   language,
   secure,
@@ -201,6 +203,7 @@ export const getOptionsUrl = ({
 
     params = {
       ...params,
+      ...fixedQueryParameters,
       ...mapped,
     };
   }


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

This introduces a new option for setting static query parameters in options (similar to mapping, but not from the data model). 

This can be done by adding the `queryParameters` property with the form:
```json
{
  "id": "some-id",
  "type": "Dropdown",
  "optionsId": "options",
  "queryParameters": {
    "name": "value"
  }
}
```

This object can be extended in the future to add [expression support](https://github.com/Altinn/app-frontend-react/issues/1181), but this would likely require a major rewrite, possibly by moving over to [tanstack query](https://github.com/Altinn/app-frontend-react/issues/1294). If and when these things happen, we could deprecate and later remove `mapping`.

## Related Issue(s)

- closes #957
- https://github.com/Altinn/altinn-studio-docs/pull/1045
- https://github.com/Altinn/altinn-studio/issues/10774

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [x] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [x] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [ ] No changes made
- Support in Altinn Studio
  - [x] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
