### PR TITLE
bash script for purging front door cache

### DIFF
--- a/.github/scripts/purge-frontdoor-cache.sh
+++ b/.github/scripts/purge-frontdoor-cache.sh
@@ -1,0 +1,65 @@
+fdSubscription=$FD_SUBSCRIPTION
+fdResourceGroup=$FD_RESOURCEGROUP
+fdProfileName=$FD_PROFILE
+fdEndpointName=$FD_ENDPOINT
+fdDomain=$FD_DOMAIN
+fdPaths=()
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --subscription)
+      fdSubscription="$2"
+      shift
+      shift
+      ;;
+    --resourcegroup)
+      fdResourceGroup="$2"
+      shift
+      shift
+      ;;
+    --profile)
+      fdProfileName="$2"
+      shift
+      shift
+      ;;
+    --endpoint)
+      fdEndpointName="$2"
+      shift
+      shift
+      ;;
+    --domain)
+      fdDomain="$2"
+      shift
+      shift
+      ;;
+    --path)
+      fdPaths+=("$2")
+      shift
+      shift
+      ;;
+    -*|--*)
+      echo "Unknown option $1"
+      exit 1
+      ;;
+    *)
+      echo "Unknown argument $1"
+      exit 1
+      ;;
+  esac
+done
+
+if [ ${#fdPaths[@]} == 0 ]; then
+    echo "No cache pruning as no paths supplied with option --path."
+fi
+
+#purge-paths-opts=()
+for path in "${fdPaths[@]}"; do
+    echo "Purging ${path}"
+    az afd endpoint purge \
+              --resource-group $fdResourceGroup \
+              --profile-name $fdProfileName \
+              --endpoint-name $fdEndpointName \
+              --domains $fdDomain \
+              --content-paths "${path}"
+    echo "Purged ${path}"
+done


### PR DESCRIPTION
## Description
Script to purge cache in azure front door. This needs to be integrated with the release script so that when new minor/patch versions are released the CDN cache is purged for the update major/minor folder

Releated to issue https://github.com/Altinn/altinn-studio/issues/7566
<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
