### PR TITLE
Feat/133 magic button

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,6 +168,7 @@
     "react-dropzone": "14.2.3",
     "react-redux": "8.1.3",
     "react-router-dom": "6.20.0",
+    "react-toastify": "^9.1.3",
     "redux": "4.2.1",
     "redux-saga": "1.2.3",
     "reselect": "4.1.8",

--- a/src/hooks/useNavigatePage.ts
+++ b/src/hooks/useNavigatePage.ts
@@ -179,9 +179,6 @@ export const useNavigatePage = () => {
     [processTasks],
   );
 
-  const navigateNext = useCallback(() => navigateToPage(next), [next, navigateToPage]);
-  const navigatePrevious = useCallback(() => navigateToPage(previous), [previous, navigateToPage]);
-
   return {
     navigateToPage,
     navigateToTask,
@@ -196,7 +193,5 @@ export const useNavigatePage = () => {
     currentPageId,
     taskId,
     previous,
-    navigateNext,
-    navigatePrevious,
   };
 };

--- a/src/hooks/useNavigatePage.ts
+++ b/src/hooks/useNavigatePage.ts
@@ -179,6 +179,9 @@ export const useNavigatePage = () => {
     [processTasks],
   );
 
+  const navigateNext = useCallback(() => navigateToPage(next), [next, navigateToPage]);
+  const navigatePrevious = useCallback(() => navigateToPage(previous), [previous, navigateToPage]);
+
   return {
     navigateToPage,
     navigateToTask,
@@ -193,5 +196,7 @@ export const useNavigatePage = () => {
     currentPageId,
     taskId,
     previous,
+    navigateNext,
+    navigatePrevious,
   };
 };

--- a/src/hooks/useNavigatePage.ts
+++ b/src/hooks/useNavigatePage.ts
@@ -185,14 +185,14 @@ export const useNavigatePage = () => {
   const getCurrentPageIndex = () => {
     const location = window.location.href;
     const _currentPageId = location.split('/').slice(-1)[0];
-    return order?.indexOf(_currentPageId) ?? -1;
+    return order?.indexOf(_currentPageId) ?? undefined;
   };
 
   const getNextPage = () => {
     const currentPageIndex = getCurrentPageIndex();
-    const nextPageIndex = currentPageIndex !== -1 ? currentPageIndex + 1 : -1;
+    const nextPageIndex = currentPageIndex !== undefined ? currentPageIndex + 1 : undefined;
 
-    if (nextPageIndex === -1) {
+    if (nextPageIndex === undefined) {
       return undefined;
     }
     return order?.[nextPageIndex];
@@ -200,9 +200,9 @@ export const useNavigatePage = () => {
 
   const getPreviousPage = () => {
     const currentPageIndex = getCurrentPageIndex();
-    const nextPageIndex = currentPageIndex !== -1 ? currentPageIndex - 1 : -1;
+    const nextPageIndex = currentPageIndex !== undefined ? currentPageIndex - 1 : undefined;
 
-    if (nextPageIndex === -1) {
+    if (nextPageIndex === undefined) {
       return undefined;
     }
     return order?.[nextPageIndex];

--- a/src/hooks/useNavigatePage.ts
+++ b/src/hooks/useNavigatePage.ts
@@ -109,6 +109,9 @@ export const useNavigatePage = () => {
       if (!page) {
         return;
       }
+      if (!order.includes(page)) {
+        return;
+      }
       setFocusId(options?.focusComponentId);
       if (options?.returnToView) {
         setReturnToView(options.returnToView);

--- a/src/hooks/useNavigatePage.ts
+++ b/src/hooks/useNavigatePage.ts
@@ -179,6 +179,56 @@ export const useNavigatePage = () => {
     [processTasks],
   );
 
+  const getCurrentPageIndex = () => {
+    const location = window.location.href;
+    const _currentPageId = location.split('/').slice(-1)[0];
+    return order?.indexOf(_currentPageId) ?? -1;
+  };
+
+  const getNextPage = () => {
+    const currentPageIndex = getCurrentPageIndex();
+    const nextPageIndex = currentPageIndex !== -1 ? currentPageIndex + 1 : -1;
+
+    if (nextPageIndex === -1) {
+      return undefined;
+    }
+    return order?.[nextPageIndex];
+  };
+
+  const getPreviousPage = () => {
+    const currentPageIndex = getCurrentPageIndex();
+    const nextPageIndex = currentPageIndex !== -1 ? currentPageIndex - 1 : -1;
+
+    if (nextPageIndex === -1) {
+      return undefined;
+    }
+    return order?.[nextPageIndex];
+  };
+
+  /**
+   * This function fetch the next page index on function
+   * invocation and then navigates to the next page. This is
+   * to be able to chain multiple ClientActions together.
+   */
+  const navigateToNextPage = () => {
+    const nextPage = getNextPage();
+    if (nextPage) {
+      navigateToPage(nextPage);
+    }
+  };
+  /**
+   * This function fetches the previous page index on
+   * function invocation and then navigates to the previous
+   * page. This is to be able to chain multiple ClientActions
+   * together.
+   */
+  const navigateToPreviousPage = () => {
+    const previousPage = getPreviousPage();
+    if (previousPage) {
+      navigateToPage(previousPage);
+    }
+  };
+
   return {
     navigateToPage,
     navigateToTask,
@@ -193,5 +243,7 @@ export const useNavigatePage = () => {
     currentPageId,
     taskId,
     previous,
+    navigateToNextPage,
+    navigateToPreviousPage,
   };
 };

--- a/src/index.css
+++ b/src/index.css
@@ -58,6 +58,18 @@
 
   --button-margin-top: 2rem;
   --button-gap: 0.75rem;
+
+  /* Toast styles */
+  --toastify-color-info: var(--fds-semantic-surface-action-primary-default);
+  --toastify-color-success: var(--fds-semantic-surface-success-default);
+  --toastify-color-warning: var(--fds-semantic-surface-warning-default);
+  --toastify-color-error: var(--fds-semantic-surface-danger-default);
+  --toastify-toast-width: 400px;
+}
+
+.Toastify__toast {
+  line-height: 1.5rem;
+  padding: var(--fds-spacing-3) var(--fds-spacing-3) var(--fds-spacing-4) var(--fds-spacing-3);
 }
 
 @media only screen and (min-width: 768px) {
@@ -121,13 +133,10 @@ option {
 select.disabled {
   border: 2px solid #6a6a6a !important;
   color: #000;
-  background:
-    url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+Cjxzdmcgd2lkdGg9IjhweCIgaGVpZ2h0PSI0cHgiIHZpZXdCb3g9IjAgMCA4IDQiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayI+CiAgICA8IS0tIEdlbmVyYXRvcjogU2tldGNoIDQwLjIgKDMzODI2KSAtIGh0dHA6Ly93d3cuYm9oZW1pYW5jb2RpbmcuY29tL3NrZXRjaCAtLT4KICAgIDx0aXRsZT5UcmlhbmdsZTwvdGl0bGU+CiAgICA8ZGVzYz5DcmVhdGVkIHdpdGggU2tldGNoLjwvZGVzYz4KICAgIDxkZWZzPjwvZGVmcz4KICAgIDxnIGlkPSJQYWdlLTEiIHN0cm9rZT0ibm9uZSIgc3Ryb2tlLXdpZHRoPSIxIiBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiPgogICAgICAgIDxwb2x5Z29uIGlkPSJUcmlhbmdsZSIgZmlsbD0iIzAwMDAwMCIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoNC4wMDAwMDAsIDIuMDAwMDAwKSBzY2FsZSgxLCAtMSkgdHJhbnNsYXRlKC00LjAwMDAwMCwgLTIuMDAwMDAwKSAiIHBvaW50cz0iNCAwIDggNCAwIDQiPjwvcG9seWdvbj4KICAgIDwvZz4KPC9zdmc+)
+  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+Cjxzdmcgd2lkdGg9IjhweCIgaGVpZ2h0PSI0cHgiIHZpZXdCb3g9IjAgMCA4IDQiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayI+CiAgICA8IS0tIEdlbmVyYXRvcjogU2tldGNoIDQwLjIgKDMzODI2KSAtIGh0dHA6Ly93d3cuYm9oZW1pYW5jb2RpbmcuY29tL3NrZXRjaCAtLT4KICAgIDx0aXRsZT5UcmlhbmdsZTwvdGl0bGU+CiAgICA8ZGVzYz5DcmVhdGVkIHdpdGggU2tldGNoLjwvZGVzYz4KICAgIDxkZWZzPjwvZGVmcz4KICAgIDxnIGlkPSJQYWdlLTEiIHN0cm9rZT0ibm9uZSIgc3Ryb2tlLXdpZHRoPSIxIiBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiPgogICAgICAgIDxwb2x5Z29uIGlkPSJUcmlhbmdsZSIgZmlsbD0iIzAwMDAwMCIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoNC4wMDAwMDAsIDIuMDAwMDAwKSBzY2FsZSgxLCAtMSkgdHJhbnNsYXRlKC00LjAwMDAwMCwgLTIuMDAwMDAwKSAiIHBvaW50cz0iNCAwIDggNCAwIDQiPjwvcG9seWdvbj4KICAgIDwvZz4KPC9zdmc+)
       no-repeat right 0.469rem center,
     repeating-linear-gradient(135deg, #efefef, #efefef 2px, #fff 3px, #fff 5px) !important;
-  background-size:
-    8px 10px,
-    cover !important;
+  background-size: 8px 10px, cover !important;
 }
 
 ol,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { Provider } from 'react-redux';
 import { createHashRouter, RouterProvider } from 'react-router-dom';
+import { Slide, ToastContainer } from 'react-toastify';
 
 import 'src/features/toggles';
 import 'src/features/logging';
@@ -36,6 +37,7 @@ import { initSagas } from 'src/redux/sagas';
 import { setupStore } from 'src/redux/store';
 import { ExprContextWrapper } from 'src/utils/layout/ExprContext';
 
+import 'react-toastify/dist/ReactToastify.css';
 import 'src/index.css';
 import '@digdir/design-system-tokens/brand/altinn/tokens.css';
 
@@ -86,6 +88,12 @@ function Root() {
                             <WindowTitleProvider>
                               <DevTools>
                                 <App />
+                                <ToastContainer
+                                  position='top-center'
+                                  theme='colored'
+                                  transition={Slide}
+                                  draggable={false}
+                                />
                               </DevTools>
                             </WindowTitleProvider>
                           </KeepAliveProvider>

--- a/src/language/texts/en.ts
+++ b/src/language/texts/en.ts
@@ -34,6 +34,9 @@ export function en() {
       sender: 'Party',
       title: 'Check your responses before submitting',
     },
+    custom_actions: {
+      general_error: 'Something went wrong with this action. Please try again later.',
+    },
     date_picker: {
       invalid_date_message: 'Invalid date format. Use the format {0}.',
       cancel_label: 'Cancel',

--- a/src/language/texts/nb.ts
+++ b/src/language/texts/nb.ts
@@ -36,6 +36,9 @@ export function nb(): FixedLanguageList {
       sender: 'Aktør',
       title: 'Se over svarene dine før du sender inn',
     },
+    custom_actions: {
+      general_error: 'Noe gikk galt med denne handlingen. Prøv igjen senere.',
+    },
     date_picker: {
       invalid_date_message: 'Ugyldig datoformat. Bruk formatet {0}.',
       cancel_label: 'Avbryt',

--- a/src/language/texts/nn.ts
+++ b/src/language/texts/nn.ts
@@ -36,6 +36,9 @@ export function nn(): FixedLanguageList {
       sender: 'Aktør',
       title: 'Sjå over svara dine før du sender inn',
     },
+    custom_actions: {
+      general_error: 'Noko gjekk gale med denne handlinga. Prøv igjen seinare.',
+    },
     date_picker: {
       invalid_date_message: 'Ugyldig datoformat. Bruk formatet {0}.',
       cancel_label: 'Avbryt',

--- a/src/layout/ActionButton/ActionButtonComponent.tsx
+++ b/src/layout/ActionButton/ActionButtonComponent.tsx
@@ -4,10 +4,10 @@ import { Button } from '@digdir/design-system-react';
 
 import type { PropsFromGenericComponent } from '..';
 
-import { useLaxProcessData } from 'src/features/instance/ProcessContext';
 import { useProcessNavigation } from 'src/features/instance/ProcessNavigationContext';
 import { Lang } from 'src/features/language/Lang';
 import { ButtonLoader } from 'src/layout/Button/ButtonLoader';
+import { useActionAuthorization } from 'src/layout/CustomButton/CustomButtonComponent';
 import { LayoutPage } from 'src/utils/layout/LayoutPage';
 import type { ActionButtonStyle } from 'src/layout/ActionButton/config.generated';
 import type { ButtonColor, ButtonVariant } from 'src/layout/Button/WrappedButton';
@@ -21,10 +21,10 @@ export type IActionButton = PropsFromGenericComponent<'ActionButton'>;
 
 export function ActionButtonComponent({ node }: IActionButton) {
   const { busyWithId, busy, next } = useProcessNavigation() || {};
-  const actionPermissions = useLaxProcessData()?.currentTask?.actions;
+  const { isAuthorized } = useActionAuthorization();
 
   const { action, buttonStyle, id, textResourceBindings } = node.item;
-  const disabled = !actionPermissions?.[action];
+  const disabled = !isAuthorized(action);
   const isLoadingHere = busyWithId === id;
 
   function handleClick() {

--- a/src/layout/CustomButton/CustomButtonComponent.tsx
+++ b/src/layout/CustomButton/CustomButtonComponent.tsx
@@ -196,7 +196,7 @@ export const CustomButtonComponent = ({ node }: Props) => {
       variant={variant}
       aria-busy={mutation.isLoading}
     >
-      <Lang id={textResourceBindings?.label} />
+      <Lang id={textResourceBindings?.title} />
     </Button>
   );
 };

--- a/src/layout/CustomButton/CustomButtonComponent.tsx
+++ b/src/layout/CustomButton/CustomButtonComponent.tsx
@@ -15,6 +15,8 @@ import { useNavigatePage, useNavigationParams } from 'src/hooks/useNavigatePage'
 import { isSpecificClientAction } from 'src/layout/CustomButton/typeHelpers';
 import { flattenObject } from 'src/utils/databindings';
 import type { PropsFromGenericComponent } from 'src/layout';
+import type { ButtonColor, ButtonVariant } from 'src/layout/Button/WrappedButton';
+import type { CustomButtonStyle } from 'src/layout/CustomButton/config.generated';
 import type * as CBTypes from 'src/layout/CustomButton/config.generated';
 import type { ClientActionHandlers } from 'src/layout/CustomButton/typeHelpers';
 import type { IUserAction } from 'src/types/shared';
@@ -155,8 +157,13 @@ export function useActionAuthorization() {
   };
 }
 
+export const buttonStyles: { [style in CustomButtonStyle]: { color: ButtonColor; variant: ButtonVariant } } = {
+  primary: { variant: 'primary', color: 'success' },
+  secondary: { variant: 'secondary', color: 'first' },
+};
+
 export const CustomButtonComponent = ({ node }: Props) => {
-  const { textResourceBindings, actions, id } = node.item;
+  const { textResourceBindings, actions, id, buttonStyle = 'secondary' } = node.item;
   const { isAuthorized } = useActionAuthorization();
   const { handleClientActions } = useHandleClientActions();
   const { performAction, mutation } = usePerformActionMutation();
@@ -178,10 +185,15 @@ export const CustomButtonComponent = ({ node }: Props) => {
     }
   };
 
+  const { color, variant } = buttonStyles[buttonStyle];
+
   return (
     <Button
+      id={`custom-button-${id}`}
       disabled={disabled}
       onClick={onClick}
+      color={color}
+      variant={variant}
       aria-busy={mutation.isLoading}
     >
       <Lang id={textResourceBindings?.label} />

--- a/src/layout/CustomButton/CustomButtonComponent.tsx
+++ b/src/layout/CustomButton/CustomButtonComponent.tsx
@@ -36,8 +36,8 @@ type FrontendActionWithMetadata = FrontendAction & { metadata: unknown };
 /**
  * A type guard to check if the action is an action that can be run entirely on the frontend
  */
-const isFrontendAction = (action: CustomAction): action is FrontendAction => action.name.startsWith('$');
-const isUserAction = (action: CustomAction): action is UserAction => !isFrontendAction(action);
+const isFrontendAction = (action: CustomAction): action is FrontendAction => action.type === 'FrontendAction';
+const isUserAction = (action: CustomAction): action is UserAction => action.type === 'UserAction';
 const hasMetadata = (action: CustomAction): action is FrontendActionWithMetadata => 'metadata' in action;
 
 type FrontendActionHandlers = {
@@ -179,6 +179,7 @@ export const CustomButtonComponent = ({ node }: Props) => {
       return;
     }
     for (const action of actions) {
+      console.log('Action', action, isUserAction(action), isFrontendAction(action));
       if (isFrontendAction(action)) {
         await handleFrontendActions([action]);
       }

--- a/src/layout/CustomButton/CustomButtonComponent.tsx
+++ b/src/layout/CustomButton/CustomButtonComponent.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+
+import { Button } from '@digdir/design-system-react';
+import { useMutation } from '@tanstack/react-query';
+
+import { useAppMutations } from 'src/core/contexts/AppQueriesProvider';
+import { FormDataActions } from 'src/features/formData/formDataSlice';
+import { Lang } from 'src/features/language/Lang';
+import { useAppDispatch } from 'src/hooks/useAppDispatch';
+import { useNavigationParams } from 'src/hooks/useNavigatePage';
+import type { PropsFromGenericComponent } from 'src/layout';
+
+type Props = PropsFromGenericComponent<'CustomButton'>;
+
+type UpdatedDataModels = Record<string, unknown>;
+
+type FrontendActionFunctions = 'navigateNext' | 'navigatePrevious' | 'navigateToPage';
+
+type FrontendAction = {
+  name: FrontendActionFunctions;
+  metadata: Record<string, unknown>;
+};
+
+export type ActionResult = {
+  updatedDataModels?: UpdatedDataModels;
+  frontendActions?: FrontendAction[];
+};
+
+type UseHandleFrontendActions = {
+  handleFrontendActions: (actions: FrontendAction[]) => Promise<void>;
+  handleDataModelUpdate: (updatedDataModels: UpdatedDataModels) => Promise<void>;
+};
+
+function useHandleFrontendActions(): UseHandleFrontendActions {
+  const dispatch = useAppDispatch();
+
+  const _handleAction = async (action: FrontendAction) => {
+    console.log('Handle Actoin: ', action);
+  };
+
+  return {
+    handleFrontendActions: async (actions) => {
+      for (const action of actions) {
+        await _handleAction(action);
+      }
+    },
+    handleDataModelUpdate: async (updatedDataModels) => {
+      Object.values(updatedDataModels).forEach((dataModel) => {
+        dispatch(FormDataActions.fetchFulfilled({ formData: dataModel }));
+      });
+    },
+  };
+}
+
+type ActionMutationProps = {
+  action: string;
+  buttonId: string;
+};
+
+function useActionMutation() {
+  const { doPerformAction } = useAppMutations();
+  const { partyId, instanceGuid } = useNavigationParams();
+  const { handleFrontendActions, handleDataModelUpdate } = useHandleFrontendActions();
+
+  return useMutation({
+    mutationFn: async ({ action, buttonId }: ActionMutationProps) => {
+      if (!instanceGuid || !partyId) {
+        throw Error('Cannot perform action without partyId and instanceGuid');
+      }
+      return doPerformAction.call(partyId, instanceGuid, { action, buttonId });
+    },
+    onSuccess: async (data) => {
+      console.log('Success: ', data);
+      if (data.updatedDataModels) {
+        await handleDataModelUpdate(data.updatedDataModels);
+      }
+      if (data.frontendActions) {
+        await handleFrontendActions(data.frontendActions);
+      }
+    },
+  });
+}
+
+export const CustomButtonComponent = ({ node }: Props) => {
+  const { textResourceBindings, action, id } = node.item;
+
+  const mutation = useActionMutation();
+
+  const onClick = async () => {
+    mutation.mutate({ action, buttonId: id });
+  };
+
+  return (
+    <Button
+      disabled={mutation.isLoading}
+      onClick={onClick}
+      aria-busy={mutation.isLoading}
+    >
+      <Lang id={textResourceBindings?.label} />
+    </Button>
+  );
+};

--- a/src/layout/CustomButton/CustomButtonComponent.tsx
+++ b/src/layout/CustomButton/CustomButtonComponent.tsx
@@ -146,9 +146,12 @@ function usePerformActionMutation(): UsePerformActionMutation {
 }
 
 export function useActionAuthorization() {
-  const userActions = useLaxProcessData()?.currentTask?.userActions;
+  const currentTask = useLaxProcessData()?.currentTask;
+  const userActions = currentTask?.userActions;
+  const actionPermissions = currentTask?.actions;
   return {
-    isAuthorized: (action: IUserAction['id']) => userActions?.find((a) => a.id === action)?.authorized ?? false,
+    isAuthorized: (action: IUserAction['id']) =>
+      (!!actionPermissions?.[action] || userActions?.find((a) => a.id === action)?.authorized) ?? false,
   };
 }
 

--- a/src/layout/CustomButton/CustomButtonComponent.tsx
+++ b/src/layout/CustomButton/CustomButtonComponent.tsx
@@ -179,7 +179,6 @@ export const CustomButtonComponent = ({ node }: Props) => {
       return;
     }
     for (const action of actions) {
-      console.log('Action', action, isUserAction(action), isFrontendAction(action));
       if (isFrontendAction(action)) {
         await handleFrontendActions([action]);
       }

--- a/src/layout/CustomButton/CustomButtonComponent.tsx
+++ b/src/layout/CustomButton/CustomButtonComponent.tsx
@@ -14,6 +14,7 @@ import { useAppDispatch } from 'src/hooks/useAppDispatch';
 import { useNavigatePage, useNavigationParams } from 'src/hooks/useNavigatePage';
 import { isSpecificClientAction } from 'src/layout/CustomButton/typeHelpers';
 import { flattenObject } from 'src/utils/databindings';
+import { promisify } from 'src/utils/promisify';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type { ButtonColor, ButtonVariant } from 'src/layout/Button/WrappedButton';
 import type * as CBTypes from 'src/layout/CustomButton/config.generated';
@@ -46,12 +47,12 @@ const isServerAction = (action: CBTypes.CustomAction): action is CBTypes.ServerA
 function useHandleClientActions(): UseHandleClientActions {
   const dispatch = useAppDispatch();
   const currentDataModelGuid = useCurrentDataModelGuid();
-  const { next, previous, navigateToPage } = useNavigatePage();
+  const { navigateToPage, navigateToNextPage, navigateToPreviousPage } = useNavigatePage();
 
   const frontendActions: ClientActionHandlers = {
-    nextPage: async () => navigateToPage(next),
-    previousPage: async () => navigateToPage(previous),
-    navigateToPage: async ({ page }) => navigateToPage(page),
+    nextPage: promisify(navigateToNextPage),
+    previousPage: promisify(navigateToPreviousPage),
+    navigateToPage: promisify<ClientActionHandlers['navigateToPage']>(async ({ page }) => navigateToPage(page)),
   };
 
   const handleClientAction = async (action: CBTypes.ClientAction) => {

--- a/src/layout/CustomButton/CustomButtonComponent.tsx
+++ b/src/layout/CustomButton/CustomButtonComponent.tsx
@@ -16,7 +16,6 @@ import { isSpecificClientAction } from 'src/layout/CustomButton/typeHelpers';
 import { flattenObject } from 'src/utils/databindings';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type { ButtonColor, ButtonVariant } from 'src/layout/Button/WrappedButton';
-import type { CustomButtonStyle } from 'src/layout/CustomButton/config.generated';
 import type * as CBTypes from 'src/layout/CustomButton/config.generated';
 import type { ClientActionHandlers } from 'src/layout/CustomButton/typeHelpers';
 import type { IUserAction } from 'src/types/shared';
@@ -157,7 +156,7 @@ export function useActionAuthorization() {
   };
 }
 
-export const buttonStyles: { [style in CustomButtonStyle]: { color: ButtonColor; variant: ButtonVariant } } = {
+export const buttonStyles: { [style in CBTypes.CustomButtonStyle]: { color: ButtonColor; variant: ButtonVariant } } = {
   primary: { variant: 'primary', color: 'success' },
   secondary: { variant: 'secondary', color: 'first' },
 };

--- a/src/layout/CustomButton/CustomButtonComponent.tsx
+++ b/src/layout/CustomButton/CustomButtonComponent.tsx
@@ -53,7 +53,7 @@ function useHandleClientActions(): UseHandleClientActions {
     navigateToPage: async ({ page }) => navigateToPage(page),
   };
 
-  const _handleAction = async (action: CBTypes.ClientAction) => {
+  const handleClientAction = async (action: CBTypes.ClientAction) => {
     if (isSpecificClientAction('navigateToPage', action)) {
       return await frontendActions[action.name](action.metadata);
     }
@@ -63,7 +63,7 @@ function useHandleClientActions(): UseHandleClientActions {
   return {
     handleClientActions: async (actions) => {
       for (const action of actions) {
-        await _handleAction(action);
+        await handleClientAction(action);
       }
     },
     handleDataModelUpdate: async (updatedDataModels) => {

--- a/src/layout/CustomButton/CustomButtonComponent.tsx
+++ b/src/layout/CustomButton/CustomButtonComponent.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { toast } from 'react-toastify';
 
 import { Button } from '@digdir/design-system-react';
 import { useMutation } from '@tanstack/react-query';
@@ -97,6 +98,18 @@ type UsePerformActionMutation = {
   performAction: (props: PerformActionMutationProps) => Promise<void>;
 };
 
+type PerformActionMutationError = {
+  response: {
+    data: {
+      error: {
+        message: string;
+        code: string;
+        metadata: Record<string, unknown>;
+      };
+    };
+  };
+};
+
 function usePerformActionMutation(): UsePerformActionMutation {
   const { doPerformAction } = useAppMutations();
   const { partyId, instanceGuid } = useNavigationParams();
@@ -118,7 +131,7 @@ function usePerformActionMutation(): UsePerformActionMutation {
      * and the side effects that are run in the onSuccess or onError callbacks.
      */
     performAction: ({ action, buttonId }: PerformActionMutationProps) =>
-      new Promise((resolve, reject) =>
+      new Promise((resolve) =>
         mutation.mutate(
           { action, buttonId },
           {
@@ -132,9 +145,12 @@ function usePerformActionMutation(): UsePerformActionMutation {
 
               resolve();
             },
-            onError: async (error) => {
-              //TODO Show toast.
-              reject(error);
+            onError: async (error: PerformActionMutationError) => {
+              if (error?.response?.data?.error?.message !== undefined) {
+                toast(error?.response?.data?.error?.message, { type: 'error' });
+              } else {
+                toast(<Lang id='custom_actions.general_error' />, { type: 'error' });
+              }
             },
           },
         ),

--- a/src/layout/CustomButton/CustomButtonComponent.tsx
+++ b/src/layout/CustomButton/CustomButtonComponent.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { Button } from '@digdir/design-system-react';
 import { useMutation } from '@tanstack/react-query';
+import type { UseMutationResult } from '@tanstack/react-query';
 
 import { useAppMutations } from 'src/core/contexts/AppQueriesProvider';
 import { useCurrentDataModelGuid } from 'src/features/datamodel/useBindingSchema';
@@ -9,21 +10,15 @@ import { FormDataActions } from 'src/features/formData/formDataSlice';
 import { useLaxProcessData } from 'src/features/instance/ProcessContext';
 import { Lang } from 'src/features/language/Lang';
 import { useAppDispatch } from 'src/hooks/useAppDispatch';
-import { useNavigationParams } from 'src/hooks/useNavigatePage';
+import { useNavigatePage, useNavigationParams } from 'src/hooks/useNavigatePage';
 import { flattenObject } from 'src/utils/databindings';
 import type { PropsFromGenericComponent } from 'src/layout';
+import type { CustomAction, FrontendAction, UserAction } from 'src/layout/CustomButton/config.generated';
 import type { IUserAction } from 'src/types/shared';
 
 type Props = PropsFromGenericComponent<'CustomButton'>;
 
 type UpdatedDataModels = Record<string, unknown>;
-
-type FrontendActionFunctions = 'navigateNext' | 'navigatePrevious' | 'navigateToPage';
-
-type FrontendAction = {
-  name: FrontendActionFunctions;
-  metadata: Record<string, unknown>;
-};
 
 export type ActionResult = {
   updatedDataModels?: UpdatedDataModels;
@@ -35,12 +30,46 @@ type UseHandleFrontendActions = {
   handleDataModelUpdate: (updatedDataModels: UpdatedDataModels) => Promise<void>;
 };
 
+type FrontendActionWithMetadata = FrontendAction & { metadata: unknown };
+
+/**
+ * A type guard to check if the action is an action that can be run entirely on the frontend
+ */
+const isFrontendAction = (action: CustomAction): action is FrontendAction => action.name.startsWith('$');
+const isUserAction = (action: CustomAction): action is UserAction => !isFrontendAction(action);
+const hasMetadata = (action: CustomAction): action is FrontendActionWithMetadata => 'metadata' in action;
+
+type FrontendActionHandlers = {
+  [Action in FrontendAction as Action['name']]: Action extends { metadata: infer Metadata }
+    ? (params: Metadata) => Promise<void>
+    : () => Promise<void>;
+};
+
 function useHandleFrontendActions(): UseHandleFrontendActions {
   const dispatch = useAppDispatch();
   const currentDataModelGuid = useCurrentDataModelGuid();
 
+  const { next, previous, navigateToPage } = useNavigatePage();
+
+  const frontendActions: FrontendActionHandlers = {
+    $nextPage: async () => navigateToPage(next),
+    $previousPage: async () => navigateToPage(previous),
+    $navigateToPage: async ({ page }) => navigateToPage(page),
+  };
+
   const _handleAction = async (action: FrontendAction) => {
-    console.log('Handle Actoin: ', action);
+    /**
+     * We pad these with the $ letter in case the backend
+     * returns frontendAction names without the $ prefix.
+     */
+    const functionName = action.name.startsWith('$') ? action.name : `$${action.name}`;
+
+    const frontendActionFn = frontendActions[functionName];
+    if (!hasMetadata(action)) {
+      return await frontendActionFn();
+    }
+
+    await frontendActionFn(action.metadata);
   };
 
   return {
@@ -58,36 +87,59 @@ function useHandleFrontendActions(): UseHandleFrontendActions {
   };
 }
 
-type ActionMutationProps = {
-  action: string;
+type PerformActionMutationProps = {
+  action: CustomAction;
   buttonId: string;
 };
 
-function useActionMutation() {
+type UsePerformActionMutation = {
+  mutation: UseMutationResult<ActionResult>;
+  performAction: (props: PerformActionMutationProps) => Promise<void>;
+};
+
+function usePerformActionMutation(): UsePerformActionMutation {
   const { doPerformAction } = useAppMutations();
   const { partyId, instanceGuid } = useNavigationParams();
-  const { handleFrontendActions, handleDataModelUpdate } = useHandleFrontendActions();
 
-  return useMutation({
-    mutationFn: async ({ action, buttonId }: ActionMutationProps) => {
+  const mutation = useMutation({
+    mutationFn: async ({ action, buttonId }: PerformActionMutationProps) => {
       if (!instanceGuid || !partyId) {
         throw Error('Cannot perform action without partyId and instanceGuid');
       }
-      return doPerformAction.call(partyId, instanceGuid, { action, buttonId });
-    },
-    onSuccess: async (data) => {
-      console.log('Success: ', data);
-      if (data.updatedDataModels) {
-        await handleDataModelUpdate(data.updatedDataModels);
-      }
-      if (data.frontendActions) {
-        await handleFrontendActions(data.frontendActions);
-      }
-    },
-    onError: async (error) => {
-      console.log('ERROR: ', error);
+      return doPerformAction.call(partyId, instanceGuid, { action: action.name, buttonId });
     },
   });
+  const { handleFrontendActions, handleDataModelUpdate } = useHandleFrontendActions();
+
+  return {
+    mutation,
+    /**
+     * We wrap the mutation in a promise to make it possible to await both the mutation,
+     * and the side effects that are run in the onSuccess or onError callbacks.
+     */
+    performAction: ({ action, buttonId }: PerformActionMutationProps) =>
+      new Promise((resolve, reject) =>
+        mutation.mutate(
+          { action, buttonId },
+          {
+            onSuccess: async (data) => {
+              if (data.updatedDataModels) {
+                await handleDataModelUpdate(data.updatedDataModels);
+              }
+              if (data.frontendActions) {
+                await handleFrontendActions(data.frontendActions);
+              }
+
+              resolve();
+            },
+            onError: async (error) => {
+              //TODO Show toast.
+              reject(error);
+            },
+          },
+        ),
+      ),
+  };
 }
 
 export function useActionAuthorization() {
@@ -98,17 +150,26 @@ export function useActionAuthorization() {
 }
 
 export const CustomButtonComponent = ({ node }: Props) => {
-  const { textResourceBindings, action, id } = node.item;
+  const { textResourceBindings, actions, id } = node.item;
   const { isAuthorized } = useActionAuthorization();
+  const { handleFrontendActions } = useHandleFrontendActions();
+  const { performAction, mutation } = usePerformActionMutation();
 
-  const mutation = useActionMutation();
-  const disabled = !isAuthorized(action) || mutation.isLoading;
+  const isPermittedToPerformActions = actions.reduce((acc, action) => acc || isAuthorized(action.name), true);
+  const disabled = !isPermittedToPerformActions || mutation.isLoading;
 
   const onClick = async () => {
     if (disabled) {
       return;
     }
-    mutation.mutate({ action, buttonId: id });
+    for (const action of actions) {
+      if (isFrontendAction(action)) {
+        await handleFrontendActions([action]);
+      }
+      if (isUserAction(action)) {
+        await performAction({ action, buttonId: id });
+      }
+    }
   };
 
   return (

--- a/src/layout/CustomButton/config.ts
+++ b/src/layout/CustomButton/config.ts
@@ -1,0 +1,15 @@
+import { CG } from 'src/codegen/CG';
+import { CompCategory } from 'src/layout/common';
+
+export const Config = new CG.component({
+  category: CompCategory.Action,
+  rendersWithLabel: false,
+  capabilities: {
+    renderInTable: false,
+    renderInButtonGroup: false,
+    renderInAccordion: false,
+    renderInAccordionGroup: false,
+  },
+})
+  .addProperty(new CG.prop('action', new CG.str()))
+  .addTextResource(new CG.trb({ name: 'label', title: 'label', description: 'The title of the button' }));

--- a/src/layout/CustomButton/config.ts
+++ b/src/layout/CustomButton/config.ts
@@ -38,4 +38,13 @@ export const Config = new CG.component({
       ),
     ),
   )
+  .addProperty(
+    new CG.prop(
+      'buttonStyle',
+      new CG.enum('primary', 'secondary')
+        .setTitle('Button style')
+        .setDescription('The style/color scheme of the button.')
+        .exportAs('CustomButtonStyle'),
+    ),
+  )
   .addTextResource(new CG.trb({ name: 'label', title: 'label', description: 'The title of the button' }));

--- a/src/layout/CustomButton/config.ts
+++ b/src/layout/CustomButton/config.ts
@@ -17,14 +17,23 @@ export const Config = new CG.component({
       new CG.arr(
         new CG.union(
           new CG.union(
-            new CG.obj(new CG.prop('name', new CG.const('$nextPage'))).exportAs('NextPageAction'),
-            new CG.obj(new CG.prop('name', new CG.const('$previousPage'))).exportAs('PreviousPageAction'),
+            new CG.obj(
+              new CG.prop('name', new CG.const('$nextPage')),
+              new CG.prop('type', new CG.const('FrontendAction')),
+            ).exportAs('NextPageAction'),
+            new CG.obj(
+              new CG.prop('name', new CG.const('$previousPage')),
+              new CG.prop('type', new CG.const('FrontendAction')),
+            ).exportAs('PreviousPageAction'),
             new CG.obj(
               new CG.prop('name', new CG.const('$navigateToPage')),
+              new CG.prop('type', new CG.const('FrontendAction')),
               new CG.prop('metadata', new CG.obj(new CG.prop('page', new CG.str()))),
             ).exportAs('NavigateToPageAction'),
           ).exportAs('FrontendAction'),
-          new CG.obj(new CG.prop('name', new CG.str())).exportAs('UserAction'),
+          new CG.obj(new CG.prop('name', new CG.str()), new CG.prop('type', new CG.const('UserAction'))).exportAs(
+            'UserAction',
+          ),
         ).exportAs('CustomAction'),
       ),
     ),

--- a/src/layout/CustomButton/config.ts
+++ b/src/layout/CustomButton/config.ts
@@ -5,8 +5,8 @@ export const Config = new CG.component({
   category: CompCategory.Action,
   rendersWithLabel: false,
   capabilities: {
-    renderInTable: false,
-    renderInButtonGroup: false,
+    renderInTable: true,
+    renderInButtonGroup: true,
     renderInAccordion: false,
     renderInAccordionGroup: false,
   },

--- a/src/layout/CustomButton/config.ts
+++ b/src/layout/CustomButton/config.ts
@@ -18,21 +18,21 @@ export const Config = new CG.component({
         new CG.union(
           new CG.union(
             new CG.obj(
-              new CG.prop('name', new CG.const('$nextPage')),
-              new CG.prop('type', new CG.const('FrontendAction')),
+              new CG.prop('name', new CG.const('nextPage')),
+              new CG.prop('type', new CG.const('ClientAction')),
             ).exportAs('NextPageAction'),
             new CG.obj(
-              new CG.prop('name', new CG.const('$previousPage')),
-              new CG.prop('type', new CG.const('FrontendAction')),
+              new CG.prop('name', new CG.const('previousPage')),
+              new CG.prop('type', new CG.const('ClientAction')),
             ).exportAs('PreviousPageAction'),
             new CG.obj(
-              new CG.prop('name', new CG.const('$navigateToPage')),
-              new CG.prop('type', new CG.const('FrontendAction')),
+              new CG.prop('name', new CG.const('navigateToPage')),
+              new CG.prop('type', new CG.const('ClientAction')),
               new CG.prop('metadata', new CG.obj(new CG.prop('page', new CG.str()))),
             ).exportAs('NavigateToPageAction'),
-          ).exportAs('FrontendAction'),
-          new CG.obj(new CG.prop('name', new CG.str()), new CG.prop('type', new CG.const('UserAction'))).exportAs(
-            'UserAction',
+          ).exportAs('ClientAction'),
+          new CG.obj(new CG.prop('name', new CG.str()), new CG.prop('type', new CG.const('ServerAction'))).exportAs(
+            'ServerAction',
           ),
         ).exportAs('CustomAction'),
       ),

--- a/src/layout/CustomButton/config.ts
+++ b/src/layout/CustomButton/config.ts
@@ -11,5 +11,22 @@ export const Config = new CG.component({
     renderInAccordionGroup: false,
   },
 })
-  .addProperty(new CG.prop('action', new CG.str()))
+  .addProperty(
+    new CG.prop(
+      'actions',
+      new CG.arr(
+        new CG.union(
+          new CG.union(
+            new CG.obj(new CG.prop('name', new CG.const('$nextPage'))).exportAs('NextPageAction'),
+            new CG.obj(new CG.prop('name', new CG.const('$previousPage'))).exportAs('PreviousPageAction'),
+            new CG.obj(
+              new CG.prop('name', new CG.const('$navigateToPage')),
+              new CG.prop('metadata', new CG.obj(new CG.prop('page', new CG.str()))),
+            ).exportAs('NavigateToPageAction'),
+          ).exportAs('FrontendAction'),
+          new CG.obj(new CG.prop('name', new CG.str())).exportAs('UserAction'),
+        ).exportAs('CustomAction'),
+      ),
+    ),
+  )
   .addTextResource(new CG.trb({ name: 'label', title: 'label', description: 'The title of the button' }));

--- a/src/layout/CustomButton/config.ts
+++ b/src/layout/CustomButton/config.ts
@@ -47,4 +47,4 @@ export const Config = new CG.component({
         .exportAs('CustomButtonStyle'),
     ),
   )
-  .addTextResource(new CG.trb({ name: 'label', title: 'label', description: 'The title of the button' }));
+  .addTextResource(new CG.trb({ name: 'title', title: 'Title', description: 'The title/text on the button' }));

--- a/src/layout/CustomButton/index.tsx
+++ b/src/layout/CustomButton/index.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import type { JSX } from 'react';
+
+import { CustomButtonDef } from 'src/layout/CustomButton/config.def.generated';
+import { CustomButtonComponent } from 'src/layout/CustomButton/CustomButtonComponent';
+import type { PropsFromGenericComponent } from 'src/layout';
+import type { LayoutNode } from 'src/utils/layout/LayoutNode';
+
+export class CustomButton extends CustomButtonDef {
+  render(props: PropsFromGenericComponent<'CustomButton'>): JSX.Element | null {
+    return <CustomButtonComponent {...props} />;
+  }
+
+  renderSummaryBoilerplate(): boolean {
+    return false;
+  }
+
+  getDisplayData(_node: LayoutNode<'Grid'>): string {
+    return '';
+  }
+
+  validateDataModelBindings(): string[] {
+    return [];
+  }
+}

--- a/src/layout/CustomButton/typeHelpers.ts
+++ b/src/layout/CustomButton/typeHelpers.ts
@@ -1,0 +1,27 @@
+import type * as CBTypes from 'src/layout/CustomButton/config.generated';
+
+/**
+ * A map containing all defined frontend actions from config and
+ * their handler type signature (with metadata parameters). Can
+ * be used to make sure that all functions have been defined.
+ */
+export type ClientActionHandlers = {
+  [Action in CBTypes.ClientAction as Action['name']]: Action extends { metadata: infer Metadata }
+    ? (params: Metadata) => Promise<void>
+    : () => Promise<void>;
+};
+
+/**
+ * A map containing all defined frontend actions from config.
+ * Is used to type guard actions on the client such that each
+ * function receives correct parameters with type safety.
+ */
+type ActionMap = {
+  [Action in CBTypes.ClientAction as Action['name']]: Action;
+};
+
+type ActionType<T extends keyof ActionMap> = T extends keyof ActionMap ? ActionMap[T] : never;
+export const isSpecificClientAction = <ActionName extends keyof ActionMap>(
+  type: ActionName,
+  action: CBTypes.CustomAction,
+): action is ActionType<ActionName> => action.name === type;

--- a/src/layout/CustomButton/typeHelpers.ts
+++ b/src/layout/CustomButton/typeHelpers.ts
@@ -21,6 +21,12 @@ type ActionMap = {
 };
 
 type ActionType<T extends keyof ActionMap> = T extends keyof ActionMap ? ActionMap[T] : never;
+
+/**
+ * A function to create a type guard for a specific action.
+ * isSpecificClientAction('navigateToPage', action) will
+ * cast the action to NavigateToPageAction.
+ */
 export const isSpecificClientAction = <ActionName extends keyof ActionMap>(
   type: ActionName,
   action: CBTypes.CustomAction,

--- a/src/queries/queries.ts
+++ b/src/queries/queries.ts
@@ -13,6 +13,7 @@ import {
   dataElementUrl,
   fileTagUrl,
   fileUploadUrl,
+  getActionsUrl,
   getActiveInstancesUrl,
   getCreateInstancesUrl,
   getCustomValidationConfigUrl,
@@ -43,6 +44,7 @@ import type { Instantiation } from 'src/features/instantiate/InstantiationContex
 import type { ITextResourceResult } from 'src/features/language/textResources';
 import type { IPdfFormat } from 'src/features/pdf/types';
 import type { ILayoutFileExternal, IOption } from 'src/layout/common.generated';
+import type { ActionResult } from 'src/layout/CustomButton/CustomButtonComponent';
 import type { ILayoutCollection } from 'src/layout/layout';
 import type { ILayoutSets, ILayoutSettings, ISimpleInstance } from 'src/types';
 import type {
@@ -120,6 +122,15 @@ export const doAttachmentAddTag = async (dataGuid: string, tagToAdd: string): Pr
     throw new Error('Failed to add tag to attachment');
   }
 
+  return response.data;
+};
+
+export const doPerformAction = async (partyId: string, dataGuid: string, data: any): Promise<ActionResult> => {
+  const response = await httpPost(getActionsUrl(partyId, dataGuid), undefined, data);
+  if (response.status !== 200) {
+    throw new Error('Failed to perform action');
+  }
+  console.log('Response: ', response);
   return response.data;
 };
 

--- a/src/queries/queries.ts
+++ b/src/queries/queries.ts
@@ -130,7 +130,6 @@ export const doPerformAction = async (partyId: string, dataGuid: string, data: a
   if (response.status !== 200) {
     throw new Error('Failed to perform action');
   }
-  console.log('Response: ', response);
   return response.data;
 };
 

--- a/src/test/renderWithProviders.tsx
+++ b/src/test/renderWithProviders.tsx
@@ -114,6 +114,7 @@ const makeMutationMocks = (): MockedMutations => ({
   doInstantiateWithPrefill: promiseMock<AppMutations['doInstantiateWithPrefill']>(),
   doProcessNext: promiseMock<AppMutations['doProcessNext']>(),
   doSetCurrentParty: promiseMock<AppMutations['doSetCurrentParty']>(),
+  doPerformAction: promiseMock<AppMutations['doPerformAction']>(),
 });
 
 const makeDefaultQueryMocks = (state: IRuntimeState): MockableQueries => ({

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -166,6 +166,14 @@ export interface IPerson {
   addressCity: string;
 }
 
+type ProcessActionIds = 'read' | 'write' | 'complete';
+
+export interface IUserAction {
+  id: ProcessActionIds | string;
+  authorized: boolean;
+  type: 'ProcessAction' | 'UserAction';
+}
+
 export interface IProcess {
   started: string;
   startEvent?: string | null;
@@ -173,6 +181,7 @@ export interface IProcess {
   ended?: string | null;
   endEvent?: string | null;
   processTasks?: ITask[];
+  userActions?: IUserAction[];
 }
 
 export interface IProfile {

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -202,7 +202,7 @@ type ProcessActionIds = 'read' | 'write' | 'complete';
 export interface IUserAction {
   id: ProcessActionIds | string;
   authorized: boolean;
-  type: 'ProcessAction' | 'UserAction';
+  type: 'ProcessAction' | 'ServerAction';
 }
 
 export type ITask = {

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -166,14 +166,6 @@ export interface IPerson {
   addressCity: string;
 }
 
-type ProcessActionIds = 'read' | 'write' | 'complete';
-
-export interface IUserAction {
-  id: ProcessActionIds | string;
-  authorized: boolean;
-  type: 'ProcessAction' | 'UserAction';
-}
-
 export interface IProcess {
   started: string;
   startEvent?: string | null;
@@ -181,7 +173,6 @@ export interface IProcess {
   ended?: string | null;
   endEvent?: string | null;
   processTasks?: ITask[];
-  userActions?: IUserAction[];
 }
 
 export interface IProfile {
@@ -206,6 +197,14 @@ export interface ISelfLinks {
   platform: string;
 }
 
+type ProcessActionIds = 'read' | 'write' | 'complete';
+
+export interface IUserAction {
+  id: ProcessActionIds | string;
+  authorized: boolean;
+  type: 'ProcessAction' | 'UserAction';
+}
+
 export type ITask = {
   flow: number;
   started: string;
@@ -218,6 +217,7 @@ export type ITask = {
   read?: boolean | null;
   write?: boolean | null;
   actions?: IProcessActions | null;
+  userActions?: IUserAction[];
 };
 
 export type IProcessActions = {

--- a/src/utils/promisify.ts
+++ b/src/utils/promisify.ts
@@ -1,0 +1,12 @@
+/**
+ * Turn a function into a promise and postpone
+ * resolving the promise until the next tick.
+ * @param fn
+ */
+export function promisify<Fn extends (...args: unknown[]) => ReturnType<Fn>>(fn: Fn) {
+  return (...arg: Parameters<Fn>) =>
+    new Promise<void>((resolve) => {
+      fn(...arg);
+      setTimeout(resolve, 0);
+    });
+}

--- a/src/utils/urls/appUrlHelper.ts
+++ b/src/utils/urls/appUrlHelper.ts
@@ -38,6 +38,8 @@ export const fileTagUrl = (dataGuid: string, tag: string | undefined) => {
 export const dataElementUrl = (dataGuid: string) => `${appPath}/instances/${window.instanceId}/data/${dataGuid}`;
 
 export const getProcessStateUrl = (instanceId: string) => `${appPath}/instances/${instanceId}/process`;
+export const getActionsUrl = (partyId: string, instanceId: string) =>
+  `${appPath}/instances/${partyId}/${instanceId}/actions`;
 
 export const getCreateInstancesUrl = (partyId: string) => `${appPath}/instances?instanceOwnerPartyId=${partyId}`;
 

--- a/test/e2e/integration/frontend-test/custom-button.ts
+++ b/test/e2e/integration/frontend-test/custom-button.ts
@@ -1,0 +1,34 @@
+describe('Custom Button', () => {
+  it('Should perform action and update the frontend with the updated datamodel', () => {
+    cy.goto('changename');
+
+    cy.findByRole('button', { name: 'Fyll ut skjema' }).click();
+    cy.findByRole('textbox', { name: 'Denne oppdateres av custom button' }).should(
+      'have.value',
+      'Her kommer det data fra backend',
+    );
+  });
+
+  it('It should show an error message if the action fails', () => {
+    cy.goto('changename');
+
+    cy.findByRole('textbox', { name: /Her kan man skrive input/ }).type('Hello b');
+    cy.findByRole('button', { name: 'Fyll ut skjema' }).click();
+    cy.findByRole('alert').should('have.text', 'Her kommer det en feilmelding');
+  });
+
+  it('It should execute frontend actions that are sendt as a result with the action', () => {
+    cy.goto('changename');
+
+    cy.findByRole('textbox', { name: /Her kan man skrive input/ }).type('Generate frontend actions');
+    cy.findByRole('button', { name: 'Fyll ut skjema' }).click();
+    cy.findByText('Oppsummering').should('be.visible');
+  });
+
+  it('It should execute frontend actions that are specified in the component', () => {
+    cy.goto('changename');
+
+    cy.findByRole('button', { name: 'Trigger frontend actions' }).click();
+    cy.findByRole('textbox', { name: /Hvor mye gjeld har du?/ }).should('be.visible');
+  });
+});

--- a/test/e2e/integration/frontend-test/custom-button.ts
+++ b/test/e2e/integration/frontend-test/custom-button.ts
@@ -13,6 +13,11 @@ describe('Custom Button', () => {
     cy.goto('changename');
 
     cy.findByRole('textbox', { name: /Her kan man skrive input/ }).type('Hello b');
+
+    cy.intercept('PUT', '**/data/**').as('saveData');
+
+    cy.wait('@saveData');
+
     cy.findByRole('button', { name: 'Fyll ut skjema' }).click();
     cy.findByRole('alert').should('have.text', 'Her kommer det en feilmelding');
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6059,6 +6059,7 @@ __metadata:
     react-redux: "npm:8.1.3"
     react-refresh: "npm:0.14.0"
     react-router-dom: "npm:6.20.0"
+    react-toastify: "npm:^9.1.3"
     redux: "npm:4.2.1"
     redux-mock-store: "npm:1.5.4"
     redux-saga: "npm:1.2.3"
@@ -7397,6 +7398,13 @@ __metadata:
   version: 1.1.1
   resolution: "clsx@npm:1.1.1"
   checksum: 5c34e1d5623e3dce0dbf22eedd4f3cc7cd0dee6b1b1ef3ad49d042c9d86372a1dc7788c2ca3213ec08e65ad0e91572ae7cb77183a478c9977bd5327e8f43ffe5
+  languageName: node
+  linkType: hard
+
+"clsx@npm:^1.1.1":
+  version: 1.2.1
+  resolution: "clsx@npm:1.2.1"
+  checksum: 34dead8bee24f5e96f6e7937d711978380647e936a22e76380290e35486afd8634966ce300fc4b74a32f3762c7d4c0303f442c3e259f4ce02374eb0c82834f27
   languageName: node
   linkType: hard
 
@@ -16028,6 +16036,18 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 6d66f3bdb65e1ec79089f80314da97c9a005087a04ee034255a5de129a4c0d9fd0bf99fa7bf642781ac2dc745ca687aae3de082bd8afdd0d117bc953241e15ad
+  languageName: node
+  linkType: hard
+
+"react-toastify@npm:^9.1.3":
+  version: 9.1.3
+  resolution: "react-toastify@npm:9.1.3"
+  dependencies:
+    clsx: "npm:^1.1.1"
+  peerDependencies:
+    react: ">=16"
+    react-dom: ">=16"
+  checksum: 51de1e51e9357a24773fbcd45a4db18bf74b8ec40d86a2bfb4a4fee23ca4f9fffdac5dfb7a3c21baea39971f72f72dfcdc79403a6de006f74d69e7bc12f8b3e0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

This PR introduces a new component `CustomButton`. This component let's application developers perform a custom function (and predefined functions in the frontend) with the click of a button.

The API looks like this: 
```json
{
  "id": "testing-custom-button",
  "actions": [
    {
      "name": "fill",
      "type": "ServerAction"
    }
  ],
  "type": "CustomButton"
}
```
The button has an array of `actions` that are performed in sequence. Each action could have a type of either `"ClientAction"` or `"ServerAction"`. `ClientActions` are performed entirely on the frontend. This PR implements three different `ClientActions`: `nextPage`, `previousPage`, and `navigateToPage`. An action can specify parameters with the `metadata` property. 

e.g: 
```json
{
  "id": "testing-custom-button-2",
  "actions": [
    {
      "name": "navigateToPage",
      "type": "ClientAction",
      "metadata": {
        "page": "grid"
      }
    }
  ],
  "type": "CustomButton"
}
```
Here, the `navigateToPage` function receives the object ` { page: string }` as an argument. 

A `ServerAction` can return any number of `ClientActions`, and these will be run before the next action specified in the `actions` parameter of `CustomButton`. 

If there is an error in a `ServerAction`, we display a toast with the error message specified in the response. I've implemented the toast in the same way Studio recently did:
![image](https://github.com/Altinn/app-frontend-react/assets/26043795/2becd8a6-5dc8-43f8-bd41-a05acc9b327b)

 There is currently no Toast component in the design system, but it has been suggested as a possible future component. 



## Related Issue(s)

- closes #133 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [x] Has been added/updated - https://github.com/Altinn/altinn-studio-docs/commit/be3c11c911f0f18c9c317ea8bd70f47e66510e6d
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
