### PR TITLE
fix: sort options based on their value not text resource key

### DIFF
--- a/src/features/options/useGetOptions.ts
+++ b/src/features/options/useGetOptions.ts
@@ -4,6 +4,7 @@ import { useGetOptionsQuery } from 'src/hooks/queries/useGetOptionsQuery';
 import { useLanguage } from 'src/hooks/useLanguage';
 import { useSourceOptions } from 'src/hooks/useSourceOptions';
 import { duplicateOptionFilter } from 'src/utils/options';
+import type { IUseLanguage } from 'src/hooks/useLanguage';
 import type { IMapping, IOption, IOptionSourceExternal } from 'src/layout/common.generated';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
@@ -55,9 +56,12 @@ const defaultOptions: IOption[] = [];
 
 type SortOrder = 'asc' | 'desc';
 const compareOptionAlphabetically =
-  (sortOrder: SortOrder = 'asc', language: string = 'nb') =>
+  (langAsString: IUseLanguage['langAsString'], sortOrder: SortOrder = 'asc', language: string = 'nb') =>
   (a: IOption, b: IOption) => {
-    const comparison = a.label.localeCompare(b.label, language, { sensitivity: 'base', numeric: true });
+    const comparison = langAsString(a.label).localeCompare(langAsString(b.label), language, {
+      sensitivity: 'base',
+      numeric: true,
+    });
     return sortOrder === 'asc' ? comparison : -comparison;
   };
 
@@ -67,7 +71,8 @@ export function useGetOptions<T extends ValueType>(props: Props<T>): OptionsResu
   const { data: fetchedOptions, isFetching } = useGetOptionsQuery(optionsId, mapping, queryParameters, secure);
   const staticOptions = optionsId ? undefined : options;
   const calculatedOptions = sourceOptions || fetchedOptions || staticOptions;
-  const { selectedLanguage } = useLanguage();
+  const { selectedLanguage, langAsString } = useLanguage();
+
   usePreselectedOptionIndex(calculatedOptions, props);
   useRemoveStaleValues(calculatedOptions, props);
 
@@ -78,7 +83,7 @@ export function useGetOptions<T extends ValueType>(props: Props<T>): OptionsResu
 
   return {
     options: sortOrder
-      ? optionsWithoutDuplicates.toSorted(compareOptionAlphabetically(sortOrder, selectedLanguage))
+      ? optionsWithoutDuplicates.toSorted(compareOptionAlphabetically(langAsString, sortOrder, selectedLanguage))
       : optionsWithoutDuplicates,
     isFetching: isFetching || !calculatedOptions,
   };

--- a/test/e2e/integration/frontend-test/components.ts
+++ b/test/e2e/integration/frontend-test/components.ts
@@ -297,15 +297,15 @@ describe('UI Components', () => {
     //RadioButtons: try to change the radiobutton to see if we get an alert
     cy.get(appFrontend.changeOfName.confirmChangeName).find('label').click();
 
-    cy.get(appFrontend.changeOfName.reasons).find('input[type="radio"]:eq(0)').should('be.checked');
+    cy.findByRole('radio', { name: /Slektskap/ }).should('be.checked');
 
-    cy.get(appFrontend.changeOfName.reasons).find('input[type="radio"]:eq(1)').click();
+    cy.findByRole('radio', { name: /Gårdsbruk/ }).click();
     cy.get(appFrontend.changeOfName.popOverCancelButton).click();
-    cy.get(appFrontend.changeOfName.reasons).find('input[type="radio"]:eq(0)').should('be.checked');
+    cy.findByRole('radio', { name: /Slektskap/ }).should('be.checked');
 
-    cy.get(appFrontend.changeOfName.reasons).find('input[type="radio"]:eq(1)').click();
+    cy.findByRole('radio', { name: /Gårdsbruk/ }).click();
     cy.get(appFrontend.changeOfName.popOverDeleteButton).click();
-    cy.get(appFrontend.changeOfName.reasons).find('input[type="radio"]:eq(1)').should('be.checked');
+    cy.findByRole('radio', { name: /Gårdsbruk/ }).should('be.checked');
   });
 
   it('should render components as summary', () => {

--- a/test/e2e/integration/frontend-test/sort-order.ts
+++ b/test/e2e/integration/frontend-test/sort-order.ts
@@ -1,0 +1,57 @@
+import { AppFrontend } from 'test/e2e/pageobjects/app-frontend';
+
+const appFrontend = new AppFrontend();
+
+describe('sortOrder', () => {
+  it('should present an options list in the order it is provided when sortOrder is not specified based on values in textResources', () => {
+    const expectedOrder = [
+      'Adoptivforelders etternavn eller mellomnavn',
+      'Annen begrunnelse ',
+      'Ektefelles etternavn eller mellomnavn',
+      'Gårdsbruk',
+      'Jeg tror navnet er nytt i NorgeDette er en hjelpetekst.',
+      'Samboers etternavn eller mellomnavn',
+      'Slektskap',
+      'Ste- eller fosterforeldres etternavn eller mellomnavn',
+      'Tidligere etternavn eller mellomnavn',
+    ];
+    cy.goto('changename');
+    cy.get(appFrontend.changeOfName.newFirstName).type('automation');
+    cy.findByRole('checkbox', { name: /Ja, jeg bekrefter/ }).click();
+
+    cy.findByRole('radiogroup', { name: /Vennligst oppgi b/ }).within(() => {
+      cy.findAllByRole('radio').each((element, i) => {
+        cy.get(`label[for="${element.attr('id')}"]`).should('have.text', expectedOrder[i]);
+      });
+    });
+  });
+
+  it('should present the provided options list sorted alphabetically in descending order when providing sortOrder "desc" based on the values in text resources', () => {
+    const expectedOrder = [
+      'Tidligere etternavn eller mellomnavn',
+      'Ste- eller fosterforeldres etternavn eller mellomnavn',
+      'Slektskap',
+      'Samboers etternavn eller mellomnavn',
+      'Jeg tror navnet er nytt i NorgeDette er en hjelpetekst.',
+      'Gårdsbruk',
+      'Ektefelles etternavn eller mellomnavn',
+      'Annen begrunnelse ',
+      'Adoptivforelders etternavn eller mellomnavn',
+    ];
+
+    cy.interceptLayout('changename', (component) => {
+      if (component.type === 'RadioButtons' && component.id === 'reason') {
+        component.sortOrder = 'desc';
+      }
+    });
+    cy.goto('changename');
+    cy.get(appFrontend.changeOfName.newFirstName).type('automation');
+    cy.findByRole('checkbox', { name: /Ja, jeg bekrefter/ }).click();
+
+    cy.findByRole('radiogroup', { name: /Vennligst oppgi b/ }).within(() => {
+      cy.findAllByRole('radio').each((element, i) => {
+        cy.get(`label[for="${element.attr('id')}"]`).should('have.text', expectedOrder[i]);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Description

Fixes an issue where `sortOrder` on selection components would sort the options according to their text resource key if this was specified. 

## Related Issue(s)

- closes #1634 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
