### PR TITLE
Fix: Removing validation messages for invisible components

### DIFF
--- a/src/features/attachments/upload/uploadAttachmentSagas.ts
+++ b/src/features/attachments/upload/uploadAttachmentSagas.ts
@@ -12,12 +12,13 @@ import { httpPost } from 'src/utils/network/networking';
 import { isAxiosError } from 'src/utils/network/sharedNetworking';
 import { fileUploadUrl } from 'src/utils/urls/appUrlHelper';
 import { customEncodeURI } from 'src/utils/urls/urlHelper';
-import { BackendValidationSeverity, getValidationMessage } from 'src/utils/validation/backendValidation';
+import { getValidationMessage } from 'src/utils/validation/backendValidation';
+import { BackendValidationSeverity } from 'src/utils/validation/backendValidationSeverity';
 import type { IAttachment } from 'src/features/attachments';
 import type { IUploadAttachmentAction } from 'src/features/attachments/upload/uploadAttachmentActions';
 import type { IUseLanguage } from 'src/hooks/useLanguage';
 import type { IRuntimeState } from 'src/types';
-import type { IComponentValidations, IValidationIssue } from 'src/utils/validation/types';
+import type { BackendValidationIssue, IComponentValidations } from 'src/utils/validation/types';
 
 export function* uploadAttachmentSaga({
   payload: { file, attachmentType, tmpAttachmentId, componentId, dataModelBindings, index },
@@ -90,7 +91,7 @@ export function* uploadAttachmentSaga({
     let validations: IComponentValidations;
 
     if (backendFeatures?.jsonObjectInDataResponse && isAxiosError(err) && err.response?.data?.result) {
-      const validationIssues: IValidationIssue[] = err.response.data.result;
+      const validationIssues: BackendValidationIssue[] = err.response.data.result;
 
       validations = {
         simpleBinding: {

--- a/src/features/formData/submit/submitFormDataSagas.ts
+++ b/src/features/formData/submit/submitFormDataSagas.ts
@@ -28,7 +28,7 @@ import type { IUpdateFormData } from 'src/features/formData/formDataTypes';
 import type { ILayoutState } from 'src/features/layout/formLayoutSlice';
 import type { IRuntimeState, IRuntimeStore, IUiConfig } from 'src/types';
 import type { LayoutPages } from 'src/utils/layout/LayoutPages';
-import type { IValidationIssue } from 'src/utils/validation/types';
+import type { BackendValidationIssue } from 'src/utils/validation/types';
 
 const LayoutSelector: (store: IRuntimeStore) => ILayoutState = (store: IRuntimeStore) => store.formLayout;
 const getApplicationMetaData = (store: IRuntimeState) => store.applicationMetadata?.applicationMetadata;
@@ -61,7 +61,7 @@ export function* submitFormSaga(): SagaIterator {
 function* submitComplete(state: IRuntimeState, resolvedNodes: LayoutPages) {
   // run validations against the datamodel
   const instanceId = state.instanceData.instance?.id;
-  const serverValidations: IValidationIssue[] | undefined = instanceId
+  const serverValidations: BackendValidationIssue[] | undefined = instanceId
     ? yield call(httpGet, getValidationUrl(instanceId))
     : undefined;
 

--- a/src/features/layout/repGroups/updateRepeatingGroupEditIndexSaga.ts
+++ b/src/features/layout/repGroups/updateRepeatingGroupEditIndexSaga.ts
@@ -21,7 +21,7 @@ import {
 import type { IUpdateRepeatingGroupsEditIndex } from 'src/features/layout/formLayoutTypes';
 import type { IRuntimeState } from 'src/types';
 import type { LayoutPages } from 'src/utils/layout/LayoutPages';
-import type { IValidationIssue } from 'src/utils/validation/types';
+import type { BackendValidationIssue } from 'src/utils/validation/types';
 
 export function* updateRepeatingGroupEditIndexSaga({
   payload: { group, index, validate, shouldAddRow },
@@ -76,7 +76,7 @@ export function* updateRepeatingGroupEditIndexSaga({
         return;
       }
 
-      const serverValidations: IValidationIssue[] = yield call(
+      const serverValidations: BackendValidationIssue[] = yield call(
         httpGet,
         getDataValidationUrl(state.instanceData.instance.id, currentTaskDataId),
         options,

--- a/src/features/layout/update/updateFormLayoutSagas.ts
+++ b/src/features/layout/update/updateFormLayoutSagas.ts
@@ -33,7 +33,7 @@ import {
 import type { ICalculatePageOrderAndMoveToNextPage, IUpdateCurrentView } from 'src/features/layout/formLayoutTypes';
 import type { IRuntimeState, IUiConfig } from 'src/types';
 import type { LayoutPages } from 'src/utils/layout/LayoutPages';
-import type { IValidationIssue } from 'src/utils/validation/types';
+import type { BackendValidationIssue } from 'src/utils/validation/types';
 
 export const selectFormLayoutState = (state: IRuntimeState) => state.formLayout;
 export const selectFormData = (state: IRuntimeState) => state.formData;
@@ -121,7 +121,7 @@ export function* updateCurrentViewSaga({
       );
 
       const validationOptions = runValidations === Triggers.ValidatePage ? options : undefined;
-      const serverValidations: IValidationIssue[] =
+      const serverValidations: BackendValidationIssue[] =
         instanceId && currentTaskDataId
           ? yield call(httpGet, getDataValidationUrl(instanceId, currentTaskDataId), validationOptions)
           : [];

--- a/src/features/validation/singleFieldValidationSagas.test.ts
+++ b/src/features/validation/singleFieldValidationSagas.test.ts
@@ -18,9 +18,9 @@ import { staticUseLanguageFromState } from 'src/hooks/useLanguage';
 import { resolvedLayoutsFromState, ResolvedNodesSelector } from 'src/utils/layout/hierarchy';
 import { httpGet } from 'src/utils/network/networking';
 import { getDataValidationUrl } from 'src/utils/urls/appUrlHelper';
-import { BackendValidationSeverity } from 'src/utils/validation/backendValidation';
+import { BackendValidationSeverity } from 'src/utils/validation/backendValidationSeverity';
 import type { IRuntimeState } from 'src/types';
-import type { IValidationIssue, IValidationObject } from 'src/utils/validation/types';
+import type { BackendValidationIssue, IValidationObject } from 'src/utils/validation/types';
 
 describe('singleFieldValidationSagas', () => {
   let mockState: IRuntimeState;
@@ -43,7 +43,7 @@ describe('singleFieldValidationSagas', () => {
       },
     };
 
-    const validationIssues: IValidationIssue[] = [
+    const validationIssues: BackendValidationIssue[] = [
       {
         code: 'error',
         description: mockErrorMessage,

--- a/src/features/validation/singleFieldValidationSagas.ts
+++ b/src/features/validation/singleFieldValidationSagas.ts
@@ -15,7 +15,7 @@ import type { IRunSingleFieldValidation } from 'src/features/validation/validati
 import type { ILayoutSets, IRuntimeState } from 'src/types';
 import type { IInstance } from 'src/types/shared';
 import type { LayoutPages } from 'src/utils/layout/LayoutPages';
-import type { IValidationIssue } from 'src/utils/validation/types';
+import type { BackendValidationIssue } from 'src/utils/validation/types';
 
 export const selectLayoutsState = (state: IRuntimeState) => state.formLayout.layouts;
 export const selectApplicationMetadataState = (state: IRuntimeState) => state.applicationMetadata.applicationMetadata;
@@ -53,7 +53,7 @@ export function* runSingleFieldValidationSaga({
     };
 
     try {
-      const serverValidations: IValidationIssue[] = yield call(httpGet, url, options);
+      const serverValidations: BackendValidationIssue[] = yield call(httpGet, url, options);
       const validationObjects = mapValidationIssues(
         serverValidations,
         resolvedNodes,

--- a/src/utils/validation/backendValidation.test.ts
+++ b/src/utils/validation/backendValidation.test.ts
@@ -1,5 +1,5 @@
 import { shouldExcludeValidationIssue, ValidationIssueSources } from 'src/utils/validation/backendValidation';
-import type { IValidationIssue } from 'src/utils/validation/types';
+import type { BackendValidationIssue } from 'src/utils/validation/types';
 
 describe('backendValidation', () => {
   describe('shouldExcludeValidationIssue', () => {
@@ -14,7 +14,7 @@ describe('backendValidation', () => {
             severity: 1,
             description: 'This is a custom validation',
             field: 'skjema.navn',
-          } as IValidationIssue,
+          } as BackendValidationIssue,
         ],
         expected: false,
       },
@@ -27,7 +27,7 @@ describe('backendValidation', () => {
             customTextKey: 'contentNotAllowed',
             source: ValidationIssueSources.File,
             field: 'skjema.navn',
-          } as IValidationIssue,
+          } as BackendValidationIssue,
         ],
         expected: false,
       },
@@ -39,7 +39,7 @@ describe('backendValidation', () => {
             severity: 1,
             description: 'skjema.navn is required in component with id navn',
             field: 'skjema.navn',
-          } as IValidationIssue,
+          } as BackendValidationIssue,
         ],
         expected: true,
       },
@@ -51,7 +51,7 @@ describe('backendValidation', () => {
             description: 'required',
             source: ValidationIssueSources.Required,
             field: 'skjema.navn',
-          } as IValidationIssue,
+          } as BackendValidationIssue,
         ],
         expected: true,
       },
@@ -63,7 +63,7 @@ describe('backendValidation', () => {
             description: 'regex',
             source: ValidationIssueSources.ModelState,
             field: 'skjema.navn',
-          } as IValidationIssue,
+          } as BackendValidationIssue,
         ],
         expected: true,
       },

--- a/src/utils/validation/backendValidation.ts
+++ b/src/utils/validation/backendValidation.ts
@@ -102,7 +102,9 @@ export function mapValidationIssues(
     return [];
   }
 
-  const allNodes = resolvedNodes.allNodes().filter((node) => !node.isHidden() && !node.item.renderAsSummary);
+  const allNodes = resolvedNodes
+    .allNodes()
+    .filter((node) => !node.isHidden({ respectTracks: true }) && !node.item.renderAsSummary);
 
   const validationOutputs: IValidationObject[] = [];
   for (const issue of issues) {

--- a/src/utils/validation/backendValidation.ts
+++ b/src/utils/validation/backendValidation.ts
@@ -1,17 +1,9 @@
+import { BackendValidationSeverity } from 'src/utils/validation/backendValidationSeverity';
 import { buildValidationObject, unmappedError } from 'src/utils/validation/validationHelpers';
 import { validationTexts } from 'src/utils/validation/validationTexts';
 import type { IUseLanguage } from 'src/hooks/useLanguage';
 import type { LayoutPages } from 'src/utils/layout/LayoutPages';
-import type { IValidationIssue, IValidationObject, ValidationSeverity } from 'src/utils/validation/types';
-
-export enum BackendValidationSeverity {
-  Unspecified = 0,
-  Error = 1,
-  Warning = 2,
-  Informational = 3,
-  Fixed = 4,
-  Success = 5,
-}
+import type { BackendValidationIssue, IValidationObject, ValidationSeverity } from 'src/utils/validation/types';
 
 /**
  * We need to map the severity we get from backend into the format used when storing in redux.
@@ -35,7 +27,7 @@ export enum ValidationIssueSources {
  * Some validations performed by the backend are also performed by the frontend.
  * We need to ignore these to prevent duplicate errors.
  */
-export function shouldExcludeValidationIssue(issue: IValidationIssue): boolean {
+export function shouldExcludeValidationIssue(issue: BackendValidationIssue): boolean {
   /*
    * Legacy required validation detection
    * Remove this condition in v4, assuming that a minimum backend version is required.
@@ -68,7 +60,11 @@ export function shouldExcludeValidationIssue(issue: IValidationIssue): boolean {
 /**
  * Gets standard validation messages for backend validation issues.
  */
-export function getValidationMessage(issue: IValidationIssue, langTools: IUseLanguage, params?: string[]): string {
+export function getValidationMessage(
+  issue: BackendValidationIssue,
+  langTools: IUseLanguage,
+  params?: string[],
+): string {
   const { langAsString } = langTools;
   if (issue.customTextKey) {
     return langAsString(issue.customTextKey, params);
@@ -98,7 +94,7 @@ export function getValidationMessage(issue: IValidationIssue, langTools: IUseLan
  * Maps validation issues from the backend into the intermediate format used by the frontend.
  */
 export function mapValidationIssues(
-  issues: IValidationIssue[],
+  issues: BackendValidationIssue[],
   resolvedNodes: LayoutPages,
   langTools: IUseLanguage,
 ): IValidationObject[] {

--- a/src/utils/validation/backendValidationSeverity.ts
+++ b/src/utils/validation/backendValidationSeverity.ts
@@ -1,0 +1,8 @@
+export enum BackendValidationSeverity {
+  Unspecified = 0,
+  Error = 1,
+  Warning = 2,
+  Informational = 3,
+  Fixed = 4,
+  Success = 5,
+}

--- a/src/utils/validation/types.d.ts
+++ b/src/utils/validation/types.d.ts
@@ -5,6 +5,7 @@ import type { IFormData } from 'src/features/formData';
 import type { IUseLanguage } from 'src/hooks/useLanguage';
 import type { ILayoutSets } from 'src/types';
 import type { IInstance } from 'src/types/shared';
+import type { BackendValidationSeverity } from 'src/utils/validation/backendValidationSeverity';
 
 /**
  * Contains all of the necessary elements from the redux store to run frontend validations.
@@ -110,12 +111,12 @@ export type ValidationKeyOrAny = ValidationKey | 'any';
 /**
  * This format is used by the backend to send validation issues to the frontend.
  */
-export interface IValidationIssue {
+export interface BackendValidationIssue {
   code: string;
   description: string;
   field: string;
   scope: string | null;
-  severity: ValidationIssueSeverity;
+  severity: BackendValidationSeverity;
   targetId: string;
   source?: string;
   customTextKey?: string;

--- a/test/e2e/integration/app-frontend/validation.ts
+++ b/test/e2e/integration/app-frontend/validation.ts
@@ -3,6 +3,9 @@ import { AppFrontend } from 'test/e2e/pageobjects/app-frontend';
 import { Common } from 'test/e2e/pageobjects/common';
 
 import { Triggers } from 'src/types';
+import { BackendValidationSeverity } from 'src/utils/validation/backendValidationSeverity';
+import type { ILayoutCompInput } from 'src/layout/Input/types';
+import type { BackendValidationIssue } from 'src/utils/validation/types';
 
 const appFrontend = new AppFrontend();
 const mui = new Common();
@@ -257,6 +260,33 @@ describe('Validation', () => {
     cy.get(appFrontend.group.comments).should('not.exist');
     cy.get(appFrontend.fieldValidation('comments')).should('not.exist');
     cy.get(appFrontend.errorReport).should('not.exist');
+
+    // Setting single field validation to trigger on the 'sendersName' component
+    cy.changeLayout((component: ILayoutCompInput) => {
+      if (component.id === 'sendersName' && component.type === 'Input') {
+        // Make sure changing this field triggers single field validation
+        component.triggers = [Triggers.Validation];
+      }
+    });
+
+    cy.intercept('GET', '**/validate', [
+      {
+        code: 'Tullevalidering',
+        description: 'Tullevalidering',
+        field: 'Endringsmelding-grp-9786.Avgiver-grp-9787.OppgavegiverNavn-datadef-68.value',
+        severity: BackendValidationSeverity.Error,
+        scope: null,
+        targetId: 'sendersName',
+      },
+    ] as BackendValidationIssue[]);
+
+    // Verify that validation message is shown, but also make sure only one error message is shown
+    // (there is a hidden layout that also binds to the same location, and a bug caused it to show
+    // up twice because of that component on the hidden layout)
+    cy.gotoNavPage('hide');
+    cy.get(appFrontend.group.sendersName).type('hello world');
+    cy.get(appFrontend.errorReport).should('contain.text', 'Tullevalidering');
+    cy.get(appFrontend.errorReport).findAllByRole('listitem').should('have.length', 1);
   });
 
   it('List component: validation messages should only show up once', () => {


### PR DESCRIPTION
## Description
In the same vein as #1384, this removes validation messages for components that are triggered by single-field validation, and were mapped to components on invisible layouts. The whole fix here is basically setting `{ respectTracks: true }`, and the rest is moving/renaming types and adding a regression test.

## Related Issue(s)

- https://altinn.slack.com/archives/C02ESDSGPN1/p1692261444104049
- #1384

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
