### PR TITLE
Fix summary content overflow

### DIFF
--- a/src/layout/Checkboxes/MultipleChoiceSummary.tsx
+++ b/src/layout/Checkboxes/MultipleChoiceSummary.tsx
@@ -17,6 +17,7 @@ const useStyles = makeStyles({
   },
   // Match style in \src\components\summary\SingleInputSummary.tsx
   data: {
+    overflowWrap: 'break-word',
     fontWeight: 500,
     fontSize: '1.125rem',
     '& p': {

--- a/src/layout/FileUpload/Summary/AttachmentSummaryComponent.module.css
+++ b/src/layout/FileUpload/Summary/AttachmentSummaryComponent.module.css
@@ -1,9 +1,26 @@
+.data {
+  overflow-wrap: break-word;
+}
+
 .row {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: minmax(0, 1fr) auto;
   border-top: 1px dashed #008fd6;
   margin-top: 10px;
   padding-top: 10px;
+}
+
+.row > div {
+  overflow-wrap: anywhere;
+}
+
+.row div:first-child {
+  justify-self: start;
+}
+
+.row div:last-child {
+  justify-self: end;
 }
 
 .emptyField {

--- a/src/layout/FileUpload/Summary/AttachmentSummaryComponent.tsx
+++ b/src/layout/FileUpload/Summary/AttachmentSummaryComponent.tsx
@@ -33,7 +33,7 @@ export function AttachmentSummaryComponent({ targetNode }: IAttachmentSummaryCom
       ) : (
         attachments.map((attachment) => (
           <div
-            className={hasTag ? classes.row : ''}
+            className={hasTag ? classes.row : classes.data}
             key={`attachment-summary-${attachment.id}`}
           >
             <div key={attachment.id}>{attachment.name}</div>

--- a/src/layout/Summary/SummaryItemCompact.module.css
+++ b/src/layout/Summary/SummaryItemCompact.module.css
@@ -1,8 +1,10 @@
 .data {
   font-weight: 500;
+  overflow-wrap: break-word;
 }
 
 .emptyField {
   font-style: italic;
   font-size: 0.875rem;
+  overflow-wrap: break-word;
 }

--- a/src/layout/Summary/SummaryItemSimple.module.css
+++ b/src/layout/Summary/SummaryItemSimple.module.css
@@ -1,9 +1,11 @@
 .data {
   font-weight: 500;
   font-size: 1.125rem;
+  overflow-wrap: break-word;
 }
 
 .emptyField {
   font-style: italic;
   line-height: 1.6875;
+  overflow-wrap: break-word;
 }


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

This fixes text overflowing the page in summary components (tested that PDF also looks right). Should also be cherry-picked and fixed in v3.

## Related Issue(s)

- closes #1531 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
