### PR TITLE
Show leftColumnHeader in Likert when mobile view

### DIFF
--- a/src/layout/Likert/RepeatingGroupsLikertContainer.test.tsx
+++ b/src/layout/Likert/RepeatingGroupsLikertContainer.test.tsx
@@ -246,6 +246,23 @@ describe('RepeatingGroupsLikertContainer', () => {
       );
     });
 
+    it('should prefix leftColumnHeader to each radio group legend', async () => {
+      const leftColumnHeader = 'Hvor fornøyd eller misfornøyd er du med:';
+      render({
+        likertContainerProps: {
+          textResourceBindings: {
+            leftColumnHeader,
+          },
+        },
+        mobileView: true,
+      });
+      validateRadioLayout(
+        defaultMockQuestions.map((q) => ({ ...q, Question: `${leftColumnHeader} ${q.Question}` })),
+        defaultMockOptions,
+        true,
+      );
+    });
+
     it('should render mobile view and click radiobuttons', async () => {
       const { mockStoreDispatch } = render({ mobileView: true });
       validateRadioLayout(defaultMockQuestions, defaultMockOptions, true);

--- a/src/layout/RadioButtons/ControlledRadioGroup.tsx
+++ b/src/layout/RadioButtons/ControlledRadioGroup.tsx
@@ -6,6 +6,7 @@ import { RadioButton } from 'src/components/form/RadioButton';
 import { RadioGroup } from 'src/components/form/RadioGroup';
 import { RequiredIndicator } from 'src/components/form/RequiredIndicator';
 import { useLanguage } from 'src/hooks/useLanguage';
+import { groupIsRepeatingLikert } from 'src/layout/Group/tools';
 import { useRadioButtons } from 'src/layout/RadioButtons/radioButtonsUtils';
 import { shouldUseRowLayout } from 'src/utils/layout';
 import type { IRadioButtonsContainerProps } from 'src/layout/RadioButtons/RadioButtonsContainerComponent';
@@ -19,8 +20,20 @@ export const ControlledRadioGroup = (props: IControlledRadioGroupProps) => {
   const { selected, handleChange, handleBlur, fetchingOptions, calculatedOptions } = useRadioButtons(props);
   const { lang, langAsString } = useLanguage();
 
+  const getLabelPrefixForLikert = () => {
+    if (
+      node.parent.item.type === 'Group' &&
+      groupIsRepeatingLikert(node.parent.item) &&
+      node.parent.item.textResourceBindings?.leftColumnHeader
+    ) {
+      return `${langAsString(node.parent.item.textResourceBindings.leftColumnHeader)} `;
+    }
+    return null;
+  };
+
   const labelText = (
     <span style={{ fontSize: '1rem', wordBreak: 'break-word' }}>
+      {getLabelPrefixForLikert()}
       {lang(textResourceBindings?.title)}
       <RequiredIndicator required={required} />
       <OptionalIndicator


### PR DESCRIPTION
## Description

When Likert is in mobile view the leftColumnHeader text is added to the radio group label.

## Related Issue(s)

- closes #1456

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
