### PR TITLE
Delete fetch layout sets saga

### DIFF
--- a/src/features/layout/fetch/fetchFormLayoutSagas.ts
+++ b/src/features/layout/fetch/fetchFormLayoutSagas.ts
@@ -8,7 +8,7 @@ import { QueueActions } from 'src/features/queue/queueSlice';
 import { ComponentConfigs } from 'src/layout/components.generated';
 import { getLayoutSetIdForApplication } from 'src/utils/appMetadata';
 import { httpGet } from 'src/utils/network/networking';
-import { getLayoutSetsUrl, getLayoutSettingsUrl, getLayoutsUrl } from 'src/utils/urls/appUrlHelper';
+import { getLayoutSettingsUrl, getLayoutsUrl } from 'src/utils/urls/appUrlHelper';
 import type { IApplicationMetadata } from 'src/features/applicationMetadata';
 import type { ExprObjConfig, ExprVal } from 'src/features/expressions/types';
 import type { ILayoutFileExternal } from 'src/layout/common.generated';
@@ -148,20 +148,5 @@ export function* watchFetchFormLayoutSettingsSaga(): SagaIterator {
   while (true) {
     yield all([take(FormLayoutActions.fetchSettings), take(FormLayoutActions.fetchFulfilled)]);
     yield call(fetchLayoutSettingsSaga);
-  }
-}
-
-export function* fetchLayoutSetsSaga(): SagaIterator {
-  try {
-    const layoutSets: ILayoutSets = yield call(httpGet, getLayoutSetsUrl());
-    yield put(FormLayoutActions.fetchSetsFulfilled({ layoutSets }));
-  } catch (error) {
-    if (error?.response?.status === 404) {
-      // We accept that the app does not have a layout sets as this is not default
-      yield put(FormLayoutActions.fetchSetsFulfilled({ layoutSets: null }));
-    } else {
-      yield put(FormLayoutActions.fetchSetsRejected({ error }));
-      window.logError('Fetching layout sets failed:\n', error);
-    }
   }
 }

--- a/src/features/layout/formLayoutSlice.ts
+++ b/src/features/layout/formLayoutSlice.ts
@@ -4,7 +4,6 @@ import type { SagaIterator } from 'redux-saga';
 import { removeHiddenValidationsSaga } from 'src/features/dynamics/conditionalRenderingSagas';
 import { FormDataActions } from 'src/features/formData/formDataSlice';
 import {
-  fetchLayoutSetsSaga,
   watchFetchFormLayoutSaga,
   watchFetchFormLayoutSettingsSaga,
 } from 'src/features/layout/fetch/fetchFormLayoutSagas';
@@ -92,9 +91,6 @@ export const formLayoutSlice = () => {
           },
         }),
         fetchRejected: genericReject,
-        fetchSets: mkAction<void>({
-          takeEvery: fetchLayoutSetsSaga,
-        }),
         fetchSetsFulfilled: mkAction<LayoutTypes.IFetchLayoutSetsFulfilled>({
           reducer: (state, action) => {
             const { layoutSets } = action.payload;


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

Turns out that layout sets fetching was also already done using tanstack and the existing saga code was left unused. This PR removes the fetch layout sets saga.

## Related Issue(s)

- #1509 
