### PR TITLE
feat: add a sortOrder property to Dropdown component to be able to so…

### DIFF
--- a/src/layout/Dropdown/DropdownComponent.test.tsx
+++ b/src/layout/Dropdown/DropdownComponent.test.tsx
@@ -172,4 +172,54 @@ describe('DropdownComponent', () => {
     await waitFor(() => expect(handleDataChange).toHaveBeenCalledWith('Value for second', { validate: true }));
     expect(handleDataChange).toHaveBeenCalledTimes(2);
   });
+
+  it('should present the options list in the order it is provided when sortOrder is not specified', async () => {
+    render({
+      component: {
+        optionsId: 'countries',
+      },
+      options: countries.options,
+    });
+
+    await userEvent.click(await screen.findByRole('combobox'));
+    const options = await screen.findAllByRole('option');
+
+    expect(options[0]).toHaveValue('norway');
+    expect(options[1]).toHaveValue('sweden');
+    expect(options[2]).toHaveValue('denmark');
+  });
+
+  it('should present the provided options list sorted alphabetically in ascending order when providing sortOrder "asc"', async () => {
+    render({
+      component: {
+        optionsId: 'countries',
+        sortOrder: 'asc',
+      },
+      options: countries.options,
+    });
+
+    await userEvent.click(await screen.findByRole('combobox'));
+    const options = await screen.findAllByRole('option');
+
+    expect(options[0]).toHaveValue('denmark');
+    expect(options[1]).toHaveValue('norway');
+    expect(options[2]).toHaveValue('sweden');
+  });
+
+  it('should present the provided options list sorted alphabetically in descending order when providing sortOrder "desc"', async () => {
+    render({
+      component: {
+        optionsId: 'countries',
+        sortOrder: 'desc',
+      },
+      options: countries.options,
+    });
+
+    await userEvent.click(await screen.findByRole('combobox'));
+    const options = await screen.findAllByRole('option');
+
+    expect(options[0]).toHaveValue('sweden');
+    expect(options[1]).toHaveValue('norway');
+    expect(options[2]).toHaveValue('denmark');
+  });
 });

--- a/src/layout/Dropdown/DropdownComponent.tsx
+++ b/src/layout/Dropdown/DropdownComponent.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { Select } from '@digdir/design-system-react';
+import type { SingleSelectOption } from '@digdir/design-system-react';
 
 import { AltinnSpinner } from 'src/components/AltinnSpinner';
 import { useGetOptions } from 'src/features/options/useGetOptions';
@@ -9,10 +10,17 @@ import { useFormattedOptions } from 'src/hooks/useFormattedOptions';
 import { useLanguage } from 'src/hooks/useLanguage';
 import type { PropsFromGenericComponent } from 'src/layout';
 
-export type IDropdownProps = PropsFromGenericComponent<'Dropdown'>;
+type SortOrder = 'asc' | 'desc';
+const compareSelectOptionAlphabetically =
+  (sortOrder: SortOrder = 'asc') =>
+  (a: SingleSelectOption, b: SingleSelectOption) => {
+    const comparison = new Intl.Collator(['nb', 'en']).compare(a.label, b.label);
+    return sortOrder === 'asc' ? comparison : -comparison;
+  };
 
+export type IDropdownProps = PropsFromGenericComponent<'Dropdown'>;
 export function DropdownComponent({ node, formData, handleDataChange, isValid, overrideDisplay }: IDropdownProps) {
-  const { id, readOnly, textResourceBindings } = node.item;
+  const { id, readOnly, textResourceBindings, sortOrder } = node.item;
   const { langAsString } = useLanguage();
   const { value: selected, setValue, saveValue } = useDelayedSavedState(handleDataChange, formData?.simpleBinding, 200);
 
@@ -43,7 +51,9 @@ export function DropdownComponent({ node, formData, handleDataChange, isValid, o
           value={selected}
           disabled={readOnly}
           error={!isValid}
-          options={formattedOptions}
+          options={
+            sortOrder ? formattedOptions.toSorted(compareSelectOptionAlphabetically(sortOrder)) : formattedOptions
+          }
           aria-label={overrideDisplay?.renderedInTable ? langAsString(textResourceBindings?.title) : undefined}
         />
       )}

--- a/src/layout/Dropdown/config.ts
+++ b/src/layout/Dropdown/config.ts
@@ -12,4 +12,12 @@ export const Config = new CG.component({
   },
 })
   .makeSelectionComponent()
-  .addDataModelBinding(CG.common('IDataModelBindingsSimple').optional({ onlyIn: Variant.Internal }));
+  .addDataModelBinding(CG.common('IDataModelBindingsSimple').optional({ onlyIn: Variant.Internal }))
+  .addProperty(
+    new CG.prop(
+      'sortOrder',
+      new CG.enum('asc', 'desc')
+        .setDescription('Sorts the code list in either ascending or descending order by label.')
+        .optional(),
+    ),
+  );


### PR DESCRIPTION
## Description
Adds a new property `sortOrder` to the `Dropdown` component. This property can take on the values `"asc"` and `"desc"`, specifying whether the options should be sorted alphabetically in ascending or descending order. If the property is not defined, then the options list will not be sorted.

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes #1598 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [x] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
