### PR TITLE
feat: add a sortOrder property to Dropdown component to be able to so…

### DIFF
--- a/src/layout/Dropdown/DropdownComponent.test.tsx
+++ b/src/layout/Dropdown/DropdownComponent.test.tsx
@@ -210,11 +210,10 @@ describe('DropdownComponent', () => {
       component: {
         optionsId: 'countries',
       },
-      options: countries.options,
     });
 
-    await userEvent.click(await screen.findByRole('combobox'));
-    const options = await screen.findAllByRole('option');
+    await act(() => user.click(screen.getByRole('combobox')));
+    const options = screen.getAllByRole('option');
 
     expect(options[0]).toHaveValue('norway');
     expect(options[1]).toHaveValue('sweden');
@@ -227,11 +226,10 @@ describe('DropdownComponent', () => {
         optionsId: 'countries',
         sortOrder: 'asc',
       },
-      options: countries.options,
     });
 
-    await userEvent.click(await screen.findByRole('combobox'));
-    const options = await screen.findAllByRole('option');
+    await act(() => user.click(screen.getByRole('combobox')));
+    const options = screen.getAllByRole('option');
 
     expect(options[0]).toHaveValue('denmark');
     expect(options[1]).toHaveValue('norway');
@@ -244,11 +242,10 @@ describe('DropdownComponent', () => {
         optionsId: 'countries',
         sortOrder: 'desc',
       },
-      options: countries.options,
     });
 
-    await userEvent.click(await screen.findByRole('combobox'));
-    const options = await screen.findAllByRole('option');
+    await act(() => user.click(screen.getByRole('combobox')));
+    const options = screen.getAllByRole('option');
 
     expect(options[0]).toHaveValue('sweden');
     expect(options[1]).toHaveValue('norway');

--- a/src/layout/Dropdown/DropdownComponent.test.tsx
+++ b/src/layout/Dropdown/DropdownComponent.test.tsx
@@ -204,4 +204,54 @@ describe('DropdownComponent', () => {
     expect(handleDataChange).toHaveBeenCalledWith('Value for second', { validate: true });
     expect(handleDataChange).toHaveBeenCalledTimes(2);
   });
+
+  it('should present the options list in the order it is provided when sortOrder is not specified', async () => {
+    render({
+      component: {
+        optionsId: 'countries',
+      },
+      options: countries.options,
+    });
+
+    await userEvent.click(await screen.findByRole('combobox'));
+    const options = await screen.findAllByRole('option');
+
+    expect(options[0]).toHaveValue('norway');
+    expect(options[1]).toHaveValue('sweden');
+    expect(options[2]).toHaveValue('denmark');
+  });
+
+  it('should present the provided options list sorted alphabetically in ascending order when providing sortOrder "asc"', async () => {
+    render({
+      component: {
+        optionsId: 'countries',
+        sortOrder: 'asc',
+      },
+      options: countries.options,
+    });
+
+    await userEvent.click(await screen.findByRole('combobox'));
+    const options = await screen.findAllByRole('option');
+
+    expect(options[0]).toHaveValue('denmark');
+    expect(options[1]).toHaveValue('norway');
+    expect(options[2]).toHaveValue('sweden');
+  });
+
+  it('should present the provided options list sorted alphabetically in descending order when providing sortOrder "desc"', async () => {
+    render({
+      component: {
+        optionsId: 'countries',
+        sortOrder: 'desc',
+      },
+      options: countries.options,
+    });
+
+    await userEvent.click(await screen.findByRole('combobox'));
+    const options = await screen.findAllByRole('option');
+
+    expect(options[0]).toHaveValue('sweden');
+    expect(options[1]).toHaveValue('norway');
+    expect(options[2]).toHaveValue('denmark');
+  });
 });

--- a/src/layout/Dropdown/DropdownComponent.tsx
+++ b/src/layout/Dropdown/DropdownComponent.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { Select } from '@digdir/design-system-react';
+import type { SingleSelectOption } from '@digdir/design-system-react';
 
 import { AltinnSpinner } from 'src/components/AltinnSpinner';
 import { useAppSelector } from 'src/hooks/useAppSelector';
@@ -12,8 +13,15 @@ import { useLanguage } from 'src/hooks/useLanguage';
 import { duplicateOptionFilter, getOptionLookupKey } from 'src/utils/options';
 import type { PropsFromGenericComponent } from 'src/layout';
 
-export type IDropdownProps = PropsFromGenericComponent<'Dropdown'>;
+type SortOrder = 'asc' | 'desc';
+const compareSelectOptionAlphabetically =
+  (sortOrder: SortOrder = 'asc') =>
+  (a: SingleSelectOption, b: SingleSelectOption) => {
+    const comparison = new Intl.Collator(['nb', 'en']).compare(a.label, b.label);
+    return sortOrder === 'asc' ? comparison : -comparison;
+  };
 
+export type IDropdownProps = PropsFromGenericComponent<'Dropdown'>;
 export function DropdownComponent({ node, formData, handleDataChange, isValid, overrideDisplay }: IDropdownProps) {
   const {
     optionsId,
@@ -25,6 +33,7 @@ export function DropdownComponent({ node, formData, handleDataChange, isValid, o
     queryParameters,
     source,
     textResourceBindings,
+    sortOrder,
   } = node.item;
   const { langAsString } = useLanguage();
   const options = (useGetOptions({ optionsId, mapping, queryParameters, source }) || staticOptions)?.filter(
@@ -76,7 +85,9 @@ export function DropdownComponent({ node, formData, handleDataChange, isValid, o
           value={value}
           disabled={readOnly}
           error={!isValid}
-          options={formattedOptions}
+          options={
+            sortOrder ? formattedOptions.toSorted(compareSelectOptionAlphabetically(sortOrder)) : formattedOptions
+          }
           aria-label={overrideDisplay?.renderedInTable ? langAsString(textResourceBindings?.title) : undefined}
         />
       )}

--- a/src/layout/Dropdown/config.ts
+++ b/src/layout/Dropdown/config.ts
@@ -12,4 +12,12 @@ export const Config = new CG.component({
   },
 })
   .makeSelectionComponent()
-  .addDataModelBinding(CG.common('IDataModelBindingsSimple').optional({ onlyIn: Variant.Internal }));
+  .addDataModelBinding(CG.common('IDataModelBindingsSimple').optional({ onlyIn: Variant.Internal }))
+  .addProperty(
+    new CG.prop(
+      'sortOrder',
+      new CG.enum('asc', 'desc')
+        .setDescription('Sorts the code list in either ascending or descending order by label.')
+        .optional(),
+    ),
+  );


### PR DESCRIPTION


## Description

Created this PR because I had merge conflicts when trying to cherry pick the commit containing the sort order code from `main` to `v3`. Just need a sanity check that this won't break anything in v3. 

## Related Issue(s)

- closes #1599 
