### PR TITLE
Fix: Hiding required validation messages for tracks-hidden pages

### DIFF
--- a/src/features/devtools/components/DevHiddenFunctionality/DevHiddenFunctionality.tsx
+++ b/src/features/devtools/components/DevHiddenFunctionality/DevHiddenFunctionality.tsx
@@ -22,7 +22,7 @@ export function DevHiddenFunctionality() {
       if (node) {
         if (ref.style.filter === pseudoHiddenCssFilter && state !== 'disabled') {
           ref.style.filter = '';
-        } else if (state === 'disabled' && node.isHidden(true, false)) {
+        } else if (state === 'disabled' && node.isHidden({ respectDevTools: false })) {
           ref.style.filter = pseudoHiddenCssFilter;
         }
       }

--- a/src/features/dynamics/conditionalRenderingSagas.ts
+++ b/src/features/dynamics/conditionalRenderingSagas.ts
@@ -66,10 +66,9 @@ export function* removeHiddenValidationsSaga({
 
 export function runExpressionRules(layouts: LayoutPages, future: Set<string>) {
   const shouldIncludeGroups = true;
-  const shouldRespectLegacyHidden = false;
   for (const layout of Object.values(layouts.all())) {
     for (const node of layout.flat(shouldIncludeGroups)) {
-      if (node.isHidden(shouldRespectLegacyHidden)) {
+      if (node.isHidden({ respectLegacy: false })) {
         future.add(node.item.id);
       }
     }

--- a/src/layout/Group/SummaryGroupComponent.test.tsx
+++ b/src/layout/Group/SummaryGroupComponent.test.tsx
@@ -78,10 +78,10 @@ describe('SummaryGroupComponent', () => {
             dataModelBinding: 'mockGroup',
           },
         },
-        currentView: 'FormLayout',
+        currentView: 'page1',
         navigationConfig: {},
         tracks: {
-          order: [],
+          order: ['page1'],
           hidden: [],
           hiddenExpr: {},
         },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -30,7 +30,7 @@ export interface ILayoutSet {
 export interface ILayoutSettings {
   pages: IPagesSettings;
   components?: IComponentsSettings;
-  receiptLayoutName: string;
+  receiptLayoutName?: string;
 }
 
 export interface IPagesSettings {

--- a/src/utils/layout/LayoutNode.ts
+++ b/src/utils/layout/LayoutNode.ts
@@ -163,7 +163,11 @@ export class LayoutNode<Item extends AnyItem = AnyItem, Type extends ComponentTy
    * Checks if this field should be hidden. This also takes into account the group this component is in, so the
    * methods returns true if the component is inside a hidden group.
    */
-  public isHidden(respectLegacy = true, respectDevTools = true): boolean {
+  public isHidden(
+    options: { respectLegacy?: boolean; respectDevTools?: boolean; respectTracks?: boolean } = {},
+  ): boolean {
+    const { respectLegacy = true, respectDevTools = true, respectTracks = false } = options;
+
     const hiddenList = respectLegacy ? this.dataSources.hiddenFields : new Set();
     if (respectDevTools && this.dataSources.devTools.isOpen && this.dataSources.devTools.hiddenComponents !== 'hide') {
       return false;
@@ -204,11 +208,15 @@ export class LayoutNode<Item extends AnyItem = AnyItem, Type extends ComponentTy
       }
     }
 
-    if (this.parent instanceof LayoutPage && this.parent.isHiddenViaTracks(this.dataSources.uiConfig)) {
+    if (
+      respectTracks &&
+      this.parent instanceof LayoutPage &&
+      this.parent.isHiddenViaTracks(this.dataSources.uiConfig)
+    ) {
       return true;
     }
 
-    return this.parent instanceof LayoutNode && this.parent.isHidden(respectLegacy);
+    return this.parent instanceof LayoutNode && this.parent.isHidden(options);
   }
 
   private firstDataModelBinding() {

--- a/src/utils/layout/LayoutNode.ts
+++ b/src/utils/layout/LayoutNode.ts
@@ -204,6 +204,10 @@ export class LayoutNode<Item extends AnyItem = AnyItem, Type extends ComponentTy
       }
     }
 
+    if (this.parent instanceof LayoutPage && this.parent.isHiddenViaTracks(this.dataSources.uiConfig)) {
+      return true;
+    }
+
     return this.parent instanceof LayoutNode && this.parent.isHidden(respectLegacy);
   }
 

--- a/src/utils/layout/LayoutPage.ts
+++ b/src/utils/layout/LayoutPage.ts
@@ -1,4 +1,5 @@
 import { runValidationOnNodes } from 'src/utils/validation/validation';
+import type { IUiConfig } from 'src/types';
 import type { AnyItem, HComponent } from 'src/utils/layout/hierarchy.types';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 import type { LayoutObject } from 'src/utils/layout/LayoutObject';
@@ -138,5 +139,32 @@ export class LayoutPage implements LayoutObject {
    */
   public runValidations(validationContext: IValidationContext): IValidationObject[] {
     return runValidationOnNodes(this.allChildren, validationContext);
+  }
+
+  public isHiddenViaTracks(uiConfig: IUiConfig): boolean {
+    const myKey = this.top.myKey;
+    if (myKey === uiConfig.currentView) {
+      // If this is the current view, then it's never hidden. This avoids settings fields as hidden when
+      // code caused this to be the current view even if it's not in the common order.
+      return false;
+    }
+
+    if (myKey === uiConfig.receiptLayoutName) {
+      // If this is the custom receipt layout, then it's never hidden.
+      return false;
+    }
+
+    if (myKey === uiConfig.pdfLayoutName) {
+      // If this is the pdf layout, then it's never hidden.
+      return false;
+    }
+
+    const { order } = uiConfig.tracks || {};
+    if (!order) {
+      // If no tracks are provided, then we can't determine if this is hidden or not
+      return false;
+    }
+
+    return !order.includes(myKey);
   }
 }

--- a/src/utils/layout/LayoutPages.ts
+++ b/src/utils/layout/LayoutPages.ts
@@ -94,6 +94,10 @@ export class LayoutPages<
     return Object.values(this.objects).flatMap((layout) => layout.flat(true));
   }
 
+  public allPageKeys(): string[] {
+    return Object.keys(this.objects);
+  }
+
   public flat<L extends keyof Collection>(exceptLayout?: L) {
     return [
       ...Object.keys(this.objects)

--- a/src/utils/validation/validation.ts
+++ b/src/utils/validation/validation.ts
@@ -39,7 +39,8 @@ export function runValidationOnNodes(
   options?: IValidationOptions,
 ): IValidationObject[] {
   const nodesToValidate = nodes.filter(
-    (node) => implementsAnyValidation(node.def) && !node.isHidden() && !node.item.renderAsSummary,
+    (node) =>
+      implementsAnyValidation(node.def) && !node.isHidden({ respectTracks: true }) && !node.item.renderAsSummary,
   );
 
   if (nodesToValidate.length === 0) {

--- a/test/e2e/integration/app-frontend/calculate-page-order.ts
+++ b/test/e2e/integration/app-frontend/calculate-page-order.ts
@@ -1,6 +1,8 @@
 import { AppFrontend } from 'test/e2e/pageobjects/app-frontend';
 
 import { Triggers } from 'src/types';
+import type { ExprUnresolved } from 'src/features/expressions/types';
+import type { ILayoutCompInput } from 'src/layout/Input/types';
 
 const appFrontend = new AppFrontend();
 
@@ -12,7 +14,32 @@ describe('Calculate Page Order', () => {
         // Intentionally empty
       },
       (layoutSet) => {
-        layoutSet.prefill.data.hidden = ['equals', ['component', 'sendersName'], 'hidePrefill'];
+        // Adding a new required field to the prefill page, just so that we have something to stop us from submitting
+        layoutSet.prefill.data.layout.push({
+          id: 'yet-another-required-field',
+          type: 'Input',
+          dataModelBindings: {
+            // Same binding as 'sendersName' on the 'hide' page
+            simpleBinding: 'Endringsmelding-grp-9786.Avgiver-grp-9787.OppgavegiverNavn-datadef-68.value',
+          },
+          textResourceBindings: {
+            title: 'Yet another required field',
+          },
+          required: true,
+        } as ExprUnresolved<ILayoutCompInput>);
+
+        layoutSet.prefill.data.hidden = [
+          'or',
+          ['equals', ['component', 'sendersName'], 'hidePrefill'],
+          [
+            'equals',
+            [
+              'dataModel',
+              'Endringsmelding-grp-9786.OversiktOverEndringene-grp-9788[1].nested-grp-1234[0].SkattemeldingEndringEtterFristKommentar-datadef-37133.value',
+            ],
+            'hidePrefill',
+          ],
+        ];
         layoutSet.repeating.data.hidden = [
           'and',
           ['equals', ['component', 'sendersName'], 'hideRepeating'],
@@ -31,7 +58,13 @@ describe('Calculate Page Order', () => {
     cy.get(appFrontend.group.showGroupToContinue).find('input').dsCheck();
 
     cy.get(appFrontend.navMenuButtons).should('have.length', 4);
+    cy.gotoNavPage('summary');
+    cy.get(appFrontend.sendinButton).click();
+    cy.get(appFrontend.errorReport).findAllByRole('listitem').should('have.length', 2);
+    cy.get(appFrontend.errorReport).should('contain.text', 'Du må fylle ut oppgave giver navn');
+    cy.get(appFrontend.errorReport).should('contain.text', 'Du må fylle ut yet another required field');
 
+    cy.gotoNavPage('repeating');
     cy.addItemToGroup(1, 11, 'automation');
     cy.get(appFrontend.nextButton).click();
     cy.wait('@getPageOrder');
@@ -41,7 +74,12 @@ describe('Calculate Page Order', () => {
     cy.get(appFrontend.group.summaryText).should('be.visible');
     cy.get(appFrontend.navMenuCurrent).should('have.text', '3. summary');
 
-    cy.get(appFrontend.navMenu).find('li > button').eq(1).click();
+    // At this point the input field on the 'hide' page is gone, so we shouldn't see it in the error report either
+    cy.get(appFrontend.sendinButton).click();
+    cy.get(appFrontend.errorReport).findAllByRole('listitem').should('have.length', 1);
+    cy.get(appFrontend.errorReport).should('contain.text', 'Du må fylle ut yet another required field');
+
+    cy.gotoNavPage('repeating');
     cy.get(appFrontend.group.row(0).editBtn).click();
     cy.get(appFrontend.group.newValue).clear();
     cy.get(appFrontend.group.newValue).type('2');
@@ -58,11 +96,26 @@ describe('Calculate Page Order', () => {
     cy.get(appFrontend.navMenuButtons).should('have.length', 3);
     cy.get(appFrontend.navMenuCurrent).should('have.text', '1. repeating');
 
-    cy.get(appFrontend.nextButton).click();
+    cy.gotoNavPage('hide');
+    cy.get(appFrontend.group.sendersName).clear();
+    cy.gotoNavPage('repeating');
+    cy.get(appFrontend.group.saveMainGroup).click();
+    cy.addItemToGroup(1, 11, 'hidePrefill');
+    cy.get(appFrontend.navMenuButtons).should('have.length', 3);
+
+    // Testing to make sure our required field hidden by an expression does not show up in the error report
+    cy.gotoNavPage('summary');
+    cy.get(appFrontend.sendinButton).click();
+    cy.get(appFrontend.errorReport).findAllByRole('listitem').should('have.length', 1);
+    cy.get(appFrontend.errorReport).should('contain.text', 'Du må fylle ut oppgave giver navn');
+
+    cy.gotoNavPage('repeating');
+    cy.get(appFrontend.group.row(1).deleteBtn).click();
+
+    cy.gotoNavPage('hide');
 
     // Clicking previous here is expected to not have any effect, because the triggered action is rejected when
     // the 'repeating' page is supposed to be hidden by the change. Clicking too fast leads to a failure...
-    cy.get(appFrontend.group.sendersName).clear();
     cy.get(appFrontend.group.sendersName).type('hideRepeating');
     cy.get(appFrontend.prevButton).click();
 


### PR DESCRIPTION
## Description
A bug was reported to me directly on Slack that seemed to cause hidden required fields to produce 'empty field' validation messages - if the pages they were in were hidden using the legacy 'tracks' functionality. I haven't bisected to verify, but I would think this might have been introduced with the recent validation refactor. There was no test for this to catch the problem when it appeared.

This should fix the issue by properly returning `true` in `node.isHidden()` for these components - although that does somewhat break the expectations for expressions - where it is expected that `component` lookups in tracks-hidden pages still work (i.e. does not always return `null`). For this reason, I'm opting to turn this behaviour off everywhere besides the validation logic.

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
