### PR TITLE
Making sure error messages on submit are still shown even if they're …

### DIFF
--- a/src/features/formData/submit/submitFormDataSagas.ts
+++ b/src/features/formData/submit/submitFormDataSagas.ts
@@ -71,7 +71,9 @@ function* submitComplete(state: IRuntimeState, resolvedNodes: LayoutPages) {
     serverValidations ?? [],
     resolvedNodes,
     staticUseLanguageFromState(state),
-    false,
+    false, // Do not filter anything. When we're submitting, all validation messages should be displayed, even if
+    // they're for hidden pages, etc, because the instance will be in a broken state if we just carry on submitting
+    // when the server tells us we're not allowed to.
   );
   const validationResult = createValidationResult(validationObjects);
   yield put(ValidationActions.updateValidations({ validationResult, merge: false }));

--- a/src/utils/layout/LayoutNode.ts
+++ b/src/utils/layout/LayoutNode.ts
@@ -26,6 +26,12 @@ import type {
 } from 'src/utils/validation/types';
 import type { IValidationOptions } from 'src/utils/validation/validation';
 
+export interface IsHiddenOptions {
+  respectLegacy?: boolean;
+  respectDevTools?: boolean;
+  respectTracks?: boolean;
+}
+
 /**
  * A LayoutNode wraps a component with information about its parent, allowing you to traverse a component (or an
  * instance of a component inside a repeating group), finding other components near it.
@@ -154,9 +160,7 @@ export class BaseLayoutNode<Item extends CompInternal = CompInternal, Type exten
    * Checks if this field should be hidden. This also takes into account the group this component is in, so the
    * methods returns true if the component is inside a hidden group.
    */
-  public isHidden(
-    options: { respectLegacy?: boolean; respectDevTools?: boolean; respectTracks?: boolean } = {},
-  ): boolean {
+  public isHidden(options: IsHiddenOptions = {}): boolean {
     const { respectLegacy = true, respectDevTools = true, respectTracks = false } = options;
 
     const hiddenList = respectLegacy ? this.dataSources.hiddenFields : new Set();

--- a/src/utils/validation/backendValidation.ts
+++ b/src/utils/validation/backendValidation.ts
@@ -2,6 +2,7 @@ import { BackendValidationSeverity } from 'src/utils/validation/backendValidatio
 import { buildValidationObject, unmappedError } from 'src/utils/validation/validationHelpers';
 import { validationTexts } from 'src/utils/validation/validationTexts';
 import type { IUseLanguage } from 'src/hooks/useLanguage';
+import type { IsHiddenOptions } from 'src/utils/layout/LayoutNode';
 import type { LayoutPages } from 'src/utils/layout/LayoutPages';
 import type { BackendValidationIssue, IValidationObject, ValidationSeverity } from 'src/utils/validation/types';
 
@@ -97,7 +98,7 @@ export function mapValidationIssues(
   issues: BackendValidationIssue[],
   resolvedNodes: LayoutPages,
   langTools: IUseLanguage,
-  respectTracks = true,
+  filterHidden: false | IsHiddenOptions = { respectTracks: true },
 ): IValidationObject[] {
   if (!resolvedNodes) {
     return [];
@@ -106,7 +107,9 @@ export function mapValidationIssues(
   const allNodes = resolvedNodes
     .allNodes()
     .filter(
-      (node) => !node.isHidden({ respectTracks }) && !('renderAsSummary' in node.item && node.item.renderAsSummary),
+      (node) =>
+        (filterHidden === false || !node.isHidden(filterHidden)) &&
+        !('renderAsSummary' in node.item && node.item.renderAsSummary),
     );
 
   const validationOutputs: IValidationObject[] = [];

--- a/test/e2e/support/global.d.ts
+++ b/test/e2e/support/global.d.ts
@@ -2,6 +2,7 @@ import type { PayloadAction } from '@reduxjs/toolkit';
 
 import type { user } from 'test/e2e/support/auth';
 
+import type { ILayoutFileExternal } from 'src/layout/common.generated';
 import type { CompOrGroupExternal, ILayouts } from 'src/layout/layout';
 import type { ILayoutSets, IRuntimeState } from 'src/types';
 
@@ -113,7 +114,7 @@ declare global {
       interceptLayout(
         taskName: FrontendTestTask | string,
         mutator?: (component: CompOrGroupExternal) => void,
-        wholeLayoutMutator?: (layoutSet: any) => void,
+        wholeLayoutMutator?: (layoutSet: { [pageName: string]: ILayoutFileExternal }) => void,
       ): Chainable<null>;
 
       /**


### PR DESCRIPTION
## Description

This makes sure we still display all error messages/validations sent by the server when the user is submitting the form, even if we end up mapping them to components that are currently hidden (or on hidden pages), regardless of the method used to hide them.

This should alleviate a few recent cases where users have ended up with broken instances and 'unknown error's/409s when submitting instances, likely because of broken backend logic causing validation messages to appear when they shouldn't.

Extensive tests have been added to make sure this doesn't happen again.

## Related Issue(s)

- https://altinn.slack.com/archives/C02FK32FBR6/p1693219611398259

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
