### PR TITLE
Remove pageRef property from Summary component

### DIFF
--- a/src/components/form/Form.test.tsx
+++ b/src/components/form/Form.test.tsx
@@ -211,7 +211,6 @@ describe('Form', () => {
       {
         id: 'the-summary',
         type: 'Summary',
-        pageRef: 'FormLayout',
         componentRef: 'field1',
       } as CompSummaryExternal,
     ];

--- a/src/features/expressions/shared-tests/functions/displayValue/summary.json
+++ b/src/features/expressions/shared-tests/functions/displayValue/summary.json
@@ -24,8 +24,7 @@
           {
             "id": "summary",
             "type": "Summary",
-            "componentRef": "penger",
-            "pageRef": "Page"
+            "componentRef": "penger"
           }
         ]
       }

--- a/src/hooks/usePdfPage.ts
+++ b/src/hooks/usePdfPage.ts
@@ -82,18 +82,13 @@ function generateAutomaticPage(
   Object.entries(layoutPages.all())
     .filter(([pageName]) => !excludedPages.has(pageName) && !hiddenPages.has(pageName) && pageOrder?.includes(pageName))
     .sort(([pA], [pB]) => (pageOrder ? pageOrder.indexOf(pA) - pageOrder.indexOf(pB) : 0))
-    .map(
-      ([pageName, layoutPage]) =>
-        [pageName, layoutPage.children().filter((node) => !excludedComponents.has(node.item.id))] as const,
-    )
-    .flatMap(([pageName, nodes]) => nodes?.map((node) => [pageName, node] as const))
-    .map(([pageName, node]) => {
+    .flatMap(([_, layoutPage]) => layoutPage.children().filter((node) => !excludedComponents.has(node.item.id)))
+    .map((node) => {
       if (node.def.shouldRenderInAutomaticPDF(node as any)) {
         return {
           id: `__pdf__${node.item.id}`,
           type: 'Summary',
           componentRef: node.item.id,
-          pageRef: pageName,
           excludedChildren: pdfFormat?.excludedComponents,
           largeGroup: node.isType('Group') && (node.isNonRepGroup() || node.isNonRepPanelGroup()),
         } as CompSummaryExternal;

--- a/src/layout/Group/SummaryGroupComponent.test.tsx
+++ b/src/layout/Group/SummaryGroupComponent.test.tsx
@@ -63,7 +63,6 @@ describe('SummaryGroupComponent', () => {
           {
             type: 'Summary',
             id: 'mySummary',
-            pageRef: 'page1',
             componentRef: 'groupComponent',
             largeGroup: false,
           },

--- a/src/layout/Summary/SummaryComponent.test.tsx
+++ b/src/layout/Summary/SummaryComponent.test.tsx
@@ -135,7 +135,6 @@ describe('SummaryComponent', () => {
       type: 'Summary',
       id: 'mySummary',
       componentRef: props.componentRef,
-      pageRef: pageId,
     });
 
     return renderWithProviders(<Wrapper />, {

--- a/src/layout/Summary/SummaryComponent.tsx
+++ b/src/layout/Summary/SummaryComponent.tsx
@@ -29,7 +29,6 @@ export interface ISummaryComponent {
 
 export function SummaryComponent({ summaryNode, overrides }: ISummaryComponent) {
   const { id, grid } = summaryNode.item;
-  const { pageRef } = summaryNode.item;
   const display = overrides?.display || summaryNode.item.display;
   const dispatch = useAppDispatch();
   const { lang, langAsString } = useLanguage();
@@ -37,14 +36,16 @@ export function SummaryComponent({ summaryNode, overrides }: ISummaryComponent) 
   const summaryItem = summaryNode.item;
   const targetNode = useResolvedNode(overrides?.targetNode || summaryNode.item.componentRef || summaryNode.item.id);
   const targetItem = targetNode?.item;
+  const targetView = targetNode?.top.top.myKey;
+
   const onChangeClick = () => {
-    if (!pageRef) {
+    if (!targetView) {
       return;
     }
 
     dispatch(
       FormLayoutActions.updateCurrentView({
-        newView: pageRef,
+        newView: targetView,
         returnToView: summaryPageName,
         focusComponentId: targetNode?.item.id,
       }),

--- a/src/layout/Summary/config.ts
+++ b/src/layout/Summary/config.ts
@@ -22,15 +22,6 @@ export const Config = new CG.component({
   )
   .addProperty(
     new CG.prop(
-      'pageRef',
-      new CG.str()
-        .optional()
-        .setTitle('Page reference')
-        .setDescription('String value indicating which layout page the referenced component is defined on.'),
-    ),
-  )
-  .addProperty(
-    new CG.prop(
       'largeGroup',
       new CG.bool()
         .optional({ default: false })


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

Remove `pageRef` option from `Summary` and get it from the target node instead.

## Related Issue(s)

- closes #1488 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
