### PR TITLE
The `<Lang />` component to replace `useLanguage()`

### DIFF
--- a/src/__mocks__/getLogoMock.ts
+++ b/src/__mocks__/getLogoMock.ts
@@ -1,0 +1,3 @@
+export function getLogoMock() {
+  return '<svg width="10mm" height="3mm" xmlns="http://www.w3.org/2000/svg"><text font-size="14px" y="10" fill="black">Altinn</text></svg>';
+}

--- a/src/components/LandmarkShortcuts.tsx
+++ b/src/components/LandmarkShortcuts.tsx
@@ -9,7 +9,7 @@ export interface ILandmarkShortcutsProps {
 
 interface ILandmarkShortcut {
   id: string;
-  text: string;
+  text: React.ReactNode;
 }
 
 const useStyles = makeStyles({

--- a/src/components/altinnAppHeader.test.tsx
+++ b/src/components/altinnAppHeader.test.tsx
@@ -19,7 +19,9 @@ describe('AltinnAppHeader', () => {
       type: undefined,
     });
 
-    expect(screen.getByText(`for ${org.name.toUpperCase()}`)).toBeInTheDocument();
+    // eslint-disable-next-line testing-library/no-node-access
+    const fullText = screen.getByText('for').parentElement!.textContent;
+    expect(fullText).toBe(`for ${org.name.toUpperCase()}`);
   });
 
   it('should not show organisation name when profile has party, and party has organisation with name, and "type" is set', async () => {

--- a/src/components/altinnAppHeader.tsx
+++ b/src/components/altinnAppHeader.tsx
@@ -6,7 +6,7 @@ import cn from 'classnames';
 import classes from 'src/components/AltinnAppHeader.module.css';
 import { LandmarkShortcuts } from 'src/components/LandmarkShortcuts';
 import { AltinnLogo, LogoColor } from 'src/components/logo/AltinnLogo';
-import { useLanguage } from 'src/features/language/useLanguage';
+import { Lang } from 'src/features/language/Lang';
 import { renderParty } from 'src/utils/party';
 import { returnUrlToAllSchemas, returnUrlToMessagebox, returnUrlToProfile } from 'src/utils/urls/urlHelper';
 import type { IProfile } from 'src/types/shared';
@@ -18,7 +18,6 @@ export interface IHeaderProps {
 
 export const AltinnAppHeader = ({ type, profile }: IHeaderProps) => {
   const party = profile?.party;
-  const { langAsString } = useLanguage();
   const blueClass = type ? classes.blueDark : classes.blueDarker;
 
   return (
@@ -30,7 +29,7 @@ export const AltinnAppHeader = ({ type, profile }: IHeaderProps) => {
         shortcuts={[
           {
             id: 'main-content',
-            text: langAsString('navigation.to_main_content'),
+            text: <Lang id='navigation.to_main_content' />,
           },
         ]}
       />
@@ -49,17 +48,17 @@ export const AltinnAppHeader = ({ type, profile }: IHeaderProps) => {
             <ul className={classes.headerLinkList}>
               <li className={classes.headerLink}>
                 <a href={returnUrlToMessagebox(window.location.origin, party?.partyId) || '#'}>
-                  {langAsString('instantiate.inbox')}
+                  <Lang id='instantiate.inbox' />
                 </a>
               </li>
               <li className={classes.headerLink}>
                 <a href={returnUrlToAllSchemas(window.location.origin) || '#'}>
-                  {langAsString('instantiate.all_forms')}
+                  <Lang id='instantiate.all_forms' />
                 </a>
               </li>
               <li className={classes.headerLink}>
                 <a href={returnUrlToProfile(window.location.origin, party?.partyId) || '#'}>
-                  {langAsString('instantiate.profile')}
+                  <Lang id='instantiate.profile' />
                 </a>
               </li>
             </ul>
@@ -71,9 +70,11 @@ export const AltinnAppHeader = ({ type, profile }: IHeaderProps) => {
                   <>
                     <span className={`d-block ${blueClass}`}>{renderParty(profile)}</span>
                     <span className={blueClass}>
-                      {party &&
-                        party.organization &&
-                        `${langAsString('general.for')} ${party.organization.name.toUpperCase()}`}
+                      {party && party.organization && (
+                        <>
+                          <Lang id='general.for' /> {party.organization.name.toUpperCase()}
+                        </>
+                      )}
                     </span>
                   </>
                 )}

--- a/src/components/altinnError.tsx
+++ b/src/components/altinnError.tsx
@@ -4,7 +4,7 @@ import classes from 'src/components/altinnError.module.css';
 import { altinnAppsIllustrationHelpCircleSvgUrl } from 'src/utils/urls/urlHelper';
 
 export interface IAltinnErrorProps {
-  statusCode: string;
+  statusCode: string | React.ReactNode;
   title: string | React.ReactNode;
   content: string | React.ReactNode;
   url?: string;

--- a/src/components/molecules/AltinnSubstatusPaper.tsx
+++ b/src/components/molecules/AltinnSubstatusPaper.tsx
@@ -5,8 +5,8 @@ import { Grid, Typography } from '@material-ui/core';
 import { AltinnInformationPaper } from 'src/components/molecules/AltinnInformationPaper';
 
 export interface IInformationPaperProps {
-  label: string;
-  description: string;
+  label: React.ReactNode;
+  description: React.ReactNode;
 }
 
 export function AltinnSubstatusPaper({ label, description }: IInformationPaperProps) {

--- a/src/components/organisms/AltinnAppHeader.test.tsx
+++ b/src/components/organisms/AltinnAppHeader.test.tsx
@@ -4,6 +4,7 @@ import { act, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 
 import { getApplicationMetadataMock } from 'src/__mocks__/getApplicationMetadataMock';
+import { getLogoMock } from 'src/__mocks__/getLogoMock';
 import { LogoColor } from 'src/components/logo/AltinnLogo';
 import { AltinnAppHeader } from 'src/components/organisms/AltinnAppHeader';
 import { renderWithInstanceAndLayout } from 'src/test/renderWithProviders';
@@ -35,8 +36,6 @@ describe('organisms/AltinnAppHeader', () => {
 
   const headerBackgroundColor = 'blue';
 
-  const mockLogo = '<svg fill="black">Altinn</svg>';
-
   interface IRenderComponentProps {
     party: IParty;
     user?: IParty;
@@ -53,7 +52,6 @@ describe('organisms/AltinnAppHeader', () => {
         />
       ),
       queries: {
-        fetchLogo: () => Promise.resolve(mockLogo),
         fetchApplicationMetadata: () => Promise.resolve(getApplicationMetadataMock({ logo })),
       },
     });
@@ -111,6 +109,7 @@ describe('organisms/AltinnAppHeader', () => {
 
   it('Should render Altinn logo if logo options are not set', async () => {
     await render({ party: partyPerson });
+    const mockLogo = getLogoMock().replace('black', LogoColor.blueDarker);
     expect(screen.getByRole('img')).toHaveAttribute('src', `data:image/svg+xml;utf8,${encodeURIComponent(mockLogo)}`);
   });
 

--- a/src/components/organisms/AltinnAppHeader.tsx
+++ b/src/components/organisms/AltinnAppHeader.tsx
@@ -9,7 +9,7 @@ import { AltinnAppHeaderMenu } from 'src/components/organisms/AltinnAppHeaderMen
 import { OrganisationLogo } from 'src/components/presentation/OrganisationLogo/OrganisationLogo';
 import { useHasAppTextsYet } from 'src/core/texts/appTexts';
 import { useApplicationMetadata } from 'src/features/applicationMetadata/ApplicationMetadataProvider';
-import { useLanguage } from 'src/features/language/useLanguage';
+import { Lang } from 'src/features/language/Lang';
 import { renderPartyName } from 'src/utils/party';
 import type { LogoColor } from 'src/components/logo/AltinnLogo';
 import type { IParty } from 'src/types/shared';
@@ -23,48 +23,40 @@ export interface IAltinnAppHeaderProps {
   headerBackgroundColor: string;
 }
 
-export const AltinnAppHeader = ({ logoColor, headerBackgroundColor, party, userParty }: IAltinnAppHeaderProps) => {
-  const { langAsString } = useLanguage();
-
-  return (
-    <AppBar
-      data-testid='AltinnAppHeader'
-      position='relative'
-      classes={{ root: classes.appBar }}
-      style={{ backgroundColor: headerBackgroundColor, color: logoColor }}
-    >
-      <LandmarkShortcuts
-        shortcuts={[
-          {
-            id: 'main-content',
-            text: langAsString('navigation.to_main_content'),
-          },
-        ]}
-      />
-      <div className={classes.container}>
-        <Logo color={logoColor} />
-        <div className={classes.wrapper}>
-          {party && userParty && party.partyId === userParty.partyId && (
-            <span className={classes.appBarText}>{renderPartyName(userParty)}</span>
-          )}
-          {party && userParty && party.partyId !== userParty.partyId && (
-            <>
-              <span className={classes.appBarText}>
-                {renderPartyName(userParty)} for {renderPartyName(party)}
-              </span>
-            </>
-          )}
-          <AltinnAppHeaderMenu
-            party={party}
-            logoColor={logoColor}
-            logoutText={langAsString('general.log_out')}
-            ariaLabel={langAsString('general.header_profile_icon_label')}
-          />
-        </div>
+export const AltinnAppHeader = ({ logoColor, headerBackgroundColor, party, userParty }: IAltinnAppHeaderProps) => (
+  <AppBar
+    data-testid='AltinnAppHeader'
+    position='relative'
+    classes={{ root: classes.appBar }}
+    style={{ backgroundColor: headerBackgroundColor, color: logoColor }}
+  >
+    <LandmarkShortcuts
+      shortcuts={[
+        {
+          id: 'main-content',
+          text: <Lang id={'navigation.to_main_content'} />,
+        },
+      ]}
+    />
+    <div className={classes.container}>
+      <Logo color={logoColor} />
+      <div className={classes.wrapper}>
+        {party && userParty && party.partyId === userParty.partyId && (
+          <span className={classes.appBarText}>{renderPartyName(userParty)}</span>
+        )}
+        {party && userParty && party.partyId !== userParty.partyId && (
+          <span className={classes.appBarText}>
+            {renderPartyName(userParty)} for {renderPartyName(party)}
+          </span>
+        )}
+        <AltinnAppHeaderMenu
+          party={party}
+          logoColor={logoColor}
+        />
       </div>
-    </AppBar>
-  );
-};
+    </div>
+  </AppBar>
+);
 
 const Logo = ({ color }: { color: LogoColor }) => {
   const hasLoaded = useHasAppTextsYet();

--- a/src/components/organisms/AltinnAppHeaderMenu.tsx
+++ b/src/components/organisms/AltinnAppHeaderMenu.tsx
@@ -4,7 +4,7 @@ import { IconButton, makeStyles, Menu, MenuItem } from '@material-ui/core';
 
 import { AltinnIcon } from 'src/components/AltinnIcon';
 import { Lang } from 'src/features/language/Lang';
-import { getPlainTextFromNode } from 'src/utils/stringHelper';
+import { useLanguage } from 'src/features/language/useLanguage';
 import { logoutUrlAltinn } from 'src/utils/urls/urlHelper';
 import type { IParty } from 'src/types/shared';
 
@@ -38,6 +38,7 @@ const useStyles = makeStyles({
 export function AltinnAppHeaderMenu({ party, logoColor }: IAltinnAppHeaderMenuProps) {
   const [anchorEl, setAnchorEl] = React.useState(null);
   const classes = useStyles();
+  const { langAsString } = useLanguage();
 
   const handleClick = (event: any) => {
     setAnchorEl(event.currentTarget);
@@ -56,7 +57,7 @@ export function AltinnAppHeaderMenu({ party, logoColor }: IAltinnAppHeaderMenuPr
       <IconButton
         aria-owns={anchorEl ? 'profile-menu' : undefined}
         aria-haspopup='true'
-        aria-label={getPlainTextFromNode(<Lang id='general.header_profile_icon_label' />)}
+        aria-label={langAsString('general.header_profile_icon_label')}
         onClick={handleClick}
         className={classes.iconButton}
         id='profile-icon-button'

--- a/src/components/organisms/AltinnAppHeaderMenu.tsx
+++ b/src/components/organisms/AltinnAppHeaderMenu.tsx
@@ -3,14 +3,14 @@ import React from 'react';
 import { IconButton, makeStyles, Menu, MenuItem } from '@material-ui/core';
 
 import { AltinnIcon } from 'src/components/AltinnIcon';
+import { Lang } from 'src/features/language/Lang';
+import { getPlainTextFromNode } from 'src/utils/stringHelper';
 import { logoutUrlAltinn } from 'src/utils/urls/urlHelper';
 import type { IParty } from 'src/types/shared';
 
 export interface IAltinnAppHeaderMenuProps {
   party: IParty | undefined;
   logoColor: string;
-  ariaLabel: string;
-  logoutText: string;
 }
 
 const useStyles = makeStyles({
@@ -35,8 +35,7 @@ const useStyles = makeStyles({
   },
 });
 
-export function AltinnAppHeaderMenu(props: IAltinnAppHeaderMenuProps) {
-  const { party, logoColor, ariaLabel, logoutText } = props;
+export function AltinnAppHeaderMenu({ party, logoColor }: IAltinnAppHeaderMenuProps) {
   const [anchorEl, setAnchorEl] = React.useState(null);
   const classes = useStyles();
 
@@ -57,7 +56,7 @@ export function AltinnAppHeaderMenu(props: IAltinnAppHeaderMenuProps) {
       <IconButton
         aria-owns={anchorEl ? 'profile-menu' : undefined}
         aria-haspopup='true'
-        aria-label={ariaLabel}
+        aria-label={getPlainTextFromNode(<Lang id='general.header_profile_icon_label' />)}
         onClick={handleClick}
         className={classes.iconButton}
         id='profile-icon-button'
@@ -98,7 +97,9 @@ export function AltinnAppHeaderMenu(props: IAltinnAppHeaderMenuProps) {
           className={classes.menuItem}
           id='logout-menu-item'
         >
-          <a href={logoutUrlAltinn(window.location.origin)}>{logoutText}</a>
+          <a href={logoutUrlAltinn(window.location.origin)}>
+            <Lang id='general.log_out' />
+          </a>
         </MenuItem>
       </Menu>
     </>

--- a/src/components/presentation/Presentation.tsx
+++ b/src/components/presentation/Presentation.tsx
@@ -14,7 +14,7 @@ import { Progress } from 'src/components/presentation/Progress';
 import { Footer } from 'src/features/footer/Footer';
 import { FormLayoutActions } from 'src/features/form/layout/formLayoutSlice';
 import { useLaxInstanceData } from 'src/features/instance/InstanceContext';
-import { useLanguage } from 'src/features/language/useLanguage';
+import { Lang } from 'src/features/language/Lang';
 import { useCurrentParty } from 'src/features/party/PartiesProvider';
 import { useAppDispatch } from 'src/hooks/useAppDispatch';
 import { useAppSelector } from 'src/hooks/useAppSelector';
@@ -32,7 +32,6 @@ export interface IPresentationProvidedProps extends PropsWithChildren {
 
 export const PresentationComponent = ({ header, type, children }: IPresentationProvidedProps) => {
   const dispatch = useAppDispatch();
-  const { lang, langAsString } = useLanguage();
   const party = useCurrentParty();
   const instance = useLaxInstanceData();
   const userParty = useAppSelector((state) => state.profile.profile?.party);
@@ -40,7 +39,7 @@ export const PresentationComponent = ({ header, type, children }: IPresentationP
   const { previous } = useAppSelector(selectPreviousAndNextPage);
   const returnToView = useAppSelector((state) => state.formLayout.uiConfig.returnToView);
 
-  const realHeader = header || (type === ProcessTaskType.Archived ? lang('receipt.receipt') : undefined);
+  const realHeader = header || (type === ProcessTaskType.Archived ? <Lang id={'receipt.receipt'} /> : undefined);
 
   const handleBackArrowButton = () => {
     if (returnToView) {
@@ -93,8 +92,8 @@ export const PresentationComponent = ({ header, type, children }: IPresentationP
       <main className={classes.page}>
         {isProcessStepsArchived && instance?.status?.substatus && (
           <AltinnSubstatusPaper
-            label={langAsString(instance.status.substatus.label)}
-            description={langAsString(instance.status.substatus.description)}
+            label={<Lang id={instance.status.substatus.label} />}
+            description={<Lang id={instance.status.substatus.description} />}
           />
         )}
         <NavBar

--- a/src/core/loading/Loader.test.tsx
+++ b/src/core/loading/Loader.test.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import { screen } from '@testing-library/react';
+
+import { Loader } from 'src/core/loading/Loader';
+import { renderWithMinimalProviders } from 'src/test/renderWithProviders';
+
+describe('Loader', () => {
+  it('should be able to render with minimal providers', async () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    await renderWithMinimalProviders({
+      renderer: () => <Loader reason={'testing-reason'} />,
+      waitUntilLoaded: false,
+    });
+
+    expect(screen.getByTestId('loader')).toBeInTheDocument();
+    expect(screen.getByTestId('loader')).toHaveAttribute('data-reason', 'testing-reason');
+    expect(console.error).not.toHaveBeenCalled();
+  });
+});

--- a/src/core/loading/Loader.tsx
+++ b/src/core/loading/Loader.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { AltinnContentIconFormData } from 'src/components/atoms/AltinnContentIconFormData';
 import { AltinnContentLoader } from 'src/components/molecules/AltinnContentLoader';
 import { PresentationComponent } from 'src/components/presentation/Presentation';
-import { useLanguage } from 'src/features/language/useLanguage';
+import { Lang } from 'src/features/language/Lang';
 import { ProcessTaskType } from 'src/types';
 
 interface LoaderProps {
@@ -11,22 +11,18 @@ interface LoaderProps {
   details?: string;
 }
 
-export function Loader({ reason, details }: LoaderProps) {
-  const { lang } = useLanguage();
-
-  return (
-    <PresentationComponent
-      header={lang('instantiate.starting')}
-      type={ProcessTaskType.Unknown}
+export const Loader = ({ reason, details }: LoaderProps) => (
+  <PresentationComponent
+    header={<Lang id='instantiate.starting' />}
+    type={ProcessTaskType.Unknown}
+  >
+    <AltinnContentLoader
+      width='100%'
+      height='400'
+      reason={reason}
+      details={details}
     >
-      <AltinnContentLoader
-        width='100%'
-        height='400'
-        reason={reason}
-        details={details}
-      >
-        <AltinnContentIconFormData />
-      </AltinnContentLoader>
-    </PresentationComponent>
-  );
-}
+      <AltinnContentIconFormData />
+    </AltinnContentLoader>
+  </PresentationComponent>
+);

--- a/src/features/instantiate/containers/InstantiationErrorPage.tsx
+++ b/src/features/instantiate/containers/InstantiationErrorPage.tsx
@@ -7,9 +7,9 @@ import { AltinnError } from 'src/components/altinnError';
 import { InstantiationContainer } from 'src/features/instantiate/containers/InstantiationContainer';
 
 export type IInstantiationErrorPageProps = {
-  title: string | JSX.Element | JSX.Element[] | null;
+  title: React.ReactNode;
   content: React.ReactNode;
-  statusCode: string;
+  statusCode: React.ReactNode;
 } & RouteProps;
 
 export function InstantiationErrorPage({ content, statusCode, title }: IInstantiationErrorPageProps) {

--- a/src/features/instantiate/containers/UnknownError.test.tsx
+++ b/src/features/instantiate/containers/UnknownError.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+
+import { screen } from '@testing-library/react';
+
+import { UnknownError } from 'src/features/instantiate/containers/UnknownError';
+import { renderWithMinimalProviders } from 'src/test/renderWithProviders';
+
+describe('Unknown error', () => {
+  it('should be able to render with minimal providers', async () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    await renderWithMinimalProviders({
+      renderer: () => <UnknownError />,
+    });
+
+    expect(screen.getByTestId('StatusCode')).toBeInTheDocument();
+    expect(screen.getByTestId('StatusCode')).toHaveTextContent('Ukjent feil');
+    expect(screen.getByTestId('AltinnError')).toHaveTextContent(
+      'Det har skjedd en ukjent feil, vennligst prøv igjen senere.',
+    );
+    // Parameters doesn't work when no providers are present
+    expect(screen.getByTestId('AltinnError')).toHaveTextContent(
+      'Om problemet vedvarer, ta kontakt med oss på brukerservice {0}.',
+    );
+
+    const calls = (console.error as jest.Mock).mock.calls;
+    const otherCalls = callsExceptWhereErrorBoundaryIsWorking(calls);
+
+    expect(otherCalls).toEqual([]);
+  });
+});
+
+function callsExceptWhereErrorBoundaryIsWorking(calls: any[]) {
+  const otherCalls: any[] = [];
+  for (const call of calls) {
+    if (
+      typeof call[0] === 'object' &&
+      call[0] &&
+      'message' in call[0] &&
+      call[0].message.includes('Language is missing')
+    ) {
+      continue;
+    }
+    if (
+      typeof call[0] === 'string' &&
+      call[0].includes('The above error occurred in the <LangComponent> component') &&
+      call[0].includes(
+        'React will try to recreate this component tree from scratch using the error boundary you provided, Lang',
+      )
+    ) {
+      continue;
+    }
+    otherCalls.push(call);
+  }
+
+  return otherCalls;
+}

--- a/src/features/instantiate/containers/UnknownError.test.tsx
+++ b/src/features/instantiate/containers/UnknownError.test.tsx
@@ -17,40 +17,7 @@ describe('Unknown error', () => {
     expect(screen.getByTestId('AltinnError')).toHaveTextContent(
       'Det har skjedd en ukjent feil, vennligst prøv igjen senere.',
     );
-    // Parameters doesn't work when no providers are present
-    expect(screen.getByTestId('AltinnError')).toHaveTextContent(
-      'Om problemet vedvarer, ta kontakt med oss på brukerservice {0}.',
-    );
 
-    const calls = (console.error as jest.Mock).mock.calls;
-    const otherCalls = callsExceptWhereErrorBoundaryIsWorking(calls);
-
-    expect(otherCalls).toEqual([]);
+    expect(console.error).not.toHaveBeenCalled();
   });
 });
-
-function callsExceptWhereErrorBoundaryIsWorking(calls: any[]) {
-  const otherCalls: any[] = [];
-  for (const call of calls) {
-    if (
-      typeof call[0] === 'object' &&
-      call[0] &&
-      'message' in call[0] &&
-      call[0].message.includes('Language is missing')
-    ) {
-      continue;
-    }
-    if (
-      typeof call[0] === 'string' &&
-      call[0].includes('The above error occurred in the <LangComponent> component') &&
-      call[0].includes(
-        'React will try to recreate this component tree from scratch using the error boundary you provided, Lang',
-      )
-    ) {
-      continue;
-    }
-    otherCalls.push(call);
-  }
-
-  return otherCalls;
-}

--- a/src/features/instantiate/containers/UnknownError.tsx
+++ b/src/features/instantiate/containers/UnknownError.tsx
@@ -6,12 +6,11 @@ import { Button } from '@digdir/design-system-react';
 import { DevToolsActions } from 'src/features/devtools/data/devToolsSlice';
 import { DevToolsTab } from 'src/features/devtools/data/types';
 import { InstantiationErrorPage } from 'src/features/instantiate/containers/InstantiationErrorPage';
-import { useLanguage } from 'src/features/language/useLanguage';
+import { Lang } from 'src/features/language/Lang';
 import { useIsDev } from 'src/hooks/useIsDev';
 
 export function UnknownError() {
   const isDev = useIsDev();
-  const { lang, langAsString } = useLanguage();
   const dispatch = useDispatch();
 
   function openLog() {
@@ -19,41 +18,41 @@ export function UnknownError() {
     dispatch(DevToolsActions.setActiveTab({ tabName: DevToolsTab.Logs }));
   }
 
-  const createUnknownErrorContent = (): JSX.Element => {
-    const customerSupport = lang('instantiate.unknown_error_customer_support', [
-      langAsString('general.customer_service_phone_number'),
-    ]);
-
-    return (
-      <>
-        {lang('instantiate.unknown_error_text')}
-        <br />
-        <br />
-        {customerSupport}
-        {isDev && (
-          <>
-            <br />
-            <br />
-            Sjekk loggen for mer informasjon.
-            <br />
-            <br />
-            <Button
-              size='small'
-              onClick={openLog}
-            >
-              Vis logg
-            </Button>
-          </>
-        )}
-      </>
-    );
-  };
-
   return (
     <InstantiationErrorPage
-      title={lang('instantiate.unknown_error_title')}
-      content={createUnknownErrorContent()}
-      statusCode={langAsString('instantiate.unknown_error_status')}
+      title={<Lang id='instantiate.unknown_error_title' />}
+      statusCode={<Lang id='instantiate.unknown_error_status' />}
+      content={
+        <>
+          <Lang id='instantiate.unknown_error_text' />
+          <br />
+          <br />
+          <Lang
+            id='instantiate.unknown_error_customer_support'
+            params={[
+              <Lang
+                key={0}
+                id='general.customer_service_phone_number'
+              />,
+            ]}
+          />
+          {isDev && (
+            <>
+              <br />
+              <br />
+              Sjekk loggen for mer informasjon.
+              <br />
+              <br />
+              <Button
+                size='small'
+                onClick={openLog}
+              >
+                Vis logg
+              </Button>
+            </>
+          )}
+        </>
+      }
     />
   );
 }

--- a/src/features/language/Lang.test.tsx
+++ b/src/features/language/Lang.test.tsx
@@ -40,6 +40,53 @@ describe('Lang', () => {
     expect(screen.getByTestId('test-subject')).toHaveTextContent('Opprett ny');
   });
 
+  it('should handle Lang components in params', async () => {
+    await renderWithMinimalProviders({
+      renderer: () => (
+        <LanguageProvider>
+          <div data-testid='test-subject'>
+            <Lang
+              id='input_components.remaining_characters'
+              params={[
+                <Lang
+                  key={0}
+                  id='instantiate.inbox'
+                />,
+                <Lang
+                  key={1}
+                  id='instantiate.profile'
+                />,
+              ]}
+            />
+          </div>
+        </LanguageProvider>
+      ),
+    });
+
+    expect(console.error).not.toHaveBeenCalled();
+    expect(screen.getByTestId('test-subject')).toHaveTextContent('Du har innboks av profil tegn igjen');
+  });
+
+  it('should fail if other elements are passed as params', async () => {
+    await renderWithMinimalProviders({
+      renderer: () => (
+        <LanguageProvider>
+          <div data-testid='test-subject'>
+            <Lang
+              id='input_components.remaining_characters'
+              params={[5, <div key={1} />]}
+            />
+          </div>
+        </LanguageProvider>
+      ),
+    });
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining('Error: Invalid element passed to Lang component') }),
+    );
+    expect(screen.getByTestId('test-subject')).toHaveTextContent('Du har {0} av {1} tegn igjen');
+  });
+
   it('should fallback if Language is not provided', async () => {
     await renderWithMinimalProviders({
       renderer: () => <TestSubject />,

--- a/src/features/language/Lang.test.tsx
+++ b/src/features/language/Lang.test.tsx
@@ -84,6 +84,8 @@ describe('Lang', () => {
     expect(console.error).toHaveBeenCalledWith(
       expect.objectContaining({ message: expect.stringContaining('Error: Invalid element passed to Lang component') }),
     );
+
+    // Should still fall back to show a value even if an exception is thrown, but no params will be replaced
     expect(screen.getByTestId('test-subject')).toHaveTextContent('Du har {0} av {1} tegn igjen');
   });
 
@@ -92,14 +94,8 @@ describe('Lang', () => {
       renderer: () => <TestSubject />,
     });
 
-    expect(console.error).toHaveBeenCalledWith(
-      expect.objectContaining({ message: expect.stringContaining('Error: Language is missing') }),
-    );
-    expect(console.error).toHaveBeenCalledWith(
-      expect.stringContaining('The above error occurred in the <LangComponent> component'),
-    );
-
     expect(screen.getByTestId('test-subject')).toHaveTextContent('Opprett ny');
+    expect(console.error).not.toHaveBeenCalled();
   });
 
   it('should use the current language if it is provided when falling back after a failure', async () => {

--- a/src/features/language/Lang.test.tsx
+++ b/src/features/language/Lang.test.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+
+import { screen } from '@testing-library/react';
+
+import { getInitialStateMock } from 'src/__mocks__/initialStateMock';
+import { Lang } from 'src/features/language/Lang';
+import { LanguageProvider } from 'src/features/language/LanguageProvider';
+import * as useLanguage from 'src/features/language/useLanguage';
+import { renderWithMinimalProviders } from 'src/test/renderWithProviders';
+
+function TestSubject() {
+  return (
+    <div data-testid='test-subject'>
+      <Lang id={'general.create_new'} />
+    </div>
+  );
+}
+
+describe('Lang', () => {
+  beforeAll(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+  afterAll(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should work properly', async () => {
+    await renderWithMinimalProviders({
+      renderer: () => (
+        <LanguageProvider>
+          <TestSubject />
+        </LanguageProvider>
+      ),
+    });
+
+    expect(console.error).not.toHaveBeenCalled();
+    expect(screen.getByTestId('test-subject')).toHaveTextContent('Opprett ny');
+  });
+
+  it('should fallback if Language is not provided', async () => {
+    await renderWithMinimalProviders({
+      renderer: () => <TestSubject />,
+    });
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining('Error: Language is missing') }),
+    );
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('The above error occurred in the <LangComponent> component'),
+    );
+
+    expect(screen.getByTestId('test-subject')).toHaveTextContent('Opprett ny');
+  });
+
+  it('should use the current language if it is provided when falling back after a failure', async () => {
+    jest.spyOn(useLanguage, 'useLanguage').mockImplementation(() => {
+      throw new Error('Lets pretend something went wrong');
+    });
+
+    await renderWithMinimalProviders({
+      renderer: () => (
+        <LanguageProvider>
+          <TestSubject />
+        </LanguageProvider>
+      ),
+      reduxState: getInitialStateMock((state) => {
+        state.deprecated.currentLanguage = 'en';
+      }),
+    });
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining('Error: Lets pretend something went wrong') }),
+    );
+    expect(screen.getByTestId('test-subject')).toHaveTextContent('Create new');
+  });
+});

--- a/src/features/language/Lang.tsx
+++ b/src/features/language/Lang.tsx
@@ -1,0 +1,82 @@
+import React, { Component } from 'react';
+
+import { useCurrentLanguage, useHasLanguageProvider } from 'src/features/language/LanguageProvider';
+import { getLanguageFromKey, useLanguage } from 'src/features/language/useLanguage';
+import { getLanguageFromCode } from 'src/language/languages';
+import type { ValidLangParam, ValidLanguageKey } from 'src/features/language/useLanguage';
+
+export interface LangComponentProps {
+  id: ValidLanguageKey | string | undefined;
+  params?: ValidLangParam[];
+}
+
+function LangComponent({ id, params }: LangComponentProps) {
+  const { lang } = useLanguage();
+  return lang(id, params);
+}
+
+function LangFallback({ id, lang }: LangComponentProps & { lang: string }) {
+  return id ? getLanguageFromKey(id, getLanguageFromCode(lang)) : undefined;
+}
+
+function LangWithLanguageFallback({ id, params }: LangComponentProps) {
+  const currentLanguage = useCurrentLanguage();
+
+  return (
+    <LangFallback
+      id={id}
+      params={params}
+      lang={currentLanguage}
+    />
+  );
+}
+
+function LangFallbackCheck({ id, params }: LangComponentProps) {
+  const hasLanguage = useHasLanguageProvider();
+
+  return hasLanguage ? (
+    <LangWithLanguageFallback
+      id={id}
+      params={params}
+    />
+  ) : (
+    <LangFallback
+      id={id}
+      params={params}
+      lang='nb'
+    />
+  );
+}
+
+interface IErrorBoundary {
+  error?: Error;
+}
+
+/**
+ * The Lang component is a wrapper around the useLanguage hook, and is used to resolve a key to
+ * a language string/element. In contrast to the useLanguage hook, this component will handle errors, such
+ * as missing providers, and try to default to a fallback language.
+ */
+export class Lang extends Component<LangComponentProps, IErrorBoundary> {
+  constructor(props: LangComponentProps) {
+    super(props);
+    this.state = { error: undefined };
+  }
+
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+
+  render() {
+    if (this.state.error) {
+      return <LangFallbackCheck id={this.props.id} />;
+    }
+
+    return (
+      <LangComponent
+        id={this.props.id}
+        params={this.props.params}
+      />
+    );
+  }
+}

--- a/src/features/language/Lang.tsx
+++ b/src/features/language/Lang.tsx
@@ -1,6 +1,6 @@
 import React, { Component, isValidElement } from 'react';
 
-import { useCurrentLanguage, useHasLanguageProvider } from 'src/features/language/LanguageProvider';
+import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
 import { getLanguageFromKey, useLanguage } from 'src/features/language/useLanguage';
 import { getLanguageFromCode } from 'src/language/languages';
 import type { ValidLangParam, ValidLanguageKey } from 'src/features/language/useLanguage';
@@ -31,32 +31,9 @@ function LangComponent<P extends Props>({ id, params }: P) {
   return lang(id, realParams);
 }
 
-function LangFallback({ id, lang }: Props & { lang: string }) {
-  return id ? getLanguageFromKey(id, getLanguageFromCode(lang)) : undefined;
-}
-
-function LangWithLanguageFallback(props: Props) {
+function LangComponentFallback({ id }: Props) {
   const currentLanguage = useCurrentLanguage();
-
-  return (
-    <LangFallback
-      {...props}
-      lang={currentLanguage}
-    />
-  );
-}
-
-function LangFallbackCheck(props: Props) {
-  const hasLanguage = useHasLanguageProvider();
-
-  return hasLanguage ? (
-    <LangWithLanguageFallback {...props} />
-  ) : (
-    <LangFallback
-      {...props}
-      lang='nb'
-    />
-  );
+  return id ? getLanguageFromKey(id, getLanguageFromCode(currentLanguage)) : undefined;
 }
 
 interface IErrorBoundary {
@@ -80,7 +57,7 @@ export class Lang<P extends Props> extends Component<P, IErrorBoundary> {
 
   render() {
     if (this.state.error) {
-      return <LangFallbackCheck {...this.props} />;
+      return <LangComponentFallback {...this.props} />;
     }
 
     return <LangComponent {...this.props} />;

--- a/src/features/language/LanguageProvider.tsx
+++ b/src/features/language/LanguageProvider.tsx
@@ -13,9 +13,18 @@ interface LanguageCtx {
   setWithLanguageSelector: (language: string) => void;
 }
 
-const { Provider, useCtx, useHasProvider } = createContext<LanguageCtx>({
+const { Provider, useCtx } = createContext<LanguageCtx>({
   name: 'Language',
-  required: true,
+  required: false,
+  default: {
+    current: 'nb',
+    updateProfile: () => {
+      throw new Error('LanguageProvider not initialized');
+    },
+    setWithLanguageSelector: () => {
+      throw new Error('LanguageProvider not initialized');
+    },
+  },
 });
 
 export const LanguageProvider = ({ children }: PropsWithChildren) => {
@@ -43,7 +52,6 @@ export const LanguageProvider = ({ children }: PropsWithChildren) => {
 };
 
 export const useCurrentLanguage = () => useCtx().current;
-export const useHasLanguageProvider = () => useHasProvider();
 export const useSetCurrentLanguage = () => {
   const { setWithLanguageSelector, updateProfile } = useCtx();
   return { setWithLanguageSelector, updateProfile };

--- a/src/features/language/LanguageProvider.tsx
+++ b/src/features/language/LanguageProvider.tsx
@@ -13,7 +13,7 @@ interface LanguageCtx {
   setWithLanguageSelector: (language: string) => void;
 }
 
-const { Provider, useCtx } = createContext<LanguageCtx>({
+const { Provider, useCtx, useHasProvider } = createContext<LanguageCtx>({
   name: 'Language',
   required: true,
 });
@@ -43,6 +43,7 @@ export const LanguageProvider = ({ children }: PropsWithChildren) => {
 };
 
 export const useCurrentLanguage = () => useCtx().current;
+export const useHasLanguageProvider = () => useHasProvider();
 export const useSetCurrentLanguage = () => {
   const { setWithLanguageSelector, updateProfile } = useCtx();
   return { setWithLanguageSelector, updateProfile };

--- a/src/features/language/useLanguage.ts
+++ b/src/features/language/useLanguage.ts
@@ -1,5 +1,5 @@
 import { useContext, useMemo } from 'react';
-import type { JSX } from 'react';
+import type { JSX, ReactElement } from 'react';
 
 import { useLaxInstanceData } from 'src/features/instance/InstanceContext';
 import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
@@ -11,6 +11,7 @@ import { FormComponentContext } from 'src/layout';
 import { getKeyWithoutIndexIndicators } from 'src/utils/databindings';
 import { transposeDataBinding } from 'src/utils/databindings/DataBinding';
 import { buildInstanceDataSources } from 'src/utils/instanceDataSources';
+import { getPlainTextFromNode } from 'src/utils/stringHelper';
 import type { IFormData } from 'src/features/formData';
 import type { TextResourceMap } from 'src/features/language/textResources';
 import type { FixedLanguageList } from 'src/language/languages';
@@ -18,16 +19,19 @@ import type { IRuntimeState } from 'src/types';
 import type { IApplicationSettings, IInstanceDataSources, ILanguage, IVariable } from 'src/types/shared';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
-type ValidParam = string | number | undefined;
+export type ValidLangParam = string | number | undefined | ReactElement;
 
 export interface IUseLanguage {
   language: ILanguage;
-  lang(key: ValidLanguageKey | string | undefined, params?: ValidParam[]): string | JSX.Element | JSX.Element[] | null;
-  langAsString(key: ValidLanguageKey | string | undefined, params?: ValidParam[]): string;
+  lang(
+    key: ValidLanguageKey | string | undefined,
+    params?: ValidLangParam[],
+  ): string | JSX.Element | JSX.Element[] | null;
+  langAsString(key: ValidLanguageKey | string | undefined, params?: ValidLangParam[]): string;
   langAsStringUsingPathInDataModel(
     key: ValidLanguageKey | string | undefined,
     dataModelPath: string,
-    params?: ValidParam[],
+    params?: ValidLangParam[],
   ): string;
 }
 
@@ -186,7 +190,7 @@ function staticUseLanguage(
     langAsStringUsingPathInDataModel(
       key: ValidLanguageKey | string | undefined,
       dataModelPath: string,
-      params?: ValidParam[],
+      params?: ValidLangParam[],
     ): string {
       if (!key) {
         return '';
@@ -208,7 +212,7 @@ function staticUseLanguage(
   };
 }
 
-function getLanguageFromKey(key: string, language: ILanguage) {
+export function getLanguageFromKey(key: string, language: ILanguage) {
   const path = key.split('.');
   const value = getNestedObject(language, path);
   if (!value || typeof value === 'object') {
@@ -285,16 +289,29 @@ function getNestedObject(nestedObj: ILanguage, pathArr: string[]) {
   return pathArr.reduce((obj, key) => (obj && obj[key] !== 'undefined' ? obj[key] : undefined), nestedObj);
 }
 
-type LangParams = (string | undefined | number)[];
+type LangParams = ValidLangParam[];
 const replaceParameters = (nameString: string | undefined, params: LangParams) => {
   if (nameString === undefined) {
     return nameString;
   }
+
   let mutatingString = nameString;
-  params.forEach((param, index: number) => {
-    if (param !== undefined) {
-      mutatingString = mutatingString.replaceAll(`{${index}}`, `${param}`);
+  for (const index in params) {
+    const param = params[index];
+    let paramAsString: string | undefined;
+    if (typeof param === 'string') {
+      paramAsString = param;
+    } else if (typeof param === 'number') {
+      paramAsString = param.toString();
+    } else if (param && typeof param === 'object') {
+      // This allows you to pass a <Lang /> component as a parameter
+      paramAsString = getPlainTextFromNode(param as ReactElement);
     }
-  });
+
+    if (paramAsString !== undefined) {
+      mutatingString = mutatingString.replaceAll(`{${index}}`, paramAsString);
+    }
+  }
+
   return mutatingString;
 };

--- a/src/features/language/useLanguage.ts
+++ b/src/features/language/useLanguage.ts
@@ -1,5 +1,5 @@
 import { useContext, useMemo } from 'react';
-import type { JSX, ReactElement } from 'react';
+import type { JSX } from 'react';
 
 import { useLaxInstanceData } from 'src/features/instance/InstanceContext';
 import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
@@ -11,7 +11,6 @@ import { FormComponentContext } from 'src/layout';
 import { getKeyWithoutIndexIndicators } from 'src/utils/databindings';
 import { transposeDataBinding } from 'src/utils/databindings/DataBinding';
 import { buildInstanceDataSources } from 'src/utils/instanceDataSources';
-import { getPlainTextFromNode } from 'src/utils/stringHelper';
 import type { IFormData } from 'src/features/formData';
 import type { TextResourceMap } from 'src/features/language/textResources';
 import type { FixedLanguageList } from 'src/language/languages';
@@ -19,7 +18,7 @@ import type { IRuntimeState } from 'src/types';
 import type { IApplicationSettings, IInstanceDataSources, ILanguage, IVariable } from 'src/types/shared';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
-export type ValidLangParam = string | number | undefined | ReactElement;
+export type ValidLangParam = string | number | undefined;
 
 export interface IUseLanguage {
   language: ILanguage;
@@ -303,9 +302,6 @@ const replaceParameters = (nameString: string | undefined, params: LangParams) =
       paramAsString = param;
     } else if (typeof param === 'number') {
       paramAsString = param.toString();
-    } else if (param && typeof param === 'object') {
-      // This allows you to pass a <Lang /> component as a parameter
-      paramAsString = getPlainTextFromNode(param as ReactElement);
     }
 
     if (paramAsString !== undefined) {

--- a/src/test/renderWithProviders.tsx
+++ b/src/test/renderWithProviders.tsx
@@ -12,6 +12,7 @@ import type { JSONSchema7 } from 'json-schema';
 
 import { getInstanceDataMock } from 'src/__mocks__/getInstanceDataMock';
 import { getLayoutSetsMock } from 'src/__mocks__/getLayoutSetsMock';
+import { getLogoMock } from 'src/__mocks__/getLogoMock';
 import { getOrgsMock } from 'src/__mocks__/getOrgsMock';
 import { getPartyMock } from 'src/__mocks__/getPartyMock';
 import { getProcessDataMock } from 'src/__mocks__/getProcessDataMock';
@@ -111,7 +112,7 @@ const makeMutationMocks = (): MockedMutations => ({
 });
 
 const makeDefaultQueryMocks = (state: IRuntimeState): MockableQueries => ({
-  fetchLogo: () => Promise.resolve(''),
+  fetchLogo: () => Promise.resolve(getLogoMock()),
   fetchApplicationMetadata: () => Promise.resolve(state.applicationMetadata.applicationMetadata!),
   fetchActiveInstances: () => Promise.resolve([]),
   fetchCurrentParty: () => Promise.resolve(getPartyMock()),


### PR DESCRIPTION
## Description

The `useLanguage()` hook is great and all, but it's not really idiomatic React, and we could do better. With the steady decline of Sagas and functions that take `langTools` as a bunch of functions used to _do stuff with later_, we can do the next great thing; referencing language keys using a React component instead.

Right now, this component is an error boundary, which makes it possible for us to render language keys (at least our own) very early in the app runtime, even before the `<LanguageProvider />` runs, and still produce some resemblance of a coherent output. This fixes potential problems I (and @bjosttveit) saw where errors early in the provider tree will throw new errors again when `<UnknownError />` may be rendered even before we have a language.

In time, we can also use this component to do something smarter. Since it takes the language key as a property, we can look up the key and branch out to different implementations in runtime. With `useLanguage()` we kind-of guarantee that we have a toolbox ready-to-go with everything you'll ever need, but that's not something we can really guarantee. For example, you can have a text resource with a variable looking up a value in a data model, and if you don't actually use that text resource we won't have to fetch the data model either. Currently we have to load every data model referenced in any of the text resources when in an info-task (see `FormDataProvider`) for this to work, but in the future we can postpone the loading until `<Lang />` is called with a key that actually needs the data model. In other words, we can't return a reactive set of functions from `useLanguage()`, but a component can be reactive.

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
