### PR TITLE
Fix custom attachment validation message

### DIFF
--- a/src/features/attachments/upload/uploadAttachmentSagas.ts
+++ b/src/features/attachments/upload/uploadAttachmentSagas.ts
@@ -91,8 +91,8 @@ export function* uploadAttachmentSaga({
   } catch (err) {
     let validations: IComponentValidations;
 
-    if (backendFeatures?.jsonObjectInDataResponse && isAxiosError(err) && err.response?.data?.result) {
-      const validationIssues: BackendValidationIssue[] = err.response.data.result;
+    if (backendFeatures?.jsonObjectInDataResponse && isAxiosError(err) && err.response?.data) {
+      const validationIssues: BackendValidationIssue[] = err.response.data;
 
       validations = {
         simpleBinding: {


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

This is the v4 equivalent change needed to fix the custom attachment validation messages that was broken when `app-lib` fixed their missing await. This seems to be the only change necessary to make all of the cypress tests pass on `frontend-test` on v8 🤞 🥳 

FYI: frontend-test on v8 has been deployed to tt02, so one validation test is expected to fail until this is merged.

## Related Issue(s)

- #1499 
