### PR TITLE
Switch back to `Altinn-DIN` font

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,24 +1,15 @@
 @import 'src/styles/tjenester3.css';
-@import url('https://altinncdn.no/fonts/inter/inter.css');
+@import url('https://altinncdn.no/fonts/altinn-din/altinn-din.css');
 
 /* Font */
 :root {
-  --font-family: 'Inter', sans-serif;
+  --font-family: 'Altinn-DIN', sans-serif;
   font-family: var(--font-family);
   font-size: 1rem;
   font-weight: normal;
   line-height: 1.5;
   text-align: left;
   color: var(--semantic-text-neutral-default);
-}
-
-@supports (font-variation-settings: normal) {
-  :root {
-    --font-family: 'Inter var', sans-serif;
-  }
-  * {
-    font-feature-settings: 'cv05';
-  }
 }
 
 /* Override design system variables */


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

Switch font back to `Altinn-DIN` until we can solve the issues that came up when switching to `Inter`.

## Related Issue(s)

- #1500 

