### PR TITLE
Replacing most `takeLatest` with `takeEvery`

### DIFF
--- a/src/features/attachments/map/mapAttachmentsSagas.ts
+++ b/src/features/attachments/map/mapAttachmentsSagas.ts
@@ -1,4 +1,4 @@
-import { all, call, put, select, take, takeLatest } from 'redux-saga/effects';
+import { all, call, put, select, take, takeEvery } from 'redux-saga/effects';
 import type { SagaIterator } from 'redux-saga';
 
 import { ApplicationMetadataActions } from 'src/features/applicationMetadata/applicationMetadataSlice';
@@ -24,7 +24,7 @@ export function* watchMapAttachmentsSaga(): SagaIterator {
     take(ApplicationMetadataActions.getFulfilled),
   ]);
   yield call(mapAttachments);
-  yield takeLatest(AttachmentActions.mapAttachments, mapAttachments);
+  yield takeEvery(AttachmentActions.mapAttachments, mapAttachments);
 }
 
 export const SelectInstanceData = (state: IRuntimeState): IData[] | undefined => state.instanceData.instance?.data;

--- a/src/features/dataLists/dataListsSlice.ts
+++ b/src/features/dataLists/dataListsSlice.ts
@@ -75,7 +75,7 @@ export const dataListsSlice = () => {
         },
       }),
       setPageSize: mkAction<ISetDataListsPageSize>({
-        takeLatest: fetchDataListsSaga,
+        takeEvery: fetchDataListsSaga,
         reducer: (state, action) => {
           const { key, size } = action.payload;
           state.dataLists[key].size = size;
@@ -83,14 +83,14 @@ export const dataListsSlice = () => {
         },
       }),
       setPageNumber: mkAction<ISetDataListsPageNumber>({
-        takeLatest: fetchDataListsSaga,
+        takeEvery: fetchDataListsSaga,
         reducer: (state, action) => {
           const { key, pageNumber } = action.payload;
           state.dataLists[key].pageNumber = pageNumber;
         },
       }),
       setSort: mkAction<ISetSort>({
-        takeLatest: fetchDataListsSaga,
+        takeEvery: fetchDataListsSaga,
         reducer: (state, action) => {
           const { key, sortColumn, sortDirection } = action.payload;
           state.dataLists[key].sortColumn = sortColumn;

--- a/src/features/dynamics/formDynamicsSlice.ts
+++ b/src/features/dynamics/formDynamicsSlice.ts
@@ -21,7 +21,7 @@ export const formDynamicsSlice = () => {
     initialState,
     actions: {
       fetch: mkAction<IFetchServiceConfigFulfilled | undefined>({
-        takeLatest: fetchDynamicsSaga,
+        takeEvery: fetchDynamicsSaga,
       }),
       fetchFulfilled: mkAction<IFetchServiceConfigFulfilled>({
         reducer: (state, action) => {

--- a/src/features/formData/formDataSlice.ts
+++ b/src/features/formData/formDataSlice.ts
@@ -98,8 +98,12 @@ export const formDataSlice = () => {
         takeEvery: updateFormDataSaga,
       }),
       updateFulfilled: mkAction<IUpdateFormData>({
-        takeLatest: [checkIfRuleShouldRunSaga, autoSaveSaga],
-        takeEvery: [checkIfOptionsShouldRefetchSaga, checkIfDataListShouldRefetchSaga],
+        takeEvery: [
+          checkIfOptionsShouldRefetchSaga,
+          checkIfDataListShouldRefetchSaga,
+          checkIfRuleShouldRunSaga,
+          autoSaveSaga,
+        ],
         reducer: (state, action) => {
           const { field, data, skipAutoSave } = action.payload;
           // Remove if data is null, undefined or empty string
@@ -126,7 +130,7 @@ export const formDataSlice = () => {
         takeLatest: saveFormDataSaga,
       }),
       deleteAttachmentReference: mkAction<IDeleteAttachmentReference>({
-        takeLatest: deleteAttachmentReferenceSaga,
+        takeEvery: deleteAttachmentReferenceSaga,
       }),
     },
     extraReducers: (builder) => {

--- a/src/features/formRules/rulesSlice.ts
+++ b/src/features/formRules/rulesSlice.ts
@@ -17,7 +17,7 @@ export const formRulesSlice = () => {
     initialState,
     actions: {
       fetch: mkAction<void>({
-        takeLatest: fetchRuleModelSaga,
+        takeEvery: fetchRuleModelSaga,
         reducer: (state) => {
           state.fetched = false;
           state.fetching = true;

--- a/src/features/instanceData/instanceDataSlice.ts
+++ b/src/features/instanceData/instanceDataSlice.ts
@@ -20,7 +20,7 @@ export const instanceDataSlice = () => {
     initialState,
     actions: {
       get: mkAction<IGetInstanceData>({
-        takeLatest: getInstanceDataSaga,
+        takeEvery: getInstanceDataSaga,
       }),
       getFulfilled: mkAction<IGetInstanceDataFulfilled>({
         reducer: (state, action) => {

--- a/src/features/instantiate/instantiation/instantiationSlice.ts
+++ b/src/features/instantiate/instantiation/instantiationSlice.ts
@@ -20,7 +20,7 @@ export const instantiationSlice = () => {
     initialState,
     actions: {
       instantiate: mkAction<void>({
-        takeLatest: instantiationSaga,
+        takeEvery: instantiationSaga,
         reducer: (state) => {
           state.instantiating = true;
         },

--- a/src/features/layout/fileUpload/watchMapFileUploaderWithTagSaga.ts
+++ b/src/features/layout/fileUpload/watchMapFileUploaderWithTagSaga.ts
@@ -1,4 +1,4 @@
-import { all, call, take, takeLatest } from 'redux-saga/effects';
+import { all, call, take, takeEvery } from 'redux-saga/effects';
 import type { SagaIterator } from 'redux-saga';
 
 import { AttachmentActions } from 'src/features/attachments/attachmentSlice';
@@ -9,7 +9,7 @@ export function* watchMapFileUploaderWithTagSaga(): SagaIterator {
   yield all([take(FormLayoutActions.fetchFulfilled), take(AttachmentActions.mapAttachmentsFulfilled)]);
   yield call(mapFileUploaderWithTagSaga);
 
-  yield takeLatest(
+  yield takeEvery(
     [AttachmentActions.mapAttachmentsFulfilled, FormLayoutActions.fetchFulfilled],
     mapFileUploaderWithTagSaga,
   );

--- a/src/features/layout/formLayoutSlice.ts
+++ b/src/features/layout/formLayoutSlice.ts
@@ -1,4 +1,4 @@
-import { put, takeLatest } from 'redux-saga/effects';
+import { put, takeEvery } from 'redux-saga/effects';
 import type { SagaIterator } from 'redux-saga';
 
 import { DataListsActions } from 'src/features/dataLists/dataListsSlice';
@@ -96,14 +96,14 @@ export const formLayoutSlice = () => {
             state.error = null;
             state.uiConfig.repeatingGroups = null;
           },
-          *takeLatest() {
+          *takeEvery() {
             yield put(OptionsActions.fetch());
             yield put(DataListsActions.fetch());
           },
         }),
         fetchRejected: genericReject,
         fetchSets: mkAction<void>({
-          takeLatest: fetchLayoutSetsSaga,
+          takeEvery: fetchLayoutSetsSaga,
         }),
         fetchSetsFulfilled: mkAction<LayoutTypes.IFetchLayoutSetsFulfilled>({
           reducer: (state, action) => {
@@ -163,7 +163,7 @@ export const formLayoutSlice = () => {
           },
         }),
         updateCurrentView: mkAction<LayoutTypes.IUpdateCurrentView>({
-          takeLatest: updateCurrentViewSaga,
+          takeEvery: updateCurrentViewSaga,
         }),
         updateCurrentViewFulfilled: mkAction<LayoutTypes.IUpdateCurrentViewFulfilled>({
           takeEvery: (action) => {
@@ -197,7 +197,7 @@ export const formLayoutSlice = () => {
           },
         }),
         repGroupAddRow: mkAction<{ groupId: string }>({
-          takeLatest: repGroupAddRowSaga,
+          takeEvery: repGroupAddRowSaga,
         }),
         repGroupAddRowFulfilled: genericSetRepeatingGroups,
         repGroupAddRowRejected: genericReject,
@@ -260,7 +260,7 @@ export const formLayoutSlice = () => {
         }),
         updateFileUploaderWithTagRejected: genericReject,
         updateFileUploaderWithTagEditIndex: mkAction<LayoutTypes.IUpdateFileUploaderWithTagEditIndex>({
-          takeLatest: updateFileUploaderWithTagEditIndexSaga,
+          takeEvery: updateFileUploaderWithTagEditIndexSaga,
         }),
         updateFileUploaderWithTagEditIndexFulfilled: mkAction<LayoutTypes.IUpdateFileUploaderWithTagEditIndexFulfilled>(
           {
@@ -276,7 +276,7 @@ export const formLayoutSlice = () => {
         ),
         updateFileUploaderWithTagEditIndexRejected: genericReject,
         updateFileUploaderWithTagChosenOptions: mkAction<LayoutTypes.IUpdateFileUploaderWithTagChosenOptions>({
-          takeLatest: updateFileUploaderWithTagChosenOptionsSaga,
+          takeEvery: updateFileUploaderWithTagChosenOptionsSaga,
         }),
         updateFileUploaderWithTagChosenOptionsFulfilled:
           mkAction<LayoutTypes.IUpdateFileUploaderWithTagChosenOptionsFulfilled>({
@@ -316,7 +316,7 @@ export const formLayoutSlice = () => {
           takeEvery: initRepeatingGroupsSaga,
           saga: () =>
             function* (): SagaIterator {
-              yield takeLatest([FormDataActions.fetchFulfilled, FormLayoutActions.fetchFulfilled], () =>
+              yield takeEvery([FormDataActions.fetchFulfilled, FormLayoutActions.fetchFulfilled], () =>
                 initRepeatingGroupsSaga({ payload: {} }),
               );
             },

--- a/src/features/party/partySlice.ts
+++ b/src/features/party/partySlice.ts
@@ -25,10 +25,10 @@ export const partySlice = () => {
     initialState,
     actions: {
       getParties: mkAction<void>({
-        takeLatest: getPartiesSaga,
+        takeEvery: getPartiesSaga,
       }),
       getCurrentParty: mkAction<void>({
-        takeLatest: getCurrentPartySaga,
+        takeEvery: getCurrentPartySaga,
       }),
       getPartiesFulfilled: mkAction<IGetPartiesFulfilled>({
         reducer: (state, action) => {
@@ -41,7 +41,7 @@ export const partySlice = () => {
         },
       }),
       selectParty: mkAction<ISelectParty>({
-        takeLatest: selectPartySaga,
+        takeEvery: selectPartySaga,
       }),
       selectPartyFulfilled: mkAction<ISelectPartyFulfilled>({
         reducer: (state, action) => {

--- a/src/features/process/processSlice.ts
+++ b/src/features/process/processSlice.ts
@@ -47,7 +47,7 @@ export const processSlice = () => {
     initialState,
     actions: {
       getTasks: mkAction<IGetTasksFulfilled>({
-        takeLatest: getTasksSaga,
+        takeEvery: getTasksSaga,
       }),
       getTasksFulfilled: mkAction<IGetTasksFulfilled>({
         reducer: (state: WritableDraft<IProcessState>, action: PayloadAction<IGetTasksFulfilled>) => {
@@ -61,10 +61,10 @@ export const processSlice = () => {
         },
       }),
       get: mkAction<void>({
-        takeLatest: getProcessStateSaga,
+        takeEvery: getProcessStateSaga,
       }),
       getFulfilled: mkAction<IGetProcessStateFulfilled>({
-        takeLatest: getTasksSaga,
+        takeEvery: getTasksSaga,
         reducer: genericFulfilledReducer,
       }),
       getRejected: mkAction<IGetProcessStateRejected>({
@@ -73,13 +73,13 @@ export const processSlice = () => {
         },
       }),
       complete: mkAction<ICompleteProcess | undefined>({
-        takeLatest: completeProcessSaga,
+        takeEvery: completeProcessSaga,
         reducer: (state, action) => {
           state.completingId = action.payload?.componentId ?? null;
         },
       }),
       completeFulfilled: mkAction<ICompleteProcessFulfilled>({
-        takeLatest: getTasksSaga,
+        takeEvery: getTasksSaga,
         reducer: (state, action) => {
           genericFulfilledReducer(state, action);
           state.completingId = null;
@@ -92,7 +92,7 @@ export const processSlice = () => {
         },
       }),
       checkIfUpdated: mkAction<void>({
-        takeLatest: checkProcessUpdated,
+        takeEvery: checkProcessUpdated,
       }),
     },
   }));

--- a/src/features/profile/profileSlice.ts
+++ b/src/features/profile/profileSlice.ts
@@ -42,7 +42,7 @@ export const profileSlice = () => {
         },
       }),
       updateSelectedAppLanguage: mkAction<IUpdateSelectedAppLanguage>({
-        *takeLatest() {
+        *takeEvery() {
           yield put(OptionsActions.fetch());
         },
         reducer: (state, action) => {

--- a/src/features/queue/queueSlice.ts
+++ b/src/features/queue/queueSlice.ts
@@ -99,7 +99,7 @@ export const queueSlice = () => {
         },
       }),
       startInitialStatelessQueue: mkAction<void>({
-        *takeLatest(): SagaIterator {
+        *takeEvery(): SagaIterator {
           yield put(IsLoadingActions.startStatelessIsLoading());
           yield put(FormLayoutActions.fetch());
           yield put(FormLayoutActions.fetchSettings());

--- a/src/features/textResources/fetch/fetchTextResourcesSagas.test.ts
+++ b/src/features/textResources/fetch/fetchTextResourcesSagas.test.ts
@@ -1,4 +1,4 @@
-import { all, call, select, take, takeLatest } from 'redux-saga/effects';
+import { all, call, select, take, takeEvery } from 'redux-saga/effects';
 import { expectSaga } from 'redux-saga-test-plan';
 
 import { ApplicationMetadataActions } from 'src/features/applicationMetadata/applicationMetadataSlice';
@@ -28,8 +28,8 @@ describe('fetchTextResourcesSagas', () => {
     expect(generator.next().value).toEqual(select(makeGetAllowAnonymousSelector()));
     expect(generator.next().value).toEqual(await waitFor(expect.anything()));
     expect(generator.next().value).toEqual(call(fetchTextResources));
-    expect(generator.next().value).toEqual(takeLatest(TextResourcesActions.fetch, fetchTextResources));
-    expect(generator.next().value).toEqual(takeLatest(ProfileActions.updateSelectedAppLanguage, fetchTextResources));
+    expect(generator.next().value).toEqual(takeEvery(TextResourcesActions.fetch, fetchTextResources));
+    expect(generator.next().value).toEqual(takeEvery(ProfileActions.updateSelectedAppLanguage, fetchTextResources));
     expect(generator.next().done).toBeTruthy();
   });
   it('should fetch text resources using default language when allowAnonymous is true', () => {

--- a/src/features/textResources/fetch/fetchTextResourcesSagas.ts
+++ b/src/features/textResources/fetch/fetchTextResourcesSagas.ts
@@ -1,4 +1,4 @@
-import { all, call, put, select, take, takeLatest } from 'redux-saga/effects';
+import { all, call, put, select, take, takeEvery } from 'redux-saga/effects';
 import type { SagaIterator } from 'redux-saga';
 
 import { ApplicationMetadataActions } from 'src/features/applicationMetadata/applicationMetadataSlice';
@@ -60,6 +60,6 @@ export function* watchFetchTextResourcesSaga(): SagaIterator {
   }
 
   yield call(fetchTextResources);
-  yield takeLatest(TextResourcesActions.fetch, fetchTextResources);
-  yield takeLatest(ProfileActions.updateSelectedAppLanguage, fetchTextResources);
+  yield takeEvery(TextResourcesActions.fetch, fetchTextResources);
+  yield takeEvery(ProfileActions.updateSelectedAppLanguage, fetchTextResources);
 }

--- a/src/features/validation/validationSlice.ts
+++ b/src/features/validation/validationSlice.ts
@@ -62,7 +62,7 @@ export const validationSlice = () => {
     initialState,
     actions: {
       runSingleFieldValidation: mkAction<IRunSingleFieldValidation>({
-        takeLatest: runSingleFieldValidationSaga,
+        takeEvery: runSingleFieldValidationSaga,
       }),
       runSingleFieldValidationRejected: mkAction<IValidationActionRejected>({
         reducer: (state, action) => {

--- a/src/redux/sagaSlice.ts
+++ b/src/redux/sagaSlice.ts
@@ -1,5 +1,5 @@
 import { createAction, createSlice } from '@reduxjs/toolkit';
-import { takeEvery, takeLatest } from 'redux-saga/effects';
+import { takeEvery } from 'redux-saga/effects';
 import type { CaseReducer, CaseReducerActions, CreateSliceOptions, PayloadAction, Slice } from '@reduxjs/toolkit';
 import type { WritableDraft } from 'immer/dist/types/types-external';
 import type { SagaIterator } from 'redux-saga';
@@ -22,12 +22,6 @@ export interface SagaAction<Payload, State> {
    * Spawns a saga on each action dispatched to the Store.
    */
   takeEvery?: PayloadSaga<Payload> | PayloadSaga<Payload>[];
-
-  /**
-   * Forks a saga on each action dispatched to the Store, and automatically cancels
-   * any previous saga task started previously if it's still running.
-   */
-  takeLatest?: PayloadSaga<Payload> | PayloadSaga<Payload>[];
 }
 
 export type ExtractPayload<Action> = Action extends SagaAction<infer Payload, any> ? Payload : never;
@@ -77,15 +71,11 @@ function asArray<T>(input: T | T[]): T[] {
   return Array.isArray(input) ? input : [input];
 }
 
-function asTake<Payload>(
-  method: 'takeLatest' | 'takeEvery',
-  actionName: string,
-  saga: PayloadSaga<Payload> | PayloadSaga<Payload>[],
-) {
+function asTakeEvery<Payload>(actionName: string, saga: PayloadSaga<Payload> | PayloadSaga<Payload>[]) {
   return asArray(saga).map(
     (target) =>
       function* (): SagaIterator {
-        yield method === 'takeLatest' ? takeLatest(actionName, target) : takeEvery(actionName, target);
+        yield takeEvery(actionName, target);
       },
   );
 }
@@ -125,12 +115,8 @@ export function createSagaSlice<
       rootSagas.push(...asArray(action.saga(actionName)));
     }
 
-    if ('takeLatest' in action && action.takeLatest) {
-      rootSagas.push(...asTake('takeLatest', actionName, action.takeLatest));
-    }
-
     if ('takeEvery' in action && action.takeEvery) {
-      rootSagas.push(...asTake('takeEvery', actionName, action.takeEvery));
+      rootSagas.push(...asTakeEvery(actionName, action.takeEvery));
     }
   }
 


### PR DESCRIPTION
## Description

Most of the time, I assume we're not thinking things all the way through, and we probably just pick from examples we're given. In redux sagas, I've seen a mix of `takeLatest` and `takeEvery` being used, [but we've also seen bugs that happen because of the more complex nature of `takeLatest` when it really shouldn't be used](https://github.com/Altinn/app-frontend-react/pull/1443/files). This PR renames most usages of `takeLatest` -> `takeEvery`, based on the assumption that most events should use `takeEvery`. Hopefully our current sagas will be re-implemented without any such 'taking' before v4 is released, but in case there are sagas left, I think they should prefer using `takeEvery`.

**Wait, what's `takeEvery`?**
In Redux Saga, you can choose when how a saga (effect of a redux action) is triggered, and how long it's supposed to live. In essence, `takeEvery` means that for every redux action dispatched, the saga effect should be executed and it should run until completion. For `takeLatest` however, it means that the saga effect is executed and runs either until completion _or until a newer action is triggered, in which case the saga is cancelled and the execution starts anew with the latest action_. For example, if we take the latest `runSingleFieldValidation` action, perform some work (such as calling the backend), and [dispatch such actions in a loop](https://github.com/Altinn/app-frontend-react/blob/0bd8b3c2561534378352c1b6f97aebea107fc24e/src/features/dynamics/conditionalRenderingSagas.ts#L28-L58), what we're really asking for is to just trigger single-field validation for the last component of the bunch (i.e., cancel all the rest of the actions). If you've ever seen redux logs where multiple actions are triggered, but only one `*Fulfilled` action is dispatched as a result, chances are you've observed `takeLatest` cancelling all but the latest action. It should **not** be our default go-to when picking a behaviour.

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [x] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
