### PR TITLE
feat(TextResources): add support for defaultValue in variables in tex…

### DIFF
--- a/schemas/json/text-resources/text-resources.schema.v1.json
+++ b/schemas/json/text-resources/text-resources.schema.v1.json
@@ -88,6 +88,11 @@
             { "$ref": "#/definitions/dataSource-instanceContext" },
             { "$ref": "#/definitions/dataSource-applicationSettings" }
           ]
+        },
+        "defaultValue": {
+          "type": "string",
+          "title": "Default value of a variable",
+          "description": "The default value that you want to display if there is no value in the data model for the variable."
         }
       },
       "required": [

--- a/src/hooks/useLanguage.ts
+++ b/src/hooks/useLanguage.ts
@@ -295,6 +295,16 @@ function replaceVariables(text: string, variables: IVariable[], dataSources: Tex
       value = applicationSettings && variable.key in applicationSettings ? applicationSettings[variable.key] : value;
     }
 
+    if (value === variable.key) {
+      /*
+       By returning value if variable.defaultValue is null, we ensure
+       that we are returning the dataModel path string instead of blank
+       value. If app developers want to return blank value, they should
+       set defaultValue to a blank space.
+      */
+      value = variable.defaultValue || value;
+    }
+
     out = out.replaceAll(`{${idx}}`, value);
   }
 

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -240,6 +240,7 @@ export interface ITextResource {
 export interface IVariable {
   key: string;
   dataSource: string;
+  defaultValue?: string;
 }
 
 export interface IAttachmentGrouping {


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

This PR adds support for a defaultValue option in variables in text resources. This would allow for app developers to provide a value to print if the variable points to a null-value in the datamodel. The current behavior is that the app displays the path to the datamodel.



## Related Issue(s)

- closes #1440
- does not close but can solve issue #754 

PR in storage:
- Altinn/altinn-storage#257

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [x] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [x] Has been added/updated   https://github.com/Altinn/altinn-studio-docs/pull/1134
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
