### PR TITLE
Fix validation message with tag title (v4)

### DIFF
--- a/src/layout/FileUploadWithTag/index.tsx
+++ b/src/layout/FileUploadWithTag/index.tsx
@@ -54,7 +54,7 @@ export class FileUploadWithTag extends FileUploadWithTagDef implements Component
             missingId +
             AsciiUnitSeparator +
             langTools.langAsString('form_filler.file_uploader_validation_error_no_chosen_tag')
-          } ${(node.item.textResourceBindings?.tagTitle || '').toLowerCase()}.`;
+          } ${langTools.langAsString(node.item.textResourceBindings?.tagTitle).toLowerCase()}.`;
           validations.push(buildValidationObject(node, 'errors', message));
         });
       }


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

Quick fix that uses language to show the text-resource binding for tag-title in validation message. Previously it would just show the raw textResourceBinding.