### PR TITLE
 Debt: Remove legacy required ValidationIssue filter

### DIFF
--- a/src/utils/validation/backendValidation.test.ts
+++ b/src/utils/validation/backendValidation.test.ts
@@ -32,18 +32,6 @@ describe('backendValidation', () => {
         expected: false,
       },
       {
-        /* Legacy required validation issue, remove in v4 assuming a minimum backend version is required */
-        props: [
-          {
-            code: 'required',
-            severity: 1,
-            description: 'skjema.navn is required in component with id navn',
-            field: 'skjema.navn',
-          } as BackendValidationIssue,
-        ],
-        expected: true,
-      },
-      {
         props: [
           {
             code: 'required',

--- a/src/utils/validation/backendValidation.ts
+++ b/src/utils/validation/backendValidation.ts
@@ -29,21 +29,6 @@ export enum ValidationIssueSources {
  * We need to ignore these to prevent duplicate errors.
  */
 export function shouldExcludeValidationIssue(issue: BackendValidationIssue): boolean {
-  /*
-   * Legacy required validation detection
-   * Remove this condition in v4, assuming that a minimum backend version is required.
-   */
-  if (issue.code == 'required' && issue.code != issue.description) {
-    // Ignore required validations from backend. They will be duplicated by frontend running the same logic.
-    // verify that code != description because user validations always have code == description
-    // and we don't want issues in case someone wants to set additional required validations in backend
-    // and uses "required" as a key.
-
-    // Using "required" as key will likeliy be OK in the future, if we manage to inteligently deduplicate
-    // errors with a shared code. (eg, only display one error with code "required" per component)
-    return true;
-  }
-
   if (issue.source === ValidationIssueSources.Required) {
     // Required validations are handled by the frontend.
     return true;


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

Assuming that v4 will require an app-lib version >= 7.14.0 we can safely remove this legacy filter for backend required-validations.

## Related Issue(s)

- https://github.com/Altinn/app-lib-dotnet/issues/287
- https://github.com/Altinn/app-frontend-react/issues/1386

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
