### PR TITLE
fix: use langAsNonProcessedString instead of langAsString in text dyn…

### DIFF
--- a/src/features/expressions/index.ts
+++ b/src/features/expressions/index.ts
@@ -619,7 +619,7 @@ export const ExprFunctions = {
         return null;
       }
 
-      return this.dataSources.langTools.langAsString(key);
+      return this.dataSources.langTools.langAsNonProcessedString(key);
     },
     args: [ExprVal.String] as const,
     returns: ExprVal.String,

--- a/src/features/language/useLanguage.ts
+++ b/src/features/language/useLanguage.ts
@@ -41,6 +41,11 @@ export interface IUseLanguage {
     params?: ValidLangParam[],
   ): string;
   langAsNonProcessedString(key: ValidLanguageKey | string | undefined, params?: ValidLangParam[]): string;
+  langAsNonProcessedStringUsingPathInDataModel(
+    key: ValidLanguageKey | string | undefined,
+    dataModelPath: string,
+    params?: ValidLangParam[],
+  ): string;
   elementAsString(element: ReactNode): string;
 }
 
@@ -196,12 +201,19 @@ function staticUseLanguage(
   const langAsNonProcessedString: IUseLanguage['langAsNonProcessedString'] = (key, params) =>
     base(key, params, undefined, false);
 
+  const langAsNonProcessedStringUsingPathInDataModel: IUseLanguage['langAsNonProcessedStringUsingPathInDataModel'] = (
+    key,
+    dataModelPath,
+    params,
+  ) => base(key, params, { dataModelPath }, false);
+
   return {
     language,
     lang,
     langAsString,
     langAsStringUsingPathInDataModel,
     langAsNonProcessedString,
+    langAsNonProcessedStringUsingPathInDataModel,
     elementAsString(element: ReactNode): string {
       return getPlainTextFromNode(element, langAsString);
     },

--- a/src/hooks/useSourceOptions.ts
+++ b/src/hooks/useSourceOptions.ts
@@ -69,6 +69,8 @@ export function getSourceOptions({ source, node, dataSources }: IGetSourceOption
           langTools: {
             ...langTools,
             langAsString: (key: string) => langTools.langAsStringUsingPathInDataModel(key, path),
+            langAsNonProcessedString: (key: string) =>
+              langTools.langAsNonProcessedStringUsingPathInDataModel(key, path),
           },
         };
 


### PR DESCRIPTION
## Description

Fixes an issue where the `text` function of dynamic expressions strips away markdown/HTML. I solved this by using `langTools.langAsNonProcessedString` in `text` functions. This led to text variables not being replaced in source options. I therefore added a new function `langAsNonProcessedStringWithPathInDataModel` to be able to correctly replace the variables for `text`-functions used in repeating groups and other components that utilize source options. 

## Related Issue(s)

- closes #1728

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
