### PR TITLE
Use local PDF generator for preview

### DIFF
--- a/src/features/devtools/components/PDFPreviewButton/PDFPreviewButton.tsx
+++ b/src/features/devtools/components/PDFPreviewButton/PDFPreviewButton.tsx
@@ -4,12 +4,18 @@ import { Button, Fieldset } from '@digdir/design-system-react';
 import { FilePdfIcon } from '@navikt/aksel-icons';
 
 import { useDevToolsStore } from 'src/features/devtools/data/DevToolsStore';
+import { useLaxInstance } from 'src/features/instance/InstanceContext';
 import { useTaskTypeFromBackend } from 'src/features/instance/ProcessContext';
+import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
+import { useIsLocalTest } from 'src/hooks/useIsDev';
 import { ProcessTaskType } from 'src/types';
 
 export const PDFPreviewButton = () => {
   const taskType = useTaskTypeFromBackend();
   const setPdfPreview = useDevToolsStore((state) => state.actions.setPdfPreview);
+  const isLocalTest = useIsLocalTest();
+  const instanceId = useLaxInstance()?.instanceId;
+  const language = useCurrentLanguage();
 
   return (
     <Fieldset
@@ -29,6 +35,18 @@ export const PDFPreviewButton = () => {
       >
         Forhåndsvis PDF
       </Button>
+      {isLocalTest && (
+        <>
+          <a
+            style={{ marginTop: '0.5rem', display: 'inline-block' }}
+            href={`/Home/PDFPreview/Index?org=${window.org}&app=${window.app}&instance=${instanceId}&lang=${language}`}
+            target='_blank'
+            rel='noreferrer'
+          >
+            Bruk lokal PDF-generator
+          </a>
+        </>
+      )}
     </Fieldset>
   );
 };

--- a/src/hooks/useIsDev.ts
+++ b/src/hooks/useIsDev.ts
@@ -9,3 +9,7 @@ const devHostNames = [
 export function useIsDev(): boolean {
   return devHostNames.some((host) => host.test(window.location.hostname));
 }
+
+export function useIsLocalTest(): boolean {
+  return /^local\.altinn\.cloud$/.test(window.location.hostname);
+}


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

See https://github.com/Altinn/app-localtest/pull/79

<img width="338" alt="image" src="https://github.com/Altinn/app-frontend-react/assets/47412359/b73d60cb-0e5f-444d-b108-c4489398ac1f">

Sends you to a PDF viewer in local-test using the current app instance and language. This is only shown in LocalTest as it cannot be done in tt02 because the PDF-generator there is not available from the outside.

