### PR TITLE
Bugfix: Multiple issues with `openByDefault`

### DIFF
--- a/src/core/contexts/zustandContext.tsx
+++ b/src/core/contexts/zustandContext.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import type { PropsWithChildren } from 'react';
 
 import deepEqual from 'fast-deep-equal';
@@ -55,13 +55,16 @@ export function createZustandContext<Store extends StoreApi<Type>, Type = Extrac
 
   function MyProvider({ children, ...props }: PropsWithChildren<Props>) {
     const storeRef = useRef<Store>();
-    if (storeRef.current) {
-      if (onReRender) {
-        onReRender(storeRef.current, props as Props);
-      }
-    } else {
+    if (!storeRef.current) {
       storeRef.current = initialCreateStore(props as Props);
     }
+
+    useEffect(() => {
+      if (onReRender && storeRef.current) {
+        onReRender(storeRef.current, props as Props);
+      }
+    });
+
     return <Provider value={storeRef.current}>{children}</Provider>;
   }
 

--- a/src/features/validation/backend/useBackendValidation.ts
+++ b/src/features/validation/backend/useBackendValidation.ts
@@ -12,6 +12,7 @@ import { mapValidationIssueToFieldValidation } from 'src/features/validation/bac
 interface RetVal {
   validations: BackendValidations;
   processedLast: BackendValidationIssueGroups | undefined;
+  initialValidationDone: boolean;
 }
 
 export function useBackendValidation(fromLastSave: BackendValidationIssueGroups | undefined): RetVal {
@@ -71,6 +72,7 @@ export function useBackendValidation(fromLastSave: BackendValidationIssueGroups 
     return {
       validations: backendValidations,
       processedLast: fromLastSave,
+      initialValidationDone: initialValidations !== undefined,
     };
   }, [fromLastSave, initialValidations]);
 }

--- a/src/layout/RepeatingGroup/OpenByDefaultProvider.test.tsx
+++ b/src/layout/RepeatingGroup/OpenByDefaultProvider.test.tsx
@@ -1,0 +1,336 @@
+import React from 'react';
+
+import { screen, waitFor } from '@testing-library/react';
+
+import { FD } from 'src/features/formData/FormDataWrite';
+import { RepeatingGroupProvider, useRepeatingGroupSelector } from 'src/layout/RepeatingGroup/RepeatingGroupContext';
+import { renderWithNode } from 'src/test/renderWithProviders';
+import type { JsonPatch } from 'src/features/formData/jsonPatch/types';
+import type { ILayout } from 'src/layout/layout';
+import type {
+  CompRepeatingGroupExternal,
+  CompRepeatingGroupInternal,
+} from 'src/layout/RepeatingGroup/config.generated';
+import type { BaseLayoutNode } from 'src/utils/layout/LayoutNode';
+
+describe('openByDefault', () => {
+  function RenderTest() {
+    const state = useRepeatingGroupSelector((state) => ({
+      editingIndex: state.editingIndex,
+      currentlyAddingRow: state.currentlyAddingRow !== undefined,
+      visibleRowIndexes: state.visibleRowIndexes.sort(),
+      hiddenRowIndexes: [...state.hiddenRowIndexes.values()].sort(),
+    }));
+
+    const data = FD.useDebouncedPick('MyGroup');
+    return (
+      <div data-testid='state'>
+        {JSON.stringify({
+          ...state,
+          data,
+        })}
+      </div>
+    );
+  }
+
+  interface Row {
+    id: string;
+    name: string;
+  }
+
+  interface Props {
+    existingRows?: Row[];
+    edit?: Partial<CompRepeatingGroupExternal['edit']>;
+    hiddenRow?: CompRepeatingGroupExternal['hiddenRow'];
+  }
+
+  function render({ existingRows, edit, hiddenRow }: Props) {
+    const layout: ILayout = [
+      {
+        id: 'myGroup',
+        type: 'RepeatingGroup',
+        dataModelBindings: {
+          group: 'MyGroup',
+        },
+        children: ['name'],
+        edit: {
+          ...edit,
+        },
+        hiddenRow,
+      },
+      {
+        id: 'name',
+        type: 'Input',
+        dataModelBindings: {
+          simpleBinding: 'MyGroup.name',
+        },
+      },
+    ];
+
+    return renderWithNode<true, BaseLayoutNode<CompRepeatingGroupInternal>>({
+      renderer: ({ node }) => (
+        <RepeatingGroupProvider node={node}>
+          <RenderTest />
+        </RepeatingGroupProvider>
+      ),
+      nodeId: 'myGroup',
+      inInstance: true,
+      queries: {
+        fetchFormData: async () => ({
+          MyGroup: existingRows ?? [],
+        }),
+        fetchLayouts: async () => ({
+          FormLayout: {
+            data: { layout },
+          },
+        }),
+      },
+    });
+  }
+
+  function getState() {
+    const json = screen.getByTestId('state').textContent;
+    return JSON.parse(json!);
+  }
+
+  interface WaitForStateProps {
+    state: any;
+    mutations?: Awaited<ReturnType<typeof render>>['mutations'];
+    expectedPatch?: JsonPatch[];
+    newModelAfterSave?: any;
+  }
+
+  async function waitUntil({ state, mutations, expectedPatch, newModelAfterSave }: WaitForStateProps) {
+    await waitFor(() => expect(getState()).toEqual(state));
+
+    if (newModelAfterSave && mutations) {
+      expect(mutations.doPatchFormData.mock).toHaveBeenCalledTimes(1);
+      expect(mutations.doPatchFormData.mock).toHaveBeenCalledWith(
+        expect.anything(),
+        expectedPatch ? expect.objectContaining({ patch: expectedPatch }) : expect.anything(),
+      );
+      mutations.doPatchFormData.resolve({
+        validationIssues: {},
+        newDataModel: newModelAfterSave,
+      });
+      (mutations.doPatchFormData.mock as jest.Mock).mockClear();
+    }
+
+    // Because this typically happens in a loop, we need to wait a little more and check again to make sure
+    // the state doesn't change again.
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(getState()).toEqual(state);
+  }
+
+  beforeAll(() => {
+    jest.spyOn(window, 'logWarn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should not add a new row by default when off', async () => {
+    await render({
+      existingRows: [],
+      edit: { openByDefault: false },
+    });
+
+    await waitUntil({
+      state: {
+        editingIndex: undefined,
+        currentlyAddingRow: false,
+        visibleRowIndexes: [],
+        hiddenRowIndexes: [],
+        data: [],
+      },
+    });
+  });
+
+  it('should add one new row by default when on', async () => {
+    await render({
+      existingRows: [],
+      edit: { openByDefault: true },
+    });
+
+    await waitUntil({
+      state: {
+        editingIndex: 0,
+        currentlyAddingRow: false,
+        visibleRowIndexes: [0],
+        hiddenRowIndexes: [],
+        data: [{}],
+      },
+    });
+  });
+
+  it('should not add a new row if one already exists', async () => {
+    await render({
+      existingRows: [{ id: '1', name: 'test' }],
+      edit: { openByDefault: true },
+    });
+
+    await waitUntil({
+      state: {
+        editingIndex: undefined,
+        currentlyAddingRow: false,
+        visibleRowIndexes: [0],
+        hiddenRowIndexes: [],
+        data: [{ id: '1', name: 'test' }],
+      },
+    });
+  });
+
+  it.each(['first', 'last'] as const)(
+    'should open the row if one exist and openByDefault is %s',
+    async (openByDefault) => {
+      await render({
+        existingRows: [{ id: '1', name: 'test' }],
+        edit: { openByDefault },
+      });
+
+      await waitUntil({
+        state: {
+          editingIndex: 0,
+          currentlyAddingRow: false,
+          visibleRowIndexes: [0],
+          hiddenRowIndexes: [],
+          data: [{ id: '1', name: 'test' }],
+        },
+      });
+    },
+  );
+
+  it.each(['first', 'last'] as const)(
+    'should add the first row if none exists and openByDefault is %s',
+    async (openByDefault) => {
+      await render({
+        existingRows: [],
+        edit: { openByDefault },
+      });
+
+      await waitUntil({
+        state: {
+          editingIndex: 0,
+          currentlyAddingRow: false,
+          visibleRowIndexes: [0],
+          hiddenRowIndexes: [],
+          data: [{}],
+        },
+      });
+    },
+  );
+
+  it.each(['first', 'last'] as const)(
+    'should not add a new row if one already exists and openByDefault is %s',
+    async (openByDefault) => {
+      await render({
+        existingRows: [{ id: '1', name: 'test' }],
+        edit: { openByDefault },
+      });
+
+      await waitUntil({
+        state: {
+          editingIndex: 0,
+          currentlyAddingRow: false,
+          visibleRowIndexes: [0],
+          hiddenRowIndexes: [],
+          data: [{ id: '1', name: 'test' }],
+        },
+      });
+    },
+  );
+
+  it.each(['first', 'last'] as const)(
+    'should open the correct row if multiple exist and openByDefault is %s',
+    async (openByDefault) => {
+      await render({
+        existingRows: [
+          { id: '1', name: 'test' },
+          { id: '2', name: 'test' },
+        ],
+        edit: { openByDefault },
+      });
+
+      await waitUntil({
+        state: {
+          editingIndex: openByDefault === 'last' ? 1 : 0,
+          currentlyAddingRow: false,
+          visibleRowIndexes: [0, 1],
+          hiddenRowIndexes: [],
+          data: [
+            { id: '1', name: 'test' },
+            { id: '2', name: 'test' },
+          ],
+        },
+      });
+    },
+  );
+
+  it.each(['first', 'last', true] as const)(
+    'should add a new row if one already exists but is hidden, and openByDefault is %s',
+    async (openByDefault) => {
+      await render({
+        existingRows: [{ id: '1', name: 'test' }],
+        edit: { openByDefault },
+        hiddenRow: ['equals', ['dataModel', 'MyGroup.name'], 'test'],
+      });
+
+      await waitUntil({
+        state: {
+          editingIndex: 1,
+          currentlyAddingRow: false,
+          visibleRowIndexes: [1],
+          hiddenRowIndexes: [0],
+          data: [{ id: '1', name: 'test' }, {}],
+        },
+      });
+    },
+  );
+
+  it.each(['first', 'last', true] as const)(
+    'should only attempt to add one new row if new rows keep getting hidden, and openByDefault is %s',
+    async (openByDefault) => {
+      await render({
+        existingRows: [{ id: '1', name: 'test' }],
+        edit: { openByDefault },
+        hiddenRow: true,
+      });
+
+      // This should fail, because the new row we add is hidden. It's too late when we've already added it, so we
+      // can't do anything about it, but a warning is logged.
+      await waitUntil({
+        state: {
+          editingIndex: undefined,
+          currentlyAddingRow: false,
+          visibleRowIndexes: [],
+          hiddenRowIndexes: [0, 1],
+          data: [{ id: '1', name: 'test' }, {}],
+        },
+      });
+
+      expect(window.logWarn).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it('should not add rows if not allowed to', async () => {
+    await render({
+      existingRows: [],
+      edit: { openByDefault: true, addButton: false },
+    });
+
+    await waitUntil({
+      state: {
+        editingIndex: undefined,
+        currentlyAddingRow: false,
+        visibleRowIndexes: [],
+        hiddenRowIndexes: [],
+        data: [],
+      },
+    });
+  });
+});

--- a/src/layout/RepeatingGroup/OpenByDefaultProvider.tsx
+++ b/src/layout/RepeatingGroup/OpenByDefaultProvider.tsx
@@ -1,0 +1,54 @@
+import React, { useEffect, useRef } from 'react';
+import type { PropsWithChildren } from 'react';
+
+import { useRepeatingGroup, useRepeatingGroupSelector } from 'src/layout/RepeatingGroup/RepeatingGroupContext';
+import type { CompRepeatingGroupInternal } from 'src/layout/RepeatingGroup/config.generated';
+import type { BaseLayoutNode } from 'src/utils/layout/LayoutNode';
+
+interface Props {
+  node: BaseLayoutNode<CompRepeatingGroupInternal>;
+}
+
+export function OpenByDefaultProvider({ node, children }: PropsWithChildren<Props>) {
+  const openByDefault = node.item.edit?.openByDefault;
+  const { addRow, openForEditing } = useRepeatingGroup();
+  const { editingIndex, isFirstRender, visibleRowIndexes } = useRepeatingGroupSelector((state) => ({
+    editingIndex: state.editingIndex,
+    isFirstRender: state.isFirstRender,
+    visibleRowIndexes: state.visibleRowIndexes,
+  }));
+
+  const numRows = visibleRowIndexes.length;
+  const firstIndex = visibleRowIndexes[0];
+  const lastIndex = visibleRowIndexes[numRows - 1];
+
+  // Making sure we don't add a row while we're already adding one
+  const working = useRef(false);
+
+  // Add new row if openByDefault is true and no rows exist. This also makes sure to add a row immediately after the
+  // last one has been deleted.
+  useEffect((): void => {
+    if (openByDefault && numRows === 0 && !working.current) {
+      working.current = true;
+      addRow().then(() => {
+        working.current = false;
+      });
+    }
+  }, [node, addRow, openByDefault, numRows]);
+
+  // Open the first or last row for editing, if openByDefault is set to 'first' or 'last'
+  useEffect((): void => {
+    if (
+      isFirstRender &&
+      openByDefault &&
+      typeof openByDefault === 'string' &&
+      ['first', 'last'].includes(openByDefault) &&
+      editingIndex === undefined
+    ) {
+      const index = openByDefault === 'last' ? lastIndex : firstIndex;
+      openForEditing(index);
+    }
+  }, [openByDefault, editingIndex, isFirstRender, firstIndex, lastIndex, openForEditing]);
+
+  return <>{children}</>;
+}

--- a/src/layout/RepeatingGroup/OpenByDefaultProvider.tsx
+++ b/src/layout/RepeatingGroup/OpenByDefaultProvider.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 import type { PropsWithChildren } from 'react';
 
+import { useAsRef } from 'src/hooks/useAsRef';
 import { useRepeatingGroup, useRepeatingGroupSelector } from 'src/layout/RepeatingGroup/RepeatingGroupContext';
 import type { CompRepeatingGroupInternal } from 'src/layout/RepeatingGroup/config.generated';
 import type { BaseLayoutNode } from 'src/utils/layout/LayoutNode';
@@ -10,34 +11,55 @@ interface Props {
 }
 
 export function OpenByDefaultProvider({ node, children }: PropsWithChildren<Props>) {
+  const groupId = node.item.id;
   const openByDefault = node.item.edit?.openByDefault;
   const { addRow, openForEditing } = useRepeatingGroup();
-  const { editingIndex, isFirstRender, visibleRowIndexes } = useRepeatingGroupSelector((state) => ({
+  const state = useRepeatingGroupSelector((state) => ({
     editingIndex: state.editingIndex,
     isFirstRender: state.isFirstRender,
     visibleRowIndexes: state.visibleRowIndexes,
+    hiddenRowIndexes: state.hiddenRowIndexes,
+    addingIndexes: state.addingIndexes,
   }));
 
-  const numRows = visibleRowIndexes.length;
-  const firstIndex = visibleRowIndexes[0];
-  const lastIndex = visibleRowIndexes[numRows - 1];
+  const stateRef = useAsRef({
+    ...state,
+    numRows: state.visibleRowIndexes.length,
+    firstIndex: state.visibleRowIndexes[0],
+    lastIndex: state.visibleRowIndexes[state.visibleRowIndexes.length - 1],
+    addRow,
+    openForEditing,
+    canAddRows: node.item.edit?.addButton ?? true,
+  });
 
-  // Making sure we don't add a row while we're already adding one
-  const working = useRef(false);
+  // When this is true, the group won't try to add more rows using openByDefault
+  const disabled = useRef(false);
 
-  // Add new row if openByDefault is true and no rows exist. This also makes sure to add a row immediately after the
-  // last one has been deleted.
+  // Add new row if openByDefault is true and no (visible) rows exist. This also makes sure to add a row
+  // immediately after the last one has been deleted.
   useEffect((): void => {
-    if (openByDefault && numRows === 0 && !working.current) {
-      working.current = true;
-      addRow().then(() => {
-        working.current = false;
-      });
-    }
-  }, [node, addRow, openByDefault, numRows]);
+    (async () => {
+      const { numRows, canAddRows } = stateRef.current;
+      if (openByDefault && numRows === 0 && canAddRows && !disabled.current) {
+        const { result } = await addRow();
+        if (result !== 'addedAndOpened') {
+          disabled.current = true;
+          window.logWarn(
+            `openByDefault for repeating group '${groupId}' returned '${result}'. You may have rules that make it ` +
+              `impossible to add a new blank row, or open the added row for editing, such as a restrictive ` +
+              `hiddenRow expression. You probably want to disable openByDefault for this group, as openByDefault ` +
+              `might create empty and invisible rows before it will disable itself. openByDefault will be disabled ` +
+              'temporarily for this group.',
+          );
+        }
+      }
+    })();
+  }, [openByDefault, stateRef, addRow, groupId]);
 
   // Open the first or last row for editing, if openByDefault is set to 'first' or 'last'
+  const isFirstRender = state.isFirstRender;
   useEffect((): void => {
+    const { editingIndex, firstIndex, lastIndex, openForEditing } = stateRef.current;
     if (
       isFirstRender &&
       openByDefault &&
@@ -48,7 +70,7 @@ export function OpenByDefaultProvider({ node, children }: PropsWithChildren<Prop
       const index = openByDefault === 'last' ? lastIndex : firstIndex;
       openForEditing(index);
     }
-  }, [openByDefault, editingIndex, isFirstRender, firstIndex, lastIndex, openForEditing]);
+  }, [openByDefault, isFirstRender, stateRef]);
 
   return <>{children}</>;
 }

--- a/src/layout/RepeatingGroup/RepeatingGroupContainer.tsx
+++ b/src/layout/RepeatingGroup/RepeatingGroupContainer.tsx
@@ -116,7 +116,7 @@ function AddButton() {
       editingNone: state.editingNone,
       editingIndex: state.editingIndex,
       visibleRowIndexes: state.visibleRowIndexes,
-      currentlyAddingRow: state.currentlyAddingRow !== undefined,
+      currentlyAddingRow: state.addingIndexes.length > 0,
     }),
   );
   const isEditingAnyRow = editingIndex !== undefined;

--- a/src/layout/RepeatingGroup/RepeatingGroupContainer.tsx
+++ b/src/layout/RepeatingGroup/RepeatingGroupContainer.tsx
@@ -24,11 +24,9 @@ interface RepeatingGroupContainerProps {
 }
 
 export function RepeatingGroupContainer({ containerDivRef }: RepeatingGroupContainerProps): JSX.Element | null {
-  const { node } = useRepeatingGroup();
-  const { editingIndex, visibleRowIndexes } = useRepeatingGroupSelector((state) => ({
+  const { node, visibleRowIndexes } = useRepeatingGroup();
+  const { editingIndex } = useRepeatingGroupSelector((state) => ({
     editingIndex: state.editingIndex,
-    isFirstRender: state.isFirstRender,
-    visibleRowIndexes: state.visibleRowIndexes,
   }));
   const isEditingAnyRow = editingIndex !== undefined;
 
@@ -109,16 +107,13 @@ export function RepeatingGroupContainer({ containerDivRef }: RepeatingGroupConta
 function AddButton() {
   const { lang, langAsString } = useLanguage();
   const { triggerFocus } = useRepeatingGroupsFocusContext();
-  const { node, addRow } = useRepeatingGroup();
-  const { editingAll, editingNone, editingIndex, visibleRowIndexes, currentlyAddingRow } = useRepeatingGroupSelector(
-    (state) => ({
-      editingAll: state.editingAll,
-      editingNone: state.editingNone,
-      editingIndex: state.editingIndex,
-      visibleRowIndexes: state.visibleRowIndexes,
-      currentlyAddingRow: state.addingIndexes.length > 0,
-    }),
-  );
+  const { node, addRow, visibleRowIndexes } = useRepeatingGroup();
+  const { editingAll, editingNone, editingIndex, currentlyAddingRow } = useRepeatingGroupSelector((state) => ({
+    editingAll: state.editingAll,
+    editingNone: state.editingNone,
+    editingIndex: state.editingIndex,
+    currentlyAddingRow: state.addingIndexes.length > 0,
+  }));
   const isEditingAnyRow = editingIndex !== undefined;
 
   const { textResourceBindings, id, edit } = node.item;

--- a/src/layout/RepeatingGroup/RepeatingGroupContext.tsx
+++ b/src/layout/RepeatingGroup/RepeatingGroupContext.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useState } from 'react';
 import type { PropsWithChildren } from 'react';
 
 import { createStore } from 'zustand';
@@ -18,31 +18,24 @@ import type { BaseLayoutNode } from 'src/utils/layout/LayoutNode';
 interface Store {
   editingAll: boolean;
   editingNone: boolean;
-  binding: string;
-
-  // If this is true, we're rendering the group for the first time in this context. This is used to
-  // determine whether we should open the first/last row for editing when first displaying the group. If, however,
-  // we run that effect every time the group is re-rendered, the user would be unable to close the row for editing.
-  isFirstRender: boolean;
-
-  visibleRowIndexes: number[];
-  hiddenRowIndexes: Set<number>;
-
   editingIndex: number | undefined;
-  editableRowIndexes: number[];
-  deletableRowIndexes: number[];
   deletingIndexes: number[];
   addingIndexes: number[];
 }
 
 interface ZustandHiddenMethods {
-  updateNode: (n: BaseLayoutNode<CompRepeatingGroupInternal>) => void;
   startAddingRow: (idx: number) => void;
+  endAddingRow: (idx: number) => void;
   startDeletingRow: (idx: number) => void;
   endDeletingRow: (idx: number, successful: boolean) => void;
 }
 
-interface ExtendedMethods {
+interface ExtendedState {
+  // If this is true, we're rendering the group for the first time in this context. This is used to
+  // determine whether we should open the first/last row for editing when first displaying the group. If, however,
+  // we run that effect every time the group is re-rendered, the user would be unable to close the row for editing.
+  isFirstRender: boolean;
+
   // Methods for getting/setting state about which rows are in edit mode
   toggleEditing: (index: number) => void;
   openForEditing: (index: number) => void;
@@ -55,23 +48,20 @@ type AddRowResult =
   | { result: 'stoppedByValidation'; index: undefined }
   | { result: 'addedAndOpened' | 'addedAndHidden'; index: number };
 
-interface ContextMethods extends ExtendedMethods {
+interface ContextMethods extends ExtendedState {
   addRow: () => Promise<AddRowResult>;
   deleteRow: (index: number) => Promise<boolean>;
   isEditing: (index: number) => boolean;
   isDeleting: (index: number) => boolean;
 }
 
-type ZustandState = Store & ZustandHiddenMethods & Omit<ExtendedMethods, 'toggleEditing'>;
-type ExtendedContext = ContextMethods & Props;
+type ZustandState = Store & ZustandHiddenMethods & Omit<ExtendedState, 'toggleEditing'>;
+type ExtendedContext = ContextMethods & Props & NodeState;
 
 const ZStore = createZustandContext({
   name: 'RepeatingGroupZ',
   required: true,
   initialCreateStore: newStore,
-  onReRender: (store, { node }) => {
-    store.getState().updateNode(node);
-  },
 });
 
 const ExtendedStore = createContext<ExtendedContext>({
@@ -79,156 +69,153 @@ const ExtendedStore = createContext<ExtendedContext>({
   required: true,
 });
 
-function newStore({ node }: Props) {
-  return createStore<ZustandState>((set) => {
-    function produceRowIndexes(n: BaseLayoutNode<CompRepeatingGroupInternal>) {
-      const hidden: number[] = [];
-      const visible: number[] = [];
-      const editable: number[] = [];
-      const deletable: number[] = [];
-      for (const row of n.item.rows) {
-        if (row.groupExpressions?.hiddenRow) {
-          hidden.push(row.index);
-        } else {
-          visible.push(row.index);
+interface NodeState {
+  numVisibleRows: number;
+  visibleRowIndexes: number[];
+  hiddenRowIndexes: Set<number>;
+  editableRowIndexes: number[];
+  deletableRowIndexes: number[];
+}
 
-          // Only the visible rows can be edited or deleted
-          if (row.groupExpressions?.edit?.editButton !== false) {
-            editable.push(row.index);
-          }
-          if (row.groupExpressions?.edit?.deleteButton !== false) {
-            deletable.push(row.index);
-          }
-        }
+function produceStateFromNode(node: BaseLayoutNode<CompRepeatingGroupInternal>): NodeState {
+  const hidden: number[] = [];
+  const visible: number[] = [];
+  const editable: number[] = [];
+  const deletable: number[] = [];
+  for (const row of node.item.rows) {
+    if (row.groupExpressions?.hiddenRow) {
+      hidden.push(row.index);
+    } else {
+      visible.push(row.index);
+
+      // Only the visible rows can be edited or deleted
+      if (row.groupExpressions?.edit?.editButton !== false) {
+        editable.push(row.index);
       }
-
-      return [visible, new Set(hidden), editable, deletable] as const;
+      if (row.groupExpressions?.edit?.deleteButton !== false) {
+        deletable.push(row.index);
+      }
     }
+  }
 
-    const [visibleRowIndexes, hiddenRowIndexes, editableRowIndexes, deletableRowIndexes] = produceRowIndexes(node);
+  visible.sort();
+  hidden.sort();
+  editable.sort();
+  deletable.sort();
 
-    return {
-      editingAll: node.item.edit?.mode === 'showAll',
-      editingNone: node.item.edit?.mode === 'onlyTable',
-      binding: node.item.dataModelBindings.group,
-      isFirstRender: true,
-      editingIndex: undefined,
-      numVisibleRows: visibleRowIndexes.length,
-      deletingIndexes: [],
-      addingIndexes: [],
+  return {
+    numVisibleRows: visible.length,
+    visibleRowIndexes: visible,
+    hiddenRowIndexes: new Set(hidden),
+    editableRowIndexes: editable,
+    deletableRowIndexes: deletable,
+  };
+}
 
-      visibleRowIndexes,
-      hiddenRowIndexes,
-      editableRowIndexes,
-      deletableRowIndexes,
+interface NewStoreProps {
+  nodeRef: React.MutableRefObject<BaseLayoutNode<CompRepeatingGroupInternal>>;
+}
 
-      closeForEditing: (idx) => {
-        set((state) => {
-          if (state.editingIndex === idx) {
-            return { editingIndex: undefined };
-          }
+function newStore({ nodeRef }: NewStoreProps) {
+  return createStore<ZustandState>((set) => ({
+    editingAll: nodeRef.current.item.edit?.mode === 'showAll',
+    editingNone: nodeRef.current.item.edit?.mode === 'onlyTable',
+    isFirstRender: true,
+    editingIndex: undefined,
+    deletingIndexes: [],
+    addingIndexes: [],
+
+    closeForEditing: (idx) => {
+      set((state) => {
+        if (state.editingIndex === idx) {
+          return { editingIndex: undefined };
+        }
+        return state;
+      });
+    },
+
+    openForEditing: (idx) => {
+      set((state) => {
+        if (state.editingIndex === idx || state.editingAll || state.editingNone) {
           return state;
-        });
-      },
+        }
+        const { editableRowIndexes } = produceStateFromNode(nodeRef.current);
+        if (!editableRowIndexes.includes(idx)) {
+          return state;
+        }
+        return { editingIndex: idx };
+      });
+    },
 
-      openForEditing: (idx) => {
-        set((state) => {
-          if (state.editingIndex === idx || state.editingAll || state.editingNone) {
-            return state;
-          }
-          if (!state.editableRowIndexes.includes(idx)) {
-            return state;
-          }
-          return { editingIndex: idx };
-        });
-      },
+    openNextForEditing: () => {
+      set((state) => {
+        if (state.editingAll || state.editingNone) {
+          return state;
+        }
+        const { editableRowIndexes } = produceStateFromNode(nodeRef.current);
+        if (state.editingIndex === undefined) {
+          return { editingIndex: editableRowIndexes[0] };
+        }
+        const isLast = state.editingIndex === editableRowIndexes[editableRowIndexes.length - 1];
+        if (isLast) {
+          return { editingIndex: undefined };
+        }
+        return { editingIndex: editableRowIndexes[editableRowIndexes.indexOf(state.editingIndex) + 1] };
+      });
+    },
 
-      openNextForEditing: () => {
-        set((state) => {
-          if (state.editingAll || state.editingNone) {
-            return state;
-          }
-          if (state.editingIndex === undefined) {
-            return { editingIndex: state.editableRowIndexes[0] };
-          }
-          const isLast = state.editingIndex === state.editableRowIndexes[state.editableRowIndexes.length - 1];
-          if (isLast) {
-            return { editingIndex: undefined };
-          }
-          return { editingIndex: state.editableRowIndexes[state.editableRowIndexes.indexOf(state.editingIndex) + 1] };
-        });
-      },
+    startAddingRow: (idx) => {
+      set((state) => {
+        if (state.addingIndexes.includes(idx)) {
+          return state;
+        }
+        return { addingIndexes: [...state.addingIndexes, idx], editingIndex: undefined };
+      });
+    },
 
-      startAddingRow: (idx) => {
-        set((state) => {
-          if (state.addingIndexes.includes(idx)) {
-            return state;
-          }
-          return { addingIndexes: [...state.addingIndexes, idx], editingIndex: undefined };
-        });
-      },
+    endAddingRow: (idx) => {
+      set((state) => {
+        const i = state.addingIndexes.indexOf(idx);
+        if (i === -1) {
+          return state;
+        }
+        return { addingIndexes: [...state.addingIndexes.slice(0, i), ...state.addingIndexes.slice(i + 1)] };
+      });
+    },
 
-      startDeletingRow: (idx) => {
-        set((state) => {
-          if (state.deletingIndexes.includes(idx)) {
-            return state;
-          }
-          return { deletingIndexes: [...state.deletingIndexes, idx] };
-        });
-      },
+    startDeletingRow: (idx) => {
+      set((state) => {
+        if (state.deletingIndexes.includes(idx)) {
+          return state;
+        }
+        return { deletingIndexes: [...state.deletingIndexes, idx] };
+      });
+    },
 
-      endDeletingRow: (idx, successful) => {
-        set((state) => {
-          const isEditing = state.editingIndex === idx;
-          const i = state.deletingIndexes.indexOf(idx);
-          if (i === -1 && !isEditing) {
-            return state;
-          }
-          if (isEditing && successful) {
-            return { editingIndex: undefined };
-          }
-          return {
-            deletingIndexes: [...state.deletingIndexes.slice(0, i), ...state.deletingIndexes.slice(i + 1)],
-            editingIndex: isEditing && successful ? undefined : state.editingIndex,
-          };
-        });
-      },
-
-      updateNode: (n: BaseLayoutNode<CompRepeatingGroupInternal>) => {
-        const [visibleRowIndexes, hiddenRowIndexes, editableRowIndexes, deletableRowIndexes] = produceRowIndexes(n);
-        set((state) => {
-          const newState: Partial<ZustandState> = {
-            binding: n.item.dataModelBindings.group,
-            visibleRowIndexes,
-            hiddenRowIndexes,
-            editableRowIndexes,
-            deletableRowIndexes,
-          };
-          if (state.editingIndex !== undefined && !visibleRowIndexes.includes(state.editingIndex)) {
-            newState.editingIndex = undefined;
-          }
-          if (state.isFirstRender) {
-            newState.isFirstRender = false;
-          }
-
-          // If the rows have been added, we can remove them from the addingIndexes list. The same thing
-          // happens for the deletingIndexes list via the endDeletingRow method.
-          const allRowIndexes = n.item.rows.map((row) => row.index);
-          const recentlyAddedIndexes = state.addingIndexes.filter((idx) => allRowIndexes.includes(idx));
-          if (recentlyAddedIndexes.length > 0) {
-            newState.addingIndexes = state.addingIndexes.filter((idx) => !recentlyAddedIndexes.includes(idx));
-          }
-
-          return newState;
-        });
-      },
-    };
-  });
+    endDeletingRow: (idx, successful) => {
+      set((state) => {
+        const isEditing = state.editingIndex === idx;
+        const i = state.deletingIndexes.indexOf(idx);
+        if (i === -1 && !isEditing) {
+          return state;
+        }
+        const deletingIndexes = [...state.deletingIndexes.slice(0, i), ...state.deletingIndexes.slice(i + 1)];
+        if (isEditing && successful) {
+          return { editingIndex: undefined, deletingIndexes };
+        }
+        return {
+          deletingIndexes,
+          editingIndex: isEditing && successful ? undefined : state.editingIndex,
+        };
+      });
+    },
+  }));
 }
 
 function useExtendedRepeatingGroupState(node: BaseLayoutNode<CompRepeatingGroupInternal>): ExtendedContext {
   const nodeRef = useAsRef(node);
-  const stateRef = useAsRef(ZStore.useSelector((state) => state));
+  const state = ZStore.useSelector((state) => state);
+  const stateRef = useAsRef(state);
 
   const appendToList = FD.useAppendToList();
   const removeIndexFromList = FD.useRemoveIndexFromList();
@@ -236,6 +223,21 @@ function useExtendedRepeatingGroupState(node: BaseLayoutNode<CompRepeatingGroupI
   const onDeleteGroupRow = useOnDeleteGroupRow();
   const onGroupCloseValidation = useOnGroupCloseValidation();
   const waitForNode = useWaitForState(nodeRef);
+  const nodeState = produceStateFromNode(node);
+  const nodeStateRef = useAsRef(nodeState);
+  const [isFirstRender, setIsFirstRender] = useState(true);
+
+  useLayoutEffect(() => {
+    setIsFirstRender(false);
+  }, []);
+
+  const editingIndex = state.editingIndex;
+  const editingIsHidden = editingIndex !== undefined && !nodeState.visibleRowIndexes.includes(editingIndex);
+  useEffect(() => {
+    if (editingIndex !== undefined && editingIsHidden) {
+      stateRef.current.closeForEditing(editingIndex);
+    }
+  }, [editingIndex, editingIsHidden, stateRef]);
 
   const maybeValidateRow = useCallback(() => {
     const { editingAll, editingIndex, editingNone } = stateRef.current;
@@ -303,7 +305,8 @@ function useExtendedRepeatingGroupState(node: BaseLayoutNode<CompRepeatingGroupI
   );
 
   const addRow = useCallback(async (): Promise<AddRowResult> => {
-    const { binding, startAddingRow } = stateRef.current;
+    const binding = nodeRef.current.item.dataModelBindings.group;
+    const { startAddingRow, endAddingRow } = stateRef.current;
     if (!binding) {
       return { result: 'stoppedByBinding', index: undefined };
     }
@@ -317,17 +320,20 @@ function useExtendedRepeatingGroupState(node: BaseLayoutNode<CompRepeatingGroupI
       newValue: {},
     });
     await waitForNode((node) => node.item.rows.some((row) => row.index === nextIndex));
-    if (stateRef.current.visibleRowIndexes.includes(nextIndex)) {
+    endAddingRow(nextIndex);
+    if (nodeStateRef.current.visibleRowIndexes.includes(nextIndex)) {
       await openForEditing(nextIndex);
       return { result: 'addedAndOpened', index: nextIndex };
     }
 
     return { result: 'addedAndHidden', index: nextIndex };
-  }, [appendToList, maybeValidateRow, nodeRef, openForEditing, stateRef, waitForNode]);
+  }, [appendToList, maybeValidateRow, nodeRef, nodeStateRef, openForEditing, stateRef, waitForNode]);
 
   const deleteRow = useCallback(
     async (index: number) => {
-      const { binding, deletableRowIndexes, startDeletingRow, endDeletingRow } = stateRef.current;
+      const binding = nodeRef.current.item.dataModelBindings.group;
+      const { deletableRowIndexes } = nodeStateRef.current;
+      const { startDeletingRow, endDeletingRow } = stateRef.current;
       if (!deletableRowIndexes.includes(index)) {
         return false;
       }
@@ -348,7 +354,7 @@ function useExtendedRepeatingGroupState(node: BaseLayoutNode<CompRepeatingGroupI
       endDeletingRow(index, false);
       return false;
     },
-    [nodeRef, onBeforeRowDeletion, onDeleteGroupRow, removeIndexFromList, stateRef],
+    [nodeRef, nodeStateRef, onBeforeRowDeletion, onDeleteGroupRow, removeIndexFromList, stateRef],
   );
 
   const isDeleting = useCallback((index: number) => stateRef.current.deletingIndexes.includes(index), [stateRef]);
@@ -363,6 +369,8 @@ function useExtendedRepeatingGroupState(node: BaseLayoutNode<CompRepeatingGroupI
     openForEditing,
     openNextForEditing,
     toggleEditing,
+    isFirstRender,
+    ...nodeState,
   };
 }
 
@@ -376,8 +384,9 @@ interface Props {
 }
 
 export function RepeatingGroupProvider({ node, children }: PropsWithChildren<Props>) {
+  const nodeRef = useAsRef(node);
   return (
-    <ZStore.Provider node={node}>
+    <ZStore.Provider nodeRef={nodeRef}>
       <ProvideTheRest node={node}>
         <OpenByDefaultProvider node={node}>{children}</OpenByDefaultProvider>
       </ProvideTheRest>

--- a/src/layout/RepeatingGroup/RepeatingGroupTable.tsx
+++ b/src/layout/RepeatingGroup/RepeatingGroupTable.tsx
@@ -11,7 +11,7 @@ import { GenericComponent } from 'src/layout/GenericComponent';
 import { GridRowRenderer } from 'src/layout/Grid/GridComponent';
 import { nodesFromGridRows } from 'src/layout/Grid/tools';
 import classes from 'src/layout/RepeatingGroup/RepeatingGroup.module.css';
-import { useRepeatingGroup, useRepeatingGroupSelector } from 'src/layout/RepeatingGroup/RepeatingGroupContext';
+import { useRepeatingGroup } from 'src/layout/RepeatingGroup/RepeatingGroupContext';
 import { RepeatingGroupsEditContainer } from 'src/layout/RepeatingGroup/RepeatingGroupsEditContainer';
 import { RepeatingGroupTableRow } from 'src/layout/RepeatingGroup/RepeatingGroupTableRow';
 import { RepeatingGroupTableTitle } from 'src/layout/RepeatingGroup/RepeatingGroupTableTitle';
@@ -20,8 +20,7 @@ import type { GridRowsInternal, ITableColumnFormatting } from 'src/layout/common
 
 export function RepeatingGroupTable(): React.JSX.Element | null {
   const mobileView = useIsMobileOrTablet();
-  const { node, isEditing } = useRepeatingGroup();
-  const visibleRowIndexes = useRepeatingGroupSelector((state) => state.visibleRowIndexes);
+  const { node, isEditing, visibleRowIndexes } = useRepeatingGroup();
   const rowsBefore = node.item.rowsBefore;
   const rowsAfter = node.item.rowsAfter;
 

--- a/src/layout/RepeatingGroup/RepeatingGroupsEditContainer.tsx
+++ b/src/layout/RepeatingGroup/RepeatingGroupsEditContainer.tsx
@@ -8,7 +8,7 @@ import cn from 'classnames';
 import { Lang } from 'src/features/language/Lang';
 import { GenericComponent } from 'src/layout/GenericComponent';
 import classes from 'src/layout/RepeatingGroup/RepeatingGroup.module.css';
-import { useRepeatingGroup, useRepeatingGroupSelector } from 'src/layout/RepeatingGroup/RepeatingGroupContext';
+import { useRepeatingGroup } from 'src/layout/RepeatingGroup/RepeatingGroupContext';
 import {
   RepeatingGroupEditRowProvider,
   useRepeatingGroupEdit,
@@ -67,9 +67,8 @@ function RepeatingGroupsEditContainerInternal({
   group: CompRepeatingGroupInternal;
   row: CompRepeatingGroupInternal['rows'][number];
 }): JSX.Element | null {
-  const { node, closeForEditing, deleteRow, openNextForEditing, isDeleting } = useRepeatingGroup();
+  const { node, closeForEditing, deleteRow, openNextForEditing, isDeleting, visibleRowIndexes } = useRepeatingGroup();
 
-  const visibleRowIndexes = useRepeatingGroupSelector((state) => state.visibleRowIndexes);
   let moreVisibleRowsAfterEditIndex = false;
   for (const visibleRowIndex of visibleRowIndexes) {
     if (visibleRowIndex > editIndex) {

--- a/test/e2e/integration/frontend-test/group.ts
+++ b/test/e2e/integration/frontend-test/group.ts
@@ -61,7 +61,7 @@ describe('Group', () => {
   [true, false].forEach((openByDefault) => {
     it(`Add and delete items on main and nested group (openByDefault = ${openByDefault ? 'true' : 'false'})`, () => {
       cy.interceptLayout('group', (c) => {
-        if (c.type === 'RepeatingGroup' && c.edit && typeof c.edit.openByDefault !== 'undefined') {
+        if (c.type === 'RepeatingGroup' && c.edit) {
           c.edit.openByDefault = openByDefault;
         }
       });
@@ -77,26 +77,17 @@ describe('Group', () => {
       cy.get(appFrontend.group.subGroup).find(appFrontend.group.edit).click();
       cy.get(appFrontend.group.subGroup).find(appFrontend.group.delete).click();
 
-      if (openByDefault) {
-        cy.get(appFrontend.group.subGroup).find(mui.tableElement).eq(0).should('not.contain.text', 'automation');
-        cy.get(appFrontend.group.comments).should('be.visible');
-      } else {
-        cy.get(appFrontend.group.subGroup).find(mui.tableElement).should('have.length', 0);
-        cy.get(appFrontend.group.addNewItemSubGroup).should('have.length', 1);
-        cy.get(appFrontend.group.comments).should('not.exist');
-      }
+      // This test used to make sure deleted rows were re-added automatically, but that is no longer the case.
+      cy.get(appFrontend.group.subGroup).find(mui.tableElement).should('have.length', 0);
+      cy.get(appFrontend.group.addNewItemSubGroup).should('be.visible');
+      cy.get(appFrontend.group.comments).should('not.exist');
 
       cy.get(appFrontend.group.mainGroup).find(appFrontend.group.editContainer).find(appFrontend.group.back).click();
       cy.get(appFrontend.group.mainGroup).find(appFrontend.group.delete).click();
 
-      if (openByDefault) {
-        cy.get(appFrontend.group.saveMainGroup).should('be.visible');
-        cy.get(appFrontend.group.mainGroup).find(mui.tableElement).should('have.length.greaterThan', 0);
-      } else {
-        cy.get(appFrontend.group.mainGroup).find(mui.tableElement).should('have.length', 0);
-        cy.get(appFrontend.group.saveMainGroup).should('not.exist');
-        cy.get(appFrontend.group.addNewItem).should('have.length', 1);
-      }
+      cy.get(appFrontend.group.mainGroup).find(mui.tableElement).should('have.length', 0);
+      cy.get(appFrontend.group.saveMainGroup).should('not.exist');
+      cy.get(appFrontend.group.addNewItem).should('have.length', 1);
     });
   });
 
@@ -461,7 +452,7 @@ describe('Group', () => {
     cy.get(appFrontend.group.subGroup).find(appFrontend.group.delete).click();
     cy.get(appFrontend.group.subGroup).find(appFrontend.group.popOverDeleteButton).click();
 
-    cy.get(appFrontend.group.subGroup).find('tbody > tr > td').eq(0).should('not.contain.text', 'automation');
+    cy.get(appFrontend.group.subGroup).find('tbody > tr > td').should('have.length', 0);
 
     // Navigate to main group and test delete warning popup cancel and confirm
     cy.get(appFrontend.group.mainGroup).find(appFrontend.group.editContainer).find(appFrontend.group.back).click();


### PR DESCRIPTION
## Description

SSB managed to use `openByDefault` together with a `hiddenRow` expression that caused newly added rows to be hidden. When we fixed `openByDefault` to respect `hiddenRow` in v4, this now caused an _infinite loop of save-requests_, as the `openByDefault` functionality tried again and again to add a new row that it could open for editing. As none of the new rows ever became visible, it got stuck in that loop.

I tried my best adding tests and fixing the issues while preserving the core functionality, but in the end I figured it's best to just make a breaking change here as well. Previously, `openByDefault` would always add a new row if none were visible in the UI, and would thus always add a row even when the user deleted the last visible one. I think this concept is flawed, and it is confusing to the user when deleting the last row just seems to 'reset' the row instead. Now, instead, the `openByDefault` functionality will only work once per 'showing' of a repeating group. The first time you navigate to the group (or when navigating back to it after it having been hidden, going back and forth between pages, etc), a new row will be added. If the added row turns out to be invisible, a warning will be logged to inform the app developer about it, but we won't try again and end up in an infinite loop.

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [x] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
