### PR TITLE
fix(AttachmentList): rewrite selectors to use createSelector from 're…

### DIFF
--- a/src/layout/AttachmentList/AttachmentListComponent.tsx
+++ b/src/layout/AttachmentList/AttachmentListComponent.tsx
@@ -5,7 +5,7 @@ import { Grid, Typography } from '@material-ui/core';
 import { AltinnAttachment } from 'src/components/atoms/AltinnAttachment';
 import { useAppSelector } from 'src/hooks/useAppSelector';
 import { useLanguage } from 'src/hooks/useLanguage';
-import { getInstancePdf, mapInstanceAttachments } from 'src/utils/attachmentsUtils';
+import { selectAttachments, selectDataTypesByIds } from 'src/selectors/dataTypes';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export type IAttachmentListProps = PropsFromGenericComponent<'AttachmentList'>;
@@ -13,26 +13,8 @@ export type IAttachmentListProps = PropsFromGenericComponent<'AttachmentList'>;
 export function AttachmentListComponent({ node }: IAttachmentListProps) {
   const { dataTypeIds, includePDF } = node.item;
   const { lang } = useLanguage();
-  const currentTaskId = useAppSelector((state) => state.instanceData.instance?.process?.currentTask?.elementId);
-  const dataForTask = useAppSelector((state) => {
-    const dataTypes = state.applicationMetadata.applicationMetadata?.dataTypes.filter(
-      (type) => type.taskId === state.instanceData.instance?.process?.currentTask?.elementId,
-    );
-    return state.instanceData.instance?.data.filter((dataElement) => {
-      if (dataTypeIds) {
-        return dataTypeIds.findIndex((id) => dataElement.dataType === id) > -1;
-      }
-      return dataTypes && dataTypes.findIndex((type) => dataElement.dataType === type.id) > -1;
-    });
-  });
-  const attachments = useAppSelector((state) => {
-    const appLogicDataTypes = state.applicationMetadata.applicationMetadata?.dataTypes.filter(
-      (dataType) => dataType.appLogic && dataType.taskId === currentTaskId,
-    );
-    return includePDF
-      ? getInstancePdf(dataForTask)
-      : mapInstanceAttachments(dataForTask, appLogicDataTypes?.map((type) => type.id) || []);
-  });
+  const dataForTask = useAppSelector(selectDataTypesByIds(dataTypeIds));
+  const attachments = useAppSelector(selectAttachments(includePDF, dataForTask));
 
   return (
     <Grid

--- a/src/layout/List/ListComponent.test.tsx
+++ b/src/layout/List/ListComponent.test.tsx
@@ -51,7 +51,7 @@ const render = ({ component, genericProps }: Partial<RenderGenericComponentTestP
 describe('ListComponent', () => {
   jest.useFakeTimers();
 
-  it('should render rows that is sent in but not rows that is not sent in', async () => {
+  it('should render rows that is sent in but not rows that is not sent in', () => {
     render();
     expect(screen.getByText('Norway')).toBeInTheDocument();
     expect(screen.getByText('Sweden')).toBeInTheDocument();

--- a/src/selectors/dataTypes.ts
+++ b/src/selectors/dataTypes.ts
@@ -1,0 +1,33 @@
+import { createSelector } from 'reselect';
+
+import { getInstancePdf, mapInstanceAttachments } from 'src/utils/attachmentsUtils';
+import type { IRuntimeState } from 'src/types';
+import type { IData } from 'src/types/shared';
+
+const selectDataTypes = (state: IRuntimeState) => state.applicationMetadata.applicationMetadata?.dataTypes;
+const selectInstanceData = (state: IRuntimeState) => state.instanceData.instance?.data;
+const selectCurrentTaskId = (state: IRuntimeState) => state.instanceData.instance?.process?.currentTask?.elementId;
+
+export const selectDataTypesByIds = (dataTypeIds: string[] | undefined) =>
+  createSelector(
+    selectDataTypes,
+    selectCurrentTaskId,
+    selectInstanceData,
+    (dataTypes = [], currentTask, instanceData) => {
+      const relevantDataTypes = dataTypes?.filter((type) => type.taskId === currentTask);
+      return instanceData?.filter((dataElement) => {
+        if (dataTypeIds) {
+          return dataTypeIds.findIndex((id) => dataElement.dataType === id) > -1;
+        }
+        return relevantDataTypes.findIndex((type) => dataElement.dataType === type.id) > -1;
+      });
+    },
+  );
+
+export const selectAttachments = (includePDF: boolean = false, dataForTask: IData[] | undefined) =>
+  createSelector(selectDataTypes, selectCurrentTaskId, (dataTypes, currentTaskId) => {
+    const appLogicDataTypes = dataTypes?.filter((dataType) => dataType.appLogic && dataType.taskId === currentTaskId);
+    return includePDF
+      ? getInstancePdf(dataForTask)
+      : mapInstanceAttachments(dataForTask, appLogicDataTypes?.map((type) => type.id) || []);
+  });


### PR DESCRIPTION
## Description

Refactor some selectors in `AttachmentListComponent` to use `reselect` which memoizes selectors and gets rid of warnings about selectors with equal inputs returning different results.

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
