### PR TITLE
Bug: CustomButton authorization

### DIFF
--- a/src/hooks/useNavigatePage.ts
+++ b/src/hooks/useNavigatePage.ts
@@ -95,9 +95,11 @@ export const useNavigatePage = () => {
     (page?: string, options?: NavigateToPageOptions) => {
       const replace = options?.replace ?? false;
       if (!page) {
+        window.logWarn('navigateToPage called without page');
         return;
       }
       if (!order.includes(page)) {
+        window.logWarn('navigateToPage called with invalid page:', `"${page}"`);
         return;
       }
 
@@ -191,9 +193,11 @@ export const useNavigatePage = () => {
    */
   const navigateToNextPage = () => {
     const nextPage = getNextPage();
-    if (nextPage) {
-      navigateToPage(nextPage);
+    if (!nextPage) {
+      window.logWarn('Tried to navigate to next page when standing on the last page.');
+      return;
     }
+    navigateToPage(nextPage);
   };
   /**
    * This function fetches the previous page index on
@@ -203,9 +207,12 @@ export const useNavigatePage = () => {
    */
   const navigateToPreviousPage = () => {
     const previousPage = getPreviousPage();
-    if (previousPage) {
-      navigateToPage(previousPage);
+
+    if (!previousPage) {
+      window.logWarn('Tried to navigate to previous page when standing on the first page.');
+      return;
     }
+    navigateToPage(previousPage);
   };
 
   return {

--- a/src/layout/CustomButton/CustomButtonComponent.test.tsx
+++ b/src/layout/CustomButton/CustomButtonComponent.test.tsx
@@ -1,0 +1,174 @@
+import React from 'react';
+
+import { screen } from '@testing-library/react';
+
+import { CustomButtonComponent } from 'src/layout/CustomButton/CustomButtonComponent';
+import { renderGenericComponentTest } from 'src/test/renderWithProviders';
+import type { CustomAction } from 'src/layout/CustomButton/config.generated';
+import type { IUserAction } from 'src/types/shared';
+
+describe('CustomButtonComponent', () => {
+  it('should be disabled if the action provided is not authorized', async () => {
+    await render({
+      actions: [{ id: 'lookupPerson', type: 'ServerAction' }],
+      actionAuthorization: [
+        {
+          id: 'lookupPerson',
+          authorized: false,
+          type: 'ServerAction',
+        },
+      ],
+    });
+
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+
+  it('should be enabled if the action provided is authorized', async () => {
+    await render({
+      actions: [{ id: 'lookupPerson', type: 'ServerAction' }],
+      actionAuthorization: [
+        {
+          id: 'lookupPerson',
+          authorized: true,
+          type: 'ServerAction',
+        },
+      ],
+    });
+
+    expect(screen.getByRole('button')).not.toBeDisabled();
+  });
+
+  it('should be disabled if one of the actions provided is not authorized', async () => {
+    await render({
+      actions: [
+        { id: 'lookupPerson', type: 'ServerAction' },
+        { id: 'fillForm', type: 'ServerAction' },
+      ],
+      actionAuthorization: [
+        {
+          id: 'lookupPerson',
+          authorized: true,
+          type: 'ServerAction',
+        },
+        {
+          id: 'calculateData',
+          authorized: true,
+          type: 'ServerAction',
+        },
+        {
+          id: 'fillForm',
+          authorized: false,
+          type: 'ServerAction',
+        },
+      ],
+    });
+  });
+
+  it('should not be disabled if one of the actions provided is not authorized but is not used in the custom button', async () => {
+    await render({
+      actions: [
+        { id: 'lookupPerson', type: 'ServerAction' },
+        { id: 'calculateData', type: 'ServerAction' },
+      ],
+      actionAuthorization: [
+        {
+          id: 'lookupPerson',
+          authorized: true,
+          type: 'ServerAction',
+        },
+        {
+          id: 'calculateData',
+          authorized: true,
+          type: 'ServerAction',
+        },
+        {
+          id: 'fillForm',
+          authorized: false,
+          type: 'ServerAction',
+        },
+      ],
+    });
+
+    expect(screen.getByRole('button')).not.toBeDisabled();
+  });
+
+  it('should not be disabled if one of the client side actions does not exist in authorizations', async () => {
+    await render({
+      actions: [
+        { id: 'lookupPerson', type: 'ServerAction' },
+        { id: 'calculateData', type: 'ServerAction' },
+        { id: 'nextPage', type: 'ClientAction' },
+      ],
+      actionAuthorization: [
+        {
+          id: 'lookupPerson',
+          authorized: true,
+          type: 'ServerAction',
+        },
+        {
+          id: 'calculateData',
+          authorized: true,
+          type: 'ServerAction',
+        },
+      ],
+    });
+
+    expect(screen.getByRole('button')).not.toBeDisabled();
+  });
+});
+
+type RenderProps = {
+  actions?: CustomAction[];
+  actionAuthorization?: IUserAction[];
+};
+
+async function render({ actions, actionAuthorization }: RenderProps = { actionAuthorization: [] }) {
+  await renderGenericComponentTest({
+    type: 'CustomButton',
+    renderer: (props) => <CustomButtonComponent {...props} />,
+    component: {
+      textResourceBindings: {
+        title: 'Custom button',
+      },
+      actions,
+    },
+    queries: {
+      fetchProcessState: async () => ({
+        started: '2024-01-03T06:52:49.716640678Z',
+        ended: null,
+        endEvent: null,
+        startEvent: '2024-01-03T06:52:49.716640678Z',
+        currentTask: {
+          userActions: [
+            {
+              id: 'read',
+              authorized: true,
+              type: 'ProcessAction',
+            },
+            {
+              id: 'write',
+              authorized: true,
+              type: 'ProcessAction',
+            },
+            {
+              id: 'complete',
+              authorized: false,
+              type: 'ProcessAction',
+            },
+            ...(actionAuthorization ?? []),
+          ],
+          read: true,
+          write: true,
+          flow: 2,
+          started: '2024-01-03T06:37:22.7573522Z',
+          elementId: 'Task_1',
+          name: 'Utfylling',
+          altinnTaskType: 'data',
+          ended: null,
+          validated: null,
+          flowType: 'CompleteCurrentMoveToNext',
+        },
+      }),
+    },
+  });
+}

--- a/src/layout/CustomButton/CustomButtonComponent.tsx
+++ b/src/layout/CustomButton/CustomButtonComponent.tsx
@@ -58,9 +58,9 @@ function useHandleClientActions(): UseHandleClientActions {
 
   const handleClientAction = async (action: CBTypes.ClientAction) => {
     if (isSpecificClientAction('navigateToPage', action)) {
-      return await frontendActions[action.name](action.metadata);
+      return await frontendActions[action.id](action.metadata);
     }
-    await frontendActions[action.name]();
+    await frontendActions[action.id]();
   };
 
   return {
@@ -97,7 +97,7 @@ function useHandleServerActionMutation(lockTools: FormDataLockTools): UsePerform
       if (!instanceGuid || !partyId) {
         throw Error('Cannot perform action without partyId and instanceGuid');
       }
-      return doPerformAction.call(partyId, instanceGuid, { action: action.name, buttonId });
+      return doPerformAction.call(partyId, instanceGuid, { action: action.id, buttonId });
     },
   });
 
@@ -145,7 +145,7 @@ export const CustomButtonComponent = ({ node }: Props) => {
   const { handleClientActions } = useHandleClientActions();
   const { handleServerAction, mutation } = useHandleServerActionMutation(lockTools);
 
-  const isPermittedToPerformActions = actions.reduce((acc, action) => acc || isAuthorized(action.name), true);
+  const isPermittedToPerformActions = actions.reduce((acc, action) => acc || isAuthorized(action.id), true);
   const disabled = !isPermittedToPerformActions || mutation.isLoading;
 
   const onClick = async () => {

--- a/src/layout/CustomButton/CustomButtonComponent.tsx
+++ b/src/layout/CustomButton/CustomButtonComponent.tsx
@@ -145,7 +145,9 @@ export const CustomButtonComponent = ({ node }: Props) => {
   const { handleClientActions } = useHandleClientActions();
   const { handleServerAction, mutation } = useHandleServerActionMutation(lockTools);
 
-  const isPermittedToPerformActions = actions.reduce((acc, action) => acc || isAuthorized(action.id), true);
+  const isPermittedToPerformActions = actions
+    .filter((action) => action.type === 'ServerAction')
+    .reduce((acc, action) => acc && isAuthorized(action.id), true);
   const disabled = !isPermittedToPerformActions || mutation.isLoading;
 
   const onClick = async () => {

--- a/src/layout/CustomButton/config.ts
+++ b/src/layout/CustomButton/config.ts
@@ -18,20 +18,20 @@ export const Config = new CG.component({
         new CG.union(
           new CG.union(
             new CG.obj(
-              new CG.prop('name', new CG.const('nextPage')),
+              new CG.prop('id', new CG.const('nextPage')),
               new CG.prop('type', new CG.const('ClientAction')),
             ).exportAs('NextPageAction'),
             new CG.obj(
-              new CG.prop('name', new CG.const('previousPage')),
+              new CG.prop('id', new CG.const('previousPage')),
               new CG.prop('type', new CG.const('ClientAction')),
             ).exportAs('PreviousPageAction'),
             new CG.obj(
-              new CG.prop('name', new CG.const('navigateToPage')),
+              new CG.prop('id', new CG.const('navigateToPage')),
               new CG.prop('type', new CG.const('ClientAction')),
               new CG.prop('metadata', new CG.obj(new CG.prop('page', new CG.str()))),
             ).exportAs('NavigateToPageAction'),
           ).exportAs('ClientAction'),
-          new CG.obj(new CG.prop('name', new CG.str()), new CG.prop('type', new CG.const('ServerAction'))).exportAs(
+          new CG.obj(new CG.prop('id', new CG.str()), new CG.prop('type', new CG.const('ServerAction'))).exportAs(
             'ServerAction',
           ),
         ).exportAs('CustomAction'),

--- a/src/layout/CustomButton/typeHelpers.ts
+++ b/src/layout/CustomButton/typeHelpers.ts
@@ -6,7 +6,7 @@ import type * as CBTypes from 'src/layout/CustomButton/config.generated';
  * be used to make sure that all functions have been defined.
  */
 export type ClientActionHandlers = {
-  [Action in CBTypes.ClientAction as Action['name']]: Action extends { metadata: infer Metadata }
+  [Action in CBTypes.ClientAction as Action['id']]: Action extends { metadata: infer Metadata }
     ? (params: Metadata) => Promise<void>
     : () => Promise<void>;
 };
@@ -17,7 +17,7 @@ export type ClientActionHandlers = {
  * function receives correct parameters with type safety.
  */
 type ActionMap = {
-  [Action in CBTypes.ClientAction as Action['name']]: Action;
+  [Action in CBTypes.ClientAction as Action['id']]: Action;
 };
 
 type ActionType<T extends keyof ActionMap> = T extends keyof ActionMap ? ActionMap[T] : never;
@@ -27,7 +27,7 @@ type ActionType<T extends keyof ActionMap> = T extends keyof ActionMap ? ActionM
  * isSpecificClientAction('navigateToPage', action) will
  * cast the action to NavigateToPageAction.
  */
-export const isSpecificClientAction = <ActionName extends keyof ActionMap>(
-  type: ActionName,
+export const isSpecificClientAction = <ActionId extends keyof ActionMap>(
+  type: ActionId,
   action: CBTypes.CustomAction,
-): action is ActionType<ActionName> => action.name === type;
+): action is ActionType<ActionId> => action.id === type;


### PR DESCRIPTION
## Description

This PR fixes an issue @RonnyB71 discovered while testing the new `CustomButton` component. It also does some minor refactoring. 

Changes: 
- Fix bug with `CustomButton` not being disabled if there are multiple actions and one of them are unauthorized. 
- Rename the `name`-property to `id`. This is the name used on the backend. The documentation is already using `id` instead of `name`.  
- Adds log warnings to the devtools console whenever a navigation fails because there is no next or previous page, or the page you try to navigate to does not exist. 

## Related Issue(s)

- closes #133 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [x] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [x] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
