### PR TITLE
fix: trying to fetch null language when no language is specified in p…

### DIFF
--- a/src/features/language/LanguageProvider.tsx
+++ b/src/features/language/LanguageProvider.tsx
@@ -34,7 +34,7 @@ export const LanguageProvider = ({ children }: PropsWithChildren) => {
     const localStorageValue = localStorage.getItem(localStorageKey);
     const urlValue = getLanguageQueryParam();
 
-    const newLanguage = urlValue ?? localStorageValue ?? profile.profileSettingPreference.language;
+    const newLanguage = urlValue ?? localStorageValue ?? profile.profileSettingPreference.language ?? 'nb';
     setCurrent(newLanguage);
     localStorage.setItem(localStorageKey, newLanguage);
   };

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -192,7 +192,7 @@ export interface IProfile {
 }
 
 export interface IProfileSettingPreference {
-  language: string;
+  language: string | null;
   preSelectedPartyId: number;
   doNotPromptForParty: boolean;
 }

--- a/test/e2e/integration/frontend-test/language.ts
+++ b/test/e2e/integration/frontend-test/language.ts
@@ -1,0 +1,58 @@
+describe('Language', () => {
+  it('should not crash if language is not specified', () => {
+    cy.goto('changename');
+    cy.intercept('GET', '**/profile/user', {
+      body: {
+        userId: 10000,
+        userName: 'user-90155202001',
+        externalIdentity: null,
+        phoneNumber: null,
+        email: 'mandolin.sentral@altinnstudiotestusers.com',
+        partyId: 600000,
+        party: {
+          partyId: 600000,
+          partyTypeName: 'person',
+          orgNumber: null,
+          ssn: '09844797998',
+          unitType: null,
+          name: 'SENTRAL MANDOLIN',
+          isDeleted: false,
+          onlyHierarchyElementWithNoAccess: false,
+          person: {
+            ssn: '09844797998',
+            name: 'SENTRAL MANDOLIN',
+            firstName: 'SENTRAL',
+            middleName: null,
+            lastName: 'MANDOLIN',
+            telephoneNumber: null,
+            mobileNumber: null,
+            mailingAddress: null,
+            mailingPostalCode: null,
+            mailingPostalCity: null,
+            addressMunicipalNumber: '3820',
+            addressMunicipalName: null,
+            addressStreetName: null,
+            addressHouseNumber: '95',
+            addressHouseLetter: '1001',
+            addressPostalCode: null,
+            addressCity: 'SELJORD',
+            dateOfDeath: null,
+          },
+          organization: null,
+          childParties: null,
+        },
+        userType: 'none',
+        profileSettingPreference: {
+          language: null,
+          preSelectedPartyId: 0,
+          doNotPromptForParty: false,
+        },
+      },
+    }).as('profile');
+    cy.intercept('GET', '**/texts/nb').as('texts');
+
+    cy.wait('@profile');
+    cy.wait('@texts');
+    cy.findByRole('heading', { name: 'Ukjent feil' }).should('not.exist');
+  });
+});


### PR DESCRIPTION


## Description

Fixes a bug where the app tries to fetch `null` language if the logged in user has not set a language preference. 

This crashed the entire app for me. 
![image](https://github.com/Altinn/app-frontend-react/assets/26043795/48b0fae1-565a-4266-955f-477ed6d98cb4)

I had not come across this error previously because a language preference had already been stored in my localstorage for all users I test with locally. I discovered this while running DGM tests in Playwright after upgrading to the v8 and v4. 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
