### PR TITLE
fix: issue with navigation redirecting to /undefined/Task_1 when remo…

### DIFF
--- a/src/hooks/useNavigatePage.ts
+++ b/src/hooks/useNavigatePage.ts
@@ -131,7 +131,7 @@ export const useNavigatePage = () => {
     if (taskType === ProcessTaskType.Archived) {
       return `/instance/${partyId}/${instanceGuid}/${TaskKeys.ProcessEnd}`;
     }
-    if (taskType !== ProcessTaskType.Data) {
+    if (taskType !== ProcessTaskType.Data && taskId !== undefined) {
       return `/instance/${partyId}/${instanceGuid}/${taskId}`;
     }
     const firstPage = order?.[0];

--- a/test/e2e/integration/frontend-test/navigation.ts
+++ b/test/e2e/integration/frontend-test/navigation.ts
@@ -1,0 +1,15 @@
+describe('Navigation', () => {
+  it('Should redirect to the current task and the first page of that task when navigating directly to the instance', () => {
+    cy.goto('changename');
+
+    cy.url().should('satisfy', (url) => url.endsWith('/Task_2/form'));
+    cy.findByLabelText(/Nytt fornavn/).should('exist');
+
+    cy.url().then((url) => {
+      cy.visit(url.replace('/Task_2/form', ''));
+    });
+
+    cy.url().should('satisfy', (url) => url.endsWith('/Task_2/form'));
+    cy.findByLabelText(/Nytt fornavn/).should('exist');
+  });
+});


### PR DESCRIPTION
## Description
If you instantiated an application, and navigated to the url without `/taskId/pageKey` at the end, the application would redirect you `/undefined/Task_1`. This resulted in an error page stating that you were on an task that is not the current task. 

This PR adds a cypress test for the case, and fixes the issue.


## Related Issue(s)

- closes #1720 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
