### PR TITLE
Renaming AddressComponent -> Address + bugfixes, improvements

### DIFF
--- a/src/codegen/Common.ts
+++ b/src/codegen/Common.ts
@@ -235,7 +235,7 @@ const common = {
 
         // Options are converted to strings when working on them internally, but externally we can handle
         // receiving them as any primitive type
-        new CG.union(new CG.str(), new CG.num(), new CG.bool()),
+        new CG.union(new CG.str(), new CG.num(), new CG.bool(), CG.null),
       ),
       new CG.prop('description', new CG.str().optional()),
       new CG.prop('helpText', new CG.str().optional()),

--- a/src/codegen/run.ts
+++ b/src/codegen/run.ts
@@ -16,14 +16,6 @@ async function getComponentList() {
   for (const file of files) {
     const stat = await fs.stat(path.join('src/layout', file));
     if (stat.isDirectory()) {
-      if (file === 'Address') {
-        // Address is a special case, because we once named it 'AddressComponent', without any over the other components
-        // having that suffix. We need to keep this for backwards compatibility, but our folder structure uses the name
-        // without the suffix.
-        out[file] = 'AddressComponent';
-        continue;
-      }
-
       out[file] = file;
     }
   }

--- a/src/core/contexts/zustandContext.tsx
+++ b/src/core/contexts/zustandContext.tsx
@@ -34,15 +34,15 @@ export function createZustandContext<Store extends StoreApi<Type>, Type = Extrac
    * a re-render if the selected value changes when compared with the previous value. Values are compared using
    * 'fast-deep-equal'.
    */
-  function useMemoSelector<U>(selector: (state: Type) => U) {
+  function useMemoSelector<U>(selector: (state: Type) => U): U {
     const prev = useRef<U | undefined>(undefined);
     return useSelector((state) => {
       const next = selector(state);
       if (deepEqual(next, prev.current)) {
-        return prev.current;
+        return prev.current as U;
       }
       prev.current = next;
-      return next;
+      return next as U;
     });
   }
 

--- a/src/core/contexts/zustandContext.tsx
+++ b/src/core/contexts/zustandContext.tsx
@@ -15,9 +15,10 @@ const dummyStore = createStore(() => ({}));
 export function createZustandContext<Store extends StoreApi<Type>, Type = ExtractFromStoreApi<Store>, Props = any>(
   props: CreateContextProps<Store> & {
     initialCreateStore: (props: Props) => Store;
+    onReRender?: (store: Store, props: Props) => void;
   },
 ) {
-  const { initialCreateStore, ...rest } = props;
+  const { initialCreateStore, onReRender, ...rest } = props;
   const { Provider, useCtx, useLaxCtx, useHasProvider } = createContext<Store>(rest);
 
   /**
@@ -54,7 +55,11 @@ export function createZustandContext<Store extends StoreApi<Type>, Type = Extrac
 
   function MyProvider({ children, ...props }: PropsWithChildren<Props>) {
     const storeRef = useRef<Store>();
-    if (!storeRef.current) {
+    if (storeRef.current) {
+      if (onReRender) {
+        onReRender(storeRef.current, props as Props);
+      }
+    } else {
       storeRef.current = initialCreateStore(props as Props);
     }
     return <Provider value={storeRef.current}>{children}</Provider>;

--- a/src/features/applicationMetadata/ApplicationMetadataProvider.tsx
+++ b/src/features/applicationMetadata/ApplicationMetadataProvider.tsx
@@ -36,7 +36,7 @@ const { Provider, useCtx, useLaxCtx, useHasProvider } = delayedContext(() =>
 
 function VerifyMinimumVersion({ children }: PropsWithChildren) {
   const { altinnNugetVersion } = useApplicationMetadata();
-  if (!altinnNugetVersion || isAtLeastVersion(altinnNugetVersion, MINIMUM_APPLICATION_VERSION.build)) {
+  if (!altinnNugetVersion || !isAtLeastVersion(altinnNugetVersion, MINIMUM_APPLICATION_VERSION.build)) {
     return <OldVersionError minVer={MINIMUM_APPLICATION_VERSION.name} />;
   }
 

--- a/src/features/applicationMetadata/ApplicationMetadataProvider.tsx
+++ b/src/features/applicationMetadata/ApplicationMetadataProvider.tsx
@@ -7,6 +7,7 @@ import { useAppQueries } from 'src/core/contexts/AppQueriesProvider';
 import { delayedContext } from 'src/core/contexts/delayedContext';
 import { createQueryContext } from 'src/core/contexts/queryContext';
 import { OldVersionError } from 'src/features/applicationMetadata/OldVersionError';
+import { isAtLeastVersion } from 'src/utils/versionCompare';
 import type { HttpClientError } from 'src/utils/network/sharedNetworking';
 
 export const MINIMUM_APPLICATION_VERSION = {
@@ -35,24 +36,7 @@ const { Provider, useCtx, useLaxCtx, useHasProvider } = delayedContext(() =>
 
 function VerifyMinimumVersion({ children }: PropsWithChildren) {
   const { altinnNugetVersion } = useApplicationMetadata();
-
-  if (!altinnNugetVersion) {
-    return <OldVersionError minVer={MINIMUM_APPLICATION_VERSION.name} />;
-  }
-
-  let isMinimumVersion = false;
-  const parts = altinnNugetVersion.split('.');
-  const expectedParts = MINIMUM_APPLICATION_VERSION.build.split('.');
-  for (const i in expectedParts) {
-    const part = parseInt(parts[i], 10);
-    const expectedPart = parseInt(expectedParts[i], 10);
-    if (part >= expectedPart) {
-      isMinimumVersion = true;
-      break;
-    }
-  }
-
-  if (!isMinimumVersion) {
+  if (!altinnNugetVersion || isAtLeastVersion(altinnNugetVersion, MINIMUM_APPLICATION_VERSION.build)) {
     return <OldVersionError minVer={MINIMUM_APPLICATION_VERSION.name} />;
   }
 

--- a/src/features/expressions/shared-tests/functions/displayValue/address.json
+++ b/src/features/expressions/shared-tests/functions/displayValue/address.json
@@ -1,5 +1,5 @@
 {
-  "name": "Display value of AddressComponent",
+  "name": "Display value of Address",
   "expression": [
     "displayValue",
     "address"
@@ -16,7 +16,7 @@
         "layout": [
           {
             "id": "address",
-            "type": "AddressComponent",
+            "type": "Address",
             "dataModelBindings": {
               "address": "Skjema.Gate",
               "zipCode": "Skjema.Postnr",

--- a/src/features/formData/FormData.test.tsx
+++ b/src/features/formData/FormData.test.tsx
@@ -246,13 +246,13 @@ describe('FormData', () => {
 
       const initialRenders = { ...renderCounts };
       expect(initialRenders).toEqual({
-        ReaderObj1Prop1: 2,
-        ReaderObj1Prop2: 2,
-        ReaderObj2Prop1: 2,
+        ReaderObj1Prop1: 1,
+        ReaderObj1Prop2: 1,
+        ReaderObj2Prop1: 1,
 
-        WriterObj1Prop1: 2,
-        WriterObj1Prop2: 2,
-        WriterObj2Prop1: 2,
+        WriterObj1Prop1: 1,
+        WriterObj1Prop2: 1,
+        WriterObj2Prop1: 1,
       });
 
       // Change a value
@@ -265,8 +265,8 @@ describe('FormData', () => {
 
       expect(renderCounts).toEqual({
         ...initialRenders,
-        ReaderObj1Prop1: 4, // TODO: These re-render twice for some reason, find out why and fix them
-        WriterObj1Prop1: 4,
+        ReaderObj1Prop1: 2,
+        WriterObj1Prop1: 2,
       });
     });
   });

--- a/src/features/formData/FormDataWrite.tsx
+++ b/src/features/formData/FormDataWrite.tsx
@@ -282,6 +282,15 @@ export const FD = {
   },
 
   /**
+   * This will pick a value from the form data, and return it. The path is expected to be a dot-separated path, and
+   * the value will be returned as-is. If the value is not found, undefined is returned. Null may also be returned if
+   * the value is explicitly set to null.
+   */
+  useDebouncedPick(path: string): FDValue {
+    return useSelector((v) => dot.pick(path, v.debouncedCurrentData));
+  },
+
+  /**
    * This returns multiple values, as picked from the form data. The values in the input object is expected to be
    * dot-separated paths, and the return value will be an object with the same keys, but with the values picked
    * from the form data. If a value is not found, undefined is returned. Null may also be returned if the value

--- a/src/features/formData/convertData.ts
+++ b/src/features/formData/convertData.ts
@@ -6,8 +6,8 @@ interface ReturnType {
 }
 
 type Value = string | number | boolean | null;
-type ValidTypes = 'string' | 'number' | 'integer' | 'boolean' | 'null';
-const AllValidTypes: ValidTypes[] = ['string', 'number', 'integer', 'boolean', 'null'];
+const AllValidTypes = ['string', 'number', 'integer', 'boolean', 'null'] as const;
+type ValidTypes = (typeof AllValidTypes)[number];
 
 /**
  * Converts a string to a value based on a schema.

--- a/src/features/formData/convertData.ts
+++ b/src/features/formData/convertData.ts
@@ -1,39 +1,87 @@
-import type { JSONSchema7 } from 'json-schema';
+import type { JSONSchema7, JSONSchema7Definition } from 'json-schema';
+
+interface ReturnType {
+  newValue: any;
+  error: boolean;
+}
+
+type Value = string | number | boolean | null;
+type ValidTypes = 'string' | 'number' | 'integer' | 'boolean' | 'null';
+const AllValidTypes: ValidTypes[] = ['string', 'number', 'integer', 'boolean', 'null'];
 
 /**
  * Converts a string to a value based on a schema.
  */
-export function convertData(
-  value: string | number | boolean,
-  schema: JSONSchema7 | undefined,
-): {
-  newValue: any;
-  error: boolean;
-} {
-  const sVal = String(value);
+export function convertData(value: Value, schema: JSONSchema7 | undefined): ReturnType {
   if (!schema) {
     // Assume it's a string if we don't have a binding. This is not likely to happen as long as components aren't
     // even rendered when their data model bindings fail.
+    return { newValue: String(value), error: false };
+  }
+
+  try {
+    return convertToType(value, schema);
+  } catch (e) {
+    window.logError(`Error converting data to schema (${JSON.stringify(schema)}) defined by data model:\n`, e);
+    return { newValue: undefined, error: true };
+  }
+}
+
+function convertToType(value: Value, schema: JSONSchema7 | JSONSchema7Definition): ReturnType {
+  if (typeof schema === 'object' && schema.anyOf) {
+    const results = schema.anyOf.map((subSchema) => convertToType(value, subSchema));
+    const validResult = results.find((result) => !result.error);
+    return validResult ?? { newValue: undefined, error: true };
+  }
+
+  if (typeof schema === 'object' && schema.oneOf) {
+    const results = schema.oneOf.map((subSchema) => convertToType(value, subSchema));
+    const validResults = results.filter((result) => !result.error);
+    if (validResults.length === 1) {
+      return validResults[0];
+    }
+    return { newValue: undefined, error: true };
+  }
+
+  if (
+    typeof schema === 'object' &&
+    schema.type &&
+    typeof schema.type === 'string' &&
+    AllValidTypes.includes(schema.type as any)
+  ) {
+    return convertToScalar(value, schema.type as ValidTypes);
+  }
+
+  throw new Error(`Unsupported schema: ${JSON.stringify(schema)}`);
+}
+
+function convertToScalar(value: Value, targetType: ValidTypes): ReturnType {
+  const sVal = String(value);
+  if (targetType === 'string') {
     return { newValue: sVal, error: false };
   }
 
-  if (schema.type === 'string') {
-    return { newValue: sVal, error: false };
-  }
-
-  if (schema.type === 'number') {
+  if (targetType === 'number') {
     const parsed = asDecimal(sVal);
     return isNaN(parsed) ? { newValue: undefined, error: true } : { newValue: parsed, error: false };
-  } else if (schema.type === 'integer') {
+  }
+
+  if (targetType === 'integer') {
     const parsed = asInt32(sVal);
     return isNaN(parsed) ? { newValue: undefined, error: true } : { newValue: parsed, error: false };
-  } else if (schema.type === 'boolean') {
+  }
+
+  if (targetType === 'boolean') {
     return sVal === 'true' || sVal === 'false'
       ? { newValue: sVal === 'true', error: false }
       : { newValue: undefined, error: true };
   }
 
-  throw new Error(`Unsupported schema type: ${schema.type}`);
+  // Nothing else matched, target type is null
+  if (sVal === 'null') {
+    return { newValue: null, error: false };
+  }
+  return { newValue: undefined, error: true };
 }
 
 /**

--- a/src/features/formData/jsonPatch/createPatch.ts
+++ b/src/features/formData/jsonPatch/createPatch.ts
@@ -63,8 +63,6 @@ function compareAny(props: CompareProps<any>) {
     return compareObjects(props);
   }
   if (Array.isArray(prev) && Array.isArray(next)) {
-    // TODO: Do something when both next and current are arrays, but prev is undefined/missing? In that case we should
-    // at least compare the arrays.
     return compareArrays(props);
   }
   compareValues(props);

--- a/src/features/formData/useDataModelBindings.test.tsx
+++ b/src/features/formData/useDataModelBindings.test.tsx
@@ -115,9 +115,6 @@ describe('useDataModelBindings', () => {
 
     let expectedRenders = 1;
 
-    // TODO: Find out why every keystroke renders the component twice
-    const rendersPerLetter = 2;
-
     expect(screen.getByTestId('value-stringy')).toHaveTextContent('""');
     expect(screen.getByTestId('value-decimal')).toHaveTextContent('""');
     expect(screen.getByTestId('value-boolean')).toHaveTextContent('""');
@@ -136,7 +133,7 @@ describe('useDataModelBindings', () => {
       newValue: fooBar,
     });
     expect(formDataMethods.setLeafValue).toHaveBeenCalledTimes(fooBar.length);
-    expectedRenders += fooBar.length * rendersPerLetter;
+    expectedRenders += fooBar.length;
     expect(screen.getByTestId('render-count')).toHaveTextContent(String(expectedRenders));
     (formDataMethods.setLeafValue as jest.Mock).mockClear();
 
@@ -152,7 +149,7 @@ describe('useDataModelBindings', () => {
       newValue: '-',
     });
 
-    expectedRenders += rendersPerLetter;
+    expectedRenders += 1;
     expect(screen.getByTestId('render-count')).toHaveTextContent(String(expectedRenders));
 
     // When we simulate a save to server, the invalid value should not be saved
@@ -183,7 +180,7 @@ describe('useDataModelBindings', () => {
     });
     expect(formDataMethods.setLeafValue).toHaveBeenCalledTimes(fullDecimal.length);
 
-    expectedRenders += (fullDecimal.length - 1) * rendersPerLetter;
+    expectedRenders += fullDecimal.length - 1;
     expect(screen.getByTestId('render-count')).toHaveTextContent(String(expectedRenders));
     (formDataMethods.setLeafValue as jest.Mock).mockClear();
 
@@ -233,7 +230,7 @@ describe('useDataModelBindings', () => {
 
     // When we typed the space, we sent a state update (as asserted above), but since the value update did not
     // actually change anything in the data model (but was valid), the component does not re-render.
-    expectedRenders += (fullInteger.length - 1) * rendersPerLetter;
+    expectedRenders += fullInteger.length - 1;
     expect(screen.getByTestId('render-count')).toHaveTextContent(String(expectedRenders));
 
     (formDataMethods.setLeafValue as jest.Mock).mockClear();
@@ -253,7 +250,7 @@ describe('useDataModelBindings', () => {
     });
     expect(formDataMethods.setLeafValue).toHaveBeenCalledTimes(4);
 
-    expectedRenders += 4 * rendersPerLetter;
+    expectedRenders += 4;
     expect(screen.getByTestId('render-count')).toHaveTextContent(String(expectedRenders));
 
     await waitFor(() => expect(mutations.doPatchFormData.mock).toHaveBeenCalledTimes(3));

--- a/src/features/options/castOptionsToStrings.ts
+++ b/src/features/options/castOptionsToStrings.ts
@@ -20,7 +20,7 @@ export function castOptionsToStrings<T extends IRawOption[] | undefined>(options
   for (const option of options) {
     newOptions.push({
       ...option,
-      value: option.value === null ? 'null' : option.value.toString(),
+      value: option.value === null ? 'null' : option.value === undefined ? '' : option.value.toString(),
     });
   }
   return newOptions as ReplaceWithStrings<T>;

--- a/src/features/options/castOptionsToStrings.ts
+++ b/src/features/options/castOptionsToStrings.ts
@@ -20,7 +20,7 @@ export function castOptionsToStrings<T extends IRawOption[] | undefined>(options
   for (const option of options) {
     newOptions.push({
       ...option,
-      value: option.value.toString(),
+      value: option.value === null ? 'null' : option.value.toString(),
     });
   }
   return newOptions as ReplaceWithStrings<T>;

--- a/src/hooks/queries/usePostPlaceQuery.ts
+++ b/src/hooks/queries/usePostPlaceQuery.ts
@@ -13,9 +13,11 @@ const __default__ = '';
  */
 export const usePostPlaceQuery = (zipCode: string | undefined, enabled: boolean) => {
   const { fetchPostPlace } = useAppQueries();
-  const _enabled = enabled && Boolean(zipCode?.length);
-  const { data, isFetching } = useQuery(['fetchPostPlace', zipCode], () => fetchPostPlace(zipCode!), {
+  const _enabled = enabled && Boolean(zipCode?.length) && zipCode !== __default__ && zipCode !== '0';
+  const { data, isFetching } = useQuery({
     enabled: _enabled,
+    queryKey: ['fetchPostPlace', zipCode],
+    queryFn: () => fetchPostPlace(zipCode!),
     onError: (error: HttpClientError) => {
       window.logError(`Fetching post place for zip code ${zipCode} failed:\n`, error);
     },

--- a/src/hooks/useAsRef.ts
+++ b/src/hooks/useAsRef.ts
@@ -20,26 +20,6 @@ export function useAsRef<T>(value: T): MutableRefObject<T> {
 }
 
 /**
- * Special version of `useAsRef` that takes a Zustand store and a selector function. The ref will be updated
- * whenever the selected value changes, without re-rendering the component/hook that uses it.
- *
- * @see https://github.com/pmndrs/zustand#transient-updates-for-often-occurring-state-changes
- */
-export function useAsRefFromSelector<T, U>(store: StoreApi<T>, selector: (state: T) => U) {
-  const ref = useRef<U>(selector(store.getState()));
-
-  useEffect(
-    () =>
-      store.subscribe((state) => {
-        ref.current = selector(state);
-      }),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [],
-  );
-  return ref;
-}
-
-/**
  * Same as `useAsRefFromSelector`, but allows the store to be `ContextNotProvided`. In that case the ref will
  * always be set to `ContextNotProvided`.
  */
@@ -64,25 +44,4 @@ export function useAsRefFromLaxSelector<T, U>(
     [store],
   );
   return ref;
-}
-
-type MutableRefMap<T> = {
-  [K in keyof T]: MutableRefObject<T[K]>;
-};
-
-/**
- * In some cases you may have lots of different states that you want to keep track of, but you don't want to
- * apply useAsRef to them individually. In that case you can use this function to create a single object that
- * contains all the states as refs.
- *
- * Be aware that this hook will break the rule of hooks if you provide a new object with different keys on every
- * render. If you need to do that, you should use `useAsRef` on them individually instead.
- */
-export function useAsRefObject<T extends Record<string, any>>(values: T): MutableRefMap<T> {
-  const manyRefs: MutableRefMap<T> = {} as any;
-  for (const key in values) {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    manyRefs[key] = useAsRef(values[key]);
-  }
-  return manyRefs;
 }

--- a/src/layout/Address/AddressComponent.test.tsx
+++ b/src/layout/Address/AddressComponent.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 
 import { AddressComponent } from 'src/layout/Address/AddressComponent';
@@ -29,11 +29,19 @@ const render = async ({ component, genericProps, ...rest }: Partial<RenderGeneri
       isValid: true,
       ...genericProps,
     },
+    ...rest,
     queries: {
-      fetchPostPlace: () => Promise.resolve({ valid: true, result: 'OSLO' }),
+      fetchPostPlace: async (input) => {
+        if (input === '0001') {
+          return { valid: true, result: 'OSLO' };
+        }
+        if (input === '0002') {
+          return { valid: true, result: 'BERGEN' };
+        }
+        return { valid: false, result: '' };
+      },
       ...rest.queries,
     },
-    ...rest,
   });
 
 describe('AddressComponent', () => {
@@ -162,7 +170,7 @@ describe('AddressComponent', () => {
   });
 
   it('should call dispatch for post place when zip code is cleared', async () => {
-    const { formDataMethods } = await render({
+    const { formDataMethods, queries } = await render({
       queries: {
         fetchFormData: async () => ({ address: 'a', zipCode: '0001', postPlace: 'Oslo' }),
       },
@@ -182,6 +190,22 @@ describe('AddressComponent', () => {
       path: 'postPlace',
       newValue: '',
     });
+
+    expect(queries.fetchPostPlace).toHaveBeenCalledTimes(1);
+  });
+
+  it('should only call fetchPostPlace once at the end, when debouncing', async () => {
+    const { queries } = await render({
+      queries: {
+        fetchFormData: async () => ({ address: 'a', zipCode: '', postPlace: '' }),
+      },
+    });
+
+    await userEvent.type(screen.getByRole('textbox', { name: 'Postnr' }), '0001{backspace}2');
+    await waitFor(() => expect(screen.getByRole('textbox', { name: 'Poststed' })).toHaveDisplayValue('BERGEN'));
+
+    expect(queries.fetchPostPlace).toHaveBeenCalledTimes(1);
+    expect(queries.fetchPostPlace).toHaveBeenCalledWith('0002');
   });
 
   it('should display no extra markings when required is false, and labelSettings.optionalIndicator is not true', async () => {

--- a/src/layout/Address/AddressComponent.test.tsx
+++ b/src/layout/Address/AddressComponent.test.tsx
@@ -7,13 +7,9 @@ import { AddressComponent } from 'src/layout/Address/AddressComponent';
 import { renderGenericComponentTest } from 'src/test/renderWithProviders';
 import type { RenderGenericComponentTestProps } from 'src/test/renderWithProviders';
 
-const render = async ({
-  component,
-  genericProps,
-  ...rest
-}: Partial<RenderGenericComponentTestProps<'AddressComponent'>> = {}) =>
+const render = async ({ component, genericProps, ...rest }: Partial<RenderGenericComponentTestProps<'Address'>> = {}) =>
   await renderGenericComponentTest({
-    type: 'AddressComponent',
+    type: 'Address',
     renderer: (props) => <AddressComponent {...props} />,
     component: {
       simplified: true,

--- a/src/layout/Address/AddressComponent.test.tsx
+++ b/src/layout/Address/AddressComponent.test.tsx
@@ -202,7 +202,9 @@ describe('AddressComponent', () => {
     });
 
     await userEvent.type(screen.getByRole('textbox', { name: 'Postnr' }), '0001{backspace}2');
-    await waitFor(() => expect(screen.getByRole('textbox', { name: 'Poststed' })).toHaveDisplayValue('BERGEN'));
+    await waitFor(() => expect(screen.getByRole('textbox', { name: 'Poststed' })).toHaveDisplayValue('BERGEN'), {
+      timeout: 15000,
+    });
 
     expect(queries.fetchPostPlace).toHaveBeenCalledTimes(1);
     expect(queries.fetchPostPlace).toHaveBeenCalledWith('0002');

--- a/src/layout/Address/AddressComponent.tsx
+++ b/src/layout/Address/AddressComponent.tsx
@@ -3,6 +3,7 @@ import React, { useEffect } from 'react';
 import { LegacyTextField } from '@digdir/design-system-react';
 
 import { Label } from 'src/components/form/Label';
+import { FD } from 'src/features/formData/FormDataWrite';
 import { useDataModelBindings } from 'src/features/formData/useDataModelBindings';
 import { Lang } from 'src/features/language/Lang';
 import { ComponentValidations } from 'src/features/validation/ComponentValidations';
@@ -30,7 +31,10 @@ export function AddressComponent({ node }: IAddressProps) {
       setValue('postPlace', newPostPlace);
     }
   });
-  const postPlaceQueryData = usePostPlaceQuery(zipCode, !hasValidationErrors(bindingValidations?.zipCode));
+
+  const zipCodeDebounced = FD.useDebouncedPick(node.item.dataModelBindings.zipCode);
+  const slowZip = typeof zipCodeDebounced === 'string' ? zipCodeDebounced : undefined;
+  const postPlaceQueryData = usePostPlaceQuery(slowZip, !hasValidationErrors(bindingValidations?.zipCode));
   useEffect(() => updatePostPlace(postPlaceQueryData), [postPlaceQueryData, updatePostPlace]);
 
   return (

--- a/src/layout/Address/AddressComponent.tsx
+++ b/src/layout/Address/AddressComponent.tsx
@@ -14,9 +14,9 @@ import { useEffectEvent } from 'src/hooks/useEffectEvent';
 import classes from 'src/layout/Address/AddressComponent.module.css';
 import type { PropsFromGenericComponent } from 'src/layout';
 
-export type IAddressComponentProps = PropsFromGenericComponent<'AddressComponent'>;
+export type IAddressProps = PropsFromGenericComponent<'Address'>;
 
-export function AddressComponent({ node }: IAddressComponentProps) {
+export function AddressComponent({ node }: IAddressProps) {
   const { id, required, readOnly, labelSettings, simplified, saveWhileTyping } = node.item;
 
   const bindingValidations = useBindingValidationsForNode(node);

--- a/src/layout/Address/index.tsx
+++ b/src/layout/Address/index.tsx
@@ -14,16 +14,16 @@ import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class Address extends AddressDef implements ValidateComponent {
-  render(props: PropsFromGenericComponent<'AddressComponent'>): JSX.Element | null {
+  render(props: PropsFromGenericComponent<'Address'>): JSX.Element | null {
     return <AddressComponent {...props} />;
   }
 
-  getDisplayData(node: LayoutNode<'AddressComponent'>): string {
+  getDisplayData(node: LayoutNode<'Address'>): string {
     const data = node.getFormData();
     return Object.values(data).join(' ');
   }
 
-  renderSummary({ targetNode }: SummaryRendererProps<'AddressComponent'>): JSX.Element | null {
+  renderSummary({ targetNode }: SummaryRendererProps<'Address'>): JSX.Element | null {
     const data = this.useDisplayData(targetNode);
     return <SummaryItemSimple formDataAsString={data} />;
   }
@@ -32,10 +32,7 @@ export class Address extends AddressDef implements ValidateComponent {
     return false;
   }
 
-  runComponentValidation(
-    node: LayoutNode<'AddressComponent'>,
-    { formData }: ValidationDataSources,
-  ): ComponentValidation[] {
+  runComponentValidation(node: LayoutNode<'Address'>, { formData }: ValidationDataSources): ComponentValidation[] {
     if (!node.item.dataModelBindings) {
       return [];
     }
@@ -76,7 +73,7 @@ export class Address extends AddressDef implements ValidateComponent {
     return validations;
   }
 
-  validateDataModelBindings(ctx: LayoutValidationCtx<'AddressComponent'>): string[] {
+  validateDataModelBindings(ctx: LayoutValidationCtx<'Address'>): string[] {
     const errors: string[] = [
       ...(this.validateDataModelBindingsAny(ctx, 'address', ['string'])[0] || []),
       ...(this.validateDataModelBindingsAny(ctx, 'zipCode', ['string', 'number', 'integer'])[0] || []),

--- a/src/layout/List/ListComponent.test.tsx
+++ b/src/layout/List/ListComponent.test.tsx
@@ -154,7 +154,7 @@ describe('ListComponent', () => {
         { path: 'CountryHighestMountain', newValue: 1738 },
       ],
     });
-    expect(screen.getByTestId('render-count')).toHaveTextContent('3');
+    expect(screen.getByTestId('render-count')).toHaveTextContent('2');
 
     // Select the third row
     await user.click(screen.getAllByRole('radio')[2]);
@@ -166,7 +166,7 @@ describe('ListComponent', () => {
         { path: 'CountryHighestMountain', newValue: 170 },
       ],
     });
-    expect(screen.getByTestId('render-count')).toHaveTextContent('5');
+    expect(screen.getByTestId('render-count')).toHaveTextContent('3');
 
     // Wait until the debounce timeout has definitely passed, then expect the form data to be saved. It should only
     // be saved once (even though we changed the value twice) because the debouncing happens globally.

--- a/src/layout/RepeatingGroup/RepeatingGroupContainer.test.tsx
+++ b/src/layout/RepeatingGroup/RepeatingGroupContainer.test.tsx
@@ -6,7 +6,7 @@ import { userEvent } from '@testing-library/user-event';
 import { getFormLayoutRepeatingGroupMock } from 'src/__mocks__/getFormLayoutGroupMock';
 import { type BackendValidationIssue, BackendValidationSeverity } from 'src/features/validation';
 import { RepeatingGroupContainer } from 'src/layout/RepeatingGroup/RepeatingGroupContainer';
-import { RepeatingGroupProvider, useRepeatingGroup } from 'src/layout/RepeatingGroup/RepeatingGroupContext';
+import { RepeatingGroupProvider, useRepeatingGroupSelector } from 'src/layout/RepeatingGroup/RepeatingGroupContext';
 import { mockMediaQuery } from 'src/test/mockMediaQuery';
 import { renderWithNode } from 'src/test/renderWithProviders';
 import type { ILayout } from 'src/layout/layout';
@@ -339,6 +339,6 @@ describe('RepeatingGroupContainer', () => {
 });
 
 function LeakEditIndex() {
-  const { editingIndex } = useRepeatingGroup();
+  const editingIndex = useRepeatingGroupSelector((state) => state.editingIndex);
   return <div data-testid='editIndex'>{editingIndex === undefined ? 'undefined' : editingIndex}</div>;
 }

--- a/src/layout/RepeatingGroup/RepeatingGroupContainer.tsx
+++ b/src/layout/RepeatingGroup/RepeatingGroupContainer.tsx
@@ -13,7 +13,7 @@ import { useLanguage } from 'src/features/language/useLanguage';
 import { ComponentValidations } from 'src/features/validation/ComponentValidations';
 import { useUnifiedValidationsForNode } from 'src/features/validation/selectors/unifiedValidationsForNode';
 import classes from 'src/layout/RepeatingGroup/RepeatingGroupContainer.module.css';
-import { useRepeatingGroup } from 'src/layout/RepeatingGroup/RepeatingGroupContext';
+import { useRepeatingGroup, useRepeatingGroupSelector } from 'src/layout/RepeatingGroup/RepeatingGroupContext';
 import { useRepeatingGroupsFocusContext } from 'src/layout/RepeatingGroup/RepeatingGroupFocusContext';
 import { RepeatingGroupsEditContainer } from 'src/layout/RepeatingGroup/RepeatingGroupsEditContainer';
 import { RepeatingGroupTable } from 'src/layout/RepeatingGroup/RepeatingGroupTable';
@@ -25,8 +25,15 @@ interface RepeatingGroupContainerProps {
 
 export function RepeatingGroupContainer({ containerDivRef }: RepeatingGroupContainerProps): JSX.Element | null {
   const { triggerFocus } = useRepeatingGroupsFocusContext();
-  const { node, isEditingAnyRow, editingIndex, addRow, openForEditing, isFirstRender, visibleRowIndexes } =
-    useRepeatingGroup();
+
+  const { node, addRow, openForEditing } = useRepeatingGroup();
+  const { isEditingAnyRow, editingIndex, isFirstRender, visibleRowIndexes } = useRepeatingGroupSelector((state) => ({
+    isEditingAnyRow: state.isEditingAnyRow,
+    editingIndex: state.editingIndex,
+    isFirstRender: state.isFirstRender,
+    visibleRowIndexes: state.visibleRowIndexes,
+  }));
+
   const { textResourceBindings, id, edit, type } = node.item;
   const { title, description, add_button, add_button_full } = textResourceBindings || {};
 

--- a/src/layout/RepeatingGroup/RepeatingGroupContainer.tsx
+++ b/src/layout/RepeatingGroup/RepeatingGroupContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import type { MutableRefObject } from 'react';
 
 import { Button } from '@digdir/design-system-react';
@@ -24,8 +24,8 @@ interface RepeatingGroupContainerProps {
 }
 
 export function RepeatingGroupContainer({ containerDivRef }: RepeatingGroupContainerProps): JSX.Element | null {
-  const { node, addRow, openForEditing } = useRepeatingGroup();
-  const { editingIndex, isFirstRender, visibleRowIndexes } = useRepeatingGroupSelector((state) => ({
+  const { node } = useRepeatingGroup();
+  const { editingIndex, visibleRowIndexes } = useRepeatingGroupSelector((state) => ({
     editingIndex: state.editingIndex,
     isFirstRender: state.isFirstRender,
     visibleRowIndexes: state.visibleRowIndexes,
@@ -36,31 +36,8 @@ export function RepeatingGroupContainer({ containerDivRef }: RepeatingGroupConta
   const { title, description } = textResourceBindings || {};
 
   const numRows = visibleRowIndexes.length;
-  const firstIndex = visibleRowIndexes[0];
   const lastIndex = visibleRowIndexes[numRows - 1];
   const validations = useUnifiedValidationsForNode(node);
-
-  // Add new row if openByDefault is true and no rows exist. This also makes sure to add a row immediately after the
-  // last one has been deleted.
-  useEffect((): void => {
-    if (edit?.openByDefault && numRows === 0) {
-      addRow().then();
-    }
-  }, [node, addRow, edit?.openByDefault, numRows]);
-
-  // Open the first or last row for editing, if openByDefault is set to 'first' or 'last'
-  useEffect((): void => {
-    if (
-      isFirstRender &&
-      edit?.openByDefault &&
-      typeof edit.openByDefault === 'string' &&
-      ['first', 'last'].includes(edit.openByDefault) &&
-      editingIndex === undefined
-    ) {
-      const index = edit.openByDefault === 'last' ? lastIndex : firstIndex;
-      openForEditing(index);
-    }
-  }, [edit?.openByDefault, editingIndex, isFirstRender, firstIndex, lastIndex, openForEditing]);
 
   if (node.isHidden() || type !== 'RepeatingGroup') {
     return null;
@@ -157,7 +134,7 @@ function AddButton() {
     return null;
   }
 
-  if (!forceShow && (tooManyRows || isEditingAnyRow)) {
+  if ((tooManyRows || isEditingAnyRow) && !forceShow) {
     return null;
   }
 

--- a/src/layout/RepeatingGroup/RepeatingGroupContainer.tsx
+++ b/src/layout/RepeatingGroup/RepeatingGroupContainer.tsx
@@ -27,12 +27,14 @@ export function RepeatingGroupContainer({ containerDivRef }: RepeatingGroupConta
   const { triggerFocus } = useRepeatingGroupsFocusContext();
 
   const { node, addRow, openForEditing } = useRepeatingGroup();
-  const { isEditingAnyRow, editingIndex, isFirstRender, visibleRowIndexes } = useRepeatingGroupSelector((state) => ({
-    isEditingAnyRow: state.isEditingAnyRow,
-    editingIndex: state.editingIndex,
-    isFirstRender: state.isFirstRender,
-    visibleRowIndexes: state.visibleRowIndexes,
-  }));
+  const { isEditingAnyRow, editingIndex, isFirstRender, visibleRowIndexes, currentlyAddingRow } =
+    useRepeatingGroupSelector((state) => ({
+      isEditingAnyRow: state.isEditingAnyRow,
+      editingIndex: state.editingIndex,
+      isFirstRender: state.isFirstRender,
+      visibleRowIndexes: state.visibleRowIndexes,
+      currentlyAddingRow: state.currentlyAddingRow !== undefined,
+    }));
 
   const { textResourceBindings, id, edit, type } = node.item;
   const { title, description, add_button, add_button_full } = textResourceBindings || {};
@@ -49,6 +51,7 @@ export function RepeatingGroupContainer({ containerDivRef }: RepeatingGroupConta
       onClick={handleOnAddButtonClick}
       onKeyUp={handleOnAddKeypress}
       variant='secondary'
+      disabled={currentlyAddingRow}
       icon={<AddIcon aria-hidden='true' />}
       iconPlacement='left'
       fullWidth

--- a/src/layout/RepeatingGroup/RepeatingGroupContext.tsx
+++ b/src/layout/RepeatingGroup/RepeatingGroupContext.tsx
@@ -19,7 +19,6 @@ interface Store {
   editingNone: boolean;
   binding: string;
   deletingIndexes: number[];
-  isEditingAnyRow: boolean;
   editingIndex: number | undefined;
 
   // If this is true, we're rendering the group for the first time in this context. This is used to
@@ -109,7 +108,6 @@ function newStore({ node }: Props) {
       binding: node.item.dataModelBindings.group,
       isFirstRender: true,
       editingIndex: undefined,
-      isEditingAnyRow: false,
       numVisibleRows: visibleRowIndexes.length,
       deletingIndexes: [],
       currentlyAddingRow: undefined,

--- a/src/layout/RepeatingGroup/RepeatingGroupContext.tsx
+++ b/src/layout/RepeatingGroup/RepeatingGroupContext.tsx
@@ -30,7 +30,6 @@ interface Store {
   numVisibleRows: number;
   visibleRowIndexes: number[];
   hiddenRowIndexes: Set<number>;
-  moreVisibleRowsAfterEditIndex: boolean;
   editableRowIndexes: number[];
   deletableRowIndexes: number[];
   currentlyAddingRow: undefined | number;
@@ -111,7 +110,6 @@ function newStore({ node }: Props) {
       isFirstRender: true,
       editingIndex: undefined,
       isEditingAnyRow: false,
-      moreVisibleRowsAfterEditIndex: false,
       numVisibleRows: visibleRowIndexes.length,
       deletingIndexes: [],
       currentlyAddingRow: undefined,
@@ -217,10 +215,6 @@ function newStore({ node }: Props) {
           }
           if (state.isFirstRender) {
             newState.isFirstRender = false;
-          }
-          if (state.editingIndex !== undefined && newState.editingIndex === state.editingIndex) {
-            newState.moreVisibleRowsAfterEditIndex =
-              visibleRowIndexes.indexOf(state.editingIndex) < visibleRowIndexes.length - 1;
           }
           return newState;
         });

--- a/src/layout/RepeatingGroup/RepeatingGroupContext.tsx
+++ b/src/layout/RepeatingGroup/RepeatingGroupContext.tsx
@@ -1,38 +1,31 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import type { PropsWithChildren } from 'react';
 
+import { createStore } from 'zustand';
+
 import { createContext } from 'src/core/contexts/context';
+import { createZustandContext } from 'src/core/contexts/zustandContext';
 import { useAttachmentDeletionInRepGroups } from 'src/features/attachments/useAttachmentDeletionInRepGroups';
 import { FD } from 'src/features/formData/FormDataWrite';
 import { useOnGroupCloseValidation } from 'src/features/validation/callbacks/onGroupCloseValidation';
 import { useOnDeleteGroupRow } from 'src/features/validation/validationContext';
-import { useAsRef, useAsRefObject } from 'src/hooks/useAsRef';
-import { useMemoDeepEqual } from 'src/hooks/useStateDeepEqual';
+import { useAsRef } from 'src/hooks/useAsRef';
 import { useWaitForState } from 'src/hooks/useWaitForState';
 import type { CompRepeatingGroupInternal } from 'src/layout/RepeatingGroup/config.generated';
 import type { BaseLayoutNode } from 'src/utils/layout/LayoutNode';
 
-interface RepeatingGroupContext {
-  node: BaseLayoutNode<CompRepeatingGroupInternal>;
+interface Store {
+  editingAll: boolean;
+  editingNone: boolean;
+  binding: string;
+  deletingIndexes: number[];
+  isEditingAnyRow: boolean;
+  editingIndex: number | undefined;
 
   // If this is true, we're rendering the group for the first time in this context. This is used to
   // determine whether we should open the first/last row for editing when first displaying the group. If, however,
   // we run that effect every time the group is re-rendered, the user would be unable to close the row for editing.
   isFirstRender: boolean;
-
-  // Methods for getting/setting state about which rows are in edit mode
-  toggleEditing: (index: number) => void;
-  openForEditing: (index: number) => void;
-  openNextForEditing: () => void;
-  closeForEditing: (index: number) => void;
-  isEditing: (index: number) => boolean;
-  isEditingAnyRow: boolean;
-  editingIndex: number | undefined;
-
-  addRow: () => Promise<void>;
-
-  deleteRow: (index: number) => Promise<boolean>;
-  isDeleting: (index: number) => boolean;
 
   numVisibleRows: number;
   visibleRowIndexes: number[];
@@ -40,274 +33,340 @@ interface RepeatingGroupContext {
   moreVisibleRowsAfterEditIndex: boolean;
   editableRowIndexes: number[];
   deletableRowIndexes: number[];
+  currentlyAddingRow: undefined | number;
 }
 
-const { Provider, useCtx } = createContext<RepeatingGroupContext>({
+interface ZustandHiddenMethods {
+  updateNode: (n: BaseLayoutNode<CompRepeatingGroupInternal>) => void;
+  startAddingRow: (idx: number) => void;
+  endAddingRow: (idx: number) => void;
+  startDeletingRow: (idx: number) => void;
+  endDeletingRow: (idx: number, successful: boolean) => void;
+}
+
+interface ExtendedMethods {
+  // Methods for getting/setting state about which rows are in edit mode
+  toggleEditing: (index: number) => void;
+  openForEditing: (index: number) => void;
+  openNextForEditing: () => void;
+  closeForEditing: (index: number) => void;
+}
+
+interface ContextMethods extends ExtendedMethods {
+  addRow: () => Promise<void>;
+  deleteRow: (index: number) => Promise<boolean>;
+  isEditing: (index: number) => boolean;
+  isDeleting: (index: number) => boolean;
+}
+
+type ZustandState = Store & ZustandHiddenMethods & Omit<ExtendedMethods, 'toggleEditing'>;
+type ExtendedContext = ContextMethods & Props;
+
+const ZStore = createZustandContext({
+  name: 'RepeatingGroupZ',
+  required: true,
+  initialCreateStore: newStore,
+});
+
+const ExtendedStore = createContext<ExtendedContext>({
   name: 'RepeatingGroup',
   required: true,
 });
 
-function usePureStates(node: BaseLayoutNode<CompRepeatingGroupInternal>) {
-  const editingAll = node.item.edit?.mode === 'showAll';
-  const editingNone = node.item.edit?.mode === 'onlyTable';
-  const binding = node.item.dataModelBindings?.group;
+function newStore({ node }: Props) {
+  return createStore<ZustandState>((set) => {
+    function produceRowIndexes(n: BaseLayoutNode<CompRepeatingGroupInternal>) {
+      const hidden: number[] = [];
+      const visible: number[] = [];
+      const editable: number[] = [];
+      const deletable: number[] = [];
+      for (const row of n.item.rows) {
+        if (row.groupExpressions?.hiddenRow) {
+          hidden.push(row.index);
+        } else {
+          visible.push(row.index);
 
-  const [visibleRowIndexes, hiddenRowIndexes, editableRowIndexes, deletableRowIndexes] = useMemoDeepEqual(() => {
-    const hidden: number[] = [];
-    const visible: number[] = [];
-    const editable: number[] = [];
-    const deletable: number[] = [];
-    for (const row of node.item.rows) {
-      if (row.groupExpressions?.hiddenRow) {
-        hidden.push(row.index);
-      } else {
-        visible.push(row.index);
-
-        // Only the visible rows can be edited or deleted
-        if (row.groupExpressions?.edit?.editButton !== false) {
-          editable.push(row.index);
-        }
-        if (row.groupExpressions?.edit?.deleteButton !== false) {
-          deletable.push(row.index);
+          // Only the visible rows can be edited or deleted
+          if (row.groupExpressions?.edit?.editButton !== false) {
+            editable.push(row.index);
+          }
+          if (row.groupExpressions?.edit?.deleteButton !== false) {
+            deletable.push(row.index);
+          }
         }
       }
+
+      return [visible, new Set(hidden), editable, deletable] as const;
     }
 
-    return [visible, new Set(hidden), editable, deletable];
-  }, [node.item.rows]);
+    const [visibleRowIndexes, hiddenRowIndexes, editableRowIndexes, deletableRowIndexes] = produceRowIndexes(node);
 
-  const [isFirstRender, setIsFirstRender] = useState(true);
-  useEffect(() => {
-    setIsFirstRender(false);
-  }, []);
+    return {
+      editingAll: node.item.edit?.mode === 'showAll',
+      editingNone: node.item.edit?.mode === 'onlyTable',
+      binding: node.item.dataModelBindings.group,
+      isFirstRender: true,
+      editingIndex: undefined,
+      isEditingAnyRow: false,
+      moreVisibleRowsAfterEditIndex: false,
+      numVisibleRows: visibleRowIndexes.length,
+      deletingIndexes: [],
+      currentlyAddingRow: undefined,
 
-  const [editingIndex, setEditingIndex] = useState<number | undefined>(undefined);
-  const [deletingIndexes, setDeletingIndexes] = useState<number[]>([]);
+      visibleRowIndexes,
+      hiddenRowIndexes,
+      editableRowIndexes,
+      deletableRowIndexes,
 
-  return {
-    editingAll,
-    editingNone,
-    numVisibleRows: visibleRowIndexes.length,
-    hiddenRowIndexes,
-    visibleRowIndexes,
-    editableRowIndexes,
-    deletableRowIndexes,
-    isFirstRender,
-    editingIndex,
-    setEditingIndex,
-    deletingIndexes,
-    setDeletingIndexes,
-    binding,
-  };
+      closeForEditing: (idx) => {
+        set((state) => {
+          if (state.editingIndex === idx) {
+            return { editingIndex: undefined };
+          }
+          return state;
+        });
+      },
+
+      openForEditing: (idx) => {
+        set((state) => {
+          if (state.editingIndex === idx || state.editingAll || state.editingNone) {
+            return state;
+          }
+          if (!state.editableRowIndexes.includes(idx)) {
+            return state;
+          }
+          return { editingIndex: idx };
+        });
+      },
+
+      openNextForEditing: () => {
+        set((state) => {
+          if (state.editingAll || state.editingNone) {
+            return state;
+          }
+          if (state.editingIndex === undefined) {
+            return { editingIndex: state.editableRowIndexes[0] };
+          }
+          const isLast = state.editingIndex === state.editableRowIndexes[state.editableRowIndexes.length - 1];
+          if (isLast) {
+            return { editingIndex: undefined };
+          }
+          return { editingIndex: state.editableRowIndexes[state.editableRowIndexes.indexOf(state.editingIndex) + 1] };
+        });
+      },
+
+      startAddingRow: (idx) => {
+        set((state) => {
+          if (state.currentlyAddingRow !== undefined) {
+            return state;
+          }
+          return { currentlyAddingRow: idx };
+        });
+      },
+
+      endAddingRow: (idx) => {
+        set((state) => {
+          if (state.currentlyAddingRow !== idx) {
+            return state;
+          }
+          return { currentlyAddingRow: undefined };
+        });
+      },
+
+      startDeletingRow: (idx) => {
+        set((state) => {
+          if (state.deletingIndexes.includes(idx)) {
+            return state;
+          }
+          return { deletingIndexes: [...state.deletingIndexes, idx] };
+        });
+      },
+
+      endDeletingRow: (idx, successful) => {
+        set((state) => {
+          const isEditing = state.editingIndex === idx;
+          const i = state.deletingIndexes.indexOf(idx);
+          if (i === -1 && !isEditing) {
+            return state;
+          }
+          if (isEditing && successful) {
+            return { editingIndex: undefined };
+          }
+          return {
+            deletingIndexes: [...state.deletingIndexes.slice(0, i), ...state.deletingIndexes.slice(i + 1)],
+            editingIndex: isEditing && successful ? undefined : state.editingIndex,
+          };
+        });
+      },
+
+      updateNode: (n: BaseLayoutNode<CompRepeatingGroupInternal>) => {
+        const [visibleRowIndexes, hiddenRowIndexes, editableRowIndexes, deletableRowIndexes] = produceRowIndexes(n);
+        set((state) => {
+          const newState: Partial<ZustandState> = {
+            binding: n.item.dataModelBindings.group,
+            visibleRowIndexes,
+            hiddenRowIndexes,
+            editableRowIndexes,
+            deletableRowIndexes,
+          };
+          if (state.editingIndex !== undefined && !visibleRowIndexes.includes(state.editingIndex)) {
+            newState.editingIndex = undefined;
+          }
+          if (state.isFirstRender) {
+            newState.isFirstRender = false;
+          }
+          if (state.editingIndex !== undefined && newState.editingIndex === state.editingIndex) {
+            newState.moreVisibleRowsAfterEditIndex =
+              visibleRowIndexes.indexOf(state.editingIndex) < visibleRowIndexes.length - 1;
+          }
+          return newState;
+        });
+      },
+    };
+  });
 }
 
-function useRepeatingGroupState(node: BaseLayoutNode<CompRepeatingGroupInternal>): RepeatingGroupContext {
+function useExtendedRepeatingGroupState(node: BaseLayoutNode<CompRepeatingGroupInternal>): ExtendedContext {
+  const nodeRef = useAsRef(node);
+  const stateRef = useAsRef(ZStore.useSelector((state) => state));
+
   const appendToList = FD.useAppendToList();
   const removeIndexFromList = FD.useRemoveIndexFromList();
   const { onBeforeRowDeletion } = useAttachmentDeletionInRepGroups(node);
   const onDeleteGroupRow = useOnDeleteGroupRow();
   const onGroupCloseValidation = useOnGroupCloseValidation();
-  const pureStates = usePureStates(node);
-  const setEditingIndex = pureStates.setEditingIndex;
-  const {
-    editingAll,
-    editingNone,
-    binding,
-    setDeletingIndexes,
-    deletingIndexes,
-    editableRowIndexes,
-    deletableRowIndexes,
-    editingIndex,
-  } = useAsRefObject(pureStates);
-  const nodeRef = useAsRef(node);
   const waitForNode = useWaitForState(nodeRef);
 
-  const validateOnSaveRow = nodeRef.current.item.validateOnSaveRow;
-
   const maybeValidateRow = useCallback(() => {
-    if (!validateOnSaveRow || editingAll.current || editingNone.current || editingIndex.current === undefined) {
+    const { editingAll, editingIndex, editingNone } = stateRef.current;
+    const validateOnSaveRow = nodeRef.current.item.validateOnSaveRow;
+    if (!validateOnSaveRow || editingAll || editingNone || editingIndex === undefined) {
       return Promise.resolve(false);
     }
-    return onGroupCloseValidation(nodeRef.current, editingIndex.current, validateOnSaveRow);
-  }, [editingAll, editingIndex, editingNone, nodeRef, onGroupCloseValidation, validateOnSaveRow]);
-
-  // Figure out if the row we were editing is now hidden, and in that case, reset the editing state
-  useEffect(() => {
-    if (pureStates.editingIndex !== undefined && pureStates.hiddenRowIndexes.has(pureStates.editingIndex)) {
-      setEditingIndex(undefined);
-    }
-  }, [pureStates.editingIndex, pureStates.hiddenRowIndexes, node, setEditingIndex]);
-
-  const toggleEditing = useCallback(
-    async (index: number) => {
-      if (editingAll.current || editingNone.current || !editableRowIndexes.current.includes(index)) {
-        return;
-      }
-      if (await maybeValidateRow()) {
-        return;
-      }
-      setEditingIndex((prev) => (prev === index ? undefined : index));
-    },
-    [editableRowIndexes, editingAll, editingNone, maybeValidateRow, setEditingIndex],
-  );
+    return onGroupCloseValidation(nodeRef.current, editingIndex, validateOnSaveRow);
+  }, [nodeRef, onGroupCloseValidation, stateRef]);
 
   const openForEditing = useCallback(
     async (index: number) => {
-      if (editingAll.current || editingNone.current || !editableRowIndexes.current.includes(index)) {
-        return;
-      }
       if (await maybeValidateRow()) {
         return;
       }
-      setEditingIndex(index);
+      stateRef.current.openForEditing(index);
     },
-    [editableRowIndexes, editingAll, editingNone, maybeValidateRow, setEditingIndex],
+    [maybeValidateRow, stateRef],
   );
 
   const openNextForEditing = useCallback(async () => {
-    if (editingAll.current || editingNone.current) {
-      return;
-    }
     if (await maybeValidateRow()) {
       return;
     }
-    setEditingIndex((prev) => {
-      if (prev === undefined) {
-        return editableRowIndexes.current[0];
-      }
-      const isLast = prev === editableRowIndexes.current[editableRowIndexes.current.length - 1];
-      if (isLast) {
-        return undefined;
-      }
-      return editableRowIndexes.current[editableRowIndexes.current.indexOf(prev) + 1];
-    });
-  }, [editableRowIndexes, editingAll, editingNone, maybeValidateRow, setEditingIndex]);
+    stateRef.current.openNextForEditing();
+  }, [maybeValidateRow, stateRef]);
 
   const closeForEditing = useCallback(
     async (index: number) => {
-      if (editingAll.current || editingNone.current) {
+      if (await maybeValidateRow()) {
         return;
       }
-      if (editingIndex.current === index && !(await maybeValidateRow())) {
-        setEditingIndex(undefined);
+      stateRef.current.closeForEditing(index);
+    },
+    [maybeValidateRow, stateRef],
+  );
+
+  const toggleEditing = useCallback(
+    async (index: number) => {
+      if (await maybeValidateRow()) {
+        return;
+      }
+      const { editingIndex, closeForEditing, openForEditing } = stateRef.current;
+      if (editingIndex === index) {
+        closeForEditing(index);
+      } else {
+        openForEditing(index);
       }
     },
-    [editingAll, editingIndex, editingNone, maybeValidateRow, setEditingIndex],
+    [maybeValidateRow, stateRef],
   );
 
   const isEditing = useCallback(
     (index: number) => {
-      if (editingAll.current) {
+      const { editingAll, editingIndex, editingNone } = stateRef.current;
+      if (editingAll) {
         return true;
       }
-      if (editingNone.current) {
+      if (editingNone) {
         return false;
       }
-      return editingIndex.current === index;
+      return editingIndex === index;
     },
-    [editingAll, editingIndex, editingNone],
+    [stateRef],
   );
 
-  const addingRowRef = useRef<number | false>(false);
   const addRow = useCallback(async () => {
-    if (binding.current && !(await maybeValidateRow()) && addingRowRef.current === false) {
+    const { binding, currentlyAddingRow, startAddingRow, endAddingRow } = stateRef.current;
+    if (binding && !currentlyAddingRow && !(await maybeValidateRow())) {
       const nextIndex = nodeRef.current.item.rows.length;
       const nextLength = nextIndex + 1;
-      addingRowRef.current = nextIndex;
+      startAddingRow(nextIndex);
       appendToList({
-        path: binding.current,
+        path: binding,
         newValue: {},
       });
       await waitForNode((node) => node.item.rows.length === nextLength);
       await openForEditing(nextIndex);
-      addingRowRef.current = false;
+      endAddingRow(nextIndex);
     }
-  }, [appendToList, binding, maybeValidateRow, nodeRef, openForEditing, waitForNode]);
+  }, [appendToList, maybeValidateRow, nodeRef, openForEditing, stateRef, waitForNode]);
 
   const deleteRow = useCallback(
     async (index: number) => {
-      if (!deletableRowIndexes.current.includes(index)) {
+      const { binding, deletableRowIndexes, startDeletingRow, endDeletingRow } = stateRef.current;
+      if (!deletableRowIndexes.includes(index)) {
         return false;
       }
 
-      setDeletingIndexes.current((prev) => {
-        if (prev.includes(index)) {
-          return prev;
-        }
-        return [...prev, index];
-      });
+      startDeletingRow(index);
       const attachmentDeletionSuccessful = await onBeforeRowDeletion(index);
-      if (attachmentDeletionSuccessful && binding.current) {
+      if (attachmentDeletionSuccessful && binding) {
         onDeleteGroupRow(nodeRef.current, index);
         removeIndexFromList({
-          path: binding.current,
+          path: binding,
           index,
         });
 
-        setEditingIndex((prev) => {
-          if (prev === index) {
-            return undefined;
-          }
-          return prev;
-        });
-        setDeletingIndexes.current((prev) => {
-          const idx = prev.indexOf(index);
-          if (idx === -1) {
-            return prev;
-          }
-          return [...prev.slice(0, idx), ...prev.slice(idx + 1)];
-        });
-
+        endDeletingRow(index, true);
         return true;
       }
 
+      endDeletingRow(index, false);
       return false;
     },
-    [
-      binding,
-      deletableRowIndexes,
-      nodeRef,
-      onBeforeRowDeletion,
-      onDeleteGroupRow,
-      removeIndexFromList,
-      setDeletingIndexes,
-      setEditingIndex,
-    ],
+    [nodeRef, onBeforeRowDeletion, onDeleteGroupRow, removeIndexFromList, stateRef],
   );
 
-  const isDeleting = useCallback((index: number) => deletingIndexes.current.includes(index), [deletingIndexes]);
-
-  const moreVisibleRowsAfterEditIndex = useMemo(() => {
-    if (pureStates.editingIndex === undefined) {
-      return false;
-    }
-    return pureStates.visibleRowIndexes.indexOf(pureStates.editingIndex) < pureStates.visibleRowIndexes.length - 1;
-  }, [pureStates.visibleRowIndexes, pureStates.editingIndex]);
+  const isDeleting = useCallback((index: number) => stateRef.current.deletingIndexes.includes(index), [stateRef]);
 
   return {
     node,
-    isFirstRender: pureStates.isFirstRender,
-    toggleEditing,
-    openForEditing,
-    openNextForEditing,
-    closeForEditing,
-    isEditing,
-    isEditingAnyRow: pureStates.editingAll
-      ? true
-      : pureStates.editingNone
-        ? false
-        : pureStates.editingIndex !== undefined,
-    editingIndex: pureStates.editingIndex,
-    numVisibleRows: pureStates.numVisibleRows,
-    visibleRowIndexes: pureStates.visibleRowIndexes,
-    hiddenRowIndexes: pureStates.hiddenRowIndexes,
-    editableRowIndexes: pureStates.editableRowIndexes,
-    deletableRowIndexes: pureStates.deletableRowIndexes,
-    moreVisibleRowsAfterEditIndex,
     addRow,
     deleteRow,
     isDeleting,
+    closeForEditing,
+    isEditing,
+    openForEditing,
+    openNextForEditing,
+    toggleEditing,
   };
+}
+
+function ProvideTheRest({ node, children }: PropsWithChildren<Props>) {
+  const extended = useExtendedRepeatingGroupState(node);
+  const updateNode = ZStore.useSelector((state) => state.updateNode);
+  useEffect(() => {
+    updateNode(node);
+  }, [node, updateNode]);
+
+  return <ExtendedStore.Provider value={extended}>{children}</ExtendedStore.Provider>;
 }
 
 interface Props {
@@ -315,8 +374,15 @@ interface Props {
 }
 
 export function RepeatingGroupProvider({ node, children }: PropsWithChildren<Props>) {
-  const state = useRepeatingGroupState(node);
-  return <Provider value={state}>{children}</Provider>;
+  return (
+    <ZStore.Provider node={node}>
+      <ProvideTheRest node={node}>{children}</ProvideTheRest>
+    </ZStore.Provider>
+  );
 }
 
-export const useRepeatingGroup = () => useCtx();
+export const useRepeatingGroup = () => ExtendedStore.useCtx();
+export const useRepeatingGroupNode = () => ExtendedStore.useCtx().node;
+export function useRepeatingGroupSelector<T>(selector: (state: Store) => T): T {
+  return ZStore.useSelector(selector);
+}

--- a/src/layout/RepeatingGroup/RepeatingGroupContext.tsx
+++ b/src/layout/RepeatingGroup/RepeatingGroupContext.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback } from 'react';
 import type { PropsWithChildren } from 'react';
 
 import { createStore } from 'zustand';
@@ -66,6 +66,9 @@ const ZStore = createZustandContext({
   name: 'RepeatingGroupZ',
   required: true,
   initialCreateStore: newStore,
+  onReRender: (store, { node }) => {
+    store.getState().updateNode(node);
+  },
 });
 
 const ExtendedStore = createContext<ExtendedContext>({
@@ -160,7 +163,7 @@ function newStore({ node }: Props) {
           if (state.currentlyAddingRow !== undefined) {
             return state;
           }
-          return { currentlyAddingRow: idx };
+          return { currentlyAddingRow: idx, editingIndex: undefined };
         });
       },
 
@@ -361,11 +364,6 @@ function useExtendedRepeatingGroupState(node: BaseLayoutNode<CompRepeatingGroupI
 
 function ProvideTheRest({ node, children }: PropsWithChildren<Props>) {
   const extended = useExtendedRepeatingGroupState(node);
-  const updateNode = ZStore.useSelector((state) => state.updateNode);
-  useEffect(() => {
-    updateNode(node);
-  }, [node, updateNode]);
-
   return <ExtendedStore.Provider value={extended}>{children}</ExtendedStore.Provider>;
 }
 

--- a/src/layout/RepeatingGroup/RepeatingGroupEditContainer.test.tsx
+++ b/src/layout/RepeatingGroup/RepeatingGroupEditContainer.test.tsx
@@ -4,7 +4,11 @@ import { screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 
 import { getMultiPageGroupMock } from 'src/__mocks__/getMultiPageGroupMock';
-import { RepeatingGroupProvider, useRepeatingGroup } from 'src/layout/RepeatingGroup/RepeatingGroupContext';
+import {
+  RepeatingGroupProvider,
+  useRepeatingGroup,
+  useRepeatingGroupSelector,
+} from 'src/layout/RepeatingGroup/RepeatingGroupContext';
 import { RepeatingGroupsEditContainer } from 'src/layout/RepeatingGroup/RepeatingGroupsEditContainer';
 import { renderWithNode } from 'src/test/renderWithProviders';
 import type { CompCheckboxesExternal } from 'src/layout/Checkboxes/config.generated';
@@ -126,7 +130,8 @@ describe('RepeatingGroupsEditContainer', () => {
 });
 
 function TestRenderer() {
-  const { editingIndex, openForEditing } = useRepeatingGroup();
+  const editingIndex = useRepeatingGroupSelector((state) => state.editingIndex);
+  const { openForEditing } = useRepeatingGroup();
 
   if (editingIndex === undefined) {
     return (

--- a/src/layout/RepeatingGroup/RepeatingGroupTable.test.tsx
+++ b/src/layout/RepeatingGroup/RepeatingGroupTable.test.tsx
@@ -5,7 +5,7 @@ import { userEvent } from '@testing-library/user-event';
 import ResizeObserverModule from 'resize-observer-polyfill';
 
 import { getFormLayoutRepeatingGroupMock } from 'src/__mocks__/getFormLayoutGroupMock';
-import { RepeatingGroupProvider, useRepeatingGroup } from 'src/layout/RepeatingGroup/RepeatingGroupContext';
+import { RepeatingGroupProvider, useRepeatingGroupSelector } from 'src/layout/RepeatingGroup/RepeatingGroupContext';
 import { RepeatingGroupTable } from 'src/layout/RepeatingGroup/RepeatingGroupTable';
 import { mockMediaQuery } from 'src/test/mockMediaQuery';
 import { renderWithNode } from 'src/test/renderWithProviders';
@@ -198,6 +198,6 @@ describe('RepeatingGroupTable', () => {
 });
 
 function LeakEditIndex() {
-  const { editingIndex } = useRepeatingGroup();
+  const editingIndex = useRepeatingGroupSelector((state) => state.editingIndex);
   return <div data-testid='editIndex'>{editingIndex === undefined ? 'undefined' : editingIndex}</div>;
 }

--- a/src/layout/RepeatingGroup/RepeatingGroupTable.tsx
+++ b/src/layout/RepeatingGroup/RepeatingGroupTable.tsx
@@ -11,7 +11,7 @@ import { GenericComponent } from 'src/layout/GenericComponent';
 import { GridRowRenderer } from 'src/layout/Grid/GridComponent';
 import { nodesFromGridRows } from 'src/layout/Grid/tools';
 import classes from 'src/layout/RepeatingGroup/RepeatingGroup.module.css';
-import { useRepeatingGroup } from 'src/layout/RepeatingGroup/RepeatingGroupContext';
+import { useRepeatingGroup, useRepeatingGroupSelector } from 'src/layout/RepeatingGroup/RepeatingGroupContext';
 import { RepeatingGroupsEditContainer } from 'src/layout/RepeatingGroup/RepeatingGroupsEditContainer';
 import { RepeatingGroupTableRow } from 'src/layout/RepeatingGroup/RepeatingGroupTableRow';
 import { RepeatingGroupTableTitle } from 'src/layout/RepeatingGroup/RepeatingGroupTableTitle';
@@ -20,7 +20,8 @@ import type { GridRowsInternal, ITableColumnFormatting } from 'src/layout/common
 
 export function RepeatingGroupTable(): React.JSX.Element | null {
   const mobileView = useIsMobileOrTablet();
-  const { node, isEditing, visibleRowIndexes } = useRepeatingGroup();
+  const { node, isEditing } = useRepeatingGroup();
+  const visibleRowIndexes = useRepeatingGroupSelector((state) => state.visibleRowIndexes);
   const rowsBefore = node.item.rowsBefore;
   const rowsAfter = node.item.rowsAfter;
 
@@ -194,14 +195,8 @@ export function RepeatingGroupTable(): React.JSX.Element | null {
           </TableHeader>
         )}
         <TableBody id={`group-${id}-table-body`}>
-          {visibleRowIndexes.map((index) => {
+          {visibleRowIndexes.map((index: number) => {
             const isEditingRow = isEditing(index) && edit?.mode !== 'onlyTable';
-            const isTableRowHidden = node.item.rows[index]?.groupExpressions?.hiddenRow;
-
-            if (isTableRowHidden) {
-              return null;
-            }
-
             return (
               <React.Fragment key={index}>
                 <RepeatingGroupTableRow

--- a/src/layout/RepeatingGroup/RepeatingGroupTableRow.tsx
+++ b/src/layout/RepeatingGroup/RepeatingGroupTableRow.tsx
@@ -98,8 +98,8 @@ export function RepeatingGroupTableRow({
     ...expressionsForRow?.textResourceBindings,
   } as CompRepeatingGroupInternal['textResourceBindings'];
 
-  const rowValdiations = useDeepValidationsForNode(node, true, index);
-  const rowHasErrors = hasValidationErrors(rowValdiations);
+  const rowValidations = useDeepValidationsForNode(node, true, index);
+  const rowHasErrors = hasValidationErrors(rowValidations);
 
   const alertOnDelete = useAlertOnChange(Boolean(edit?.alertOnDelete), deleteRow);
 

--- a/src/layout/RepeatingGroup/RepeatingGroupsEditContainer.tsx
+++ b/src/layout/RepeatingGroup/RepeatingGroupsEditContainer.tsx
@@ -8,7 +8,7 @@ import cn from 'classnames';
 import { Lang } from 'src/features/language/Lang';
 import { GenericComponent } from 'src/layout/GenericComponent';
 import classes from 'src/layout/RepeatingGroup/RepeatingGroup.module.css';
-import { useRepeatingGroup } from 'src/layout/RepeatingGroup/RepeatingGroupContext';
+import { useRepeatingGroup, useRepeatingGroupSelector } from 'src/layout/RepeatingGroup/RepeatingGroupContext';
 import {
   RepeatingGroupEditRowProvider,
   useRepeatingGroupEdit,
@@ -67,8 +67,8 @@ function RepeatingGroupsEditContainerInternal({
   group: CompRepeatingGroupInternal;
   row: CompRepeatingGroupInternal['rows'][number];
 }): JSX.Element | null {
-  const { node, closeForEditing, deleteRow, openNextForEditing, isDeleting, moreVisibleRowsAfterEditIndex } =
-    useRepeatingGroup();
+  const { node, closeForEditing, deleteRow, openNextForEditing, isDeleting } = useRepeatingGroup();
+  const moreVisibleRowsAfterEditIndex = useRepeatingGroupSelector((state) => state.moreVisibleRowsAfterEditIndex);
   const { multiPageEnabled, multiPageIndex, nextMultiPage, prevMultiPage, hasNextMultiPage, hasPrevMultiPage } =
     useRepeatingGroupEdit();
   const id = node.item.id;

--- a/src/layout/RepeatingGroup/RepeatingGroupsEditContainer.tsx
+++ b/src/layout/RepeatingGroup/RepeatingGroupsEditContainer.tsx
@@ -68,7 +68,16 @@ function RepeatingGroupsEditContainerInternal({
   row: CompRepeatingGroupInternal['rows'][number];
 }): JSX.Element | null {
   const { node, closeForEditing, deleteRow, openNextForEditing, isDeleting } = useRepeatingGroup();
-  const moreVisibleRowsAfterEditIndex = useRepeatingGroupSelector((state) => state.moreVisibleRowsAfterEditIndex);
+
+  const visibleRowIndexes = useRepeatingGroupSelector((state) => state.visibleRowIndexes);
+  let moreVisibleRowsAfterEditIndex = false;
+  for (const visibleRowIndex of visibleRowIndexes) {
+    if (visibleRowIndex > editIndex) {
+      moreVisibleRowsAfterEditIndex = true;
+      break;
+    }
+  }
+
   const { multiPageEnabled, multiPageIndex, nextMultiPage, prevMultiPage, hasNextMultiPage, hasPrevMultiPage } =
     useRepeatingGroupEdit();
   const id = node.item.id;

--- a/src/test/renderWithProviders.tsx
+++ b/src/test/renderWithProviders.tsx
@@ -1,4 +1,4 @@
-import React, { StrictMode } from 'react';
+import React from 'react';
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import type { PropsWithChildren } from 'react';
 
@@ -403,23 +403,21 @@ const renderBase = async ({
   ) as AppMutations;
 
   const ProviderWrapper = ({ children }: PropsWithChildren) => (
-    <StrictMode>
-      <Providers
-        Router={router || PageNavigationRouter({ currentPageId: 'formLayout' })}
-        queryClient={queryClient}
-        queries={{
-          ...queryMocks,
-          ...mutationMocks,
-        }}
+    <Providers
+      Router={router || PageNavigationRouter({ currentPageId: 'formLayout' })}
+      queryClient={queryClient}
+      queries={{
+        ...queryMocks,
+        ...mutationMocks,
+      }}
+    >
+      <RenderStart
+        devTools={false}
+        dataModelFetcher={false}
       >
-        <RenderStart
-          devTools={false}
-          dataModelFetcher={false}
-        >
-          {children}
-        </RenderStart>
-      </Providers>
-    </StrictMode>
+        {children}
+      </RenderStart>
+    </Providers>
   );
 
   const startTime = Date.now();

--- a/src/utils/versionCompare.test.ts
+++ b/src/utils/versionCompare.test.ts
@@ -1,0 +1,27 @@
+import { isAtLeastVersion } from 'src/utils/versionCompare';
+
+describe('versionCompare', () => {
+  interface TestCase {
+    version: string;
+    minVersion: string;
+    expected: boolean;
+  }
+
+  const testCases: TestCase[] = [
+    { version: '1.0.0', minVersion: '1.0.0', expected: true },
+    { version: '1.0.0', minVersion: '1.0.1', expected: false },
+    { version: '1.0.0', minVersion: '0.9.9', expected: true },
+    { version: '8.0.0', minVersion: '7.9.9', expected: true },
+    { version: '8.0.15', minVersion: '8.0.14', expected: true },
+    { version: '8.1.15', minVersion: '8.0.16', expected: true },
+    { version: '8.1.15', minVersion: '8.1.14', expected: true },
+    { version: '8.1.15', minVersion: '8.1.15', expected: true },
+    { version: '8.1.15', minVersion: '8.1.16', expected: false },
+    { version: '8.1.15', minVersion: '8.2.14', expected: false },
+    { version: '8.1.15', minVersion: '9.0.0', expected: false },
+  ];
+
+  test.each(testCases)('isAtLeastVersion($version, $minVersion) returns $expected', (testCase) => {
+    expect(isAtLeastVersion(testCase.version, testCase.minVersion)).toBe(testCase.expected);
+  });
+});

--- a/src/utils/versionCompare.ts
+++ b/src/utils/versionCompare.ts
@@ -1,0 +1,19 @@
+/**
+ * Checks if the given version is at least the given minimum version. Expects the version numbers to be
+ * dot-separated numbers, e.g. "1.0.15". String parts, such as 'preview', 'alpha', 'rc' are not supported.
+ */
+export function isAtLeastVersion(version: string, minVersion: string): boolean {
+  const parts = version.split('.');
+  const expectedParts = minVersion.split('.');
+  for (const i in expectedParts) {
+    const expected = parseInt(expectedParts[i], 10);
+    const actual = parseInt(parts[i], 10);
+    if (actual > expected) {
+      return true;
+    }
+    if (actual < expected) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/test/e2e/integration/frontend-test/components.ts
+++ b/test/e2e/integration/frontend-test/components.ts
@@ -428,7 +428,6 @@ describe('UI Components', () => {
       cy.get(appFrontend.changeOfName.newFirstName).type('rrr');
       cy.get('#form-content-newFirstName').contains(`Du har overskredet maks antall tegn med ${7 - maxLength}`);
 
-      /* TODO: Comment these back in after validation refactor
       // Display data model validation below component if maxLength in layout and datamodel is different
       if (maxLength !== 4) {
         cy.get('#form-content-newFirstName').should('contain', 'Bruk 4 eller færre tegn');
@@ -437,7 +436,6 @@ describe('UI Components', () => {
       }
       cy.get(appFrontend.errorReport).should('be.visible');
       cy.get(appFrontend.errorReport).should('contain.text', 'Bruk 4 eller færre tegn');
-       */
     });
   });
 

--- a/test/e2e/integration/frontend-test/components.ts
+++ b/test/e2e/integration/frontend-test/components.ts
@@ -232,7 +232,7 @@ describe('UI Components', () => {
   it('radios, checkboxes and other components can be readOnly', () => {
     cy.interceptLayout('changename', (component) => {
       const formTypes: CompExternal['type'][] = [
-        'AddressComponent',
+        'Address',
         'Checkboxes',
         'Datepicker',
         'Dropdown',

--- a/test/e2e/integration/frontend-test/group.ts
+++ b/test/e2e/integration/frontend-test/group.ts
@@ -560,6 +560,10 @@ describe('Group', () => {
       }
     });
 
+    // Reset state by going back and forth
+    cy.gotoNavPage('prefill');
+    cy.gotoNavPage('repeating');
+
     cy.get(appFrontend.group.addNewItem).click();
     cy.get(appFrontend.group.editContainer).should('not.exist');
     cy.get(appFrontend.group.mainGroupTableBody).find('tr').should('have.length', 5);

--- a/test/e2e/integration/frontend-test/group.ts
+++ b/test/e2e/integration/frontend-test/group.ts
@@ -45,7 +45,11 @@ describe('Group', () => {
         cy.get(appFrontend.group.mainGroup).should('exist');
         cy.get(appFrontend.group.addNewItem).click();
         cy.get(appFrontend.group.mainGroup).should('exist');
-        cy.get(appFrontend.group.addNewItem).should('not.exist');
+
+        // At this point the button would disappear in v3, as the new rows were empty and simply hallucinated in
+        // app-frontend until they had data. In v4, we keep the button visible, as it is not possible to add more rows
+        // even if they are empty, as empty objects are a thing now.
+        cy.get(appFrontend.group.addNewItem).should('exist');
       } else {
         cy.get(appFrontend.group.addNewItem).click();
         cy.get(appFrontend.group.mainGroup).should('exist');

--- a/test/e2e/integration/frontend-test/pdf.ts
+++ b/test/e2e/integration/frontend-test/pdf.ts
@@ -34,8 +34,7 @@ describe('PDF', () => {
     cy.findByRole('textbox', { name: /gateadresse/i }).type('Økern 1');
     cy.findByRole('textbox', { name: /postnr/i }).type('0101');
 
-    // TODO: Comment back in when Address component works again
-    // cy.findByRole('textbox', { name: /poststed/i }).should('have.value', 'OSLO');
+    cy.findByRole('textbox', { name: /poststed/i }).should('have.value', 'OSLO');
 
     cy.testPdf(() => {
       cy.findByRole('table').should('contain.text', 'Mottaker:Testdepartementet');

--- a/test/e2e/integration/frontend-test/validation.ts
+++ b/test/e2e/integration/frontend-test/validation.ts
@@ -513,6 +513,10 @@ describe('Validation', () => {
       }
     });
 
+    // Go back to the first page and then here again to reset the repeating group after the change above
+    cy.gotoNavPage('prefill');
+    cy.gotoNavPage('repeating');
+
     cy.get(appFrontend.errorReport).findAllByRole('listitem').should('have.length', 1);
     cy.get(appFrontend.group.editContainer).should('not.exist');
     cy.get(appFrontend.group.addNewItem).click();


### PR DESCRIPTION
## Description

- Removing `StrictMode` in unit tests. The reason everything rendered twice in some unit tests was that I didn't read enough about what StrictMode does, and when I saw that it purposely renders everything twice, it's obviously the cause of this problem. The profiler in the browser detects strict mode and fixes the numbers for us. 
- Adding back some commented-out code in Cypress tests (should have been commented back in when validation was rewritten). Hoping it works. :pray:
- Extracting out a version compare function I implemented in #1745 (thanks for the suggestion @mikaelrss, the function didn't even work correctly).
- Rewriting RepeatingGroupContext to use Zustand for the core states. This fixes a whole lot of state-keeping issues that could cause the repeating group 'add button' to disappear. I've tried adding tests for it, but wasn't able to ever reproduce it in Cypress for some reason. Still, with this rewrite it all seems to behave better.
- Renaming `AddressComponent` -> `Address`
- Slowing down the rate of requests for post places in the `Address` component (it mistakenly sent a request once for every letter the user typed). Added regression tests.
- Allowing `null` values in option lists, as per https://github.com/Altinn/app-lib-dotnet/pull/417. I also extended the data conversion function to allow for schemas with `oneOf` and `anyOf`, as it was useful in the unit-test I wrote.

## Related Issue(s)

- closes #1495

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [x] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [x] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
