### PR TITLE
fix: update types to httpGetRaw and httpGet 

### DIFF
--- a/src/components/presentation/NavBar.tsx
+++ b/src/components/presentation/NavBar.tsx
@@ -48,10 +48,13 @@ export const NavBar = ({ type }: INavBarProps) => {
     }
 
     if (queryParameterReturnUrl) {
-      httpGet(getRedirectUrl(queryParameterReturnUrl))
+      httpGet<string>(getRedirectUrl(queryParameterReturnUrl))
         .then((response) => response)
         .catch(() => messageBoxUrl)
         .then((returnUrl) => {
+          if (returnUrl == null) {
+            return;
+          }
           window.location.assign(returnUrl);
         });
     }

--- a/src/features/options/useGetOptionsQuery.ts
+++ b/src/features/options/useGetOptionsQuery.ts
@@ -37,7 +37,7 @@ export const useGetOptionsQuery = (
     queryKey: ['fetchOptions', url],
     queryFn: async () => {
       const result = await fetchOptions(url);
-      return { ...result, data: castOptionsToStrings(result.data) };
+      return { ...result, data: castOptionsToStrings(result?.data) };
     },
     enabled: !!optionsId,
   });

--- a/src/queries/queries.ts
+++ b/src/queries/queries.ts
@@ -187,7 +187,7 @@ export const fetchLayouts = (layoutSetId: string): Promise<ILayoutCollection> =>
 export const fetchLayoutSettings = (layoutSetId: string | undefined): Promise<ILayoutSettings> =>
   httpGet(getLayoutSettingsUrl(layoutSetId));
 
-export const fetchOptions = (url: string): Promise<AxiosResponse<IRawOption[], any>> => httpGetRaw(url);
+export const fetchOptions = (url: string): Promise<AxiosResponse<IRawOption[]> | null> => httpGetRaw<IRawOption[]>(url);
 
 export const fetchDataList = (url: string): Promise<IDataList> => httpGet(url);
 

--- a/src/utils/network/networking.ts
+++ b/src/utils/network/networking.ts
@@ -7,16 +7,22 @@ export enum HttpStatusCodes {
   Forbidden = 403,
 }
 
-export async function httpGet(url: string, options?: AxiosRequestConfig): Promise<any> {
+export async function httpGet<ResponseData = any>(
+  url: string,
+  options?: AxiosRequestConfig,
+): Promise<ResponseData | null> {
   const headers = options?.headers as RawAxiosRequestHeaders | undefined;
   const response: AxiosResponse = await axios.get(url, {
     ...options,
     headers: { ...headers, Pragma: 'no-cache' },
   });
-  return response.data ? response.data : null;
+  return response.data ?? null;
 }
 
-export async function httpGetRaw(url: string, options?: AxiosRequestConfig): Promise<any> {
+export async function httpGetRaw<ResponseData = any>(
+  url: string,
+  options?: AxiosRequestConfig,
+): Promise<AxiosResponse<ResponseData> | null> {
   const headers = options?.headers as RawAxiosRequestHeaders | undefined;
   const response: AxiosResponse = await axios.get(url, {
     ...options,


### PR DESCRIPTION
## Description

This PR adds types to the `httpGet` and `httpGetRaw` functions such that they reflect the possibility of them returning `null`. I also made them generic, so that we can specify what we expect the response data to be when returning. 

This also led to fixing a unchecked instance of a nullable data response trying to be accessed in the code in `useGetOptionsQuery`

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [x] Issue(s) created for support in Studio - This was discovered by the release of `v3.68.3` which broke the app preview of studio. Discussion can be found here: https://altinndevops.slack.com/archives/CDU1S3NLW/p1706010593719699
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
