### PR TITLE
Workaround for critical bug when pressing back button in browser (for stateless->stateful apps)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -149,10 +149,7 @@ function PreventNavigatingBackWrapper({
   const instantiating = useAppSelector((state) => state.instantiation.instantiating);
   const waitingToRedirectToInstance = useRef(false);
 
-  const hasInstanceData =
-    !!instanceData &&
-    !(Array.isArray(instanceData) && instanceData.length === 0) &&
-    !(instanceData && typeof instanceData === 'object' && Object.keys(instanceData).length === 0);
+  const hasInstanceData = instanceData && typeof instanceData === 'object' && Object.keys(instanceData).length > 0;
 
   if (path === 'instance' && waitingToRedirectToInstance.current) {
     waitingToRedirectToInstance.current = false;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { Route, Routes } from 'react-router-dom';
 
+import { AltinnContentIconFormData } from 'src/components/atoms/AltinnContentIconFormData';
+import { AltinnContentLoader } from 'src/components/molecules/AltinnContentLoader';
+import { PresentationComponent } from 'src/components/wrappers/Presentation';
 import { ProcessWrapper } from 'src/components/wrappers/ProcessWrapper';
 import { Entrypoint } from 'src/features/entrypoint/Entrypoint';
 import { PartySelection } from 'src/features/instantiate/containers/PartySelection';
@@ -20,9 +23,11 @@ import { useAlwaysPromptForParty } from 'src/hooks/useAlwaysPromptForParty';
 import { useAppDispatch } from 'src/hooks/useAppDispatch';
 import { useAppSelector } from 'src/hooks/useAppSelector';
 import { useKeepAlive } from 'src/hooks/useKeepAlive';
+import { useLanguage } from 'src/hooks/useLanguage';
 import { useUpdatePdfState } from 'src/hooks/useUpdatePdfState';
 import { makeGetAllowAnonymousSelector } from 'src/selectors/getAllowAnonymous';
 import { selectAppName, selectAppOwner } from 'src/selectors/language';
+import { ProcessTaskType } from 'src/types';
 import type { IApplicationSettings } from 'src/types/shared';
 
 import '@digdir/design-system-tokens/brand/altinn/tokens.css';
@@ -101,15 +106,27 @@ const AppInternal = ({ applicationSettings }: AppInternalProps): JSX.Element | n
         <Routes>
           <Route
             path='/'
-            element={<Entrypoint allowAnonymous={allowAnonymous} />}
+            element={
+              <PreventNavigatingBackWrapper path={'root'}>
+                <Entrypoint allowAnonymous={allowAnonymous} />
+              </PreventNavigatingBackWrapper>
+            }
           />
           <Route
             path='/partyselection/*'
-            element={<PartySelection />}
+            element={
+              <PreventNavigatingBackWrapper path={'partySelection'}>
+                <PartySelection />
+              </PreventNavigatingBackWrapper>
+            }
           />
           <Route
             path='/instance/:partyId/:instanceGuid'
-            element={<ProcessWrapper isFetching={isFetching} />}
+            element={
+              <PreventNavigatingBackWrapper path={'instance'}>
+                <ProcessWrapper isFetching={isFetching} />
+              </PreventNavigatingBackWrapper>
+            }
           />
         </Routes>
       </>
@@ -122,3 +139,34 @@ const AppInternal = ({ applicationSettings }: AppInternalProps): JSX.Element | n
 
   return null;
 };
+
+function PreventNavigatingBackWrapper({
+  children,
+  path,
+}: React.PropsWithChildren<{ path: 'root' | 'instance' | 'partySelection' }>) {
+  const { langAsString } = useLanguage();
+  const instanceData = useAppSelector((state) => state.instanceData.instance);
+
+  if (instanceData && path !== 'instance') {
+    // When you have instance data, but you're looking at some other route in the application, it can only mean that you
+    // pressed the history back button in the browser. This breaks the application, so we reload the page to get you
+    // back to the correct state.
+
+    window.location.reload();
+    return (
+      <PresentationComponent
+        header={langAsString('instantiate.starting')}
+        type={ProcessTaskType.Unknown}
+      >
+        <AltinnContentLoader
+          width='100%'
+          height='400'
+        >
+          <AltinnContentIconFormData />
+        </AltinnContentLoader>
+      </PresentationComponent>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Route, Routes } from 'react-router-dom';
 
 import { AltinnContentIconFormData } from 'src/components/atoms/AltinnContentIconFormData';
@@ -146,8 +146,21 @@ function PreventNavigatingBackWrapper({
 }: React.PropsWithChildren<{ path: 'root' | 'instance' | 'partySelection' }>) {
   const { langAsString } = useLanguage();
   const instanceData = useAppSelector((state) => state.instanceData.instance);
+  const instantiating = useAppSelector((state) => state.instantiation.instantiating);
+  const waitingToRedirectToInstance = useRef(false);
 
-  if (instanceData && path !== 'instance') {
+  const hasInstanceData =
+    !!instanceData &&
+    !(Array.isArray(instanceData) && instanceData.length === 0) &&
+    !(instanceData && typeof instanceData === 'object' && Object.keys(instanceData).length === 0);
+
+  if (path === 'instance' && waitingToRedirectToInstance.current) {
+    waitingToRedirectToInstance.current = false;
+  }
+
+  if (path === 'root' && instantiating) {
+    waitingToRedirectToInstance.current = true;
+  } else if (path !== 'instance' && hasInstanceData && !instantiating && !waitingToRedirectToInstance.current) {
     // When you have instance data, but you're looking at some other route in the application, it can only mean that you
     // pressed the history back button in the browser. This breaks the application, so we reload the page to get you
     // back to the correct state.

--- a/src/features/instanceData/getInstanceDataSagas.ts
+++ b/src/features/instanceData/getInstanceDataSagas.ts
@@ -16,8 +16,10 @@ export function* getInstanceDataSaga({ payload: { instanceId } }: PayloadAction<
     if (error.response && error.response.status === 403 && error.response.data) {
       const reqAuthLevel = error.response.data.RequiredAuthenticationLevel;
       if (reqAuthLevel) {
-        putWithoutConfig(invalidateCookieUrl);
+        putWithoutConfig(invalidateCookieUrl).then();
         yield call(redirectToUpgrade, reqAuthLevel);
+      } else {
+        yield put(InstanceDataActions.getRejected({ error }));
       }
     } else {
       yield put(InstanceDataActions.getRejected({ error }));

--- a/src/features/instanceData/instanceDataSlice.ts
+++ b/src/features/instanceData/instanceDataSlice.ts
@@ -20,7 +20,7 @@ export const instanceDataSlice = () => {
     initialState,
     actions: {
       get: mkAction<IGetInstanceData>({
-        takeLatest: getInstanceDataSaga,
+        takeEvery: getInstanceDataSaga,
       }),
       getFulfilled: mkAction<IGetInstanceDataFulfilled>({
         reducer: (state, action) => {

--- a/src/features/instantiate/instantiation/instantiationSlice.ts
+++ b/src/features/instantiate/instantiation/instantiationSlice.ts
@@ -25,6 +25,11 @@ export const instantiationSlice = () => {
           state.instantiating = true;
         },
       }),
+      instantiateWithPrefill: mkAction<void>({
+        reducer: (state) => {
+          state.instantiating = true;
+        },
+      }),
       instantiateFulfilled: mkAction<IInstantiateFulfilled>({
         reducer: (state, { payload }) => {
           state.instanceId = payload.instanceId;

--- a/src/hooks/queries/useActiveInstancesQuery.ts
+++ b/src/hooks/queries/useActiveInstancesQuery.ts
@@ -2,21 +2,16 @@ import { useQuery } from '@tanstack/react-query';
 import type { UseQueryResult } from '@tanstack/react-query';
 
 import { useAppQueriesContext } from 'src/contexts/appQueriesContext';
-import { InstanceDataActions } from 'src/features/instanceData/instanceDataSlice';
-import { useAppDispatch } from 'src/hooks/useAppDispatch';
 import type { ISimpleInstance } from 'src/types';
 import type { HttpClientError } from 'src/utils/network/sharedNetworking';
 
 export const useActiveInstancesQuery = (partyId?: string, enabled?: boolean): UseQueryResult<ISimpleInstance[]> => {
-  const dispatch = useAppDispatch();
   const { fetchActiveInstances } = useAppQueriesContext();
   return useQuery(['getActiveInstances'], () => fetchActiveInstances(partyId || ''), {
     enabled,
-    onSuccess: (instanceData) => {
+    onSuccess: (active) => {
       // Sort array by last changed date
-      instanceData.sort((a, b) => new Date(a.lastChanged).getTime() - new Date(b.lastChanged).getTime());
-
-      dispatch(InstanceDataActions.getFulfilled({ instanceData }));
+      active.sort((a, b) => new Date(a.lastChanged).getTime() - new Date(b.lastChanged).getTime());
     },
     onError: (error: HttpClientError) => {
       console.warn(error);

--- a/src/layout/InstantiationButton/InstantiationButton.tsx
+++ b/src/layout/InstantiationButton/InstantiationButton.tsx
@@ -20,6 +20,7 @@ export const InstantiationButton = ({ children, ...props }: Props) => {
   const party = useAppSelector((state) => state.party.selectedParty);
 
   const instantiate = () => {
+    dispatch(InstantiationActions.instantiateWithPrefill());
     const prefill = mapFormData(formData, props.mapping);
     instantiateWithPrefill({
       prefill,


### PR DESCRIPTION
## Description
When a stateless app goes from being stateless to being stateful (i.e. creating an instance), the browser address bar changes to include the instance ID. If you pressed the back button at this point, `App.tsx` would just render the components it thought should render at this point, but the rest of the state would remain as before - with the full state used in the instance, including the state needed to save data. In `udir/pbu-test-anonym`, navigating here triggers saving (as page navigation triggers saving in that app), and it caused data to be truncated in the data model. As the Likert component (used heavily in that app) stores the questions in the data model, all the questions disappeared, rendering the app and instance broken and useless.

This works around the issue by refreshing the page to get rid of our outdated state from redux. Hopefully we won't even have this issue in v4, as we're aiming for getting rid of redux and the global state entirely there.

## Related Issue(s)

- https://altinn.slack.com/archives/C02EVE4TKA6/p1697105003754029

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
