### PR TITLE
Showing the current git branch in LocalTest when picking a frontend version

### DIFF
--- a/webpack.config.development.js
+++ b/webpack.config.development.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 const env = require('dotenv').config().parsed ?? {};
 const path = require('path');
+const fs = require('fs');
 
 const ForkTsCheckerNotifierWebpackPlugin = require('fork-ts-checker-notifier-webpack-plugin');
 const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
@@ -28,6 +29,16 @@ console.log('WEBPACK_SILENT =', !enableNotifier);
 console.log('WEBPACK_SOURCE_MAPS =', enableSourceMaps);
 console.log('WEBPACK_MINIFY =', enableMinify);
 console.log('====================================');
+
+// Find the git current branch name from .git/HEAD. This is used in LocalTest to show you the current branch name.
+// We can't just read this when starting, as you may want to switch branch while the dev server is running. This
+// will be called every time you refresh/reload the dev server.
+const branchName = {
+  toString() {
+    const hasGitFolder = fs.existsSync('.git');
+    return hasGitFolder ? fs.readFileSync('.git/HEAD', 'utf-8').trim().split('/').pop() : 'unknown-branch';
+  },
+};
 
 module.exports = {
   ...common,
@@ -71,7 +82,10 @@ module.exports = {
     historyApiFallback: true,
     allowedHosts: 'all',
     hot: true,
-    headers: { 'Access-Control-Allow-Origin': '*' },
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'X-Altinn-Frontend-Branch': branchName,
+    },
     client: {
       overlay: {
         errors: true,


### PR DESCRIPTION
## Description
This makes the dev server return a header that indicates the current branch you're developing on. Which in turn should soon make the branch visible in the 'pick frontend version' selector in LocalTest.

## Related Issue(s)

- https://github.com/Altinn/app-localtest/pull/74

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [x] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
