### PR TITLE
Fix: Validations on hidden pages should still stop user from submitting

### DIFF
--- a/src/features/formData/submit/submitFormDataSagas.ts
+++ b/src/features/formData/submit/submitFormDataSagas.ts
@@ -71,6 +71,7 @@ function* submitComplete(state: IRuntimeState, resolvedNodes: LayoutPages) {
     serverValidations ?? [],
     resolvedNodes,
     staticUseLanguageFromState(state),
+    false,
   );
   const validationResult = createValidationResult(validationObjects);
   yield put(ValidationActions.updateValidations({ validationResult, merge: false }));

--- a/src/utils/validation/backendValidation.ts
+++ b/src/utils/validation/backendValidation.ts
@@ -97,6 +97,7 @@ export function mapValidationIssues(
   issues: BackendValidationIssue[],
   resolvedNodes: LayoutPages,
   langTools: IUseLanguage,
+  respectTracks = true,
 ): IValidationObject[] {
   if (!resolvedNodes) {
     return [];
@@ -104,7 +105,7 @@ export function mapValidationIssues(
 
   const allNodes = resolvedNodes
     .allNodes()
-    .filter((node) => !node.isHidden({ respectTracks: true }) && !node.item.renderAsSummary);
+    .filter((node) => !node.isHidden({ respectTracks }) && !node.item.renderAsSummary);
 
   const validationOutputs: IValidationObject[] = [];
   for (const issue of issues) {

--- a/test/e2e/integration/app-frontend/validation.ts
+++ b/test/e2e/integration/app-frontend/validation.ts
@@ -145,6 +145,24 @@ describe('Validation', () => {
     cy.get(appFrontend.changeOfName.newLastName).should('be.focused');
   });
 
+  it('Process should not continue if any validation fails, even if unmappable', () => {
+    cy.goto('changename');
+    cy.fillOut('changename');
+
+    cy.get(appFrontend.grid.bolig.percent).numberFormatClear();
+    cy.get(appFrontend.grid.studie.percent).numberFormatClear();
+    cy.get(appFrontend.grid.kredittkort.percent).numberFormatClear();
+    cy.get(appFrontend.grid.kredittkort.percent).type('44');
+    cy.get(appFrontend.grid.studie.percent).type('56');
+
+    // When filling out the credit card field with 44%, there is a special validation that triggers and is added to
+    // a field on a hidden page. Even though this should not happen, we should still not be able to continue, as
+    // submitting the form now when there is a validation error should not be possible - and attempting it will cause
+    // the dreaded 'unknown error' message to appear.
+    cy.get(appFrontend.sendinButton).click();
+    cy.get(appFrontend.errorReport).should('contain.text', 'Valideringsmelding på felt som aldri vises');
+  });
+
   it('Validation on uploaded attachment type', () => {
     cy.goto('changename');
     cy.get(appFrontend.changeOfName.upload).selectFile('test/e2e/fixtures/test.png', { force: true });


### PR DESCRIPTION
## Description
After #1397, the user could possibly submit the form in the end, even if backend reported some validation messages that mapped to hidden components (specifically, components hidden by tracks). This is a backend/custom validation handler bug, but it should still not cause 'unknown error' on the frontend. Even though we cannot point the user to the field, we should still inform them about what the backend tells us is wrong (perhaps there's a possibility for them to fix it in the form that we don't know about).

## Related Issue(s)

- https://altinn.slack.com/archives/C02ESDSGPN1/p1692800896354389?thread_ts=1692261444.104049&cid=C02ESDSGPN1

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Changes/additions to component properties
  - [ ] Changes are reflected in both `src/layout/layout.d.ts` and `layout.schema.v1.json`, and these are all backwards-compatible
  - [x] No changes made
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
