### PR TITLE
Remove global `list-style-type: none;`

### DIFF
--- a/src/features/validation/ComponentValidations.tsx
+++ b/src/features/validation/ComponentValidations.tsx
@@ -62,7 +62,7 @@ function ErrorValidations({ validations, node }: { validations: NodeValidation<'
   return (
     <div style={{ paddingTop: '0.375rem' }}>
       <ErrorMessage size='small'>
-        <ol style={{ padding: 0, margin: 0 }}>
+        <ol style={{ padding: 0, margin: 0, listStyleType: 'none' }}>
           {validations.map((validation) => (
             <li
               role='alert'

--- a/src/index.css
+++ b/src/index.css
@@ -144,10 +144,6 @@ dl {
   margin-top: 0;
 }
 
-ol {
-  list-style-type: none;
-}
-
 svg,
 img {
   vertical-align: middle;


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

Yet another small error when removing `tjenester3.css`. Setting this global css was a bit to aggressive when it only needed to be set in validation messages. This had the side effect of removing numbers from all lists 😅 

before:
<img width="374" alt="image" src="https://github.com/Altinn/app-frontend-react/assets/47412359/67a46f30-0535-4653-8982-d02da2a6cb95">

after:
<img width="374" alt="image" src="https://github.com/Altinn/app-frontend-react/assets/47412359/12844735-a736-4ca8-929c-880e4a1d28c8">

I havent tested this very thoroughly, but percy did not find any differences 🤷 

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
