### PR TITLE
refactor properties of IOptionSource to have suppport for expressions.

### DIFF
--- a/src/codegen/Common.ts
+++ b/src/codegen/Common.ts
@@ -231,9 +231,11 @@ const common = {
       ),
       new CG.prop(
         'label',
-        new CG.str()
+        new CG.expr(ExprVal.String)
           .setTitle('Label')
-          .setDescription('Reference to a text resource to be used as the option label.')
+          .setDescription(
+            'A label of the option displayed in Radio- and Checkbox groups. Can be plain text, a text resource binding, or a dynamic expression.',
+          )
           .addExample('some.text.key'),
       ),
       new CG.prop(
@@ -245,21 +247,21 @@ const common = {
       ),
       new CG.prop(
         'description',
-        new CG.str()
+        new CG.expr(ExprVal.String)
           .optional()
           .setTitle('Description')
           .setDescription(
-            'A description of the option displayed in Radio- and Checkbox groups. Can be plain text or a text resource binding.',
+            'A description of the option displayed in Radio- and Checkbox groups. Can be plain text, a text resource binding, or a dynamic expression.',
           )
           .addExample('some.text.key', 'My Description'),
       ),
       new CG.prop(
         'helpText',
-        new CG.str()
+        new CG.expr(ExprVal.String)
           .optional()
           .setTitle('Help Text')
           .setDescription(
-            'A help text for the option displayed in Radio- and Checkbox groups. Can be plain text or a text resource binding.',
+            'A help text for the option displayed in Radio- and Checkbox groups. Can be plain text, a text resource binding, or a dynamic expression.',
           )
           .addExample('some.text.key', 'My Help Text'),
       ),

--- a/src/features/options/useGetOptions.ts
+++ b/src/features/options/useGetOptions.ts
@@ -4,7 +4,7 @@ import { useGetOptionsQuery } from 'src/hooks/queries/useGetOptionsQuery';
 import { useLanguage } from 'src/hooks/useLanguage';
 import { useSourceOptions } from 'src/hooks/useSourceOptions';
 import { duplicateOptionFilter } from 'src/utils/options';
-import type { IMapping, IOption, IOptionSource } from 'src/layout/common.generated';
+import type { IMapping, IOption, IOptionSourceExternal } from 'src/layout/common.generated';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 type ValueType = 'single' | 'multi';
@@ -41,9 +41,7 @@ interface Props<T extends ValueType> {
   secure?: boolean;
   mapping?: IMapping;
   queryParameters?: Record<string, string>;
-
-  // Fetch options from repeating group
-  source?: IOptionSource;
+  source?: IOptionSourceExternal;
 
   sortOrder?: SortOrder;
 }

--- a/src/hooks/useSourceOptions.ts
+++ b/src/hooks/useSourceOptions.ts
@@ -10,12 +10,12 @@ import { convertDataBindingToModel, getKeyWithoutIndexIndicators } from 'src/uti
 import { transposeDataBinding } from 'src/utils/databindings/DataBinding';
 import { selectDataSourcesFromState } from 'src/utils/layout/hierarchy';
 import { memoize } from 'src/utils/memoize';
-import type { IOption, IOptionSource } from 'src/layout/common.generated';
+import type { IOption, IOptionSourceExternal } from 'src/layout/common.generated';
 import type { HierarchyDataSources } from 'src/layout/layout';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 interface IUseSourceOptionsArgs {
-  source: IOptionSource | undefined;
+  source: IOptionSourceExternal | undefined;
   node: LayoutNode;
 }
 


### PR DESCRIPTION
In #1614 support for dynamic expressions in code lists based on repeating groups was added. This PR did not include an update to the properties of `IOptionSource` which is the basis for generating schema, types, and future documentation of these properties. 

This PR adds these properties. 
