### PR TITLE
Chore/validation hooks fix navigation

### DIFF
--- a/src/__mocks__/getHierarchyDataSourcesMock.ts
+++ b/src/__mocks__/getHierarchyDataSourcesMock.ts
@@ -7,6 +7,7 @@ export function getHierarchyDataSourcesMock(): HierarchyDataSources {
     formData: {},
     attachments: {},
     uiConfig: {} as any,
+    pageNavigationConfig: { currentView: null },
     options: {},
     applicationSettings: {} as any,
     instanceDataSources: {} as any,

--- a/src/__mocks__/getHierarchyDataSourcesMock.ts
+++ b/src/__mocks__/getHierarchyDataSourcesMock.ts
@@ -7,7 +7,7 @@ export function getHierarchyDataSourcesMock(): HierarchyDataSources {
     formData: {},
     attachments: {},
     uiConfig: {} as any,
-    pageNavigationConfig: { currentView: null },
+    pageNavigationConfig: { hidden: [], hiddenExpr: {} },
     options: {},
     applicationSettings: {} as any,
     instanceDataSources: {} as any,

--- a/src/__mocks__/getUiConfigStateMock.ts
+++ b/src/__mocks__/getUiConfigStateMock.ts
@@ -2,11 +2,6 @@ import type { IUiConfig } from 'src/types';
 
 export const getUiConfigStateMock = (customStates?: Partial<IUiConfig>): IUiConfig => ({
   focus: null,
-  pageOrderConfig: {
-    hidden: [],
-    hiddenExpr: {},
-    order: ['FormLayout'],
-  },
   hiddenFields: [],
   repeatingGroups: {
     group: {

--- a/src/__mocks__/getUiConfigStateMock.ts
+++ b/src/__mocks__/getUiConfigStateMock.ts
@@ -22,7 +22,6 @@ export const getUiConfigStateMock = (customStates?: Partial<IUiConfig>): IUiConf
       dataModelBinding: 'Group',
     },
   },
-  currentView: 'FormLayout',
   excludePageFromPdf: [],
   excludeComponentFromPdf: [],
   ...customStates,

--- a/src/components/form/Form.test.tsx
+++ b/src/components/form/Form.test.tsx
@@ -220,7 +220,7 @@ describe('Form', () => {
   async function render(layout = mockComponents, customState: Partial<IRuntimeState> = {}) {
     await renderWithInstanceAndLayout({
       renderer: () => <Form />,
-      router: PageNavigationRouter('FormLayout'),
+      router: PageNavigationRouter({ currentPageId: 'FormLayout' }),
       queries: {
         fetchLayouts: () => Promise.resolve({}),
         fetchLayoutSettings: () => Promise.resolve({ pages: { order: ['FormLayout', '2', '3'] } }),

--- a/src/components/form/Form.tsx
+++ b/src/components/form/Form.tsx
@@ -8,15 +8,15 @@ import { ErrorReport } from 'src/components/message/ErrorReport';
 import { ReadyForPrint } from 'src/components/ReadyForPrint';
 import { FrontendValidationSource } from 'src/features/validation';
 import { useTaskErrors } from 'src/features/validation/validationProvider';
-import { useNavigatePage } from 'src/hooks/useNavigatePage';
+import { useCurrentView } from 'src/hooks/useNavigatePage';
 import { GenericComponent } from 'src/layout/GenericComponent';
 import { extractBottomButtons, hasRequiredFields } from 'src/utils/formLayout';
 import { useExprContext } from 'src/utils/layout/ExprContext';
 
 export function Form() {
-  const { currentPageId } = useNavigatePage();
+  const currentPageId = useCurrentView();
   const nodes = useExprContext();
-  const page = nodes?.all?.()?.[currentPageId];
+  const page = currentPageId ? nodes?.all?.()?.[currentPageId] : undefined;
 
   const { formErrors, taskErrors } = useTaskErrors();
   const hasErrors = Boolean(formErrors.length) || Boolean(taskErrors.length);

--- a/src/features/devtools/components/ExpressionPlayground/ExpressionPlayground.tsx
+++ b/src/features/devtools/components/ExpressionPlayground/ExpressionPlayground.tsx
@@ -14,7 +14,7 @@ import { useAppDispatch } from 'src/hooks/useAppDispatch';
 import { useAppSelector } from 'src/hooks/useAppSelector';
 import { useNavigatePage } from 'src/hooks/useNavigatePage';
 import { useExprContext } from 'src/utils/layout/ExprContext';
-import { selectDataSourcesFromState } from 'src/utils/layout/hierarchy';
+import { createSelectDataSourcesFromState } from 'src/utils/layout/hierarchy';
 import type { ExprConfig, Expression, ExprFunction } from 'src/features/expressions/types';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 import type { LayoutPage } from 'src/utils/layout/LayoutPage';
@@ -46,7 +46,7 @@ export const ExpressionPlayground = () => {
   ]);
   const nodes = useExprContext();
   const { currentPageId } = useNavigatePage();
-  const dataSources = useAppSelector(selectDataSourcesFromState);
+  const dataSources = useAppSelector(createSelectDataSourcesFromState(currentPageId ?? null));
 
   const setOutputWithHistory = useCallback(
     (newValue: string, isError: boolean): boolean => {

--- a/src/features/devtools/components/ExpressionPlayground/ExpressionPlayground.tsx
+++ b/src/features/devtools/components/ExpressionPlayground/ExpressionPlayground.tsx
@@ -10,6 +10,7 @@ import { DevToolsTab } from 'src/features/devtools/data/types';
 import { evalExpr } from 'src/features/expressions';
 import { ExprVal } from 'src/features/expressions/types';
 import { asExpression } from 'src/features/expressions/validation';
+import { usePageNavigationConfig } from 'src/features/form/layout/PageNavigationContext';
 import { useAppDispatch } from 'src/hooks/useAppDispatch';
 import { useAppSelector } from 'src/hooks/useAppSelector';
 import { useNavigatePage } from 'src/hooks/useNavigatePage';
@@ -34,6 +35,7 @@ export const ExpressionPlayground = () => {
   const input = useAppSelector((state) => state.devTools.exprPlayground.expression);
   const forPage = useAppSelector((state) => state.devTools.exprPlayground.forPage);
   const forComponentId = useAppSelector((state) => state.devTools.exprPlayground.forComponentId);
+  const pageNavigationConfig = usePageNavigationConfig();
   const dispatch = useAppDispatch();
 
   const [showAllSteps, setShowAllSteps] = React.useState(false);
@@ -46,7 +48,8 @@ export const ExpressionPlayground = () => {
   ]);
   const nodes = useExprContext();
   const { currentPageId } = useNavigatePage();
-  const dataSources = useAppSelector(createSelectDataSourcesFromState(currentPageId ?? null));
+
+  const dataSources = useAppSelector(createSelectDataSourcesFromState(pageNavigationConfig));
 
   const setOutputWithHistory = useCallback(
     (newValue: string, isError: boolean): boolean => {

--- a/src/features/devtools/components/LayoutInspector/LayoutInspector.tsx
+++ b/src/features/devtools/components/LayoutInspector/LayoutInspector.tsx
@@ -13,12 +13,13 @@ import { DevToolsTab } from 'src/features/devtools/data/types';
 import { useLayoutValidationForPage } from 'src/features/devtools/layoutValidation/useLayoutValidation';
 import { FormLayoutActions } from 'src/features/form/layout/formLayoutSlice';
 import { useAppSelector } from 'src/hooks/useAppSelector';
+import { useCurrentView } from 'src/hooks/useNavigatePage';
 import { getParsedLanguageFromText } from 'src/language/sharedLanguage';
 import { useExprContext } from 'src/utils/layout/ExprContext';
 
 export const LayoutInspector = () => {
   const selectedComponent = useAppSelector((state) => state.devTools.layoutInspector.selectedComponentId);
-  const { currentView } = useAppSelector((state) => state.formLayout.uiConfig);
+  const currentView = useCurrentView();
   const layouts = useAppSelector((state) => state.formLayout.layouts);
   const [componentProperties, setComponentProperties] = useState<string | null>(null);
   const [propertiesHaveChanged, setPropertiesHaveChanged] = useState(false);
@@ -44,7 +45,7 @@ export const LayoutInspector = () => {
     [dispatch],
   );
 
-  const currentLayout = layouts?.[currentView];
+  const currentLayout = currentView ? layouts?.[currentView] : undefined;
   const matchingNodes = selectedComponent ? nodes?.findAllById(selectedComponent) || [] : [];
   const validationErrorsForPage = useLayoutValidationForPage() || {};
 
@@ -77,7 +78,9 @@ export const LayoutInspector = () => {
           }
         });
 
-        dispatch(FormLayoutActions.updateLayouts({ [currentView]: updatedLayout }));
+        if (currentView) {
+          dispatch(FormLayoutActions.updateLayouts({ [currentView]: updatedLayout }));
+        }
 
         setPropertiesHaveChanged(false);
         return;

--- a/src/features/devtools/layoutValidation/all.test.tsx
+++ b/src/features/devtools/layoutValidation/all.test.tsx
@@ -24,10 +24,8 @@ describe('All known apps should work with layout validation', () => {
 
   const allLayoutSets = getAllLayoutSets(dir);
   it.each(allLayoutSets)('$appName/$setName', async ({ layouts, setName }) => {
-    const firstKey = Object.keys(layouts)[0];
     const reduxState = getInitialStateMock();
     reduxState.formLayout.layouts = layouts;
-    reduxState.formLayout.uiConfig.currentView = firstKey;
     reduxState.devTools.isOpen = true;
     reduxState.applicationMetadata.applicationMetadata!.onEntry = {
       show: setName,

--- a/src/features/devtools/layoutValidation/useLayoutValidation.tsx
+++ b/src/features/devtools/layoutValidation/useLayoutValidation.tsx
@@ -7,6 +7,7 @@ import { dotNotationToPointer } from 'src/features/datamodel/notations';
 import { lookupBindingInSchema } from 'src/features/datamodel/SimpleSchemaTraversal';
 import { useCurrentDataModelType } from 'src/features/datamodel/useBindingSchema';
 import { useLayoutSchemaValidation } from 'src/features/devtools/layoutValidation/useLayoutSchemaValidation';
+import { usePageNavigationConfig } from 'src/features/form/layout/PageNavigationContext';
 import { generateSimpleRepeatingGroups } from 'src/features/form/layout/repGroups/generateSimpleRepeatingGroups';
 import { useCurrentLayoutSetId } from 'src/features/form/layout/useCurrentLayoutSetId';
 import { useAppSelector } from 'src/hooks/useAppSelector';
@@ -78,7 +79,8 @@ function useDataModelBindingsValidation(props: LayoutValidationProps) {
   const schema = useDataModelSchema();
   const dataType = useCurrentDataModelType();
   const currentView = useCurrentView();
-  const dataSources = useAppSelector(createSelectDataSourcesFromState(currentView ?? null));
+  const pageNavigationConfig = usePageNavigationConfig();
+  const dataSources = useAppSelector(createSelectDataSourcesFromState(pageNavigationConfig));
   const nodes = useMemo(
     () => generateEntireHierarchy(layouts, currentView, repeatingGroups, dataSources, getLayoutComponentObject),
     [layouts, currentView, repeatingGroups, dataSources],

--- a/src/features/devtools/layoutValidation/useLayoutValidation.tsx
+++ b/src/features/devtools/layoutValidation/useLayoutValidation.tsx
@@ -11,8 +11,9 @@ import { generateSimpleRepeatingGroups } from 'src/features/form/layout/repGroup
 import { useCurrentLayoutSetId } from 'src/features/form/layout/useCurrentLayoutSetId';
 import { useAppSelector } from 'src/hooks/useAppSelector';
 import { useIsDev } from 'src/hooks/useIsDev';
+import { useCurrentView } from 'src/hooks/useNavigatePage';
 import { getLayoutComponentObject } from 'src/layout';
-import { selectDataSourcesFromState } from 'src/utils/layout/hierarchy';
+import { createSelectDataSourcesFromState } from 'src/utils/layout/hierarchy';
 import { generateEntireHierarchy } from 'src/utils/layout/HierarchyGenerator';
 import { getRootElementPath } from 'src/utils/schemaUtils';
 import { duplicateStringFilter } from 'src/utils/stringHelper';
@@ -76,11 +77,11 @@ function useDataModelBindingsValidation(props: LayoutValidationProps) {
   const repeatingGroups = useMemo(() => generateSimpleRepeatingGroups(layouts), [layouts]);
   const schema = useDataModelSchema();
   const dataType = useCurrentDataModelType();
-  const dataSources = useAppSelector(selectDataSourcesFromState);
-  const currentPage = useAppSelector((state) => state.formLayout.uiConfig.currentView);
+  const currentView = useCurrentView();
+  const dataSources = useAppSelector(createSelectDataSourcesFromState(currentView ?? null));
   const nodes = useMemo(
-    () => generateEntireHierarchy(layouts, currentPage, repeatingGroups, dataSources, getLayoutComponentObject),
-    [layouts, currentPage, repeatingGroups, dataSources],
+    () => generateEntireHierarchy(layouts, currentView, repeatingGroups, dataSources, getLayoutComponentObject),
+    [layouts, currentView, repeatingGroups, dataSources],
   );
 
   const layoutLoaded = useIsLayoutLoaded();
@@ -137,9 +138,13 @@ export const useLayoutValidation = () => useCtx();
 export const useLayoutValidationForPage = () => {
   const ctx = useLayoutValidation();
   const layoutSetId = useCurrentLayoutSetId() || 'default';
-  const currentPage = useAppSelector((state) => state.formLayout.uiConfig.currentView);
+  const currentView = useCurrentView();
 
-  return ctx?.[layoutSetId]?.[currentPage];
+  if (!currentView) {
+    return;
+  }
+
+  return ctx?.[layoutSetId]?.[currentView];
 };
 
 export function LayoutValidationProvider({ children }: PropsWithChildren) {

--- a/src/features/expressions/ExprContext.ts
+++ b/src/features/expressions/ExprContext.ts
@@ -8,13 +8,16 @@ import type { ExprConfig, Expression, ExprPositionalArgs } from 'src/features/ex
 import type { IFormData } from 'src/features/formData';
 import type { IUseLanguage } from 'src/features/language/useLanguage';
 import type { AllOptionsMap } from 'src/features/options/useAllOptions';
-import type { IUiConfig } from 'src/types';
+import type { IHiddenLayoutsExternal, IUiConfig } from 'src/types';
 import type { IApplicationSettings, IAuthContext, IInstanceDataSources } from 'src/types/shared';
 import type { BaseLayoutNode, LayoutNode } from 'src/utils/layout/LayoutNode';
 import type { LayoutPage } from 'src/utils/layout/LayoutPage';
 
 export type PageNavigationConfig = {
-  currentView: string | null;
+  currentView?: string;
+  order?: string[];
+  hidden: string[];
+  hiddenExpr: IHiddenLayoutsExternal;
 };
 
 export interface ContextDataSources {

--- a/src/features/expressions/ExprContext.ts
+++ b/src/features/expressions/ExprContext.ts
@@ -13,12 +13,17 @@ import type { IApplicationSettings, IAuthContext, IInstanceDataSources } from 's
 import type { BaseLayoutNode, LayoutNode } from 'src/utils/layout/LayoutNode';
 import type { LayoutPage } from 'src/utils/layout/LayoutPage';
 
+export type PageNavigationConfig = {
+  currentView: string | null;
+};
+
 export interface ContextDataSources {
   instanceDataSources: IInstanceDataSources | null;
   applicationSettings: IApplicationSettings | null;
   formData: IFormData;
   attachments: IAttachments;
   uiConfig: IUiConfig;
+  pageNavigationConfig: PageNavigationConfig;
   options: AllOptionsMap;
   authContext: Partial<IAuthContext> | null;
   hiddenFields: Set<string>;

--- a/src/features/form/FormContext.tsx
+++ b/src/features/form/FormContext.tsx
@@ -11,6 +11,7 @@ import { RulesProvider } from 'src/features/form/rules/RulesContext';
 import { FormDataProvider } from 'src/features/formData/FormDataContext';
 import { AllOptionsProvider } from 'src/features/options/useAllOptions';
 import { ValidationContext } from 'src/features/validation/validationProvider';
+import { ExprContextWrapper } from 'src/utils/layout/ExprContext';
 
 /**
  * This helper-context provider is used to provide all the contexts needed for forms to work
@@ -21,19 +22,21 @@ export function FormProvider({ children }: React.PropsWithChildren) {
       <LayoutsProvider>
         <LayoutSettingsProvider>
           <UiConfigProvider>
-            <FormDataProvider>
-              <DataModelSchemaProvider>
-                <AttachmentsProvider>
-                  <ValidationContext>
-                    <DynamicsProvider>
-                      <RulesProvider>
-                        <AllOptionsProvider>{children}</AllOptionsProvider>
-                      </RulesProvider>
-                    </DynamicsProvider>
-                  </ValidationContext>
-                </AttachmentsProvider>
-              </DataModelSchemaProvider>
-            </FormDataProvider>
+            <ExprContextWrapper>
+              <FormDataProvider>
+                <DataModelSchemaProvider>
+                  <AttachmentsProvider>
+                    <ValidationContext>
+                      <DynamicsProvider>
+                        <RulesProvider>
+                          <AllOptionsProvider>{children}</AllOptionsProvider>
+                        </RulesProvider>
+                      </DynamicsProvider>
+                    </ValidationContext>
+                  </AttachmentsProvider>
+                </DataModelSchemaProvider>
+              </FormDataProvider>
+            </ExprContextWrapper>
           </UiConfigProvider>
         </LayoutSettingsProvider>
       </LayoutsProvider>

--- a/src/features/form/layout/LayoutsContext.tsx
+++ b/src/features/form/layout/LayoutsContext.tsx
@@ -44,7 +44,6 @@ function useLayoutQuery() {
       dispatch(
         FormLayoutActions.fetchFulfilled({
           layouts: result.layouts,
-          hiddenLayoutsExpressions: result.hiddenLayoutsExpressions,
           layoutSetId: currentLayoutSetId || null,
         }),
       );
@@ -69,7 +68,6 @@ function useLayoutQuery() {
       dispatch(
         FormLayoutActions.fetchFulfilled({
           layouts: query.data.layouts,
-          hiddenLayoutsExpressions: query.data.hiddenLayoutsExpressions,
           layoutSetId: currentLayoutSetId || null,
         }),
       );

--- a/src/features/form/layout/PageNavigationContext.tsx
+++ b/src/features/form/layout/PageNavigationContext.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
 
 import { createContext } from 'src/core/contexts/context';
+import { useCurrentView, useOrder } from 'src/hooks/useNavigatePage';
+import type { PageNavigationConfig } from 'src/features/expressions/ExprContext';
 import type { IComponentScrollPos } from 'src/features/form/layout/formLayoutTypes';
 import type { IHiddenLayoutsExternal } from 'src/types';
 
@@ -69,3 +71,14 @@ export function PageNavigationProvider({ children }: React.PropsWithChildren) {
 }
 
 export const usePageNavigationContext = () => useCtx();
+export const usePageNavigationConfig = (): PageNavigationConfig => {
+  const currentView = useCurrentView();
+  const { hidden, hiddenExpr } = usePageNavigationContext();
+  const order = useOrder();
+  return {
+    currentView,
+    hidden,
+    hiddenExpr,
+    order,
+  };
+};

--- a/src/features/form/layout/formLayoutSlice.ts
+++ b/src/features/form/layout/formLayoutSlice.ts
@@ -27,11 +27,6 @@ export const initialState: ILayoutState = {
     hiddenFields: [],
     repeatingGroups: null,
     receiptLayoutName: undefined,
-    pageOrderConfig: {
-      hidden: [],
-      hiddenExpr: {},
-      order: null,
-    },
     keepScrollPos: undefined,
     excludePageFromPdf: null,
     excludeComponentFromPdf: null,
@@ -56,10 +51,8 @@ export const formLayoutSlice = () => {
       actions: {
         fetchFulfilled: mkAction<LayoutTypes.IFetchLayoutFulfilled>({
           reducer: (state, action) => {
-            const { layouts, hiddenLayoutsExpressions, layoutSetId } = action.payload;
+            const { layouts, layoutSetId } = action.payload;
             state.layouts = layouts;
-            state.uiConfig.pageOrderConfig.order = Object.keys(layouts);
-            state.uiConfig.pageOrderConfig.hiddenExpr = hiddenLayoutsExpressions;
             state.uiConfig.repeatingGroups = null;
             state.layoutSetId = layoutSetId;
           },
@@ -84,10 +77,6 @@ export const formLayoutSlice = () => {
             state.uiConfig.receiptLayoutName = settings?.receiptLayoutName;
             if (settings && settings.pages) {
               updateCommonPageSettings(state, settings.pages);
-              const order = settings.pages.order;
-              if (order) {
-                state.uiConfig.pageOrderConfig.order = order;
-              }
             }
 
             state.uiConfig.pdfLayoutName = settings?.pages.pdfLayoutName;
@@ -152,11 +141,6 @@ export const formLayoutSlice = () => {
             if (group && state.uiConfig.repeatingGroups && state.uiConfig.repeatingGroups[group]) {
               state.uiConfig.repeatingGroups[group].isLoading = false;
             }
-          },
-        }),
-        updateHiddenLayouts: mkAction<LayoutTypes.IHiddenLayoutsUpdate>({
-          reducer: (state, action) => {
-            state.uiConfig.pageOrderConfig.hidden = action.payload.hiddenLayouts;
           },
         }),
         initRepeatingGroups: mkAction<LayoutTypes.IInitRepeatingGroups>({

--- a/src/features/form/layout/formLayoutSlice.ts
+++ b/src/features/form/layout/formLayoutSlice.ts
@@ -27,7 +27,6 @@ export const initialState: ILayoutState = {
     hiddenFields: [],
     repeatingGroups: null,
     receiptLayoutName: undefined,
-    currentView: 'FormLayout',
     pageOrderConfig: {
       hidden: [],
       hiddenExpr: {},

--- a/src/features/form/layout/formLayoutTypes.ts
+++ b/src/features/form/layout/formLayoutTypes.ts
@@ -1,6 +1,6 @@
 import type { IFormData } from 'src/features/formData';
 import type { ILayouts } from 'src/layout/layout';
-import type { IHiddenLayoutsExternal, ILayoutSets, ILayoutSettings } from 'src/types';
+import type { ILayoutSets, ILayoutSettings } from 'src/types';
 
 export interface IFormLayoutActionRejected {
   error: Error | null;
@@ -9,7 +9,6 @@ export interface IFormLayoutActionRejected {
 
 export interface IFetchLayoutFulfilled {
   layouts: ILayouts;
-  hiddenLayoutsExpressions: IHiddenLayoutsExternal;
   layoutSetId: string | null;
 }
 
@@ -67,10 +66,6 @@ export interface IUpdateRepeatingGroupsEditIndexFulfilled {
 export interface IComponentScrollPos {
   componentId: string;
   offsetTop: number | undefined;
-}
-
-export interface IHiddenLayoutsUpdate {
-  hiddenLayouts: string[];
 }
 
 export interface IInitRepeatingGroups {

--- a/src/features/form/layout/repGroups/repGroupDeleteRowSaga.test.ts
+++ b/src/features/form/layout/repGroups/repGroupDeleteRowSaga.test.ts
@@ -6,13 +6,11 @@ import { FormLayoutActions } from 'src/features/form/layout/formLayoutSlice';
 import { repGroupDeleteRowSaga } from 'src/features/form/layout/repGroups/repGroupDeleteRowSaga';
 import { selectFormData, selectFormLayoutState } from 'src/features/form/layout/update/updateFormLayoutSagas';
 import { FormDataActions } from 'src/features/formData/formDataSlice';
-import { resolvedLayoutsFromState, ResolvedNodesSelector } from 'src/utils/layout/hierarchy';
 import type { IDataModelBindings } from 'src/layout/layout';
 import type { IRuntimeState } from 'src/types';
 
 describe('repGroupDeleteRowSaga', function () {
-  // TODO(1508): hopefully this test can be removed rep group does not use sagas
-  it.skip('should remove attachment references from formData', () => {
+  it('should remove attachment references from formData', () => {
     const state: IRuntimeState = getInitialStateMock();
     state.formLayout.layouts?.FormLayout?.push({
       id: 'repeating-group',
@@ -61,7 +59,6 @@ describe('repGroupDeleteRowSaga', function () {
       .provide([
         [select(selectFormLayoutState), selectFormLayoutState(state)],
         [select(selectFormData), selectFormData(state)],
-        [select(ResolvedNodesSelector('FormLayout')), resolvedLayoutsFromState('FormLayout')(state)],
       ])
       .put(
         FormLayoutActions.repGroupDeleteRowFulfilled({

--- a/src/features/form/layout/repGroups/repGroupDeleteRowSaga.test.ts
+++ b/src/features/form/layout/repGroups/repGroupDeleteRowSaga.test.ts
@@ -11,7 +11,8 @@ import type { IDataModelBindings } from 'src/layout/layout';
 import type { IRuntimeState } from 'src/types';
 
 describe('repGroupDeleteRowSaga', function () {
-  it('should remove attachment references from formData', () => {
+  // TODO(1508): hopefully this test can be removed rep group does not use sagas
+  it.skip('should remove attachment references from formData', () => {
     const state: IRuntimeState = getInitialStateMock();
     state.formLayout.layouts?.FormLayout?.push({
       id: 'repeating-group',
@@ -60,7 +61,7 @@ describe('repGroupDeleteRowSaga', function () {
       .provide([
         [select(selectFormLayoutState), selectFormLayoutState(state)],
         [select(selectFormData), selectFormData(state)],
-        [select(ResolvedNodesSelector), resolvedLayoutsFromState(state)],
+        [select(ResolvedNodesSelector('FormLayout')), resolvedLayoutsFromState('FormLayout')(state)],
       ])
       .put(
         FormLayoutActions.repGroupDeleteRowFulfilled({

--- a/src/features/receipt/ReceiptContainer.test.tsx
+++ b/src/features/receipt/ReceiptContainer.test.tsx
@@ -6,6 +6,7 @@ import { getInstanceDataMock } from 'src/__mocks__/getInstanceDataMock';
 import { getInitialStateMock } from 'src/__mocks__/initialStateMock';
 import { staticUseLanguageForTests } from 'src/features/language/useLanguage';
 import { getSummaryDataObject, ReceiptContainer } from 'src/features/receipt/ReceiptContainer';
+import { PageKeys, TaskKeys } from 'src/hooks/useNavigatePage';
 import { renderWithInstanceAndLayout } from 'src/test/renderWithProviders';
 import { PageNavigationRouter } from 'src/test/routerUtils';
 import type { SummaryDataObject } from 'src/components/table/AltinnSummaryTable';
@@ -108,7 +109,7 @@ const render = async ({ autoDeleteOnProcessEnd = false, hasPdf = true }: IRender
   return await renderWithInstanceAndLayout({
     renderer: () => <ReceiptContainer />,
     reduxState,
-    router: PageNavigationRouter(),
+    router: PageNavigationRouter({ currentPageId: PageKeys.Receipt, currentTaskId: TaskKeys.ProcessEnd }),
     queries: {
       fetchFormData: () => Promise.resolve({}),
     },

--- a/src/features/receipt/ReceiptContainer.tsx
+++ b/src/features/receipt/ReceiptContainer.tsx
@@ -126,12 +126,6 @@ export const ReceiptContainer = () => {
     }
   }, [instance, applicationMetadata]);
 
-  // React.useEffect(() => {
-  //   if (!process?.ended) {
-  //     navigateToPage(PageKeys.Confirmation);
-  //   }
-  // }, [process?.ended, navigateToPage]);
-
   const requirementMissing = !attachments
     ? 'attachments'
     : !applicationMetadata

--- a/src/features/validation/validationProvider.tsx
+++ b/src/features/validation/validationProvider.tsx
@@ -42,6 +42,7 @@ import {
   setVisibilityForNode,
 } from 'src/features/validation/visibility';
 import { useAppSelector } from 'src/hooks/useAppSelector';
+import { useOrder } from 'src/hooks/useNavigatePage';
 import { useExprContext } from 'src/utils/layout/ExprContext';
 import type { Visibility } from 'src/features/validation/visibility';
 import type { PageValidation, ValidationMasks } from 'src/layout/common.generated';
@@ -265,7 +266,7 @@ export function useOnPageValidation() {
   const setNodeVisibility = useCtx().setNodeVisibility;
   const state = useCtx().state;
   const validating = useCtx().validating;
-  const pageOrder = useAppSelector((state) => state.formLayout.uiConfig.pageOrderConfig.order);
+  const pageOrder = useOrder();
 
   /* Ensures the callback will have the latest state */
   const callback = useEffectEvent((currentPage: LayoutPage, config: PageValidation): boolean => {

--- a/src/hooks/useNavigatePage.ts
+++ b/src/hooks/useNavigatePage.ts
@@ -48,6 +48,8 @@ export const useNavigationParams = () => {
   };
 };
 
+export const useCurrentView = () => useNavigationParams().pageKey;
+
 export const useNavigatePage = () => {
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
@@ -149,11 +151,14 @@ export const useNavigatePage = () => {
   );
 
   const navigateToTask = useCallback(
-    (taskId?: string, options?: NavigateOptions) => {
-      const url = `/instance/${partyId}/${instanceGuid}/${taskId ?? lastTaskId}`;
+    (newTaskId?: string, options?: NavigateOptions) => {
+      if (newTaskId === taskId) {
+        return;
+      }
+      const url = `/instance/${partyId}/${instanceGuid}/${newTaskId ?? lastTaskId}`;
       navigate(url, options);
     },
-    [partyId, instanceGuid, lastTaskId, navigate],
+    [partyId, instanceGuid, lastTaskId, navigate, taskId],
   );
 
   const isCurrentTask = useMemo(() => currentTaskId === taskId, [currentTaskId, taskId]);

--- a/src/hooks/useNavigatePage.ts
+++ b/src/hooks/useNavigatePage.ts
@@ -49,6 +49,12 @@ export const useNavigationParams = () => {
 };
 
 export const useCurrentView = () => useNavigationParams().pageKey;
+export const useOrder = () => {
+  const { orderWithHidden } = useUiConfigContext();
+  const { hidden } = usePageNavigationContext();
+  const hiddenPages = useMemo(() => new Set(hidden), [hidden]);
+  return useMemo(() => orderWithHidden?.filter((page) => !hiddenPages.has(page)), [orderWithHidden, hiddenPages]);
+};
 
 export const useNavigatePage = () => {
   const navigate = useNavigate();
@@ -59,17 +65,11 @@ export const useNavigatePage = () => {
   const lastTaskId = processTasks?.slice(-1)[0]?.elementId;
 
   const { partyId, instanceGuid, taskId, pageKey } = useNavigationParams();
-  const { orderWithHidden } = useUiConfigContext();
   const autoSaveBehavior = useAppSelector((state) => state.formLayout.uiConfig.autoSaveBehavior);
 
-  const { setFocusId, setReturnToView, hidden } = usePageNavigationContext();
+  const { setFocusId, setReturnToView } = usePageNavigationContext();
   const taskType = useTaskType(taskId);
-
-  const hiddenPages = useMemo(() => new Set(hidden), [hidden]);
-  const order = useMemo(
-    () => orderWithHidden?.filter((page) => !hiddenPages.has(page)),
-    [orderWithHidden, hiddenPages],
-  );
+  const order = useOrder();
 
   const currentPageId = pageKey ?? '';
   const currentPageIndex = order?.indexOf(currentPageId) ?? -1;

--- a/src/hooks/usePdfPage.ts
+++ b/src/hooks/usePdfPage.ts
@@ -1,17 +1,18 @@
 import { useMemo } from 'react';
 
+import { usePageNavigationConfig } from 'src/features/form/layout/PageNavigationContext';
 import { usePdfFormatQuery } from 'src/features/pdf/usePdfFormatQuery';
 import { useAppSelector } from 'src/hooks/useAppSelector';
-import { useCurrentView } from 'src/hooks/useNavigatePage';
 import { getLayoutComponentObject } from 'src/layout';
 import { useExprContext } from 'src/utils/layout/ExprContext';
 import { dataSourcesFromState } from 'src/utils/layout/hierarchy';
 import { generateHierarchy } from 'src/utils/layout/HierarchyGenerator';
+import type { PageNavigationConfig } from 'src/features/expressions/ExprContext';
 import type { IPdfFormat } from 'src/features/pdf/types';
 import type { CompInstanceInformationExternal } from 'src/layout/InstanceInformation/config.generated';
 import type { HierarchyDataSources, ILayout } from 'src/layout/layout';
 import type { CompSummaryExternal } from 'src/layout/Summary/config.generated';
-import type { IPageOrderConfig, IRepeatingGroups } from 'src/types';
+import type { IRepeatingGroups } from 'src/types';
 import type { LayoutPage } from 'src/utils/layout/LayoutPage';
 import type { LayoutPages } from 'src/utils/layout/LayoutPages';
 
@@ -19,9 +20,8 @@ const PDF_LAYOUT_NAME = '__pdf__';
 
 export const usePdfPage = (): LayoutPage | null => {
   const layoutPages = useExprContext();
-  const currentView = useCurrentView();
-  const dataSources = useAppSelector(dataSourcesFromState(currentView ?? null));
-  const pageOrderConfig = useAppSelector((state) => state.formLayout.uiConfig.pageOrderConfig);
+  const pageNavigationConfig = usePageNavigationConfig();
+  const dataSources = useAppSelector(dataSourcesFromState(pageNavigationConfig));
   const repeatingGroups = useAppSelector((state) => state.formLayout.uiConfig.repeatingGroups);
   const pdfLayoutName = useAppSelector((state) => state.formLayout.uiConfig.pdfLayoutName);
 
@@ -34,10 +34,10 @@ export const usePdfPage = (): LayoutPage | null => {
 
   const automaticPdfPage = useMemo(() => {
     if (readyForPrint && method === 'auto') {
-      return generateAutomaticPage(pdfFormat!, pageOrderConfig!, layoutPages!, dataSources, repeatingGroups!);
+      return generateAutomaticPage(pdfFormat!, pageNavigationConfig!, layoutPages!, dataSources, repeatingGroups!);
     }
     return null;
-  }, [readyForPrint, method, pdfFormat, pageOrderConfig, layoutPages, dataSources, repeatingGroups]);
+  }, [readyForPrint, method, pdfFormat, pageNavigationConfig, layoutPages, dataSources, repeatingGroups]);
 
   if (!readyForPrint) {
     return null;
@@ -52,7 +52,7 @@ export const usePdfPage = (): LayoutPage | null => {
 
 function generateAutomaticPage(
   pdfFormat: IPdfFormat,
-  pageOrderConfig: IPageOrderConfig,
+  pageNavigationConfig: PageNavigationConfig,
   layoutPages: LayoutPages,
   dataSources: HierarchyDataSources,
   repeatingGroups: IRepeatingGroups,
@@ -77,8 +77,8 @@ function generateAutomaticPage(
 
   const excludedPages = new Set(pdfFormat?.excludedPages);
   const excludedComponents = new Set(pdfFormat?.excludedComponents);
-  const hiddenPages = new Set(pageOrderConfig.hidden);
-  const pageOrder = pageOrderConfig.order;
+  const hiddenPages = new Set(pageNavigationConfig.hidden);
+  const pageOrder = pageNavigationConfig.order;
 
   // Iterate over all pages, and add all components that should be included in the automatic PDF as summary components
   Object.entries(layoutPages.all())

--- a/src/hooks/usePdfPage.ts
+++ b/src/hooks/usePdfPage.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 
 import { usePdfFormatQuery } from 'src/features/pdf/usePdfFormatQuery';
 import { useAppSelector } from 'src/hooks/useAppSelector';
+import { useCurrentView } from 'src/hooks/useNavigatePage';
 import { getLayoutComponentObject } from 'src/layout';
 import { useExprContext } from 'src/utils/layout/ExprContext';
 import { dataSourcesFromState } from 'src/utils/layout/hierarchy';
@@ -18,7 +19,8 @@ const PDF_LAYOUT_NAME = '__pdf__';
 
 export const usePdfPage = (): LayoutPage | null => {
   const layoutPages = useExprContext();
-  const dataSources = useAppSelector(dataSourcesFromState);
+  const currentView = useCurrentView();
+  const dataSources = useAppSelector(dataSourcesFromState(currentView ?? null));
   const pageOrderConfig = useAppSelector((state) => state.formLayout.uiConfig.pageOrderConfig);
   const repeatingGroups = useAppSelector((state) => state.formLayout.uiConfig.repeatingGroups);
   const pdfLayoutName = useAppSelector((state) => state.formLayout.uiConfig.pdfLayoutName);

--- a/src/hooks/useSourceOptions.ts
+++ b/src/hooks/useSourceOptions.ts
@@ -5,8 +5,8 @@ import { pick } from 'dot-object';
 import { evalExpr } from 'src/features/expressions';
 import { ExprVal } from 'src/features/expressions/types';
 import { asExpression } from 'src/features/expressions/validation';
+import { usePageNavigationConfig } from 'src/features/form/layout/PageNavigationContext';
 import { useAppSelector } from 'src/hooks/useAppSelector';
-import { useCurrentView } from 'src/hooks/useNavigatePage';
 import { convertDataBindingToModel, getKeyWithoutIndexIndicators } from 'src/utils/databindings';
 import { transposeDataBinding } from 'src/utils/databindings/DataBinding';
 import { createSelectDataSourcesFromState } from 'src/utils/layout/hierarchy';
@@ -21,8 +21,8 @@ interface IUseSourceOptionsArgs {
 }
 
 export const useSourceOptions = ({ source, node }: IUseSourceOptionsArgs): IOption[] | undefined => {
-  const currentView = useCurrentView();
-  const dataSources = useAppSelector(createSelectDataSourcesFromState(currentView ?? null));
+  const pageNavigationConfig = usePageNavigationConfig();
+  const dataSources = useAppSelector(createSelectDataSourcesFromState(pageNavigationConfig));
 
   return useMemo(() => getSourceOptions({ source, node, dataSources }), [source, node, dataSources]);
 };

--- a/src/hooks/useSourceOptions.ts
+++ b/src/hooks/useSourceOptions.ts
@@ -6,9 +6,10 @@ import { evalExpr } from 'src/features/expressions';
 import { ExprVal } from 'src/features/expressions/types';
 import { asExpression } from 'src/features/expressions/validation';
 import { useAppSelector } from 'src/hooks/useAppSelector';
+import { useCurrentView } from 'src/hooks/useNavigatePage';
 import { convertDataBindingToModel, getKeyWithoutIndexIndicators } from 'src/utils/databindings';
 import { transposeDataBinding } from 'src/utils/databindings/DataBinding';
-import { selectDataSourcesFromState } from 'src/utils/layout/hierarchy';
+import { createSelectDataSourcesFromState } from 'src/utils/layout/hierarchy';
 import { memoize } from 'src/utils/memoize';
 import type { IOption, IOptionSourceExternal } from 'src/layout/common.generated';
 import type { HierarchyDataSources } from 'src/layout/layout';
@@ -20,7 +21,8 @@ interface IUseSourceOptionsArgs {
 }
 
 export const useSourceOptions = ({ source, node }: IUseSourceOptionsArgs): IOption[] | undefined => {
-  const dataSources = useAppSelector(selectDataSourcesFromState);
+  const currentView = useCurrentView();
+  const dataSources = useAppSelector(createSelectDataSourcesFromState(currentView ?? null));
 
   return useMemo(() => getSourceOptions({ source, node, dataSources }), [source, node, dataSources]);
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -35,7 +35,6 @@ import { ProfileProvider } from 'src/features/profile/ProfileProvider';
 import * as queries from 'src/queries/queries';
 import { initSagas } from 'src/redux/sagas';
 import { setupStore } from 'src/redux/store';
-import { ExprContextWrapper } from 'src/utils/layout/ExprContext';
 
 import 'react-toastify/dist/ReactToastify.css';
 import 'src/index.css';
@@ -75,37 +74,35 @@ function Root() {
   return (
     <InstantiationProvider>
       <PageNavigationProvider>
-        <ExprContextWrapper>
-          <ApplicationMetadataProvider>
-            <OrgsProvider>
-              <ApplicationSettingsProvider>
-                <LayoutSetsProvider>
-                  <FooterLayoutProvider>
-                    <ProfileProvider>
-                      <PartyProvider>
-                        <TextResourcesProvider>
-                          <KeepAliveProvider>
-                            <WindowTitleProvider>
-                              <DevTools>
-                                <App />
-                                <ToastContainer
-                                  position='top-center'
-                                  theme='colored'
-                                  transition={Slide}
-                                  draggable={false}
-                                />
-                              </DevTools>
-                            </WindowTitleProvider>
-                          </KeepAliveProvider>
-                        </TextResourcesProvider>
-                      </PartyProvider>
-                    </ProfileProvider>
-                  </FooterLayoutProvider>
-                </LayoutSetsProvider>
-              </ApplicationSettingsProvider>
-            </OrgsProvider>
-          </ApplicationMetadataProvider>
-        </ExprContextWrapper>
+        <ApplicationMetadataProvider>
+          <OrgsProvider>
+            <ApplicationSettingsProvider>
+              <LayoutSetsProvider>
+                <FooterLayoutProvider>
+                  <ProfileProvider>
+                    <PartyProvider>
+                      <TextResourcesProvider>
+                        <KeepAliveProvider>
+                          <WindowTitleProvider>
+                            <DevTools>
+                              <App />
+                              <ToastContainer
+                                position='top-center'
+                                theme='colored'
+                                transition={Slide}
+                                draggable={false}
+                              />
+                            </DevTools>
+                          </WindowTitleProvider>
+                        </KeepAliveProvider>
+                      </TextResourcesProvider>
+                    </PartyProvider>
+                  </ProfileProvider>
+                </FooterLayoutProvider>
+              </LayoutSetsProvider>
+            </ApplicationSettingsProvider>
+          </OrgsProvider>
+        </ApplicationMetadataProvider>
       </PageNavigationProvider>
     </InstantiationProvider>
   );

--- a/src/layout/Group/GroupContainer.tsx
+++ b/src/layout/Group/GroupContainer.tsx
@@ -18,7 +18,7 @@ import {
 } from 'src/features/validation/validationProvider';
 import { useAppDispatch } from 'src/hooks/useAppDispatch';
 import { useAppSelector } from 'src/hooks/useAppSelector';
-import { useNavigationParams } from 'src/hooks/useNavigatePage';
+import { useCurrentView } from 'src/hooks/useNavigatePage';
 import { RepeatingGroupsEditContainer } from 'src/layout/Group/RepeatingGroupsEditContainer';
 import { useRepeatingGroupsFocusContext } from 'src/layout/Group/RepeatingGroupsFocusContext';
 import { RepeatingGroupTable } from 'src/layout/Group/RepeatingGroupTable';
@@ -32,7 +32,7 @@ export interface IGroupProps {
 
 export function GroupContainer({ node }: IGroupProps): JSX.Element | null {
   const dispatch = useAppDispatch();
-  const { pageKey } = useNavigationParams();
+  const currentView = useCurrentView();
 
   const { triggerFocus } = useRepeatingGroupsFocusContext();
   const resolvedTextBindings = node.item.textResourceBindings;
@@ -94,7 +94,7 @@ export function GroupContainer({ node }: IGroupProps): JSX.Element | null {
 
   const addNewRowToGroup = useCallback(async () => {
     if (!edit?.alwaysShowAddButton || edit?.mode === 'showAll') {
-      dispatch(FormLayoutActions.repGroupAddRow({ groupId: id, currentPageId: pageKey }));
+      dispatch(FormLayoutActions.repGroupAddRow({ groupId: id, currentPageId: currentView }));
     }
 
     if (edit?.mode !== 'showAll' && edit?.mode !== 'onlyTable') {
@@ -112,7 +112,7 @@ export function GroupContainer({ node }: IGroupProps): JSX.Element | null {
           group: id,
           index: repeatingGroupIndex + 1,
           shouldAddRow: !!edit?.alwaysShowAddButton,
-          currentPageId: pageKey,
+          currentPageId: currentView,
         }),
       );
       setMultiPageIndex(0);
@@ -125,7 +125,7 @@ export function GroupContainer({ node }: IGroupProps): JSX.Element | null {
     id,
     node,
     onGroupCloseValidation,
-    pageKey,
+    currentView,
     repeatingGroupIndex,
     setMultiPageIndex,
     validateOnSaveRow,
@@ -161,7 +161,7 @@ export function GroupContainer({ node }: IGroupProps): JSX.Element | null {
     const attachmentDeletionSuccessful = await onBeforeRowDeletion(index);
     if (attachmentDeletionSuccessful) {
       onDeleteGroupRow(node, index);
-      dispatch(FormLayoutActions.repGroupDeleteRow({ groupId: id, index, currentPageId: pageKey }));
+      dispatch(FormLayoutActions.repGroupDeleteRow({ groupId: id, index, currentPageId: currentView }));
     } else {
       dispatch(FormLayoutActions.repGroupDeleteRowCancelled({ groupId: id, index }));
     }
@@ -180,7 +180,7 @@ export function GroupContainer({ node }: IGroupProps): JSX.Element | null {
       FormLayoutActions.updateRepeatingGroupsEditIndex({
         group: id,
         index,
-        currentPageId: pageKey,
+        currentPageId: currentView,
       }),
     );
     if (edit?.multiPage && index > -1) {

--- a/src/layout/Group/RepeatingGroupsTable.test.tsx
+++ b/src/layout/Group/RepeatingGroupsTable.test.tsx
@@ -36,7 +36,6 @@ const getLayout = (group: CompGroupRepeatingExternal, components: CompOrGroupExt
           index: 3,
         },
       },
-      currentView: 'FormLayout',
       focus: undefined,
       pageOrderConfig: {
         order: ['FormLayout'],

--- a/src/layout/Group/RepeatingGroupsTable.test.tsx
+++ b/src/layout/Group/RepeatingGroupsTable.test.tsx
@@ -37,11 +37,6 @@ const getLayout = (group: CompGroupRepeatingExternal, components: CompOrGroupExt
         },
       },
       focus: undefined,
-      pageOrderConfig: {
-        order: ['FormLayout'],
-        hidden: [],
-        hiddenExpr: {},
-      },
       excludePageFromPdf: [],
       excludeComponentFromPdf: [],
     },

--- a/src/layout/InstantiationButton/InstantiationButton.test.tsx
+++ b/src/layout/InstantiationButton/InstantiationButton.test.tsx
@@ -18,10 +18,13 @@ const render = async () =>
     },
     inInstance: false,
     router: ({ children }) => (
-      <MemoryRouter initialEntries={['/']}>
+      <MemoryRouter
+        basename={'/ttd/test'}
+        initialEntries={['/ttd/test/instance/1337/dfe95272-6873-48a6-abae-57b3f7c18689/Task_1/formLayout']}
+      >
         <Routes>
           <Route
-            path={'/'}
+            path={'/instance/1337/dfe95272-6873-48a6-abae-57b3f7c18689/Task_1/formLayout'}
             element={children}
           />
           <Route

--- a/src/layout/Likert/RepeatingGroupsLikertContainerTestUtils.tsx
+++ b/src/layout/Likert/RepeatingGroupsLikertContainerTestUtils.tsx
@@ -126,11 +126,7 @@ const createLayout = (
       },
     },
     focus: null,
-    pageOrderConfig: {
-      order: null,
-      hidden: [],
-      hiddenExpr: {},
-    },
+
     excludePageFromPdf: [],
     excludeComponentFromPdf: [],
   },

--- a/src/layout/Likert/RepeatingGroupsLikertContainerTestUtils.tsx
+++ b/src/layout/Likert/RepeatingGroupsLikertContainerTestUtils.tsx
@@ -125,7 +125,6 @@ const createLayout = (
         editIndex: -1,
       },
     },
-    currentView: 'FormLayout',
     focus: null,
     pageOrderConfig: {
       order: null,

--- a/src/layout/NavigationBar/NavigationBarComponent.test.tsx
+++ b/src/layout/NavigationBar/NavigationBarComponent.test.tsx
@@ -41,7 +41,7 @@ const render = async () => {
           },
         }),
     },
-    router: PageNavigationRouter('page1'),
+    router: PageNavigationRouter({ currentPageId: 'page1' }),
     reduxState: getInitialStateMock((state) => {
       state.formLayout = {
         layoutsets: null,
@@ -52,7 +52,6 @@ const render = async () => {
             hiddenExpr: {},
             hidden: [],
           },
-          currentView: 'page1',
           focus: 'focus',
           hiddenFields: [],
           repeatingGroups: {},

--- a/src/layout/NavigationBar/NavigationBarComponent.test.tsx
+++ b/src/layout/NavigationBar/NavigationBarComponent.test.tsx
@@ -47,11 +47,6 @@ const render = async () => {
         layoutsets: null,
         layoutSetId: null,
         uiConfig: {
-          pageOrderConfig: {
-            order: ['page1', 'page2', 'page3'],
-            hiddenExpr: {},
-            hidden: [],
-          },
           focus: 'focus',
           hiddenFields: [],
           repeatingGroups: {},

--- a/src/layout/NavigationButtons/NavigationButtonsComponent.test.tsx
+++ b/src/layout/NavigationButtons/NavigationButtonsComponent.test.tsx
@@ -56,11 +56,6 @@ describe('NavigationButtons', () => {
       focus: null,
       hiddenFields: [],
       repeatingGroups: {},
-      pageOrderConfig: {
-        order: ['layout1', 'layout2'],
-        hidden: [],
-        hiddenExpr: {},
-      },
       excludePageFromPdf: [],
       excludeComponentFromPdf: [],
     },

--- a/src/layout/NavigationButtons/NavigationButtonsComponent.test.tsx
+++ b/src/layout/NavigationButtons/NavigationButtonsComponent.test.tsx
@@ -53,7 +53,6 @@ describe('NavigationButtons', () => {
       ],
     },
     uiConfig: {
-      currentView: 'layout1',
       focus: null,
       hiddenFields: [],
       repeatingGroups: {},
@@ -84,7 +83,7 @@ describe('NavigationButtons', () => {
           Promise.resolve({ sets: [{ dataType: 'test-data-model', id: 'message', tasks: ['Task_1'] }] }),
         fetchLayoutSettings: () => Promise.resolve({ pages: { order: ['layout1', 'layout2'] } }),
       },
-      router: PageNavigationRouter(currentPageId),
+      router: PageNavigationRouter({ currentPageId }),
     });
   };
 

--- a/src/layout/Panel/PanelGroupContainer.test.tsx
+++ b/src/layout/Panel/PanelGroupContainer.test.tsx
@@ -64,7 +64,6 @@ describe('PanelGroupContainer', () => {
     uiConfig: {
       ...initialState.formLayout.uiConfig,
       hiddenFields: [],
-      currentView: 'FormLayout',
     },
     layoutsets: null,
   };

--- a/src/layout/Panel/PanelReferenceGroupContainer.test.tsx
+++ b/src/layout/Panel/PanelReferenceGroupContainer.test.tsx
@@ -61,7 +61,6 @@ describe('PanelGroupContainer', () => {
     uiConfig: {
       ...initialState.formLayout.uiConfig,
       hiddenFields: [],
-      currentView: 'FormLayout',
     },
     layoutsets: null,
   };

--- a/src/layout/Panel/PanelReferenceGroupContainer.tsx
+++ b/src/layout/Panel/PanelReferenceGroupContainer.tsx
@@ -12,7 +12,7 @@ import { getVariant } from 'src/components/form/Panel';
 import { FormLayoutActions } from 'src/features/form/layout/formLayoutSlice';
 import { Lang } from 'src/features/language/Lang';
 import { useAppDispatch } from 'src/hooks/useAppDispatch';
-import { useNavigationParams } from 'src/hooks/useNavigatePage';
+import { useCurrentView } from 'src/hooks/useNavigatePage';
 import { GenericComponent } from 'src/layout/GenericComponent';
 import { CustomIcon } from 'src/layout/Panel/CustomPanelIcon';
 import type { CompGroupNonRepeatingPanelInternal } from 'src/layout/Group/config.generated';
@@ -24,7 +24,7 @@ export interface IPanelGroupContainerProps {
 
 export function PanelReferenceGroupContainer({ node }: IPanelGroupContainerProps) {
   const dispatch = useAppDispatch();
-  const { pageKey } = useNavigationParams();
+  const currentView = useCurrentView();
 
   const container = node.item.panel ? node.item : undefined;
   const [open, setOpen] = useState<boolean>(!container?.panel?.groupReference);
@@ -43,7 +43,7 @@ export function PanelReferenceGroupContainer({ node }: IPanelGroupContainerProps
       dispatch(
         FormLayoutActions.repGroupAddRow({
           groupId: referencedGroupNode.item.id,
-          currentPageId: pageKey,
+          currentPageId: currentView,
         }),
       );
     }

--- a/src/test/renderWithProviders.tsx
+++ b/src/test/renderWithProviders.tsx
@@ -37,7 +37,7 @@ import { OrgsProvider } from 'src/features/orgs/OrgsProvider';
 import { PartyProvider } from 'src/features/party/PartiesProvider';
 import { ProfileProvider } from 'src/features/profile/ProfileProvider';
 import { useAppSelector } from 'src/hooks/useAppSelector';
-import { useNavigationParams } from 'src/hooks/useNavigatePage';
+import { useCurrentView } from 'src/hooks/useNavigatePage';
 import { setupStore } from 'src/redux/store';
 import { PageNavigationRouter } from 'src/test/routerUtils';
 import { AltinnAppTheme } from 'src/theme/altinnAppTheme';
@@ -426,7 +426,6 @@ export const renderWithInstanceAndLayout = async ({
         initialEntries={[`/ttd/test/instance/${exampleInstanceId}/${initialPage}`]}
       >
         <Routes>
-          Pro
           <Route
             path={'instance/:partyId/:instanceGuid/*'}
             element={children}
@@ -464,8 +463,7 @@ const WaitForNodes = ({
   nodeId,
 }: PropsWithChildren<{ waitForAllNodes: boolean; nodeId?: string }>) => {
   const layouts = useAppSelector((state) => state.formLayout.layouts);
-  const { pageKey, taskId, partyId, instanceGuid } = useNavigationParams();
-  const currentView = pageKey;
+  const currentView = useCurrentView();
   const repeatingGroups = useAppSelector((state) => state.formLayout.uiConfig.repeatingGroups);
   const nodes = useExprContext();
 

--- a/src/test/renderWithProviders.tsx
+++ b/src/test/renderWithProviders.tsx
@@ -37,7 +37,9 @@ import { OrgsProvider } from 'src/features/orgs/OrgsProvider';
 import { PartyProvider } from 'src/features/party/PartiesProvider';
 import { ProfileProvider } from 'src/features/profile/ProfileProvider';
 import { useAppSelector } from 'src/hooks/useAppSelector';
+import { useNavigationParams } from 'src/hooks/useNavigatePage';
 import { setupStore } from 'src/redux/store';
+import { PageNavigationRouter } from 'src/test/routerUtils';
 import { AltinnAppTheme } from 'src/theme/altinnAppTheme';
 import { ExprContextWrapper, useExprContext } from 'src/utils/layout/ExprContext';
 import type { AppMutations, AppQueries, AppQueriesContext } from 'src/core/contexts/AppQueriesProvider';
@@ -304,7 +306,7 @@ const renderBase = async ({
 
   const ProviderWrapper = ({ children }: PropsWithChildren) => (
     <Providers
-      Router={router}
+      Router={router || PageNavigationRouter({ currentPageId: 'formLayout' })}
       queryClient={queryClient}
       queries={{
         ...queryMocks,
@@ -393,7 +395,8 @@ export const renderWithoutInstanceAndLayout = async (props: ExtendedRenderOption
 export const renderWithInstanceAndLayout = async ({
   renderer,
   reduxState: _reduxState,
-  initialPage = '',
+  router,
+  initialPage = 'Task_1/formLayout',
   ...renderOptions
 }: ExtendedRenderOptions) => {
   const reduxState = _reduxState || getInitialStateMock();
@@ -423,6 +426,7 @@ export const renderWithInstanceAndLayout = async ({
         initialEntries={[`/ttd/test/instance/${exampleInstanceId}/${initialPage}`]}
       >
         <Routes>
+          Pro
           <Route
             path={'instance/:partyId/:instanceGuid/*'}
             element={children}
@@ -448,7 +452,7 @@ export const renderWithInstanceAndLayout = async ({
       fetchInstanceData: () => Promise.resolve(reduxState.deprecated.lastKnownInstance || getInstanceDataMock()),
       fetchProcessState: () => Promise.resolve(reduxState.deprecated.lastKnownProcess || getProcessDataMock()),
     },
-    router: InstanceRouter,
+    router: router || InstanceRouter,
     reduxState,
     ...renderOptions,
   });
@@ -460,7 +464,8 @@ const WaitForNodes = ({
   nodeId,
 }: PropsWithChildren<{ waitForAllNodes: boolean; nodeId?: string }>) => {
   const layouts = useAppSelector((state) => state.formLayout.layouts);
-  const currentView = useAppSelector((state) => state.formLayout.uiConfig.currentView);
+  const { pageKey, taskId, partyId, instanceGuid } = useNavigationParams();
+  const currentView = pageKey;
   const repeatingGroups = useAppSelector((state) => state.formLayout.uiConfig.repeatingGroups);
   const nodes = useExprContext();
 

--- a/src/test/routerUtils.tsx
+++ b/src/test/routerUtils.tsx
@@ -2,12 +2,14 @@ import React from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
 export const PageNavigationRouter =
-  (currentPageId: string = 'layout1') =>
+  ({ currentPageId = 'layout1', currentTaskId = 'Task_1' } = {}) =>
   // eslint-disable-next-line react/display-name
   ({ children }: { children: React.ReactNode }) => (
     <MemoryRouter
       basename={'/ttd/test'}
-      initialEntries={[`/ttd/test/instance/1337/dfe95272-6873-48a6-abae-57b3f7c18689/Task_1/${currentPageId}`]}
+      initialEntries={[
+        `/ttd/test/instance/1337/dfe95272-6873-48a6-abae-57b3f7c18689/${currentTaskId}/${currentPageId}`,
+      ]}
     >
       <Routes>
         <Route

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -82,37 +82,10 @@ export interface IUiConfig {
   focus: string | null | undefined;
   hiddenFields: string[];
   repeatingGroups: IRepeatingGroups | null;
-  pageOrderConfig: IPageOrderConfig;
   excludePageFromPdf: string[] | null;
   excludeComponentFromPdf: string[] | null;
   pdfLayoutName?: string;
   keepScrollPos?: IComponentScrollPos;
-}
-
-/**
- * This state includes everything needed to calculate which layouts should be shown, and their order.
- */
-export interface IPageOrderConfig {
-  /**
-   * The main 'order' is the list of layouts available, or which layouts the server tells us to display. If a layout
-   * is not in this list, it should be considered hidden. It will be null until layouts have been fetched.
-   *
-   * Do NOT use this directly, as it will not respect layouts hidden using expressions!
-   * @see getLayoutOrderFromPageOrderConfig
-   * @see selectLayoutOrder
-   */
-  order: string[] | null;
-
-  /**
-   * This state contains the results from calculating `hiddenExpr` (expressions to decide if a certain layout should
-   * be hidden or not). If a layout is in this list, is should also not be displayed.
-   */
-  hidden: string[];
-
-  /**
-   * List of expressions containing logic used to show/hide certain layouts.
-   */
-  hiddenExpr: IHiddenLayoutsExternal;
 }
 
 export enum ProcessTaskType {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -78,7 +78,6 @@ export interface IHiddenLayoutsExternal {
 export interface IUiConfig {
   autoSaveBehavior?: 'onChangePage' | 'onChangeFormData';
   receiptLayoutName?: string;
-  currentView: string;
   returnToView?: string;
   focus: string | null | undefined;
   hiddenFields: string[];

--- a/src/utils/databindings.ts
+++ b/src/utils/databindings.ts
@@ -166,7 +166,6 @@ export function getGroupDataModelBinding(repeatingGroup: IRepeatingGroup, groupI
  * @deprecated
  * @see useExprContext
  * @see useResolvedNode
- * @see ResolvedNodesSelector
  */
 function getParentGroup(groupId: string, layout: ILayout): CompGroupExternal | undefined {
   if (!groupId || !layout) {

--- a/src/utils/layout/ExprContext.tsx
+++ b/src/utils/layout/ExprContext.tsx
@@ -7,10 +7,9 @@ import {
   shouldUpdate,
 } from 'src/features/form/dynamics/conditionalRenderingSagas';
 import { FormLayoutActions } from 'src/features/form/layout/formLayoutSlice';
-import { usePageNavigationContext } from 'src/features/form/layout/PageNavigationContext';
+import { usePageNavigationConfig, usePageNavigationContext } from 'src/features/form/layout/PageNavigationContext';
 import { useAppDispatch } from 'src/hooks/useAppDispatch';
 import { useAppSelector } from 'src/hooks/useAppSelector';
-import { useCurrentView } from 'src/hooks/useNavigatePage';
 import { runConditionalRenderingRules } from 'src/utils/conditionalRendering';
 import { _private, createSelectDataSourcesFromState } from 'src/utils/layout/hierarchy';
 import { BaseLayoutNode } from 'src/utils/layout/LayoutNode';
@@ -92,8 +91,8 @@ function useLegacyHiddenComponents(resolvedNodes: LayoutPages | undefined) {
   const formData = useAppSelector((state) => state.formData.formData);
   const rules = useAppSelector((state) => state.formDynamics.conditionalRendering);
   const repeatingGroups = useAppSelector((state) => state.formLayout.uiConfig.repeatingGroups);
-  const currentView = useCurrentView();
-  const dataSources = useAppSelector(createSelectDataSourcesFromState(currentView ?? null));
+  const pageNavigationConfig = usePageNavigationConfig();
+  const dataSources = useAppSelector(createSelectDataSourcesFromState(pageNavigationConfig));
   const { setHiddenPages, hidden, hiddenExpr } = usePageNavigationContext();
   const dispatch = useAppDispatch();
 

--- a/src/utils/layout/ExprContext.tsx
+++ b/src/utils/layout/ExprContext.tsx
@@ -10,8 +10,9 @@ import { FormLayoutActions } from 'src/features/form/layout/formLayoutSlice';
 import { usePageNavigationContext } from 'src/features/form/layout/PageNavigationContext';
 import { useAppDispatch } from 'src/hooks/useAppDispatch';
 import { useAppSelector } from 'src/hooks/useAppSelector';
+import { useCurrentView } from 'src/hooks/useNavigatePage';
 import { runConditionalRenderingRules } from 'src/utils/conditionalRendering';
-import { _private, selectDataSourcesFromState } from 'src/utils/layout/hierarchy';
+import { _private, createSelectDataSourcesFromState } from 'src/utils/layout/hierarchy';
 import { BaseLayoutNode } from 'src/utils/layout/LayoutNode';
 import type { LayoutNodeFromObj } from 'src/layout/layout';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
@@ -91,7 +92,8 @@ function useLegacyHiddenComponents(resolvedNodes: LayoutPages | undefined) {
   const formData = useAppSelector((state) => state.formData.formData);
   const rules = useAppSelector((state) => state.formDynamics.conditionalRendering);
   const repeatingGroups = useAppSelector((state) => state.formLayout.uiConfig.repeatingGroups);
-  const dataSources = useAppSelector(selectDataSourcesFromState);
+  const currentView = useCurrentView();
+  const dataSources = useAppSelector(createSelectDataSourcesFromState(currentView ?? null));
   const { setHiddenPages, hidden, hiddenExpr } = usePageNavigationContext();
   const dispatch = useAppDispatch();
 

--- a/src/utils/layout/LayoutNode.ts
+++ b/src/utils/layout/LayoutNode.ts
@@ -206,7 +206,7 @@ export class BaseLayoutNode<Item extends CompInternal = CompInternal, Type exten
     if (
       respectTracks &&
       this.parent instanceof LayoutPage &&
-      this.parent.isHiddenViaTracks(this.dataSources.uiConfig)
+      this.parent.isHiddenViaTracks(this.dataSources.uiConfig, this.dataSources.pageNavigationConfig)
     ) {
       return true;
     }

--- a/src/utils/layout/LayoutPage.ts
+++ b/src/utils/layout/LayoutPage.ts
@@ -133,9 +133,9 @@ export class LayoutPage implements LayoutObject {
     };
   }
 
-  public isHiddenViaTracks(uiConfig: IUiConfig, contextBasedUiConfig: PageNavigationConfig): boolean {
+  public isHiddenViaTracks(uiConfig: IUiConfig, pageNavigationConfig: PageNavigationConfig): boolean {
     const myKey = this.top.myKey;
-    if (myKey === contextBasedUiConfig.currentView) {
+    if (myKey === pageNavigationConfig.currentView) {
       // If this is the current view, then it's never hidden. This avoids settings fields as hidden when
       // code caused this to be the current view even if it's not in the common order.
       return false;
@@ -151,7 +151,7 @@ export class LayoutPage implements LayoutObject {
       return false;
     }
 
-    const { order } = uiConfig.pageOrderConfig || {};
+    const { order } = pageNavigationConfig;
     if (!order) {
       // If no pageOrderConfig is provided, then we can't determine if this is hidden or not
       return false;

--- a/src/utils/layout/LayoutPage.ts
+++ b/src/utils/layout/LayoutPage.ts
@@ -1,3 +1,4 @@
+import type { PageNavigationConfig } from 'src/features/expressions/ExprContext';
 import type { CompExceptGroup, CompInternal } from 'src/layout/layout';
 import type { IUiConfig } from 'src/types';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
@@ -132,9 +133,9 @@ export class LayoutPage implements LayoutObject {
     };
   }
 
-  public isHiddenViaTracks(uiConfig: IUiConfig): boolean {
+  public isHiddenViaTracks(uiConfig: IUiConfig, contextBasedUiConfig: PageNavigationConfig): boolean {
     const myKey = this.top.myKey;
-    if (myKey === uiConfig.currentView) {
+    if (myKey === contextBasedUiConfig.currentView) {
       // If this is the current view, then it's never hidden. This avoids settings fields as hidden when
       // code caused this to be the current view even if it's not in the common order.
       return false;

--- a/src/utils/layout/hierarchy.test.ts
+++ b/src/utils/layout/hierarchy.test.ts
@@ -2,7 +2,7 @@ import { getHierarchyDataSourcesMock } from 'src/__mocks__/getHierarchyDataSourc
 import { getInitialStateMock } from 'src/__mocks__/initialStateMock';
 import { getLayoutComponentObject } from 'src/layout';
 import { getRepeatingGroups } from 'src/utils/formLayout';
-import { _private, resolvedLayoutsFromState } from 'src/utils/layout/hierarchy';
+import { _private, dataSourcesFromState } from 'src/utils/layout/hierarchy';
 import { generateHierarchy } from 'src/utils/layout/HierarchyGenerator';
 import { BaseLayoutNode } from 'src/utils/layout/LayoutNode';
 import { LayoutPage } from 'src/utils/layout/LayoutPage';
@@ -15,6 +15,7 @@ import type { IRepeatingGroups } from 'src/types';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 const { resolvedNodesInLayouts } = _private;
+const testPageNavigationConfig = { currentView: 'formLayout', hidden: [], hiddenExpr: {}, order: [] };
 
 describe('Hierarchical layout tools', () => {
   const header: Omit<CompHeaderExternal, 'id'> = { type: 'Header', size: 'L' };
@@ -546,7 +547,12 @@ describe('Hierarchical layout tools', () => {
     const state = getInitialStateMock();
     (state.formLayout.layouts as any)['page2'] = layout;
     state.formLayout.uiConfig.repeatingGroups = manyRepeatingGroups;
-    const resolved = resolvedLayoutsFromState('formLayout')(state);
+    const resolved = resolvedNodesInLayouts(
+      state.formLayout.layouts,
+      'FormLayout',
+      state.formLayout.uiConfig.repeatingGroups,
+      dataSourcesFromState(testPageNavigationConfig)(state),
+    );
 
     const field3 = resolved?.findById('field3');
     expect(field3?.item.id).toEqual('field3');
@@ -641,7 +647,12 @@ describe('Hierarchical layout tools', () => {
           index: 2,
         },
       };
-      const resolved = resolvedLayoutsFromState('formLayot')(state);
+      const resolved = resolvedNodesInLayouts(
+        state.formLayout.layouts,
+        'FormLayout',
+        state.formLayout.uiConfig.repeatingGroups,
+        dataSourcesFromState(testPageNavigationConfig)(state),
+      );
       const dataBindingFor = (id: string) => {
         const item = resolved?.findById(id)?.item || undefined;
         const dmBindings = item && 'dataModelBindings' in item ? item?.dataModelBindings : undefined;

--- a/src/utils/layout/hierarchy.test.ts
+++ b/src/utils/layout/hierarchy.test.ts
@@ -546,7 +546,7 @@ describe('Hierarchical layout tools', () => {
     const state = getInitialStateMock();
     (state.formLayout.layouts as any)['page2'] = layout;
     state.formLayout.uiConfig.repeatingGroups = manyRepeatingGroups;
-    const resolved = resolvedLayoutsFromState(state);
+    const resolved = resolvedLayoutsFromState('formLayout')(state);
 
     const field3 = resolved?.findById('field3');
     expect(field3?.item.id).toEqual('field3');
@@ -641,8 +641,7 @@ describe('Hierarchical layout tools', () => {
           index: 2,
         },
       };
-      state.formLayout.uiConfig.currentView = 'page1';
-      const resolved = resolvedLayoutsFromState(state);
+      const resolved = resolvedLayoutsFromState('formLayot')(state);
       const dataBindingFor = (id: string) => {
         const item = resolved?.findById(id)?.item || undefined;
         const dmBindings = item && 'dataModelBindings' in item ? item?.dataModelBindings : undefined;

--- a/test/e2e/integration/frontend-test/validation.ts
+++ b/test/e2e/integration/frontend-test/validation.ts
@@ -680,12 +680,7 @@ describe('Validation', () => {
     cy.get(appFrontend.errorReport).should('contain.text', 'Tullevalidering');
   });
 
-  /**
-   * TODO(Page navigation):
-   * This test is skipped due to a mismatch between order in redux which is used for node.isHidden()
-   * and the order in UiConfigProvider where only the UiConfigProvider is correct.
-   */
-  it.skip('Navigating to one task and navigating back should not produce error messages for hidden pages', () => {
+  it('Navigating to one task and navigating back should not produce error messages for hidden pages', () => {
     cy.goto('group');
     cy.gotoNavPage('summary');
     cy.get(appFrontend.sendinButton).click();


### PR DESCRIPTION
## Description

This PR implements a fix which provides the correct data to the node hierarchy. The node hierarchy previously read data about order and current view from redux. This data is used to calculate if a node is hidden or not, which in turn was used by the validation to determine if a component should be validated or not.  

I unskipped the test, and put the `ExprContextWrapper` inside the `UiConfigProvider` as we discussed @bjosttveit. I cleared this with @olemartinorg, and we'll just fix potential merge conflicts if they should occur from this. 

## Related Issue(s)

- #1508

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
