### PR TITLE
Make PDF tests less hacky

### DIFF
--- a/test/e2e/support/custom.ts
+++ b/test/e2e/support/custom.ts
@@ -469,8 +469,6 @@ Cypress.Commands.add('getSummary', (label) => {
 });
 
 Cypress.Commands.add('testPdf', (callback, returnToForm = false) => {
-  const DEFAULT_COMMAND_TIMEOUT = Cypress.config().defaultCommandTimeout;
-
   cy.log('Testing PDF');
 
   // Make sure instantiation is completed before we get the url
@@ -488,15 +486,11 @@ Cypress.Commands.add('testPdf', (callback, returnToForm = false) => {
   });
   cy.reload();
 
-  // Wait for readyForPrint, after this everything should be rendered so setting the command timeout to zero
-  cy.get('#pdfView > #readyForPrint').should('exist');
-  cy.then(() => Cypress.config('defaultCommandTimeout', 0));
-
-  // Run tests from callback
-  callback();
-
-  // Reset command timeout and go back to regular view
-  cy.then(() => Cypress.config('defaultCommandTimeout', DEFAULT_COMMAND_TIMEOUT));
+  // Wait for readyForPrint, after this everything should be rendered so using timeout: 0
+  cy.get('#pdfView > #readyForPrint').then({ timeout: 0 }, () => {
+    // Run tests from callback
+    callback();
+  });
 
   if (returnToForm) {
     cy.location('href').then((href) => {

--- a/test/e2e/support/custom.ts
+++ b/test/e2e/support/custom.ts
@@ -487,10 +487,12 @@ Cypress.Commands.add('testPdf', (callback, returnToForm = false) => {
   cy.reload();
 
   // Wait for readyForPrint, after this everything should be rendered so using timeout: 0
-  cy.get('#pdfView > #readyForPrint').then({ timeout: 0 }, () => {
-    // Run tests from callback
-    callback();
-  });
+  cy.get('#pdfView > #readyForPrint')
+    .should('exist')
+    .then({ timeout: 0 }, () => {
+      // Run tests from callback
+      callback();
+    });
 
   if (returnToForm) {
     cy.location('href').then((href) => {


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

Use `.then()` instead of setting default command timeout.