### PR TITLE
Fixing JSON parsing in schema tests

### DIFF
--- a/src/utils/layout/getAllLayoutSets.ts
+++ b/src/utils/layout/getAllLayoutSets.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
+import type { ILayoutFileExternal } from 'src/layout/common.generated';
 import type { ILayouts } from 'src/layout/layout';
 import type { ILayoutSets } from 'src/types';
 
@@ -46,14 +47,9 @@ export function getAllLayoutSets(dir: string): AppLayoutSet[] {
       const layouts: ILayouts = {};
       const entireFiles: { [key: string]: unknown } = {};
       for (const layoutFile of layoutFiles.filter((s) => !s.startsWith('.') && s.endsWith('.json'))) {
-        const fileContent = fs.readFileSync(path.join(...setPath, layoutFile));
-        let layoutContent;
-        try {
-          layoutContent = JSON.parse(fileContent.toString().trim());
-        } catch (e) {
-          // console.log('  ', layoutFile, '(failed to parse)', e);
-          continue;
-        }
+        const filePath = path.join(...setPath, layoutFile);
+        const fileContent = fs.readFileSync(filePath);
+        const layoutContent = parseJsonTolerantly<ILayoutFileExternal>(fileContent.toString());
         layouts[layoutFile.replace('.json', '')] = layoutContent.data.layout;
         entireFiles[layoutFile.replace('.json', '')] = layoutContent;
       }
@@ -68,6 +64,45 @@ export function getAllLayoutSets(dir: string): AppLayoutSet[] {
   }
 
   return out;
+}
+
+/**
+ * Parse JSON that may contain comments, trailing commas, etc.
+ */
+export function parseJsonTolerantly<T>(content: string): T {
+  // Remove multiline comments
+  content = content.replace(/\/\*([\s\S]*?)\*\//g, '$1');
+
+  // Remove single-line comments, but not in strings
+  content = content.replace(/^(.*?)\/\/(.*)$/gm, (_, m1, m2) => {
+    const quoteCount = m1.split(/(?<!\\)"/).length - 1;
+    if (quoteCount % 2 === 0) {
+      return m1;
+    }
+
+    return `${m1}//${m2}`;
+  });
+
+  // Remove trailing commas
+  content = content.replace(/,\s*([\]}])/g, '$1');
+
+  // Remove zero-width spaces, non-breaking spaces, etc.
+  content = content.replace(/[\u200B-\u200D\uFEFF]/g, '');
+
+  try {
+    return JSON.parse(content);
+  } catch (e) {
+    const position = e.message.match(/position (\d+)/);
+    if (position) {
+      const pos = parseInt(position[1], 10);
+      const before = content.substring(0, pos);
+      const line = before.split('\n').length;
+      const column = before.split('\n').pop()?.length ?? 0;
+      throw new Error(`${e.message} (line ${line}, column ${column})`);
+    }
+
+    throw new Error(`Failed to parse JSON: ${e.message}`);
+  }
 }
 
 export function getAllApps(dir: string): string[] {

--- a/src/utils/layout/schema.test.ts
+++ b/src/utils/layout/schema.test.ts
@@ -11,7 +11,7 @@ import layoutSchema from 'schemas/json/layout/layout.schema.v1.json';
 import textResourcesSchema from 'schemas/json/text-resources/text-resources.schema.v1.json';
 import type { ErrorObject } from 'ajv';
 
-import { getAllApps, getAllLayoutSets } from 'src/utils/layout/getAllLayoutSets';
+import { getAllApps, getAllLayoutSets, parseJsonTolerantly } from 'src/utils/layout/getAllLayoutSets';
 import type { CompTypes } from 'src/layout/layout';
 
 function withValues(targetObject: any) {
@@ -111,14 +111,8 @@ describe('Layout schema', () => {
         if (!resourceFile.match(/^resource\.[a-z]{2}\.json$/)) {
           continue;
         }
-        let resources: any;
-        try {
-          const content = fs.readFileSync(`${folder}/${resourceFile}`, 'utf-8');
-          resources = JSON.parse(content);
-        } catch (e) {
-          console.error(`Failed to parse ${folder}/${resourceFile}`, e);
-          continue;
-        }
+        const content = fs.readFileSync(`${folder}/${resourceFile}`, 'utf-8');
+        const resources = parseJsonTolerantly(content.toString());
 
         it(`${app}/${resourceFile}`, () => {
           validate(resources);
@@ -150,14 +144,8 @@ describe('Layout schema', () => {
       if (!fs.existsSync(metaDataFile)) {
         continue;
       }
-      let metadata: any;
-      try {
-        const content = fs.readFileSync(metaDataFile, 'utf-8');
-        metadata = JSON.parse(content);
-      } catch (e) {
-        console.error(`Failed to parse ${metaDataFile}`, e);
-        continue;
-      }
+      const content = fs.readFileSync(metaDataFile, 'utf-8');
+      const metadata = parseJsonTolerantly(content.toString());
 
       it(metaDataFile, () => {
         validate(metadata);


### PR DESCRIPTION
## Description
This should allow our apps-based schema tests to more tolerantly parse all existing JSON files we currently test against in Altinn 3 apps. The tests should now disregard any trailing commas, comments, etc in JSON files (just like in real app environments, where the server-side parser strips this away for us).

## Related Issue(s)

- https://altinndevops.slack.com/archives/C045EB3JA9X/p1692970657083799

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
