### PR TITLE
Bug fix when using nynorsk in number formatting

### DIFF
--- a/src/utils/formattingUtils.ts
+++ b/src/utils/formattingUtils.ts
@@ -32,7 +32,13 @@ export const formatNumber = (
     return defaultFormat;
   }
 
-  const intlFormatting = new Intl.NumberFormat(locale ?? 'nb', options).formatToParts(parseFloat(number));
+  //This is a temporary fix until Intl.NumberFormat is fixed in Chrome using nynorsk
+  //https://stackoverflow.com/questions/72173540/datetime-internationalization-not-working-for-norwegian-nynorsk-locale
+  const browserSupportsLocale =
+    locale && locale.includes('nn') ? Intl.NumberFormat.supportedLocalesOf(['nn', 'nn-NO']).length > 0 : true;
+  const finalLocale = browserSupportsLocale && locale ? locale : 'nb';
+
+  const intlFormatting = new Intl.NumberFormat(finalLocale, options).formatToParts(parseFloat(number));
   const intlResult = defaultFormat;
 
   intlFormatting.forEach((part) => {


### PR DESCRIPTION
## Description
This pull request (PR) checks whether the selected language is nynorsk and if the browser supports using it with Intl.NumberFormatting. If these conditions are not met, the system defaults to using bokmål.


<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes https://github.com/Altinn/app-frontend-react/issues/1422

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
