### PR TITLE
Enable help text in grid cells to use language resource files

### DIFF
--- a/src/layout/Grid/GridComponent.tsx
+++ b/src/layout/Grid/GridComponent.tsx
@@ -193,7 +193,7 @@ function CellWithComponent({ node, className, columnStyleOptions }: CellWithComp
 
 function CellWithText({ children, className, columnStyleOptions, help }: CellWithTextProps) {
   const columnStyles = columnStyleOptions && getColumnStyles(columnStyleOptions);
-
+  const { lang } = useLanguage();
   return (
     <TableCell
       className={cn(css.tableCellFormatting, className)}
@@ -209,7 +209,7 @@ function CellWithText({ children, className, columnStyleOptions, help }: CellWit
         {help && (
           <HelpTextContainer
             title={getPlainTextFromNode(children)}
-            helpText={help}
+            helpText={lang(help)}
           />
         )}
       </span>
@@ -229,7 +229,7 @@ function CellWithLabel({ className, columnStyleOptions, referenceComponent }: Ce
   const required =
     (referenceComponent && 'required' in referenceComponent.item && referenceComponent.item.required) ?? false;
   const componentId = referenceComponent?.item.id ?? referenceComponent?.item.baseComponentId;
-
+  const { lang } = useLanguage();
   return (
     <TableCell
       className={cn(css.tableCellFormatting, className)}
@@ -243,7 +243,7 @@ function CellWithLabel({ className, columnStyleOptions, referenceComponent }: Ce
               labelText={title}
               id={componentId}
               required={required}
-              helpText={help}
+              helpText={lang(help)}
             />
           </span>
           <Description


### PR DESCRIPTION
## Description
Enable help text in grid cells to use language resource files by wrapping with lang.


<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

Slack: https://altinn.slack.com/archives/C02ESDSC929/p1693308226424219

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [x] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
