### PR TITLE
Fixing some complex text resource lookups

### DIFF
--- a/src/features/language/useLanguage.test.tsx
+++ b/src/features/language/useLanguage.test.tsx
@@ -149,4 +149,41 @@ describe('useLanguage', () => {
       '<h1 class="fds-heading-heading fds-heading-large">This is my message</h1>',
     );
   });
+
+  it('langAsString() should work with complex lookups and arrays', async () => {
+    await renderWithoutInstanceAndLayout({
+      renderer: () => <TestSimple input={'complex'} />,
+      queries: {
+        fetchTextResources: async () => ({
+          language: 'nb',
+          resources: [
+            {
+              id: 'complex',
+              // This complex text resource becomes an array of string elements, and failed to render as string
+              // previously.
+              value: "Hvor mange {0} <p style='text-transform: lowercase;'>{1}<p> brukte gatekjøkkenet i {2}?",
+              variables: [
+                { key: 'firstValue', dataSource: 'applicationSettings' },
+                { key: 'secondValue', dataSource: 'applicationSettings' },
+                { key: 'thirdValue', dataSource: 'applicationSettings' },
+              ],
+            },
+          ],
+        }),
+        fetchApplicationSettings: async () => ({
+          firstValue: 'liter',
+          secondValue: 'FRITYROLJE',
+          thirdValue: '2019',
+        }),
+      },
+    });
+
+    // We don't exactly parse the HTML, but we do remove the tags.
+    expect(screen.getByTestId('as-string').innerHTML).toEqual(
+      'Hvor mange liter FRITYROLJE brukte gatekjøkkenet i 2019?',
+    );
+    expect(screen.getByTestId('as-element')).toHaveTextContent(
+      'Hvor mange liter FRITYROLJE brukte gatekjøkkenet i 2019?',
+    );
+  });
 });

--- a/src/features/language/useLanguage.ts
+++ b/src/features/language/useLanguage.ts
@@ -225,18 +225,19 @@ const getPlainTextFromNode = (node: ReactNode, langAsString: IUseLanguage['langA
   if (typeof node === 'string') {
     return node;
   }
-  if (isValidElement(node)) {
-    if (node.type === Lang) {
-      return langAsString(node.props.id, node.props.params);
-    }
+  let text = '';
+  for (const innerNode of Children.toArray(node)) {
+    if (isValidElement(innerNode)) {
+      if (innerNode.type === Lang) {
+        return langAsString(innerNode.props.id, innerNode.props.params);
+      }
 
-    let text = '';
-    Children.forEach(node.props.children, (child) => {
-      text += getPlainTextFromNode(child, langAsString);
-    });
-    return text;
+      Children.forEach(innerNode.props.children, (child) => {
+        text += getPlainTextFromNode(child, langAsString);
+      });
+    }
   }
-  return '';
+  return text;
 };
 
 export function getLanguageFromKey(key: string, language: ILanguage) {

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -240,7 +240,7 @@ export interface ITextResource {
 
 export interface IVariable {
   key: string;
-  dataSource: string;
+  dataSource: 'instanceContext' | 'applicationSettings' | 'dataModel.default' | `dataModel.${string}`;
   defaultValue?: string;
 }
 


### PR DESCRIPTION
## Description

An app used a text resource that looked something like this:
```json
{
  "id": "...",
  "value": "Hvor mange {0} <p style='text-transform: lowercase;'>{1}<p> brukte gatekjøkkenet i {2}?",
  "variables": [
    { "key": "enhet", "dataSource": "dataModel.default", "defaultValue": "liter" },
    { "key": "vare", "dataSource": "dataModel.default", "defaultValue": "FRITYROLJE" },
    { "key": "aar", "dataSource": "dataModel.default", "defaultValue": "2023" },
  ],
}
```

It failed when the react nodes are made into an array, and `langAsString()` returned empty. This should fix the problem, and adds a test for it.

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
