### PR TITLE
Fix checkbox label alignment

### DIFF
--- a/src/layout/Checkboxes/CheckboxesContainerComponent.module.css
+++ b/src/layout/Checkboxes/CheckboxesContainerComponent.module.css
@@ -8,10 +8,17 @@
   flex-direction: row;
   gap: var(--fds-spacing-2);
 }
+
 .horizontal div div {
   display: block;
 }
-.checkBoxLabelContainer {
+
+.checkboxGroup div label {
+  display: inline-flex;
+  padding-left: 3px;
+}
+
+.checkboxLabelContainer {
   display: flex;
   gap: var(--fds-spacing-1);
   align-items: center;

--- a/src/layout/Checkboxes/CheckboxesContainerComponent.tsx
+++ b/src/layout/Checkboxes/CheckboxesContainerComponent.tsx
@@ -107,7 +107,7 @@ export const CheckboxContainerComponent = ({
       onBlur={handleBlur}
     >
       <Checkbox.Group
-        className={cn({ [classes.horizontal]: horizontal })}
+        className={cn({ [classes.horizontal]: horizontal }, classes.checkboxGroup)}
         legend={labelTextGroup}
         description={lang(textResourceBindings?.description)}
         disabled={readOnly}
@@ -144,7 +144,7 @@ export const CheckboxContainerComponent = ({
               size='small'
             >
               {
-                <span className={cn({ 'sr-only': hideLabel }, classes.checkBoxLabelContainer)}>
+                <span className={cn({ 'sr-only': hideLabel }, classes.checkboxLabelContainer)}>
                   {langAsString(option.label)}
                   {option.helpText && (
                     <HelpText title={getPlainTextFromNode(option.helpText)}>{lang(option.helpText)}</HelpText>


### PR DESCRIPTION
## Description

The css in the component from the designsystem somehow broke. The default label css was overriding the css given to the label component used in the checkbox component. This happened even though the css given to the label in the checkbox component was given later and should have higher priority.

I added more specific and thus more highly prioritised css to the checkboxGroup that targets the label to override the css to what had been overridden internally in the DS.

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

<img width="298" alt="image" src="https://github.com/Altinn/app-frontend-react/assets/32294735/c53f940d-f00f-4c2c-a48d-d96eb415fd58">
<img width="291" alt="image" src="https://github.com/Altinn/app-frontend-react/assets/32294735/defdaaeb-8750-410d-9b83-ce0fe8dc184b">


## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
