### PR TITLE
Make sure buttons are not visible in PDF

### DIFF
--- a/src/components/form/HelpTextContainer.module.css
+++ b/src/components/form/HelpTextContainer.module.css
@@ -1,3 +1,9 @@
 .helpTextContainer {
   padding: 2px 4px;
 }
+
+@media print {
+  .helpTextContainer {
+    display: none;
+  }
+}

--- a/src/features/pdf/PDFView.module.css
+++ b/src/features/pdf/PDFView.module.css
@@ -1,3 +1,13 @@
+.pdf-wrapper {
+  /* Hide interactive elements from PDF
+   * This makes testing easier as cypress does not support rendering in @media print mode
+   * @see https://github.com/cypress-io/cypress/issues/790
+   */
+  button,
+  [role='button'] {
+    display: none !important;
+  }
+}
 .pdf-wrapper h1 {
   margin-top: 0;
 }

--- a/src/features/pdf/PDFView.module.css
+++ b/src/features/pdf/PDFView.module.css
@@ -3,8 +3,8 @@
    * This makes testing easier as cypress does not support rendering in @media print mode
    * @see https://github.com/cypress-io/cypress/issues/790
    */
-  button,
-  [role='button'] {
+  & button,
+  & [role='button'] {
     display: none !important;
   }
 }

--- a/src/features/pdf/PDFView.tsx
+++ b/src/features/pdf/PDFView.tsx
@@ -9,22 +9,10 @@ import { usePdfPage } from 'src/hooks/usePdfPage';
 import { CompCategory } from 'src/layout/common';
 import { GenericComponent } from 'src/layout/GenericComponent';
 import { GroupComponent } from 'src/layout/Group/GroupComponent';
-import { LargeLikertSummaryContainer } from 'src/layout/Likert/Summary/LargeLikertSummaryContainer';
-import { LargeGroupSummaryContainer } from 'src/layout/RepeatingGroup/Summary/LargeGroupSummaryContainer';
 import { SummaryComponent } from 'src/layout/Summary/SummaryComponent';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 const PDFComponent = ({ node }: { node: LayoutNode }) => {
-  const commonProps = <T extends LayoutNode>(node: T) => ({
-    groupNode: node,
-    renderLayoutNode: (child: LayoutNode) => (
-      <PDFComponent
-        key={child.item.id}
-        node={child}
-      />
-    ),
-  });
-
   if (node.isType('Summary') || ('renderAsSummary' in node.item && node.item.renderAsSummary)) {
     return (
       <SummaryComponent
@@ -36,11 +24,18 @@ const PDFComponent = ({ node }: { node: LayoutNode }) => {
       />
     );
   } else if (node.isType('Group')) {
-    return <GroupComponent {...commonProps(node)} />;
-  } else if (node.isType('RepeatingGroup')) {
-    return <LargeGroupSummaryContainer {...commonProps(node)} />;
-  } else if (node.isType('Likert')) {
-    return <LargeLikertSummaryContainer {...commonProps(node)} />;
+    // Support grouping of summary components
+    return (
+      <GroupComponent
+        groupNode={node}
+        renderLayoutNode={(child: LayoutNode) => (
+          <PDFComponent
+            key={child.item.id}
+            node={child}
+          />
+        )}
+      />
+    );
   } else if (node.isCategory(CompCategory.Presentation)) {
     return (
       <GenericComponent

--- a/src/layout/Grid/GridSummaryComponent.tsx
+++ b/src/layout/Grid/GridSummaryComponent.tsx
@@ -4,7 +4,11 @@ import { nodesFromGrid } from 'src/layout/Grid/tools';
 import { SummaryComponent } from 'src/layout/Summary/SummaryComponent';
 import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 
-export function GridSummaryComponent({ targetNode, summaryNode }: SummaryRendererProps<'Grid'>): JSX.Element | null {
+export function GridSummaryComponent({
+  targetNode,
+  summaryNode,
+  overrides,
+}: SummaryRendererProps<'Grid'>): JSX.Element | null {
   const nodes = nodesFromGrid(targetNode).filter((node) => 'renderSummary' in node.def);
 
   return (
@@ -15,8 +19,10 @@ export function GridSummaryComponent({ targetNode, summaryNode }: SummaryRendere
           summaryNode={summaryNode}
           overrides={{
             targetNode: node,
+            ...overrides,
             display: {
               hideBottomBorder: idx === nodes.length - 1,
+              ...overrides?.display,
             },
           }}
         />

--- a/src/layout/Group/__snapshots__/SummaryGroupComponent.test.tsx.snap
+++ b/src/layout/Group/__snapshots__/SummaryGroupComponent.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`SummaryGroupComponent SummaryGroupComponent -- should match snapshot 1`
       </span>
       <button
         aria-label="Change: Mock group"
-        class="fds-button-button fds-utility-focusable fds-button-small fds-button-tertiary fds-button-second"
+        class="fds-button-button fds-utility-focusable fds-button-small fds-button-tertiary fds-button-second editButton"
         type="button"
       >
         Change

--- a/src/layout/RepeatingGroup/Summary/__snapshots__/SummaryRepeatingGroup.test.tsx.snap
+++ b/src/layout/RepeatingGroup/Summary/__snapshots__/SummaryRepeatingGroup.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`SummaryGroupComponent SummaryGroupComponent -- should match snapshot 1`
       </span>
       <button
         aria-label="Change: Mock group"
-        class="fds-button-button fds-utility-focusable fds-button-small fds-button-tertiary fds-button-second"
+        class="fds-button-button fds-utility-focusable fds-button-small fds-button-tertiary fds-button-second editButton"
         type="button"
       >
         Change

--- a/src/layout/Summary/EditButton.module.css
+++ b/src/layout/Summary/EditButton.module.css
@@ -1,0 +1,5 @@
+@media print {
+  .editButton {
+    display: none;
+  }
+}

--- a/src/layout/Summary/EditButton.tsx
+++ b/src/layout/Summary/EditButton.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 import { Button } from '@digdir/design-system-react';
 import { Edit } from '@navikt/ds-icons';
 
+import classes from 'src/layout/Summary/EditButton.module.css';
+
 export interface IEditButtonProps {
   onClick: () => void;
   editText: string | null;
@@ -12,6 +14,7 @@ export interface IEditButtonProps {
 export function EditButton(props: IEditButtonProps) {
   return (
     <Button
+      className={classes.editButton}
       variant='tertiary'
       color='second'
       size='small'

--- a/test/e2e/support/custom.ts
+++ b/test/e2e/support/custom.ts
@@ -459,6 +459,7 @@ Cypress.Commands.add('getSummary', (label) => {
   cy.get(`[data-testid^=summary-]:has(span:contains(${label}))`);
 });
 
+const DEFAULT_COMMAND_TIMEOUT = Cypress.config().defaultCommandTimeout;
 Cypress.Commands.add('testPdf', (callback, returnToForm = false) => {
   cy.log('Testing PDF');
 
@@ -489,9 +490,17 @@ Cypress.Commands.add('testPdf', (callback, returnToForm = false) => {
   // Wait for readyForPrint, after this everything should be rendered so using timeout: 0
   cy.get('#pdfView > #readyForPrint')
     .should('exist')
-    .then({ timeout: 0 }, () => {
+    .then(() => {
+      Cypress.config('defaultCommandTimeout', 0);
+
+      // Verify that generic elements that should be hidden are not present
+      cy.findAllByRole('button').should('not.exist');
       // Run tests from callback
       callback();
+
+      cy.then(() => {
+        Cypress.config('defaultCommandTimeout', DEFAULT_COMMAND_TIMEOUT);
+      });
     });
 
   if (returnToForm) {


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

- Made Grid summary respect overrides
- Make helptext and edit buttons invisible in `@media print`
- Hide all buttons in pdfView (mostly for cypress, since print emulation is not possible without chrome-specific hacks)
- Command-timeout in PDF-tests were broken, fixed
- Cleaned up `PDFComponent`

## Related Issue(s)

- closes #1773 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
