### PR TITLE
Exclude expression validations from backend

### DIFF
--- a/src/utils/validation/backendValidation.ts
+++ b/src/utils/validation/backendValidation.ts
@@ -22,6 +22,7 @@ export enum ValidationIssueSources {
   File = 'File',
   ModelState = 'ModelState',
   Required = 'Required',
+  Expression = 'Expression',
 }
 
 /**
@@ -34,9 +35,14 @@ export function shouldExcludeValidationIssue(issue: BackendValidationIssue): boo
     return true;
   }
 
-  // eslint-disable-next-line sonarjs/prefer-single-boolean-return
   if (issue.source === ValidationIssueSources.ModelState) {
     // This is handled by schema validation.
+    return true;
+  }
+
+  // eslint-disable-next-line sonarjs/prefer-single-boolean-return
+  if (issue.source === ValidationIssueSources.Expression) {
+    // This is handled by the frontend
     return true;
   }
 


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

I noticed that the expression-validation tests were a bit flaky, and it turns out I forgot to exclude expression validations from the backend in the original PR 🤦 . This was not an issue in normal use since the frontend and backend seem to always agree on what is valid and what is not. But it looks like there are some subtleties when it comes to saving delay triggering single field validations and repeating group triggered validations that could cause a mismatch if the order of requests was unlucky, due to cypress being very fast. This should hopefully fix the flakyness.

## Related Issue(s)

- #1540 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
