### PR TITLE
Switch to `-v3` test apps

### DIFF
--- a/test/e2e/fixtures/attachment.json
+++ b/test/e2e/fixtures/attachment.json
@@ -4,7 +4,7 @@
   "filename": "test.pdf",
   "contentType": "application/pdf",
   "selfLinks": {
-    "apps": "https://altinn3local.no/ttd/frontend-test/instances/"
+    "apps": "https://altinn3local.no/ttd/frontend-test-v3/instances/"
   },
   "size": 4,
   "locked": false,

--- a/test/e2e/integration/anonymous-stateless-app/anonymous.ts
+++ b/test/e2e/integration/anonymous-stateless-app/anonymous.ts
@@ -17,9 +17,7 @@ describe('Anonymous (stateless)', () => {
     cy.get(appFrontend.profileIconButton).should('not.exist');
     cy.get(appFrontend.stateless.name).invoke('val').should('be.empty');
     cy.get(appFrontend.stateless.number).should('have.value', '1234');
-    cy.get(appFrontend.header)
-      .should('contain.text', appFrontend.apps.anonymousStateless)
-      .and('contain.text', texts.ttd);
+    cy.get(appFrontend.header).should('contain.text', 'anonymous-stateless-app').and('contain.text', texts.ttd);
   });
 
   it('should trigger data processing on changes in form fields', () => {

--- a/test/e2e/integration/frontend-test/all-process-steps.ts
+++ b/test/e2e/integration/frontend-test/all-process-steps.ts
@@ -74,7 +74,7 @@ function testConfirmationPage() {
     const maybeInstanceId = getInstanceIdRegExp().exec(url);
     const instanceId = maybeInstanceId ? maybeInstanceId[1] : 'instance-id-not-found';
     cy.get(appFrontend.confirm.body).contains(instanceId);
-    cy.get(appFrontend.confirm.body).should('contain.text', appFrontend.apps.frontendTest);
+    cy.get(appFrontend.confirm.body).should('contain.text', 'frontend-test');
   });
 }
 

--- a/test/e2e/integration/frontend-test/all-process-steps.ts
+++ b/test/e2e/integration/frontend-test/all-process-steps.ts
@@ -55,7 +55,7 @@ function testConfirmationPage() {
     .find('a')
     .should('have.length', 5) // This is the number of process data tasks
     .first()
-    .should('contain.text', `${appFrontend.apps.frontendTest}.pdf`);
+    .should('contain.text', 'frontend-test.pdf');
 
   cy.get(appFrontend.confirm.uploadedAttachments)
     .last()
@@ -150,7 +150,7 @@ function testReceiptPage() {
     .find('a')
     .should('have.length', 5) // This is the number of process data tasks
     .first()
-    .should('contain.text', `${appFrontend.apps.frontendTest}.pdf`);
+    .should('contain.text', 'frontend-test.pdf');
 
   cy.get(appFrontend.receipt.uploadedAttachments)
     .last()

--- a/test/e2e/integration/frontend-test/components.ts
+++ b/test/e2e/integration/frontend-test/components.ts
@@ -11,7 +11,7 @@ describe('UI Components', () => {
     cy.get('body').should('have.css', 'background-color', 'rgb(239, 239, 239)');
     cy.get(appFrontend.loadingAnimation).should('be.visible');
     cy.get(appFrontend.closeButton).should('be.visible');
-    cy.get(appFrontend.header).should('contain.text', appFrontend.apps.frontendTest).and('contain.text', texts.ttd);
+    cy.get(appFrontend.header).should('contain.text', 'frontend-test').and('contain.text', texts.ttd);
     cy.get(appFrontend.message.logo).then((image) => {
       cy.wrap(image).find('img').should('have.attr', 'alt', 'Altinn logo');
       cy.wrap(image)

--- a/test/e2e/integration/frontend-test/layout-sets.ts
+++ b/test/e2e/integration/frontend-test/layout-sets.ts
@@ -5,7 +5,7 @@ it('should be possible to render the app even if layout-sets are not configured'
   cy.intercept('GET', '**/api/layoutsets', { statusCode: 204, body: '' });
   cy.intercept('GET', '**/api/resource/FormLayout.json', {
     statusCode: 302,
-    headers: { location: '/ttd/frontend-test/api/layouts/message' },
+    headers: { location: '/ttd/frontend-test-v3/api/layouts/message' },
   });
 
   cy.goto('message');

--- a/test/e2e/integration/frontend-test/message.ts
+++ b/test/e2e/integration/frontend-test/message.ts
@@ -35,8 +35,8 @@ describe('Message', () => {
     cy.url().then((url) => {
       const instantiateUrl =
         Cypress.env('environment') === 'local'
-          ? 'http://local.altinn.cloud/ttd/frontend-test'
-          : 'https://ttd.apps.tt02.altinn.no/ttd/frontend-test/';
+          ? 'http://local.altinn.cloud/ttd/frontend-test-v3'
+          : 'https://ttd.apps.tt02.altinn.no/ttd/frontend-test-v3/';
       const maybeInstanceId = instanceIdExpr.exec(url);
       const instanceId = maybeInstanceId ? maybeInstanceId[1] : 'instance-id-not-found';
       cy.get(appFrontend.startAgain).contains(instanceId);

--- a/test/e2e/integration/frontend-test/message.ts
+++ b/test/e2e/integration/frontend-test/message.ts
@@ -40,7 +40,7 @@ describe('Message', () => {
       const maybeInstanceId = instanceIdExpr.exec(url);
       const instanceId = maybeInstanceId ? maybeInstanceId[1] : 'instance-id-not-found';
       cy.get(appFrontend.startAgain).contains(instanceId);
-      cy.get(appFrontend.startAgain).should('contain.text', appFrontend.apps.frontendTest);
+      cy.get(appFrontend.startAgain).should('contain.text', 'frontend-test');
       cy.get(appFrontend.startAgain).find('a:contains("her")').should('have.attr', 'href', instantiateUrl);
 
       cy.get('a:contains("Intern lenke i nytt vindu")')

--- a/test/e2e/integration/frontend-test/on-entry.ts
+++ b/test/e2e/integration/frontend-test/on-entry.ts
@@ -63,7 +63,7 @@ describe('On Entry', () => {
   });
 
   const createIntercept = (defaultSelectedOption: number) => ({
-    id: 'ttd/frontend-test',
+    id: 'ttd/frontend-test-v3',
     org: 'ttd',
     title: {
       nb: 'frontend-test',
@@ -124,7 +124,7 @@ describe('On Entry', () => {
     cy.startAppInstance(appFrontend.apps.frontendTest);
     cy.get(appFrontend.closeButton).should('be.visible');
     cy.get(appFrontend.selectInstance.container).should('be.visible');
-    cy.intercept('POST', `/ttd/frontend-test/instances?instanceOwnerPartyId*`).as('createdInstance');
+    cy.intercept('POST', `/ttd/frontend-test-v3/instances?instanceOwnerPartyId*`).as('createdInstance');
     cy.get(appFrontend.selectInstance.newInstance).click();
     cy.wait('@createdInstance').its('response.statusCode').should('eq', 201);
     cy.url().should('not.contain', instanceIdExamples[0]);

--- a/test/e2e/integration/stateless-app/stateless.ts
+++ b/test/e2e/integration/stateless-app/stateless.ts
@@ -20,7 +20,7 @@ describe('Stateless', () => {
     cy.get(appFrontend.stateless.name).type('test');
     cy.get(appFrontend.stateless.name).blur();
     cy.get(appFrontend.stateless.name).should('have.value', 'automation');
-    cy.get(appFrontend.header).should('contain.text', appFrontend.apps.stateless).and('contain.text', texts.ttd);
+    cy.get(appFrontend.header).should('contain.text', 'stateless-app').and('contain.text', texts.ttd);
     cy.snapshot('stateless');
   });
 

--- a/test/e2e/pageobjects/app-frontend.ts
+++ b/test/e2e/pageobjects/app-frontend.ts
@@ -2,17 +2,17 @@ import texts from 'test/e2e/fixtures/texts.json';
 
 export class AppFrontend {
   public apps = {
-    /** @see https://dev.altinn.studio/repos/ttd/frontend-test */
-    frontendTest: 'frontend-test',
+    /** @see https://dev.altinn.studio/repos/ttd/frontend-test-v3 */
+    frontendTest: 'frontend-test-v3',
 
-    /** @see https://dev.altinn.studio/repos/ttd/stateless-app */
-    stateless: 'stateless-app',
+    /** @see https://dev.altinn.studio/repos/ttd/stateless-app-v3 */
+    stateless: 'stateless-app-v3',
 
-    /** @see https://dev.altinn.studio/repos/ttd/anonymous-stateless-app */
-    anonymousStateless: 'anonymous-stateless-app',
+    /** @see https://dev.altinn.studio/repos/ttd/anonymous-stateless-app-v3 */
+    anonymousStateless: 'anonymous-stateless-app-v3',
 
-    /** @see https://dev.altinn.studio/repos/ttd/signing-test */
-    signingTest: 'signing-test',
+    /** @see https://dev.altinn.studio/repos/ttd/signing-test-v3 */
+    signingTest: 'signing-test-v3',
   };
 
   //Start app instance page

--- a/test/e2e/support/custom.ts
+++ b/test/e2e/support/custom.ts
@@ -154,7 +154,7 @@ const knownWcagViolations: KnownViolation[] = [
     spec: 'signing-test/double-signing.ts',
     test: 'accountant -> manager -> auditor',
     id: 'list',
-    nodeLength: 1,
+    nodeLength: 2,
   },
   {
     spec: 'anonymous-stateless-app/validation.ts',


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

- Copied and deployed `-v3` versions of the test apps used for cypress
- I kept the app name the same (e.g. `frontend-test`) so I had to change out some places where the app-id variable (`frontend-test-v3`) was used in place of the app name.
- The update to wcag violation was due to the existing signing test app not being deployed to the latest version in main. I have deployed a new version there and updated this in `main` as well.