### PR TITLE
Fix: Language Selector Not Updating Text Resources Correctly

### DIFF
--- a/src/hooks/queries/useGetTextResourcesQuery.ts
+++ b/src/hooks/queries/useGetTextResourcesQuery.ts
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+
 import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 import type { AxiosError } from 'axios';
 
@@ -13,15 +15,20 @@ export const useGetTextResourcesQuery = (enabled: boolean): UseQueryResult<IText
   const { fetchTextResources } = useAppQueries();
   const { selectedLanguage } = useLanguage();
 
-  return useQuery(['fetchTextResources', selectedLanguage], () => fetchTextResources(selectedLanguage), {
+  const queryResult = useQuery(['fetchTextResources', selectedLanguage], () => fetchTextResources(selectedLanguage), {
     enabled,
-    onSuccess: (textResourceResult) => {
-      dispatch(TextResourcesActions.fetchFulfilled(textResourceResult));
-    },
     onError: (error: AxiosError) => {
       dispatch(TextResourcesActions.fetchRejected({ error }));
       dispatch(QueueActions.appTaskQueueError({ error }));
       window.logError('Fetching text resources failed:\n', error);
     },
   });
+
+  useEffect(() => {
+    if (queryResult.data) {
+      dispatch(TextResourcesActions.fetchFulfilled(queryResult.data));
+    }
+  }, [queryResult.data, dispatch]);
+
+  return queryResult;
 };

--- a/test/e2e/integration/frontend-test/components.ts
+++ b/test/e2e/integration/frontend-test/components.ts
@@ -402,4 +402,19 @@ describe('UI Components', () => {
     cy.get(appFrontend.changeOfName.reference).should('have.value', 'Sophie Salt');
     cy.get(appFrontend.changeOfName.reference2).should('have.value', 'Dole');
   });
+
+  it('should be possible to change language back and forth and reflect the change in the UI', () => {
+    cy.goto('changename');
+
+    const changeLang = (lang: string, elName: string) => {
+      cy.findByRole('combobox', { name: elName }).click();
+      cy.findByRole('option', { name: lang }).click();
+    };
+
+    cy.get('[data-testid="label-newFirstName"]').should('contain.text', 'Nytt fornavn');
+    changeLang('Engelsk', 'Språk');
+    cy.get('[data-testid="label-newFirstName"]').should('contain.text', 'New first name');
+    changeLang('Norwegian bokmål', 'Language');
+    cy.get('[data-testid="label-newFirstName"]').should('contain.text', 'Nytt fornavn');
+  });
 });


### PR DESCRIPTION
## Description

This PR addresses an issue related to Tanstack Query's onSuccess behavior, as discussed in [this Slack thread](https://altinndevops.slack.com/archives/C045EB3JA9X/p1699365150848939). When switching from Norwegian -> English -> Norwegian, the text elements would become stuck in English. This occurred because Tanstack Query's `onSuccess` wasn't triggered again once the data was fetched and cached.

To resolve this, the `onSuccess` logic has been replaced with a `useEffect`. This ensures that the language change is detected even when the data is already in the cache


<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes #1632 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
