### PR TITLE
Fix issues in new CheckBox component + fix styling RadioButtonGroup

### DIFF
--- a/src/layout/Checkboxes/CheckboxesContainerComponent.tsx
+++ b/src/layout/Checkboxes/CheckboxesContainerComponent.tsx
@@ -111,7 +111,7 @@ export const CheckboxContainerComponent = ({
             size='small'
           >
             {
-              <span className={`${hideLabel ? 'sr-only' : ''} ${classes.checkBoxLabelContainer}`}>
+              <span className={cn({ 'sr-only': hideLabel }, classes.checkBoxLabelContainer)}>
                 {langAsString(option.label)}
                 {option.helpText && (
                   <HelpText title={getPlainTextFromNode(option.helpText)}>{lang(option.helpText)}</HelpText>

--- a/src/layout/Checkboxes/CheckboxesContainerComponent.tsx
+++ b/src/layout/Checkboxes/CheckboxesContainerComponent.tsx
@@ -95,7 +95,7 @@ export const CheckboxContainerComponent = ({
         description={lang(textResourceBindings?.description)}
         disabled={readOnly}
         onChange={(values) => handleChange(values)}
-        hideLegend={!overrideDisplay?.renderLegend}
+        hideLegend={overrideDisplay?.renderLegend === false}
         error={!isValid}
         aria-label={ariaLabel}
         value={selected}

--- a/src/layout/Checkboxes/CheckboxesContainerComponent.tsx
+++ b/src/layout/Checkboxes/CheckboxesContainerComponent.tsx
@@ -61,7 +61,7 @@ export const CheckboxContainerComponent = ({
     }
   };
 
-  const labelText = (
+  const labelTextGroup = (
     <span className={classes.checkBoxLabelContainer}>
       {lang(node.item.textResourceBindings?.title)}
       <RequiredIndicator required={required} />
@@ -91,11 +91,11 @@ export const CheckboxContainerComponent = ({
     >
       <Checkbox.Group
         className={cn({ [classes.horizontal]: horizontal })}
-        legend={labelText}
+        legend={labelTextGroup}
         description={lang(textResourceBindings?.description)}
         disabled={readOnly}
         onChange={(values) => handleChange(values)}
-        hideLegend={overrideDisplay?.renderLegend}
+        hideLegend={!overrideDisplay?.renderLegend}
         error={!isValid}
         aria-label={ariaLabel}
         value={selected}
@@ -110,14 +110,14 @@ export const CheckboxContainerComponent = ({
             checked={selected.includes(option.value)}
             size='small'
           >
-            {hideLabel ? null : (
-              <span className={classes.checkBoxLabelContainer}>
+            {
+              <span className={`${hideLabel ? 'sr-only' : ''} ${classes.checkBoxLabelContainer}`}>
                 {langAsString(option.label)}
                 {option.helpText && (
                   <HelpText title={getPlainTextFromNode(option.helpText)}>{lang(option.helpText)}</HelpText>
                 )}
               </span>
-            )}
+            }
           </Checkbox>
         ))}
       </Checkbox.Group>

--- a/src/layout/RadioButtons/ControlledRadioGroup.tsx
+++ b/src/layout/RadioButtons/ControlledRadioGroup.tsx
@@ -62,17 +62,16 @@ export const ControlledRadioGroup = (props: IControlledRadioGroupProps) => {
         >
           <Radio.Group
             legend={
-              overrideDisplay?.renderLegend === false ? null : (
-                <span className={classes.label}>
-                  {labelText}
-                  {textResourceBindings?.help ? (
-                    <HelpText title={langAsString(textResourceBindings?.help)}>
-                      {lang(textResourceBindings?.help)}
-                    </HelpText>
-                  ) : null}
-                </span>
-              )
+              <span className={classes.label}>
+                {labelText}
+                {textResourceBindings?.help ? (
+                  <HelpText title={langAsString(textResourceBindings?.help)}>
+                    {lang(textResourceBindings?.help)}
+                  </HelpText>
+                ) : null}
+              </span>
             }
+            hideLegend={overrideDisplay?.renderLegend === false}
             description={lang(textResourceBindings?.description)}
             error={!isValid}
             disabled={readOnly}


### PR DESCRIPTION
## Description
- Fix WCAG issue in new checkbox component - enable SR-only when rendered in table and there are only one checkBox.
- Fix the logic of hiding checkbox group when rendered in table/grid
- Added hideLegend prop to radioButtonGroup so it use the same styling of margin as checkBoxGroup.


<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [x] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
