### PR TITLE
Fix: Do not filter backend validations on submit

### DIFF
--- a/src/features/formData/submit/submitFormDataSagas.ts
+++ b/src/features/formData/submit/submitFormDataSagas.ts
@@ -74,6 +74,7 @@ function* submitComplete(state: IRuntimeState, resolvedNodes: LayoutPages) {
     false, // Do not filter anything. When we're submitting, all validation messages should be displayed, even if
     // they're for hidden pages, etc, because the instance will be in a broken state if we just carry on submitting
     // when the server tells us we're not allowed to.
+    false, // Do not filter sources. We want to show all validation messages for the same reason as above.
   );
   const validationResult = createValidationResult(validationObjects);
   yield put(ValidationActions.updateValidations({ validationResult, merge: false }));

--- a/src/utils/validation/backendValidation.ts
+++ b/src/utils/validation/backendValidation.ts
@@ -99,6 +99,7 @@ export function mapValidationIssues(
   resolvedNodes: LayoutPages,
   langTools: IUseLanguage,
   filterHidden: false | IsHiddenOptions = { respectTracks: true },
+  filterSources: boolean = true,
 ): IValidationObject[] {
   if (!resolvedNodes) {
     return [];
@@ -114,7 +115,7 @@ export function mapValidationIssues(
 
   const validationOutputs: IValidationObject[] = [];
   for (const issue of issues) {
-    if (shouldExcludeValidationIssue(issue)) {
+    if (filterSources && shouldExcludeValidationIssue(issue)) {
       continue;
     }
 


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

This is related to the linked issue. I discovered this when I activated `RemoveHiddenDataPreview` in `frontend-test`, since this causes required validation to be run on the backend. This app uses old dynamics to hide fields, and so the required validation fails because the backend cannot take old dynamics into account when doing the validation. This caused an unknown error with the response `Cannot complete/close current task {currentElementId}. The data element(s) assigned to the task are not valid!`. This change makes it so that validationissues are not filtered out by source on submit, which should be fine since the backend validation is not called until all frontend validations are fixed so it should not cause duplicates.

## Related Issue(s)

- https://github.com/Altinn/app-frontend-react/pull/1416

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
