### PR TITLE
Upgrade design system to 0.35.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "@altinn/altinn-design-system": "0.29.1",
     "@babel/polyfill": "7.12.1",
     "@date-io/moment": "1.3.13",
-    "@digdir/design-system-react": "^0.32.1",
+    "@digdir/design-system-react": "^0.34.0",
     "@digdir/design-system-tokens": "^0.8.1",
     "@material-ui/core": "4.12.4",
     "@material-ui/pickers": "3.3.11",

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "@altinn/altinn-design-system": "0.29.1",
     "@babel/polyfill": "7.12.1",
     "@date-io/moment": "1.3.13",
-    "@digdir/design-system-react": "^0.34.0",
+    "@digdir/design-system-react": "^0.35.0",
     "@digdir/design-system-tokens": "^0.8.1",
     "@material-ui/core": "4.12.4",
     "@material-ui/pickers": "3.3.11",

--- a/src/components/form/RadioButton.test.tsx
+++ b/src/components/form/RadioButton.test.tsx
@@ -48,7 +48,7 @@ describe('RadioButton', () => {
     const helpTextButton = screen.getByRole('button', { name: /Hjelpetekst: trykk på knappen/i });
     expect(helpTextButton).toBeVisible();
     await userEvent.click(helpTextButton);
-    expect(await screen.findByRole('tooltip')).toHaveTextContent('Hjelpetekst: trykk på knappen');
+    expect(await screen.findByRole('dialog')).toHaveTextContent('Hjelpetekst: trykk på knappen');
   });
   it('should render with hidden label', async () => {
     render({ label: 'Dette er en knapp', hideLabel: true });

--- a/src/components/molecules/DeleteWarningPopover.tsx
+++ b/src/components/molecules/DeleteWarningPopover.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Button, Popover } from '@digdir/design-system-react';
+import { Button, LegacyPopover } from '@digdir/design-system-react';
 import { makeStyles } from '@material-ui/core';
 
 import { useLanguage } from 'src/hooks/useLanguage';
@@ -37,7 +37,7 @@ export function DeleteWarningPopover({
   const classes = useStyles();
   const { lang } = useLanguage();
   return (
-    <Popover
+    <LegacyPopover
       variant='warning'
       placement={placement}
       trigger={children}
@@ -65,6 +65,6 @@ export function DeleteWarningPopover({
           {lang('general.cancel')}
         </Button>
       </div>
-    </Popover>
+    </LegacyPopover>
   );
 }

--- a/src/layout/RadioButtons/RadioButtonsContainerComponent.test.tsx
+++ b/src/layout/RadioButtons/RadioButtonsContainerComponent.test.tsx
@@ -232,14 +232,14 @@ describe('RadioButtonsContainerComponent', () => {
     await userEvent.click(
       screen.getByRole('button', { name: 'Help Text: The value from the group is: Label for first' }),
     );
-    expect(await screen.findByRole('tooltip')).toHaveTextContent(
+    expect(await screen.findByRole('dialog')).toHaveTextContent(
       'Help Text: The value from the group is: Label for first',
     );
 
     await userEvent.click(
       screen.getByRole('button', { name: 'Help Text: The value from the group is: Label for second' }),
     );
-    expect(await screen.findByRole('tooltip')).toHaveTextContent(
+    expect(await screen.findByRole('dialog')).toHaveTextContent(
       'Help Text: The value from the group is: Label for second',
     );
 

--- a/test/e2e/integration/frontend-test/components.ts
+++ b/test/e2e/integration/frontend-test/components.ts
@@ -257,17 +257,15 @@ describe('UI Components', () => {
     cy.get(appFrontend.changeOfName.confirmChangeName).findByText('Dette er en beskrivelse.').should('be.visible');
     cy.get(appFrontend.changeOfName.confirmChangeName).findByRole('button').click();
     cy.get(appFrontend.changeOfName.confirmChangeName)
-      .findByRole('dialog', { name: 'Dette er en hjelpetekst.' })
-      .should('be.visible');
+      .findByRole('dialog')
+      .should('contain.text', 'Dette er en hjelpetekst.');
 
     cy.get(appFrontend.changeOfName.confirmChangeName).find('label').click();
     cy.get(appFrontend.changeOfName.reasons).should('be.visible');
 
     cy.get(appFrontend.changeOfName.reasons).findByText('Dette er en beskrivelse.').should('be.visible');
     cy.get(appFrontend.changeOfName.reasons).findByRole('button').click();
-    cy.get(appFrontend.changeOfName.reasons)
-      .findByRole('dialog', { name: 'Dette er en hjelpetekst.' })
-      .should('be.visible');
+    cy.get(appFrontend.changeOfName.reasons).findByRole('dialog').should('contain.text', 'Dette er en hjelpetekst.');
   });
 
   it("alert on change if radioButton or checkBox has 'alertOnChange' set to true", () => {

--- a/test/e2e/integration/frontend-test/components.ts
+++ b/test/e2e/integration/frontend-test/components.ts
@@ -18,8 +18,9 @@ describe('UI Components', () => {
         .parentsUntil(appFrontend.message.logoFormContent)
         .eq(1)
         .should('have.css', 'justify-content', 'center');
-      cy.wrap(image).parent().siblings().find(appFrontend.helpText.open).click();
-      cy.get(appFrontend.helpText.alert).contains('Altinn logo').type('{esc}');
+      cy.wrap(image).parent().siblings().find(appFrontend.helpText.button).click();
+      cy.get(appFrontend.helpText.alert).should('contain.text', 'Altinn logo');
+      cy.get(appFrontend.helpText.alert).trigger('keydown', { keyCode: 27 }); // Press ESC key
       cy.get(appFrontend.helpText.alert).should('not.exist');
     });
     cy.get('body').should('have.css', 'background-color', 'rgb(239, 239, 239)');

--- a/test/e2e/integration/frontend-test/components.ts
+++ b/test/e2e/integration/frontend-test/components.ts
@@ -256,7 +256,7 @@ describe('UI Components', () => {
     cy.get(appFrontend.changeOfName.confirmChangeName).findByText('Dette er en beskrivelse.').should('be.visible');
     cy.get(appFrontend.changeOfName.confirmChangeName).findByRole('button').click();
     cy.get(appFrontend.changeOfName.confirmChangeName)
-      .findByRole('tooltip', { name: 'Dette er en hjelpetekst.' })
+      .findByRole('dialog', { name: 'Dette er en hjelpetekst.' })
       .should('be.visible');
 
     cy.get(appFrontend.changeOfName.confirmChangeName).find('label').click();
@@ -265,7 +265,7 @@ describe('UI Components', () => {
     cy.get(appFrontend.changeOfName.reasons).findByText('Dette er en beskrivelse.').should('be.visible');
     cy.get(appFrontend.changeOfName.reasons).findByRole('button').click();
     cy.get(appFrontend.changeOfName.reasons)
-      .findByRole('tooltip', { name: 'Dette er en hjelpetekst.' })
+      .findByRole('dialog', { name: 'Dette er en hjelpetekst.' })
       .should('be.visible');
   });
 

--- a/test/e2e/integration/frontend-test/grid.ts
+++ b/test/e2e/integration/frontend-test/grid.ts
@@ -148,11 +148,11 @@ describe('Grid component', () => {
     cy.goto('changename');
     cy.navPage('grid').click();
 
-    cy.get(appFrontend.grid.grid).find('tr:eq(1) td:eq(0)').find(appFrontend.helpText.open).click();
+    cy.get(appFrontend.grid.grid).find('tr:eq(1) td:eq(0)').find(appFrontend.helpText.button).click();
     cy.get(appFrontend.helpText.alert).should('contain.text', 'Help text');
 
     cy.get(appFrontend.grid.grid).find('tr:eq(2) td:eq(0)').should('contain.text', 'Dette er en beskrivende tekst');
-    cy.get(appFrontend.grid.grid).find('tr:eq(2) td:eq(0)').find(appFrontend.helpText.open).click();
+    cy.get(appFrontend.grid.grid).find('tr:eq(2) td:eq(0)').find(appFrontend.helpText.button).click();
     cy.get(appFrontend.grid.grid).find('tr:eq(2) td:eq(0) label').click();
     // eslint-disable-next-line cypress/unsafe-to-chain-command
     cy.focused().should('have.attr', 'id', 'fordeling-studie');

--- a/test/e2e/pageobjects/app-frontend.ts
+++ b/test/e2e/pageobjects/app-frontend.ts
@@ -39,9 +39,8 @@ export class AppFrontend {
   public printButton = 'button:contains("Print / Lagre PDF")';
 
   public helpText = {
-    open: 'button[aria-expanded=false]',
-    close: 'button[aria-expanded=true]',
-    alert: 'div[role="tooltip"]',
+    button: 'button[class^="HelpText"]',
+    alert: 'div[role="dialog"]',
   };
 
   public navMenu = '#navigation-menu';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2487,9 +2487,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@digdir/design-system-react@npm:^0.34.0":
-  version: 0.34.0
-  resolution: "@digdir/design-system-react@npm:0.34.0"
+"@digdir/design-system-react@npm:^0.35.0":
+  version: 0.35.0
+  resolution: "@digdir/design-system-react@npm:0.35.0"
   dependencies:
     "@altinn/figma-design-tokens": "npm:^6.0.1"
     "@digdir/design-system-tokens": "npm:^0.8.1"
@@ -2499,7 +2499,7 @@ __metadata:
   peerDependencies:
     react: ">=18.2.0"
     react-dom: ">=18.2.0"
-  checksum: 30ee2e9bf23c8bcdb5b240b8e50b880555a243a00ffe5763f7c5bd1acccb736eecdf19d15e1db8759e8af528301336bcf4ed0cbfabb6d6e2b4ce5eceb7ce226c
+  checksum: ad8716455f1be725ad09c9b2ec5ea00a864b1ea6199a37fa9b61c4e53dcd27984b41e11e4f3b8a12a99e502b99fcae76c993272bf3fa61de4a876ed24d1b25c8
   languageName: node
   linkType: hard
 
@@ -5748,7 +5748,7 @@ __metadata:
     "@babel/runtime": "npm:^7.21.0"
     "@babel/runtime-corejs3": "npm:^7.21.0"
     "@date-io/moment": "npm:1.3.13"
-    "@digdir/design-system-react": "npm:^0.34.0"
+    "@digdir/design-system-react": "npm:^0.35.0"
     "@digdir/design-system-tokens": "npm:^0.8.1"
     "@material-ui/core": "npm:4.12.4"
     "@material-ui/pickers": "npm:3.3.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2487,9 +2487,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@digdir/design-system-react@npm:^0.32.1":
-  version: 0.32.1
-  resolution: "@digdir/design-system-react@npm:0.32.1"
+"@digdir/design-system-react@npm:^0.34.0":
+  version: 0.34.0
+  resolution: "@digdir/design-system-react@npm:0.34.0"
   dependencies:
     "@altinn/figma-design-tokens": "npm:^6.0.1"
     "@digdir/design-system-tokens": "npm:^0.8.1"
@@ -2499,7 +2499,7 @@ __metadata:
   peerDependencies:
     react: ">=18.2.0"
     react-dom: ">=18.2.0"
-  checksum: 220eee9fd66f9fe02e541ea20a931727ae53bd859ab9825d053ffb8f78419bbff755799ec0ab094b8e243e61c545cb1e80f82eca2d7ca72f0b5958cee6640ccd
+  checksum: 30ee2e9bf23c8bcdb5b240b8e50b880555a243a00ffe5763f7c5bd1acccb736eecdf19d15e1db8759e8af528301336bcf4ed0cbfabb6d6e2b4ce5eceb7ce226c
   languageName: node
   linkType: hard
 
@@ -5748,7 +5748,7 @@ __metadata:
     "@babel/runtime": "npm:^7.21.0"
     "@babel/runtime-corejs3": "npm:^7.21.0"
     "@date-io/moment": "npm:1.3.13"
-    "@digdir/design-system-react": "npm:^0.32.1"
+    "@digdir/design-system-react": "npm:^0.34.0"
     "@digdir/design-system-tokens": "npm:^0.8.1"
     "@material-ui/core": "npm:4.12.4"
     "@material-ui/pickers": "npm:3.3.11"


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

Switched `DeleteWarningPopover` to use `LegacyPopover`, for migration issue, see https://github.com/Altinn/app-frontend-react/issues/1601.

It is possible that this PR fixes the issues related to `HelpText`, as this should already use the new popover.

## Related Issue(s)

- closes #1615 
