### PR TITLE
Filter required and model validations from backend by source

### DIFF
--- a/src/utils/validation/backendValidation.test.ts
+++ b/src/utils/validation/backendValidation.test.ts
@@ -1,0 +1,78 @@
+import { shouldExcludeValidationIssue, ValidationIssueSources } from 'src/utils/validation/backendValidation';
+import type { IValidationIssue } from 'src/utils/validation/types';
+
+describe('backendValidation', () => {
+  describe('shouldExcludeValidationIssue', () => {
+    const tests: {
+      props: Parameters<typeof shouldExcludeValidationIssue>;
+      expected: ReturnType<typeof shouldExcludeValidationIssue>;
+    }[] = [
+      {
+        props: [
+          {
+            code: 'This is a custom validation',
+            severity: 1,
+            description: 'This is a custom validation',
+            field: 'skjema.navn',
+          } as IValidationIssue,
+        ],
+        expected: false,
+      },
+      {
+        props: [
+          {
+            code: 'ContentTypeNotAllowed',
+            severity: 1,
+            description: 'Content type not allowed',
+            customTextKey: 'contentNotAllowed',
+            source: ValidationIssueSources.File,
+            field: 'skjema.navn',
+          } as IValidationIssue,
+        ],
+        expected: false,
+      },
+      {
+        /* Legacy required validation issue, remove in v4 assuming a minimum backend version is required */
+        props: [
+          {
+            code: 'required',
+            severity: 1,
+            description: 'skjema.navn is required in component with id navn',
+            field: 'skjema.navn',
+          } as IValidationIssue,
+        ],
+        expected: true,
+      },
+      {
+        props: [
+          {
+            code: 'required',
+            severity: 1,
+            description: 'required',
+            source: ValidationIssueSources.Required,
+            field: 'skjema.navn',
+          } as IValidationIssue,
+        ],
+        expected: true,
+      },
+      {
+        props: [
+          {
+            code: 'regex',
+            severity: 1,
+            description: 'regex',
+            source: ValidationIssueSources.ModelState,
+            field: 'skjema.navn',
+          } as IValidationIssue,
+        ],
+        expected: true,
+      },
+    ];
+    tests.forEach(({ props, expected }) => {
+      it(`should return ${expected} when called with ${JSON.stringify(props)}`, () => {
+        const result = shouldExcludeValidationIssue(...props);
+        expect(result).toEqual(expected);
+      });
+    });
+  });
+});

--- a/src/utils/validation/backendValidation.ts
+++ b/src/utils/validation/backendValidation.ts
@@ -56,6 +56,7 @@ export function shouldExcludeValidationIssue(issue: IValidationIssue): boolean {
     return true;
   }
 
+  // eslint-disable-next-line sonarjs/prefer-single-boolean-return
   if (issue.source === ValidationIssueSources.ModelState) {
     // This is handled by schema validation.
     return true;

--- a/src/utils/validation/backendValidation.ts
+++ b/src/utils/validation/backendValidation.ts
@@ -25,12 +25,21 @@ export const severityMap: { [s in BackendValidationSeverity]: ValidationSeverity
   [BackendValidationSeverity.Unspecified]: 'unspecified',
 };
 
+export enum ValidationIssueSources {
+  File = 'File',
+  ModelState = 'ModelState',
+  Required = 'Required',
+}
+
 /**
  * Some validations performed by the backend are also performed by the frontend.
  * We need to ignore these to prevent duplicate errors.
  */
 function shouldExcludeValidationIssue(issue: IValidationIssue): boolean {
-  // eslint-disable-next-line sonarjs/prefer-single-boolean-return
+  /*
+   * Legacy required validation detection
+   * Remove this condition in v4, assuming that a minimum backend version is required.
+   */
   if (issue.code == 'required' && issue.code != issue.description) {
     // Ignore required validations from backend. They will be duplicated by frontend running the same logic.
     // verify that code != description because user validations always have code == description
@@ -41,6 +50,17 @@ function shouldExcludeValidationIssue(issue: IValidationIssue): boolean {
     // errors with a shared code. (eg, only display one error with code "required" per component)
     return true;
   }
+
+  if (issue.source === ValidationIssueSources.Required) {
+    // Required validations are handled by the frontend.
+    return true;
+  }
+
+  if (issue.source === ValidationIssueSources.ModelState) {
+    // This is handled by schema validation.
+    return true;
+  }
+
   return false;
 }
 

--- a/src/utils/validation/backendValidation.ts
+++ b/src/utils/validation/backendValidation.ts
@@ -35,7 +35,7 @@ export enum ValidationIssueSources {
  * Some validations performed by the backend are also performed by the frontend.
  * We need to ignore these to prevent duplicate errors.
  */
-function shouldExcludeValidationIssue(issue: IValidationIssue): boolean {
+export function shouldExcludeValidationIssue(issue: IValidationIssue): boolean {
   /*
    * Legacy required validation detection
    * Remove this condition in v4, assuming that a minimum backend version is required.

--- a/src/utils/validation/validationTexts.ts
+++ b/src/utils/validation/validationTexts.ts
@@ -1,11 +1,10 @@
 import type { ValidLanguageKey } from 'src/hooks/useLanguage';
+import type { ValidationIssueSources } from 'src/utils/validation/backendValidation';
 
 export type IValidationTextMap = {
-  [source: string]:
-    | undefined
-    | {
-        [code: string]: ValidLanguageKey | undefined;
-      };
+  [source in ValidationIssueSources]?: {
+    [code: string]: ValidLanguageKey | undefined;
+  };
 };
 
 /**


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes #1386
- backend PR: https://github.com/Altinn/app-lib-dotnet/pull/289

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
