### PR TITLE
Avoid page break in alert component (PDF)

### DIFF
--- a/src/layout/Alert/Alert.module.css
+++ b/src/layout/Alert/Alert.module.css
@@ -1,3 +1,9 @@
+@media print {
+  .container {
+    break-inside: avoid;
+  }
+}
+
 .title {
   font-weight: 500;
   font-size: 1.25rem;

--- a/src/layout/Alert/AlertBaseComponent.tsx
+++ b/src/layout/Alert/AlertBaseComponent.tsx
@@ -22,6 +22,7 @@ export type AlertBaseComponentProps = {
 
 export const AlertBaseComponent = ({ title, children, useAsAlert, severity, ariaLabel }: AlertBaseComponentProps) => (
   <AlertDesignSystem
+    className={styles.container}
     severity={severity}
     role={useAsAlert ? 'alert' : undefined}
     aria-live={useAsAlert ? calculateAriaLive(severity) : undefined}

--- a/src/layout/Group/SummaryGroupComponent.module.css
+++ b/src/layout/Group/SummaryGroupComponent.module.css
@@ -9,7 +9,7 @@
 }
 @media print {
   .border {
-    page-break-inside: avoid;
+    break-inside: avoid;
   }
 }
 


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

Avoid page break inside the alert component in PDF. (also update `page-break-inside` to `break-inside`)

Before:
![image](https://github.com/Altinn/app-frontend-react/assets/47412359/d9ef1a6b-02e0-471f-b4e8-ef331ddcdac0)

After:
![image](https://github.com/Altinn/app-frontend-react/assets/47412359/78989a8a-e579-4826-9163-2a1038d72d12)
