### PR TITLE
Attachmentlist config

### DIFF
--- a/src/components/atoms/AltinnAttachment.tsx
+++ b/src/components/atoms/AltinnAttachment.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 
 import { List, ListItem, ListItemIcon, ListItemText, makeStyles, Typography } from '@material-ui/core';
-import { FileIcon } from '@navikt/aksel-icons';
 import cn from 'classnames';
 
 import { useLanguage } from 'src/hooks/useLanguage';
+import { FileExtensionIcon } from 'src/layout/FileUpload/FileUploadTable/AttachmentFileName';
+import { getFileEnding } from 'src/utils/attachment';
 import { makeUrlRelativeIfSameDomain } from 'src/utils/urls/urlHelper';
 import type { IAttachment } from 'src/types/shared';
 
@@ -103,9 +104,9 @@ export function AltinnAttachment({ attachments, listDisableVerticalPadding, nest
                 key={index}
               >
                 <ListItemIcon>
-                  <FileIcon
+                  <FileExtensionIcon
+                    fileEnding={getFileEnding(attachment.name)}
                     className={classes.icon}
-                    aria-hidden
                   />
                 </ListItemIcon>
                 <ListItemText

--- a/src/features/confirm/containers/ConfirmPage.tsx
+++ b/src/features/confirm/containers/ConfirmPage.tsx
@@ -5,7 +5,11 @@ import { ProcessNavigation } from 'src/components/presentation/ProcessNavigation
 import { ReadyForPrint } from 'src/components/ReadyForPrint';
 import { returnConfirmSummaryObject } from 'src/features/confirm/helpers/returnConfirmSummaryObject';
 import { useLanguage } from 'src/hooks/useLanguage';
-import { getAttachmentGroupings, getInstancePdf, mapInstanceAttachments } from 'src/utils/attachmentsUtils';
+import {
+  filterInstanceAttachments,
+  filterInstancePdfAttachments,
+  getAttachmentGroupings,
+} from 'src/utils/attachmentsUtils';
 import type { IApplicationMetadata } from 'src/features/applicationMetadata';
 import type { IInstance, IParty } from 'src/types/shared';
 
@@ -36,7 +40,7 @@ export const ConfirmPage = ({ instance, parties, appName, applicationMetadata }:
     if (instance?.data && applicationMetadata) {
       const appLogicDataTypes = applicationMetadata.dataTypes.filter((dataType) => !!dataType.appLogic);
 
-      return mapInstanceAttachments(
+      return filterInstanceAttachments(
         instance.data,
         appLogicDataTypes.map((type) => type.id),
       );
@@ -53,7 +57,7 @@ export const ConfirmPage = ({ instance, parties, appName, applicationMetadata }:
         instanceMetaDataObject={getInstanceMetaObject()}
         title={lang('confirm.title')}
         titleSubmitted={lang('confirm.answers')}
-        pdf={getInstancePdf(instance?.data)}
+        pdf={filterInstancePdfAttachments(instance?.data)}
       />
       <ProcessNavigation />
       <ReadyForPrint />

--- a/src/features/receipt/ReceiptContainer.test.tsx
+++ b/src/features/receipt/ReceiptContainer.test.tsx
@@ -101,7 +101,6 @@ function getMockState({
       id: 'ReceiptAttachmentList',
       type: 'AttachmentList',
       dataTypeIds: ['ref-data-as-pdf'],
-      includePDF: true,
     },
   ];
 

--- a/src/features/receipt/ReceiptContainer.tsx
+++ b/src/features/receipt/ReceiptContainer.tsx
@@ -15,7 +15,11 @@ import { useInstanceIdParams } from 'src/hooks/useInstanceIdParams';
 import { useLanguage } from 'src/hooks/useLanguage';
 import { getAppReceiver } from 'src/language/sharedLanguage';
 import { layoutsSelector } from 'src/selectors/layout';
-import { getAttachmentGroupings, getInstancePdf, mapInstanceAttachments } from 'src/utils/attachmentsUtils';
+import {
+  filterInstanceAttachments,
+  filterInstancePdfAttachments,
+  getAttachmentGroupings,
+} from 'src/utils/attachmentsUtils';
 import { returnUrlToArchive } from 'src/utils/urls/urlHelper';
 import type { SummaryDataObject } from 'src/components/table/AltinnSummaryTable';
 import type { IUseLanguage } from 'src/hooks/useLanguage';
@@ -68,7 +72,7 @@ export const returnInstanceMetaDataObject = (
 
 export const ReceiptContainer = () => {
   const dispatch = useAppDispatch();
-  const [attachments, setAttachments] = useState<IAttachment[]>([]);
+  const [attachments, setAttachments] = useState<IAttachment[] | undefined>([]);
   const [pdf, setPdf] = useState<IAttachment[] | undefined>(undefined);
   const [lastChangedDateTime, setLastChangedDateTime] = useState('');
   const [instanceMetaObject, setInstanceMetaObject] = useState<SummaryDataObject>({});
@@ -114,14 +118,13 @@ export const ReceiptContainer = () => {
 
   useEffect(() => {
     if (instance && instance.data && applicationMetadata) {
-      const appLogicDataTypes = applicationMetadata.dataTypes.filter((dataType) => !!dataType.appLogic);
+      const defaultElementIds = applicationMetadata.dataTypes
+        .filter((dataType) => !!dataType.appLogic)
+        .map((type) => type.id);
 
-      const attachmentsResult = mapInstanceAttachments(
-        instance.data,
-        appLogicDataTypes.map((type) => type.id),
-      );
+      const attachmentsResult = filterInstanceAttachments(instance.data, defaultElementIds);
       setAttachments(attachmentsResult);
-      setPdf(getInstancePdf(instance.data));
+      setPdf(filterInstancePdfAttachments(instance.data));
       setLastChangedDateTime(moment(instance.lastChanged).format('DD.MM.YYYY / HH:mm'));
     }
   }, [instance, applicationMetadata]);

--- a/src/layout/AttachmentList/AttachmentListComponent.test.tsx
+++ b/src/layout/AttachmentList/AttachmentListComponent.test.tsx
@@ -7,41 +7,89 @@ import { renderGenericComponentTest } from 'src/test/renderWithProviders';
 import type { IData } from 'src/types/shared';
 
 describe('FileUploadComponent', () => {
-  it('should render default AttachmentList component', () => {
+  it('should render with only specific attachments and without pdf', () => {
+    render(['not-ref-data-as-pdf']);
+    expect(screen.getByText('2mb.txt')).toBeInTheDocument();
+    expect(screen.queryByText('testData1.pdf')).not.toBeInTheDocument();
+  });
+  it('should render with only pdf attachments', () => {
+    render(['ref-data-as-pdf']);
+    expect(screen.getByText('testData1.pdf')).toBeInTheDocument();
+    expect(screen.queryByText('2mb.txt')).not.toBeInTheDocument();
+  });
+  it('should render with all attachments', () => {
+    render(['include-all']);
+    expect(screen.getByText('2mb.txt')).toBeInTheDocument();
+    expect(screen.getByText('testData1.pdf')).toBeInTheDocument();
+  });
+  it('should render with all attachments and without pdf', () => {
     render();
-    expect(screen.getByText('Attachments')).toBeInTheDocument();
+    expect(screen.getByText('2mb.txt')).toBeInTheDocument();
+    expect(screen.queryByText('testData1.pdf')).not.toBeInTheDocument();
   });
 });
 
-const render = () => {
+const render = (ids?: string[]) => {
   renderGenericComponentTest({
     type: 'AttachmentList',
     renderer: (props) => <AttachmentListComponent {...props} />,
     component: {
-      dataTypeIds: ['test-data-type-1'],
+      dataTypeIds: ids,
       textResourceBindings: {
         title: 'Attachments',
       },
     },
     manipulateState: (state) => {
       if (state.instanceData.instance) {
-        const dataElement: IData = {
-          id: 'test-data-element-1',
-          instanceGuid: state.instanceData.instance.id,
-          dataType: 'test-data-type-1',
-          filename: 'testData1.pdf',
-          contentType: 'application/pdf',
-          blobStoragePath: '',
-          size: 1234,
-          locked: false,
-          refs: [],
-          created: new Date('2021-01-01').toISOString(),
-          createdBy: 'testUser',
-          lastChanged: new Date('2021-01-01').toISOString(),
-          lastChangedBy: 'testUser',
-        };
-        state.instanceData.instance.data = [dataElement];
+        const dataElement: IData = generateDataElement(
+          'test-data-type-1',
+          'ref-data-as-pdf',
+          'testData1.pdf',
+          'application/pdf',
+        );
+        const dataElement1: IData = generateDataElement(
+          'test-data-type-2',
+          'not-ref-data-as-pdf',
+          '2mb.txt',
+          'text/plain',
+        );
+        state.instanceData.instance.data = [dataElement, dataElement1];
+      }
+      if (state.applicationMetadata.applicationMetadata) {
+        const dataType1 = generateDataType('ref-data-as-pdf', 'application/pdf');
+        const dataType2 = generateDataType('not-ref-data-as-pdf', 'text/plain');
+        state.applicationMetadata.applicationMetadata.dataTypes = [dataType1, dataType2];
       }
     },
   });
 };
+
+const generateDataElement = (id: string, dataType: string, filename: string, contentType: string) => ({
+  id,
+  instanceGuid: 'mockInstanceGuid',
+  dataType,
+  filename,
+  contentType,
+  blobStoragePath: '',
+  size: 1234,
+  locked: false,
+  refs: [],
+  created: new Date('2021-01-01').toISOString(),
+  createdBy: 'testUser',
+  lastChanged: new Date('2021-01-01').toISOString(),
+  lastChangedBy: 'testUser',
+});
+
+const generateDataType = (id: string, dataType: string) => ({
+  id,
+  taskId: 'mockElementId',
+  allowedContentTypes: [dataType],
+  maxSize: 5,
+  maxCount: 3,
+  minCount: 0,
+  enablePdfCreation: true,
+  enableFileScan: false,
+  validationErrorOnPendingFileScan: false,
+  enabledFileAnalysers: ['mimeTypeAnalyser'],
+  enabledFileValidators: ['mimeTypeValidator'],
+});

--- a/src/layout/AttachmentList/AttachmentListComponent.tsx
+++ b/src/layout/AttachmentList/AttachmentListComponent.tsx
@@ -11,11 +11,9 @@ import type { PropsFromGenericComponent } from 'src/layout';
 export type IAttachmentListProps = PropsFromGenericComponent<'AttachmentList'>;
 
 export function AttachmentListComponent({ node }: IAttachmentListProps) {
-  const { dataTypeIds } = node.item;
   const { lang } = useLanguage();
-  const dataForTask = useAppSelector(selectDataTypesByIds(dataTypeIds));
+  const dataForTask = useAppSelector(selectDataTypesByIds(node.item.dataTypeIds));
   const attachments = useAppSelector(selectAttachments(dataForTask));
-
   return (
     <Grid
       item={true}

--- a/src/layout/AttachmentList/AttachmentListComponent.tsx
+++ b/src/layout/AttachmentList/AttachmentListComponent.tsx
@@ -13,7 +13,9 @@ export type IAttachmentListProps = PropsFromGenericComponent<'AttachmentList'>;
 export function AttachmentListComponent({ node }: IAttachmentListProps) {
   const { lang } = useLanguage();
   const dataForTask = useAppSelector(selectDataTypesByIds(node.item.dataTypeIds));
-  const attachments = useAppSelector(selectAttachments(dataForTask));
+
+  const includePdf = node.item.dataTypeIds?.some((id) => ['ref-data-as-pdf', 'include-all'].includes(id));
+  const attachments = useAppSelector(selectAttachments(dataForTask, includePdf));
   return (
     <Grid
       item={true}

--- a/src/layout/AttachmentList/AttachmentListComponent.tsx
+++ b/src/layout/AttachmentList/AttachmentListComponent.tsx
@@ -6,6 +6,7 @@ import { AltinnAttachment } from 'src/components/atoms/AltinnAttachment';
 import { useAppSelector } from 'src/hooks/useAppSelector';
 import { useLanguage } from 'src/hooks/useLanguage';
 import { selectAttachments, selectDataTypesByIds } from 'src/selectors/dataTypes';
+import { DataTypeReference } from 'src/utils/attachmentsUtils';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export type IAttachmentListProps = PropsFromGenericComponent<'AttachmentList'>;
@@ -14,7 +15,9 @@ export function AttachmentListComponent({ node }: IAttachmentListProps) {
   const { lang } = useLanguage();
   const dataForTask = useAppSelector(selectDataTypesByIds(node.item.dataTypeIds));
 
-  const includePdf = node.item.dataTypeIds?.some((id) => ['ref-data-as-pdf', 'include-all'].includes(id));
+  const includePdf = node.item.dataTypeIds?.some((id) =>
+    [DataTypeReference.RefDataAsPdf, DataTypeReference.IncludeAll].includes(id as DataTypeReference),
+  );
   const attachments = useAppSelector(selectAttachments(dataForTask, includePdf));
   return (
     <Grid

--- a/src/layout/AttachmentList/AttachmentListComponent.tsx
+++ b/src/layout/AttachmentList/AttachmentListComponent.tsx
@@ -11,10 +11,10 @@ import type { PropsFromGenericComponent } from 'src/layout';
 export type IAttachmentListProps = PropsFromGenericComponent<'AttachmentList'>;
 
 export function AttachmentListComponent({ node }: IAttachmentListProps) {
-  const { dataTypeIds, includePDF } = node.item;
+  const { dataTypeIds } = node.item;
   const { lang } = useLanguage();
   const dataForTask = useAppSelector(selectDataTypesByIds(dataTypeIds));
-  const attachments = useAppSelector(selectAttachments(includePDF, dataForTask));
+  const attachments = useAppSelector(selectAttachments(dataForTask));
 
   return (
     <Grid

--- a/src/layout/AttachmentList/config.ts
+++ b/src/layout/AttachmentList/config.ts
@@ -26,13 +26,4 @@ export const Config = new CG.component({
         .setTitle('Data type IDs')
         .setDescription('List of data type IDs for the attachment list to show'),
     ),
-  )
-  .addProperty(
-    new CG.prop(
-      'includePDF',
-      new CG.bool()
-        .optional()
-        .setTitle('Include PDF?')
-        .setDescription('Whether to include the generated PDF summary files in the attachment list'),
-    ),
   );

--- a/src/layout/FileUpload/FileUploadTable/AttachmentFileName.tsx
+++ b/src/layout/FileUpload/FileUploadTable/AttachmentFileName.tsx
@@ -53,7 +53,7 @@ type FileExtensionIconProps = {
   className?: string;
 };
 
-const FileExtensionIcon = ({ fileEnding, className }: FileExtensionIconProps) => {
+export const FileExtensionIcon = ({ fileEnding, className }: FileExtensionIconProps) => {
   const iconMap = {
     '.pdf': FilePdfIcon,
     '.doc': FileWordIcon,
@@ -67,7 +67,7 @@ const FileExtensionIcon = ({ fileEnding, className }: FileExtensionIconProps) =>
   return (
     <IconComponent
       className={className}
-      aria-hidden={true}
+      aria-hidden
     />
   );
 };

--- a/src/selectors/dataTypes.ts
+++ b/src/selectors/dataTypes.ts
@@ -27,7 +27,8 @@ export const selectDataTypesByIds = (dataTypeIds: string[] | undefined) =>
 export const selectAttachments = (includePDF: boolean = false, dataForTask: IData[] | undefined) =>
   createSelector(selectDataTypes, selectCurrentTaskId, (dataTypes, currentTaskId) => {
     const appLogicDataTypes = dataTypes?.filter((dataType) => dataType.appLogic && dataType.taskId === currentTaskId);
-    return includePDF
-      ? getInstancePdf(dataForTask)
-      : mapInstanceAttachments(dataForTask, appLogicDataTypes?.map((type) => type.id) || []);
+
+    const pdfResult = getInstancePdf(dataForTask) || [];
+    const attachmentResult = mapInstanceAttachments(dataForTask, appLogicDataTypes?.map((type) => type.id) || []);
+    return [...pdfResult, ...attachmentResult];
   });

--- a/src/selectors/dataTypes.ts
+++ b/src/selectors/dataTypes.ts
@@ -24,7 +24,7 @@ export const selectDataTypesByIds = (dataTypeIds: string[] | undefined) =>
     },
   );
 
-export const selectAttachments = (includePDF: boolean = false, dataForTask: IData[] | undefined) =>
+export const selectAttachments = (dataForTask: IData[] | undefined) =>
   createSelector(selectDataTypes, selectCurrentTaskId, (dataTypes, currentTaskId) => {
     const appLogicDataTypes = dataTypes?.filter((dataType) => dataType.appLogic && dataType.taskId === currentTaskId);
 

--- a/src/selectors/dataTypes.ts
+++ b/src/selectors/dataTypes.ts
@@ -1,6 +1,6 @@
 import { createSelector } from 'reselect';
 
-import { getInstancePdf, mapInstanceAttachments } from 'src/utils/attachmentsUtils';
+import { filterInstanceAttachments } from 'src/utils/attachmentsUtils';
 import type { IRuntimeState } from 'src/types';
 import type { IData } from 'src/types/shared';
 
@@ -26,9 +26,9 @@ export const selectDataTypesByIds = (dataTypeIds: string[] | undefined) =>
 
 export const selectAttachments = (dataForTask: IData[] | undefined) =>
   createSelector(selectDataTypes, selectCurrentTaskId, (dataTypes, currentTaskId) => {
-    const appLogicDataTypes = dataTypes?.filter((dataType) => dataType.appLogic && dataType.taskId === currentTaskId);
+    const defaultElementIds =
+      dataTypes?.filter((dataType) => dataType.appLogic && dataType.taskId === currentTaskId).map((type) => type.id) ||
+      [];
 
-    const pdfResult = getInstancePdf(dataForTask) || [];
-    const attachmentResult = mapInstanceAttachments(dataForTask, appLogicDataTypes?.map((type) => type.id) || []);
-    return [...pdfResult, ...attachmentResult];
+    return filterInstanceAttachments(dataForTask, defaultElementIds);
   });

--- a/src/selectors/dataTypes.ts
+++ b/src/selectors/dataTypes.ts
@@ -1,6 +1,6 @@
 import { createSelector } from 'reselect';
 
-import { filterInstanceAttachments, filterInstancePdfAttachments } from 'src/utils/attachmentsUtils';
+import { DataTypeReference, filterInstanceAttachments, filterInstancePdfAttachments } from 'src/utils/attachmentsUtils';
 import type { IRuntimeState } from 'src/types';
 import type { IData } from 'src/types/shared';
 
@@ -15,7 +15,7 @@ export const selectDataTypesByIds = (dataTypeIds: string[] | undefined) =>
     selectInstanceData,
     (dataTypes = [], currentTask, instanceData) => {
       const relevantDataTypes = dataTypes.filter((type) => type.taskId === currentTask);
-      const useSpecificDataTypeIds = dataTypeIds && !dataTypeIds?.includes('include-all');
+      const useSpecificDataTypeIds = dataTypeIds && !dataTypeIds?.includes(DataTypeReference.IncludeAll);
 
       return instanceData?.filter((dataElement) =>
         useSpecificDataTypeIds

--- a/src/selectors/dataTypes.ts
+++ b/src/selectors/dataTypes.ts
@@ -15,12 +15,12 @@ export const selectDataTypesByIds = (dataTypeIds: string[] | undefined) =>
     selectInstanceData,
     (dataTypes = [], currentTask, instanceData) => {
       const relevantDataTypes = dataTypes?.filter((type) => type.taskId === currentTask);
-      return instanceData?.filter((dataElement) => {
-        if (dataTypeIds) {
-          return dataTypeIds.findIndex((id) => dataElement.dataType === id) > -1;
-        }
-        return relevantDataTypes.findIndex((type) => dataElement.dataType === type.id) > -1;
-      });
+      const useSpecificDataTypeIds = dataTypeIds && !dataTypeIds?.includes('include-all');
+      return instanceData?.filter((dataElement) =>
+        useSpecificDataTypeIds
+          ? dataTypeIds.includes(dataElement.dataType)
+          : relevantDataTypes.some((type) => type.id === dataElement.dataType),
+      );
     },
   );
 

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -39,7 +39,6 @@ export interface IAttachment {
   iconClass: string;
   url?: string;
   dataType: string;
-  includePDF?: boolean;
   tags?: string[];
 }
 

--- a/src/utils/attachmentsUtils.test.ts
+++ b/src/utils/attachmentsUtils.test.ts
@@ -1,4 +1,4 @@
-import { getInstancePdf, mapInstanceAttachments } from 'src/utils/attachmentsUtils';
+import { filterInstanceAttachments, filterInstancePdfAttachments } from 'src/utils/attachmentsUtils';
 import type { IData } from 'src/types/shared';
 
 test('mapInstanceAttachments() returns correct attachment array', () => {
@@ -185,9 +185,9 @@ test('mapInstanceAttachments() returns correct attachment array', () => {
     },
   ];
 
-  expect(mapInstanceAttachments(instance.data as unknown as IData[], ['585b2f4e-5ecb-417b-9d01-82b6e889e1d1'])).toEqual(
-    attachmentsTestData,
-  );
+  expect(
+    filterInstanceAttachments(instance.data as unknown as IData[], ['585b2f4e-5ecb-417b-9d01-82b6e889e1d1']),
+  ).toEqual(attachmentsTestData);
 });
 
 test('getInstancePdf() returns correct attachement', () => {
@@ -235,5 +235,5 @@ test('getInstancePdf() returns correct attachement', () => {
     },
   ];
 
-  expect(getInstancePdf(data as unknown as IData[])).toEqual(expectedResult);
+  expect(filterInstancePdfAttachments(data as unknown as IData[])).toEqual(expectedResult);
 });

--- a/src/utils/attachmentsUtils.test.ts
+++ b/src/utils/attachmentsUtils.test.ts
@@ -1,7 +1,7 @@
 import { filterInstanceAttachments, filterInstancePdfAttachments } from 'src/utils/attachmentsUtils';
 import type { IData } from 'src/types/shared';
 
-test('mapInstanceAttachments() returns correct attachment array', () => {
+test('filterInstanceAttachments() returns correct attachment array', () => {
   const instance = {
     id: '50001/c1572504-9fb6-4829-9652-3ca9c82dabb9',
     instanceOwnerId: '50001',
@@ -190,7 +190,7 @@ test('mapInstanceAttachments() returns correct attachment array', () => {
   ).toEqual(attachmentsTestData);
 });
 
-test('getInstancePdf() returns correct attachement', () => {
+test('filterInstancePdfAttachments() returns correct attachement', () => {
   const data = [
     {
       id: '585b2f4e-5ecb-417b-9d01-82b6e889e1d1',

--- a/src/utils/attachmentsUtils.ts
+++ b/src/utils/attachmentsUtils.ts
@@ -1,50 +1,30 @@
 import type { IUseLanguage } from 'src/hooks/useLanguage';
 import type { IApplication, IAttachment, IAttachmentGrouping, IData, IDataType } from 'src/types/shared';
 
-export const mapInstanceAttachments = (
+export const filterInstanceAttachments = (
   data: IData[] | undefined,
   defaultElementIds: string[],
-  platform?: boolean,
-): IAttachment[] => {
-  if (!data) {
-    return [];
-  }
-  const tempAttachments: IAttachment[] = [];
-  data.forEach((dataElement: IData) => {
-    if (defaultElementIds.indexOf(dataElement.dataType) > -1 || dataElement.dataType === 'ref-data-as-pdf') {
-      return;
-    }
-
-    tempAttachments.push({
-      name: dataElement.filename,
-      url: platform ? dataElement.selfLinks?.platform : dataElement.selfLinks?.apps,
-      iconClass: 'reg reg-attachment',
-      dataType: dataElement.dataType,
-    });
-  });
-  return tempAttachments;
+): IAttachment[] | undefined => {
+  const filteredData = data?.filter((dataElement: IData) => defaultElementIds?.indexOf(dataElement.dataType) !== -1);
+  return getInstanceAttachments(filteredData);
 };
 
-export const getInstancePdf = (data: IData[] | undefined, platform?: boolean): IAttachment[] | undefined => {
+export const filterInstancePdfAttachments = (data: IData[] | undefined): IAttachment[] | undefined => {
+  const filteredData = data?.filter((dataElement: IData) => dataElement.dataType === 'ref-data-as-pdf');
+  return getInstanceAttachments(filteredData);
+};
+
+const getInstanceAttachments = (data: IData[] | undefined): IAttachment[] | undefined => {
   if (!data) {
     return undefined;
   }
 
-  const pdfElements = data.filter((element) => element.dataType === 'ref-data-as-pdf');
-
-  if (!pdfElements) {
-    return undefined;
-  }
-
-  return pdfElements.map((element) => {
-    const pdfUrl = platform ? element.selfLinks?.platform : element.selfLinks?.apps;
-    return {
-      name: element.filename,
-      url: pdfUrl,
-      iconClass: 'reg reg-attachment',
-      dataType: element.dataType,
-    };
-  });
+  return data.map((dataElement: IData) => ({
+    name: dataElement.filename,
+    url: dataElement.selfLinks?.apps,
+    iconClass: 'reg reg-attachment',
+    dataType: dataElement.dataType,
+  }));
 };
 
 /**

--- a/src/utils/attachmentsUtils.ts
+++ b/src/utils/attachmentsUtils.ts
@@ -5,7 +5,10 @@ export const filterInstanceAttachments = (
   data: IData[] | undefined,
   defaultElementIds: string[],
 ): IAttachment[] | undefined => {
-  const filteredData = data?.filter((dataElement: IData) => defaultElementIds?.indexOf(dataElement.dataType) === -1);
+  const filteredData = data?.filter(
+    (dataElement: IData) =>
+      !(defaultElementIds.includes(dataElement.dataType) || dataElement.dataType === 'ref-data-as-pdf'),
+  );
   return getInstanceAttachments(filteredData);
 };
 

--- a/src/utils/attachmentsUtils.ts
+++ b/src/utils/attachmentsUtils.ts
@@ -5,7 +5,7 @@ export const filterInstanceAttachments = (
   data: IData[] | undefined,
   defaultElementIds: string[],
 ): IAttachment[] | undefined => {
-  const filteredData = data?.filter((dataElement: IData) => defaultElementIds?.indexOf(dataElement.dataType) !== -1);
+  const filteredData = data?.filter((dataElement: IData) => defaultElementIds?.indexOf(dataElement.dataType) === -1);
   return getInstanceAttachments(filteredData);
 };
 

--- a/src/utils/attachmentsUtils.ts
+++ b/src/utils/attachmentsUtils.ts
@@ -1,19 +1,24 @@
 import type { IUseLanguage } from 'src/hooks/useLanguage';
 import type { IApplication, IAttachment, IAttachmentGrouping, IData, IDataType } from 'src/types/shared';
 
+export enum DataTypeReference {
+  IncludeAll = 'include-all',
+  RefDataAsPdf = 'ref-data-as-pdf',
+}
+
 export const filterInstanceAttachments = (
   data: IData[] | undefined,
   defaultElementIds: string[],
 ): IAttachment[] | undefined => {
   const filteredData = data?.filter(
     (dataElement: IData) =>
-      !(defaultElementIds.includes(dataElement.dataType) || dataElement.dataType === 'ref-data-as-pdf'),
+      !(defaultElementIds.includes(dataElement.dataType) || dataElement.dataType === DataTypeReference.RefDataAsPdf),
   );
   return getInstanceAttachments(filteredData);
 };
 
 export const filterInstancePdfAttachments = (data: IData[] | undefined): IAttachment[] | undefined => {
-  const filteredData = data?.filter((dataElement: IData) => dataElement.dataType === 'ref-data-as-pdf');
+  const filteredData = data?.filter((dataElement: IData) => dataElement.dataType === DataTypeReference.RefDataAsPdf);
   return getInstanceAttachments(filteredData);
 };
 

--- a/test/e2e/support/customReceipt.ts
+++ b/test/e2e/support/customReceipt.ts
@@ -9,7 +9,7 @@ export const customReceipt: ILayout = [
     textResourceBindings: { title: 'Takk for din innsending, dette er en veldig fin custom kvittering.' },
   },
   { id: 'r-header-pdfs', type: 'Header', size: 'M', textResourceBindings: { title: 'receipt.title_submitted' } },
-  { id: 'r-pdfs', type: 'AttachmentList', dataTypeIds: ['ref-data-as-pdf'], includePDF: true },
+  { id: 'r-pdfs', type: 'AttachmentList', dataTypeIds: ['ref-data-as-pdf'] },
   { id: 'r-header-attachments', type: 'Header', size: 'M', textResourceBindings: { title: 'receipt.attachments' } },
   { id: 'r-attachments', type: 'AttachmentList', dataTypeIds: ['fileUpload-changename'] },
 ];


### PR DESCRIPTION
## Description

Refactored the code by removing the includePdf property and introduced some adjustments to the `dataTypeIds` for more flexibility. The config options for dataTypeIds are now:

- To display only attachments from the "fileUpload-changename" task:
``
"dataTypeIds": ["fileUpload-changename"] 
``
- To display attachments from "fileUpload-changename" and pdf-generated attachments:
`` "dataTypeIds": ["fileUpload-changename", "ref-data-as-pdf"] ``
- If dataTypeIds is not configured, all attachments from the task are included, except pdf-generated:
`` "dataTypeIds": undefined ``
- To include all attachments from the task, including pdf-generated ones:
`` "dataTypeIds": ["include-all"] ``

Removed the `platform` parameter and corresponding logic in the AttachmentUtils file, as it was found to be consistently undefined.

Added unit tests covering various configurations to ensure the implementation.

Included file type icons to the attachment list (not that relevant to the issue, but was a quick add)

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes https://github.com/Altinn/app-frontend-react/issues/1489

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [x] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [x] Has been added/updated
  https://github.com/Altinn/altinn-studio-docs/commit/690db6f958a9573504dff17cd030a2050c1401cf
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
