### PR TITLE
fix: if defaultValue in text variables is set to empty string, the ap…

### DIFF
--- a/src/hooks/useLanguage.ts
+++ b/src/hooks/useLanguage.ts
@@ -274,9 +274,9 @@ function replaceVariables(text: string, variables: IVariable[], dataSources: Tex
        By returning value if variable.defaultValue is null, we ensure
        that we are returning the dataModel path string instead of blank
        value. If app developers want to return blank value, they should
-       set defaultValue to a blank space.
+       set defaultValue to an empty string.
       */
-      value = variable.defaultValue || value;
+      value = variable.defaultValue ?? value;
     }
 
     out = out.replaceAll(`{${idx}}`, value);


### PR DESCRIPTION
## Description
Previously, an app developer would need to set a blank string to display no value because of the logical or operator. When switching to the null coalescing operator, an app developer can set the value  `""` to display nothing when a text variable is pointing to a `null` value.
<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
