### PR TITLE
Make dev check not care about port

### DIFF
--- a/src/hooks/useIsDev.test.ts
+++ b/src/hooks/useIsDev.test.ts
@@ -3,8 +3,8 @@ import { useIsDev } from 'src/hooks/useIsDev';
 
 const location = window.location;
 
-function mockHostName(host: string) {
-  jest.spyOn(window, 'location', 'get').mockReturnValue({ ...location, host });
+function mockHostName(hostname: string) {
+  jest.spyOn(window, 'location', 'get').mockReturnValue({ ...location, hostname });
 }
 
 describe('useIsDev', () => {
@@ -12,48 +12,48 @@ describe('useIsDev', () => {
     jest.spyOn(window, 'location', 'get').mockRestore();
   });
 
-  it('should return true if host is local.altinn.cloud', () => {
+  it('should return true if hostname is local.altinn.cloud', () => {
     mockHostName('local.altinn.cloud');
-    expect(window.location.host).toBe('local.altinn.cloud');
+    expect(window.location.hostname).toBe('local.altinn.cloud');
     expect(useIsDev()).toBe(true);
   });
 
-  it('should return true if host is dev.altinn.studio', () => {
+  it('should return true if hostname is dev.altinn.studio', () => {
     mockHostName('dev.altinn.studio');
-    expect(window.location.host).toBe('dev.altinn.studio');
+    expect(window.location.hostname).toBe('dev.altinn.studio');
     expect(useIsDev()).toBe(true);
   });
 
-  it('should return true if host is altinn.studio', () => {
+  it('should return true if hostname is altinn.studio', () => {
     mockHostName('altinn.studio');
-    expect(window.location.host).toBe('altinn.studio');
+    expect(window.location.hostname).toBe('altinn.studio');
     expect(useIsDev()).toBe(true);
   });
 
-  it('should return true if host is studio.localhost', () => {
+  it('should return true if hostname is studio.localhost', () => {
     mockHostName('studio.localhost');
-    expect(window.location.host).toBe('studio.localhost');
+    expect(window.location.hostname).toBe('studio.localhost');
     expect(useIsDev()).toBe(true);
   });
 
-  it('should return false if host is altinn3local.no', () => {
+  it('should return false if hostname is altinn3local.no', () => {
     mockHostName('altinn3local.no');
-    expect(window.location.host).toBe('altinn3local.no');
+    expect(window.location.hostname).toBe('altinn3local.no');
     expect(useIsDev()).toBe(false);
   });
 
   orgs.forEach((org) => {
-    it(`should return true if host is ${org}.apps.tt02.altinn.no`, () => {
+    it(`should return true if hostname is ${org}.apps.tt02.altinn.no`, () => {
       mockHostName(`${org}.apps.tt02.altinn.no`);
-      expect(window.location.host).toBe(`${org}.apps.tt02.altinn.no`);
+      expect(window.location.hostname).toBe(`${org}.apps.tt02.altinn.no`);
       expect(useIsDev()).toBe(true);
     });
   });
 
   orgs.forEach((org) => {
-    it(`should return false if host is ${org}.apps.altinn.no`, () => {
+    it(`should return false if hostname is ${org}.apps.altinn.no`, () => {
       mockHostName(`${org}.apps.altinn.no`);
-      expect(window.location.host).toBe(`${org}.apps.altinn.no`);
+      expect(window.location.hostname).toBe(`${org}.apps.altinn.no`);
       expect(useIsDev()).toBe(false);
     });
   });

--- a/src/hooks/useIsDev.ts
+++ b/src/hooks/useIsDev.ts
@@ -7,5 +7,5 @@ const devHostNames = [
 ];
 
 export function useIsDev(): boolean {
-  return devHostNames.some((host) => host.test(window.location.host));
+  return devHostNames.some((host) => host.test(window.location.hostname));
 }


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

Running localtest in podman means I cannot use port 80, so the `host` becomes `local.altinn.cloud:port`, but `hostname` remains as `local.altinn.cloud` so I think switching to check the `hostname` instead is better. Otherwise I will not see errors on components and the dev tools button is hidden when using podman.