### PR TITLE
Fix/1779 likert error report

### DIFF
--- a/src/features/instantiate/selection/InstanceSelection.module.css
+++ b/src/features/instantiate/selection/InstanceSelection.module.css
@@ -15,6 +15,10 @@
   width: 100%;
 }
 
+.table tr:hover {
+  background-color: unset;
+}
+
 .tableFooter {
   background-color: var(--fds-semantic-background-subtle);
 }

--- a/src/features/instantiate/selection/InstanceSelection.module.css
+++ b/src/features/instantiate/selection/InstanceSelection.module.css
@@ -22,6 +22,9 @@
 .tableFooter {
   background-color: var(--fds-semantic-background-subtle);
 }
+tr.tableFooter:hover {
+  background-color: var(--fds-semantic-background-subtle);
+}
 
 .startNewButtonContainer {
   margin-top: 12px;

--- a/src/features/instantiate/selection/InstanceSelection.module.css
+++ b/src/features/instantiate/selection/InstanceSelection.module.css
@@ -11,6 +11,14 @@
   margin-top: 26px;
 }
 
+.table {
+  width: 100%;
+}
+
+.tableFooter {
+  background-color: var(--fds-semantic-background-subtle);
+}
+
 .startNewButtonContainer {
   margin-top: 12px;
 }

--- a/src/features/instantiate/selection/InstanceSelection.module.css
+++ b/src/features/instantiate/selection/InstanceSelection.module.css
@@ -15,12 +15,40 @@
   width: 100%;
 }
 
+/* ====
+TODO(1779): Remove these styles after going through all the different Table styles in
+Altinn, and making sure they are consistent. */
+
+.table {
+  box-shadow:
+    0 1px 1px rgba(0, 0, 0, 0.12),
+    0 2px 2px rgba(0, 0, 0, 0.12);
+}
+@media (max-width: 992px) {
+  .table {
+    border-top: 1px solid #dde3e5;
+  }
+}
+.table th {
+  background-color: #f5f5f5;
+  border-bottom: 1px solid #dde3e5;
+  padding-top: 15px;
+  padding-bottom: 15px;
+}
+
+.table td {
+  border-bottom: 1px solid #dde3e5;
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+/* ==== */
+
 .table tr:hover {
   background-color: unset;
 }
 
 .tableFooter {
-  background-color: var(--fds-semantic-background-subtle);
+  background-color: #f5f5f5; /* Remove this when upgrading to the new design system component look*/
 }
 tr.tableFooter:hover {
   background-color: var(--fds-semantic-background-subtle);

--- a/src/features/instantiate/selection/InstanceSelection.tsx
+++ b/src/features/instantiate/selection/InstanceSelection.tsx
@@ -1,17 +1,7 @@
 import React, { useState } from 'react';
 
 import { Pagination } from '@altinn/altinn-design-system';
-import {
-  Button,
-  Heading,
-  LegacyTable,
-  LegacyTableBody,
-  LegacyTableCell,
-  LegacyTableFooter,
-  LegacyTableHeader,
-  LegacyTableRow,
-  Paragraph,
-} from '@digdir/design-system-react';
+import { Button, Heading, Paragraph, Table } from '@digdir/design-system-react';
 import { Edit as EditIcon } from '@navikt/ds-icons';
 import type { DescriptionText } from '@altinn/altinn-design-system/dist/types/src/components/Pagination/Pagination';
 
@@ -89,11 +79,15 @@ function InstanceSelection() {
       >
         <Lang id={'instance_selection.left_of'} />
       </Heading>
-      <LegacyTable id='instance-selection-mobile-table'>
-        <LegacyTableBody>
+      <Table
+        id='instance-selection-mobile-table'
+        className={classes.table}
+        border
+      >
+        <Table.Body>
           {paginatedInstances.map((instance) => (
-            <LegacyTableRow key={instance.id}>
-              <LegacyTableCell className={classes.mobileTableCell}>
+            <Table.Row key={instance.id}>
+              <Table.Cell className={classes.mobileTableCell}>
                 <div>
                   <b>{langAsString('instance_selection.last_changed')}:</b>
                   <br />
@@ -104,8 +98,8 @@ function InstanceSelection() {
                   <br />
                   <span>{instance.lastChangedBy}</span>
                 </div>
-              </LegacyTableCell>
-              <LegacyTableCell>
+              </Table.Cell>
+              <Table.Cell>
                 <div className={classes.tableButtonWrapper}>
                   <Button
                     variant='tertiary'
@@ -118,14 +112,15 @@ function InstanceSelection() {
                     aria-label={`${langAsString('instance_selection.continue')}`}
                   />
                 </div>
-              </LegacyTableCell>
-            </LegacyTableRow>
+              </Table.Cell>
+            </Table.Row>
           ))}
-        </LegacyTableBody>
+        </Table.Body>
         {instances.length > rowsPerPageOptions[0] && (
-          <LegacyTableFooter>
-            <LegacyTableRow>
-              <LegacyTableCell colSpan={2}>
+          <tfoot>
+            <Table.Row className={classes.tableFooter}>
+              {/* @ts-expect-error this will be fixed in v0.48.0 of the design system */}
+              <Table.Cell colSpan={2}>
                 <div className={classes.paginationWrapperMobile}>
                   <Pagination
                     numberOfRows={instances.length}
@@ -139,34 +134,38 @@ function InstanceSelection() {
                     descriptionTexts={language && (language['list_component'] as DescriptionText)}
                   />
                 </div>
-              </LegacyTableCell>
-            </LegacyTableRow>
-          </LegacyTableFooter>
+              </Table.Cell>
+            </Table.Row>
+          </tfoot>
         )}
-      </LegacyTable>
+      </Table>
     </>
   );
 
   const renderTable = () => (
     <div className={classes.tableContainer}>
-      <LegacyTable id='instance-selection-table'>
-        <LegacyTableHeader id='instance-selection-table-header'>
-          <LegacyTableRow>
-            <LegacyTableCell>
+      <Table
+        id='instance-selection-table'
+        className={classes.table}
+        border
+      >
+        <Table.Head id='instance-selection-table-header'>
+          <Table.Row>
+            <Table.HeaderCell>
               <Lang id={'instance_selection.last_changed'} />
-            </LegacyTableCell>
-            <LegacyTableCell>
+            </Table.HeaderCell>
+            <Table.HeaderCell>
               <Lang id={'instance_selection.changed_by'} />
-            </LegacyTableCell>
-            <LegacyTableCell />
-          </LegacyTableRow>
-        </LegacyTableHeader>
-        <LegacyTableBody id='instance-selection-table-body'>
+            </Table.HeaderCell>
+            <Table.HeaderCell />
+          </Table.Row>
+        </Table.Head>
+        <Table.Body id='instance-selection-table-body'>
           {paginatedInstances.map((instance: ISimpleInstance) => (
-            <LegacyTableRow key={instance.id}>
-              <LegacyTableCell>{getDateDisplayString(instance.lastChanged)}</LegacyTableCell>
-              <LegacyTableCell>{instance.lastChangedBy}</LegacyTableCell>
-              <LegacyTableCell className={classes.buttonCell}>
+            <Table.Row key={instance.id}>
+              <Table.Cell>{getDateDisplayString(instance.lastChanged)}</Table.Cell>
+              <Table.Cell>{instance.lastChangedBy}</Table.Cell>
+              <Table.Cell className={classes.buttonCell}>
                 <div className={classes.tableButtonWrapper}>
                   <Button
                     variant='tertiary'
@@ -179,14 +178,15 @@ function InstanceSelection() {
                     <Lang id={'instance_selection.continue'} />
                   </Button>
                 </div>
-              </LegacyTableCell>
-            </LegacyTableRow>
+              </Table.Cell>
+            </Table.Row>
           ))}
-        </LegacyTableBody>
+        </Table.Body>
         {instances.length > rowsPerPageOptions[0] && (
-          <LegacyTableFooter>
-            <LegacyTableRow>
-              <LegacyTableCell colSpan={3}>
+          <tfoot>
+            <Table.Row className={classes.tableFooter}>
+              {/* @ts-expect-error this will be fixed in v0.48.0 of the design system */}
+              <Table.Cell colSpan={3}>
                 <div className={classes.paginationWrapper}>
                   <Pagination
                     numberOfRows={instances.length}
@@ -200,11 +200,11 @@ function InstanceSelection() {
                     descriptionTexts={language && (language['list_component'] as DescriptionText)}
                   />
                 </div>
-              </LegacyTableCell>
-            </LegacyTableRow>
-          </LegacyTableFooter>
+              </Table.Cell>
+            </Table.Row>
+          </tfoot>
         )}
-      </LegacyTable>
+      </Table>
     </div>
   );
 

--- a/src/features/instantiate/selection/InstanceSelection.tsx
+++ b/src/features/instantiate/selection/InstanceSelection.tsx
@@ -82,7 +82,6 @@ function InstanceSelection() {
       <Table
         id='instance-selection-mobile-table'
         className={classes.table}
-        border
       >
         <Table.Body>
           {paginatedInstances.map((instance) => (
@@ -147,7 +146,6 @@ function InstanceSelection() {
       <Table
         id='instance-selection-table'
         className={classes.table}
-        border
       >
         <Table.Head id='instance-selection-table-header'>
           <Table.Row>

--- a/src/features/validation/ComponentValidations.tsx
+++ b/src/features/validation/ComponentValidations.tsx
@@ -10,13 +10,13 @@ import type { NodeValidation } from 'src/features/validation';
 import type { AlertSeverity } from 'src/layout/Alert/config.generated';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
-export function ComponentValidations({
-  validations,
-  node,
-}: {
+type Props = {
   validations: NodeValidation[] | undefined;
   node?: LayoutNode;
-}) {
+  ariaHide?: boolean;
+};
+
+export function ComponentValidations({ validations, node, ariaHide = false }: Props) {
   if (!validations || validations.length === 0) {
     return null;
   }
@@ -26,7 +26,10 @@ export function ComponentValidations({
   const success = validationsOfSeverity(validations, 'success');
 
   return (
-    <div data-validation={node?.item.id}>
+    <div
+      data-validation={node?.item.id}
+      aria-hidden={ariaHide}
+    >
       {errors.length > 0 && (
         <ErrorValidations
           validations={errors}

--- a/src/features/validation/ComponentValidations.tsx
+++ b/src/features/validation/ComponentValidations.tsx
@@ -13,10 +13,9 @@ import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 type Props = {
   validations: NodeValidation[] | undefined;
   node?: LayoutNode;
-  ariaHide?: boolean;
 };
 
-export function ComponentValidations({ validations, node, ariaHide = false }: Props) {
+export function ComponentValidations({ validations, node }: Props) {
   if (!validations || validations.length === 0) {
     return null;
   }
@@ -26,10 +25,7 @@ export function ComponentValidations({ validations, node, ariaHide = false }: Pr
   const success = validationsOfSeverity(validations, 'success');
 
   return (
-    <div
-      data-validation={node?.item.id}
-      aria-hidden={ariaHide}
-    >
+    <div data-validation={node?.item.id}>
       {errors.length > 0 && (
         <ErrorValidations
           validations={errors}

--- a/src/language/texts/en.ts
+++ b/src/language/texts/en.ts
@@ -335,5 +335,8 @@ export function en() {
         'This version of the app frontend is not compatible with the version of the backend libraries you are using. Update to the latest version of the packages and try again.',
       min_backend_version: 'Minimum backend version is {0}',
     },
+    likert: {
+      left_column_default_header_text: 'Question',
+    },
   };
 }

--- a/src/language/texts/nb.ts
+++ b/src/language/texts/nb.ts
@@ -338,5 +338,8 @@ export function nb(): FixedLanguageList {
         'Denne versjonen av app frontend er ikke kompatibel med den versjonen av backend-bibliotekene du bruker. Oppdater til nyeste versjon av pakkene og prøv igjen.',
       min_backend_version: 'Minimum backend versjon er {0}',
     },
+    likert: {
+      left_column_default_header_text: 'Spørsmål',
+    },
   };
 }

--- a/src/language/texts/nn.ts
+++ b/src/language/texts/nn.ts
@@ -338,5 +338,8 @@ export function nn(): FixedLanguageList {
         'Denne versjonen av app frontend er ikkje kompatibel med den versjonen av backend-biblioteka du brukar. Oppdater til nyaste versjon av pakkane og prøv igjen.',
       min_backend_version: 'Minimum backend versjon er {0}',
     },
+    likert: {
+      left_column_default_header_text: 'Spørsmål',
+    },
   };
 }

--- a/src/layout/Accordion/index.tsx
+++ b/src/layout/Accordion/index.tsx
@@ -11,9 +11,9 @@ import type { ComponentHierarchyGenerator } from 'src/utils/layout/HierarchyGene
 export class Accordion extends AccordionDef {
   private _hierarchyGenerator = new AccordionHierarchyGenerator();
 
-  render(props: PropsFromGenericComponent<'Accordion'>): React.JSX.Element | null {
-    return <AccordionComponent {...props} />;
-  }
+  render = (props: PropsFromGenericComponent<'Accordion'>): React.JSX.Element | null => (
+    <AccordionComponent {...props} />
+  );
 
   hierarchyGenerator(): ComponentHierarchyGenerator<'Accordion'> {
     return this._hierarchyGenerator;

--- a/src/layout/AccordionGroup/index.tsx
+++ b/src/layout/AccordionGroup/index.tsx
@@ -13,9 +13,9 @@ import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 export class AccordionGroup extends AccordionGroupDef {
   private _hierarchyGenerator = new AccordionGroupHierarchyGenerator();
 
-  render(props: PropsFromGenericComponent<'AccordionGroup'>): JSX.Element | null {
-    return <AccordionGroupComponent {...props} />;
-  }
+  render = (props: PropsFromGenericComponent<'AccordionGroup'>): JSX.Element | null => (
+    <AccordionGroupComponent {...props} />
+  );
 
   hierarchyGenerator(): ComponentHierarchyGenerator<'AccordionGroup'> {
     return this._hierarchyGenerator;

--- a/src/layout/ActionButton/index.tsx
+++ b/src/layout/ActionButton/index.tsx
@@ -5,7 +5,7 @@ import { ActionButtonDef } from 'src/layout/ActionButton/config.def.generated';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export class ActionButton extends ActionButtonDef {
-  render(props: PropsFromGenericComponent<'ActionButton'>): JSX.Element | null {
-    return <ActionButtonComponent {...props} />;
-  }
+  render = (props: PropsFromGenericComponent<'ActionButton'>): JSX.Element | null => (
+    <ActionButtonComponent {...props} />
+  );
 }

--- a/src/layout/Address/index.tsx
+++ b/src/layout/Address/index.tsx
@@ -14,9 +14,7 @@ import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class Address extends AddressDef implements ValidateComponent {
-  render(props: PropsFromGenericComponent<'Address'>): JSX.Element | null {
-    return <AddressComponent {...props} />;
-  }
+  render = (props: PropsFromGenericComponent<'Address'>): JSX.Element | null => <AddressComponent {...props} />;
 
   getDisplayData(node: LayoutNode<'Address'>): string {
     const data = node.getFormData();

--- a/src/layout/Alert/index.tsx
+++ b/src/layout/Alert/index.tsx
@@ -5,7 +5,5 @@ import { AlertDef } from 'src/layout/Alert/config.def.generated';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export class Alert extends AlertDef {
-  render(props: PropsFromGenericComponent<'Alert'>): JSX.Element | null {
-    return <AlertComponent {...props} />;
-  }
+  render = (props: PropsFromGenericComponent<'Alert'>): JSX.Element | null => <AlertComponent {...props} />;
 }

--- a/src/layout/AttachmentList/index.tsx
+++ b/src/layout/AttachmentList/index.tsx
@@ -5,7 +5,7 @@ import { AttachmentListDef } from 'src/layout/AttachmentList/config.def.generate
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export class AttachmentList extends AttachmentListDef {
-  render(props: PropsFromGenericComponent<'AttachmentList'>): JSX.Element | null {
-    return <AttachmentListComponent {...props} />;
-  }
+  render = (props: PropsFromGenericComponent<'AttachmentList'>): JSX.Element | null => (
+    <AttachmentListComponent {...props} />
+  );
 }

--- a/src/layout/Button/index.tsx
+++ b/src/layout/Button/index.tsx
@@ -5,7 +5,5 @@ import { ButtonDef } from 'src/layout/Button/config.def.generated';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export class Button extends ButtonDef {
-  render(props: PropsFromGenericComponent<'Button'>): JSX.Element | null {
-    return <ButtonComponent {...props} />;
-  }
+  render = (props: PropsFromGenericComponent<'Button'>): JSX.Element | null => <ButtonComponent {...props} />;
 }

--- a/src/layout/ButtonGroup/index.tsx
+++ b/src/layout/ButtonGroup/index.tsx
@@ -12,9 +12,7 @@ import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 export class ButtonGroup extends ButtonGroupDef {
   private _hierarchyGenerator = new ButtonGroupHierarchyGenerator();
 
-  render(props: PropsFromGenericComponent<'ButtonGroup'>): JSX.Element | null {
-    return <ButtonGroupComponent {...props} />;
-  }
+  render = (props: PropsFromGenericComponent<'ButtonGroup'>): JSX.Element | null => <ButtonGroupComponent {...props} />;
 
   shouldRenderInAutomaticPDF() {
     return false;

--- a/src/layout/Checkboxes/index.tsx
+++ b/src/layout/Checkboxes/index.tsx
@@ -15,9 +15,9 @@ import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class Checkboxes extends CheckboxesDef {
-  render(props: PropsFromGenericComponent<'Checkboxes'>): JSX.Element | null {
-    return <CheckboxContainerComponent {...props} />;
-  }
+  render = (props: PropsFromGenericComponent<'Checkboxes'>): JSX.Element | null => (
+    <CheckboxContainerComponent {...props} />
+  );
 
   private getSummaryData(
     node: LayoutNode<'Checkboxes'>,

--- a/src/layout/Custom/index.tsx
+++ b/src/layout/Custom/index.tsx
@@ -9,9 +9,7 @@ import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class Custom extends CustomDef {
-  render(props: PropsFromGenericComponent<'Custom'>): JSX.Element | null {
-    return <CustomWebComponent {...props} />;
-  }
+  render = (props: PropsFromGenericComponent<'Custom'>): JSX.Element | null => <CustomWebComponent {...props} />;
 
   getDisplayData(node: LayoutNode<'Custom'>): string {
     const data = node.getFormData();

--- a/src/layout/CustomButton/index.tsx
+++ b/src/layout/CustomButton/index.tsx
@@ -7,9 +7,9 @@ import type { PropsFromGenericComponent } from 'src/layout';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class CustomButton extends CustomButtonDef {
-  render(props: PropsFromGenericComponent<'CustomButton'>): JSX.Element | null {
-    return <CustomButtonComponent {...props} />;
-  }
+  render = (props: PropsFromGenericComponent<'CustomButton'>): JSX.Element | null => (
+    <CustomButtonComponent {...props} />
+  );
 
   renderSummaryBoilerplate(): boolean {
     return false;

--- a/src/layout/Datepicker/index.tsx
+++ b/src/layout/Datepicker/index.tsx
@@ -21,9 +21,7 @@ import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class Datepicker extends DatepickerDef implements ValidateComponent {
-  render(props: PropsFromGenericComponent<'Datepicker'>): JSX.Element | null {
-    return <DatepickerComponent {...props} />;
-  }
+  render = (props: PropsFromGenericComponent<'Datepicker'>): JSX.Element | null => <DatepickerComponent {...props} />;
 
   getDisplayData(node: LayoutNode<'Datepicker'>, { currentLanguage }: DisplayDataProps): string {
     if (!node.item.dataModelBindings?.simpleBinding) {

--- a/src/layout/Dropdown/index.tsx
+++ b/src/layout/Dropdown/index.tsx
@@ -11,9 +11,7 @@ import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class Dropdown extends DropdownDef {
-  render(props: PropsFromGenericComponent<'Dropdown'>): JSX.Element | null {
-    return <DropdownComponent {...props} />;
-  }
+  render = (props: PropsFromGenericComponent<'Dropdown'>): JSX.Element | null => <DropdownComponent {...props} />;
 
   getDisplayData(node: LayoutNode<'Dropdown'>, { langTools, options }: DisplayDataProps): string {
     if (!node.item.dataModelBindings?.simpleBinding) {

--- a/src/layout/FileUpload/index.tsx
+++ b/src/layout/FileUpload/index.tsx
@@ -14,9 +14,7 @@ import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class FileUpload extends FileUploadDef implements ValidateComponent {
-  render(props: PropsFromGenericComponent<'FileUpload'>): JSX.Element | null {
-    return <FileUploadComponent {...props} />;
-  }
+  render = (props: PropsFromGenericComponent<'FileUpload'>): JSX.Element | null => <FileUploadComponent {...props} />;
 
   renderDefaultValidations(): boolean {
     return false;

--- a/src/layout/FileUploadWithTag/index.tsx
+++ b/src/layout/FileUploadWithTag/index.tsx
@@ -14,9 +14,9 @@ import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class FileUploadWithTag extends FileUploadWithTagDef implements ValidateComponent {
-  render(props: PropsFromGenericComponent<'FileUploadWithTag'>): JSX.Element | null {
-    return <FileUploadComponent {...props} />;
-  }
+  render = (props: PropsFromGenericComponent<'FileUploadWithTag'>): JSX.Element | null => (
+    <FileUploadComponent {...props} />
+  );
 
   renderDefaultValidations(): boolean {
     return false;

--- a/src/layout/GenericComponent.tsx
+++ b/src/layout/GenericComponent.tsx
@@ -120,6 +120,7 @@ function ActualGenericComponent<Type extends CompTypes = CompTypes>({
       | HTMLSelectElement
       | HTMLInputElement
       | HTMLTextAreaElement;
+
     if (maybeInput) {
       maybeInput.focus();
     }
@@ -162,7 +163,10 @@ function ActualGenericComponent<Type extends CompTypes = CompTypes>({
   if (layoutComponent.directRender(componentProps) || overrideDisplay?.directRender) {
     return (
       <FormComponentContextProvider value={formComponentContext}>
-        <RenderComponent {...componentProps} />
+        <RenderComponent
+          {...componentProps}
+          ref={containerDivRef}
+        />
       </FormComponentContextProvider>
     );
   }

--- a/src/layout/Grid/Grid.module.css
+++ b/src/layout/Grid/Grid.module.css
@@ -12,8 +12,12 @@ tr > .fullWidthCellLast {
   padding-right: var(--modal-padding-x);
 }
 
-.fullWidth {
+.table {
   width: 100%;
+}
+
+.table tr:hover {
+  background-color: unset;
 }
 
 .contentFormatting {

--- a/src/layout/Grid/Grid.module.css
+++ b/src/layout/Grid/Grid.module.css
@@ -16,6 +16,32 @@ tr > .fullWidthCellLast {
   width: 100%;
 }
 
+/* ====
+TODO(1779): Remove these styles after going through all the different Table styles in
+Altinn, and making sure they are consistent. */
+.table {
+  box-shadow:
+    0 1px 1px rgba(0, 0, 0, 0.12),
+    0 2px 2px rgba(0, 0, 0, 0.12);
+}
+@media (max-width: 992px) {
+  .table {
+    border-top: 1px solid #dde3e5;
+  }
+}
+.table th {
+  background-color: #f5f5f5;
+  border-bottom: 1px solid #dde3e5;
+  padding-top: 15px;
+  padding-bottom: 15px;
+}
+.table td {
+  border-bottom: 1px solid #dde3e5;
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+/* ==== */
+
 .table tr:hover {
   background-color: unset;
 }

--- a/src/layout/Grid/Grid.module.css
+++ b/src/layout/Grid/Grid.module.css
@@ -5,11 +5,15 @@
 }
 
 tr > .fullWidthCellFirst {
-  padding-left: calc(var(--modal-padding-x) - var(--table-input-margin));
+  padding-left: var(--modal-padding-x);
 }
 
 tr > .fullWidthCellLast {
-  padding-right: calc(var(--modal-padding-x) - var(--table-input-margin));
+  padding-right: var(--modal-padding-x);
+}
+
+.fullWidth {
+  width: 100%;
 }
 
 .contentFormatting {

--- a/src/layout/Grid/GridComponent.tsx
+++ b/src/layout/Grid/GridComponent.tsx
@@ -45,7 +45,7 @@ export function RenderGrid(props: PropsFromGenericComponent<'Grid'>) {
     >
       <Table
         id={node.item.id}
-        className={css.fullWidth}
+        className={css.table}
       >
         {title && (
           <Caption

--- a/src/layout/Grid/GridComponent.tsx
+++ b/src/layout/Grid/GridComponent.tsx
@@ -1,13 +1,7 @@
 import React from 'react';
 import type { PropsWithChildren } from 'react';
 
-import {
-  LegacyTable,
-  LegacyTableBody,
-  LegacyTableCell,
-  LegacyTableHeader,
-  LegacyTableRow,
-} from '@digdir/design-system-react';
+import { Table } from '@digdir/design-system-react';
 import cn from 'classnames';
 
 import { ConditionalWrapper } from 'src/components/ConditionalWrapper';
@@ -49,7 +43,10 @@ export function RenderGrid(props: PropsFromGenericComponent<'Grid'>) {
       condition={shouldHaveFullWidth}
       wrapper={(child) => <FullWidthWrapper>{child}</FullWidthWrapper>}
     >
-      <LegacyTable id={node.item.id}>
+      <Table
+        id={node.item.id}
+        className={css.fullWidth}
+      >
         {title && (
           <Caption
             className={cn({ [css.captionFullWidth]: shouldHaveFullWidth })}
@@ -68,7 +65,7 @@ export function RenderGrid(props: PropsFromGenericComponent<'Grid'>) {
             node={node}
           />
         ))}
-      </LegacyTable>
+      </Table>
     </ConditionalWrapper>
   );
 }
@@ -110,6 +107,7 @@ export function GridRowRenderer({ row, isNested, mutableColumnSettings, node }: 
                 key={`${cell.text}/${cellIdx}`}
                 className={className}
                 help={cell?.help}
+                isHeader={row.header}
                 columnStyleOptions={textCellSettings}
               >
                 <Lang
@@ -128,6 +126,7 @@ export function GridRowRenderer({ row, isNested, mutableColumnSettings, node }: 
               <CellWithLabel
                 key={`${cell.labelFrom}/${cellIdx}`}
                 className={className}
+                isHeader={row.header}
                 columnStyleOptions={textCellSettings}
                 referenceComponent={closestComponent}
               />
@@ -140,6 +139,7 @@ export function GridRowRenderer({ row, isNested, mutableColumnSettings, node }: 
           <CellWithComponent
             key={`${componentId}/${cellIdx}`}
             node={componentNode}
+            isHeader={row.header}
             className={className}
             columnStyleOptions={mutableColumnSettings[cellIdx]}
           />
@@ -156,22 +156,23 @@ function InternalRow({ header, readOnly, children }: InternalRowProps) {
 
   if (header) {
     return (
-      <LegacyTableHeader>
-        <LegacyTableRow className={className}>{children}</LegacyTableRow>
-      </LegacyTableHeader>
+      <Table.Head>
+        <Table.Row className={className}>{children}</Table.Row>
+      </Table.Head>
     );
   }
 
   return (
-    <LegacyTableBody>
-      <LegacyTableRow className={className}>{children}</LegacyTableRow>
-    </LegacyTableBody>
+    <Table.Body>
+      <Table.Row className={className}>{children}</Table.Row>
+    </Table.Body>
   );
 }
 
 interface CellProps {
   className?: string;
   columnStyleOptions?: ITableColumnProperties;
+  isHeader?: boolean;
 }
 
 interface CellWithComponentProps extends CellProps {
@@ -186,11 +187,12 @@ interface CellWithLabelProps extends CellProps {
   referenceComponent?: LayoutNode;
 }
 
-function CellWithComponent({ node, className, columnStyleOptions }: CellWithComponentProps) {
+function CellWithComponent({ node, className, columnStyleOptions, isHeader = false }: CellWithComponentProps) {
+  const CellComponent = isHeader ? Table.HeaderCell : Table.Cell;
   if (node && !node.isHidden()) {
     const columnStyles = columnStyleOptions && getColumnStyles(columnStyleOptions);
     return (
-      <LegacyTableCell
+      <CellComponent
         className={cn(css.tableCellFormatting, className)}
         style={columnStyles}
       >
@@ -202,18 +204,20 @@ function CellWithComponent({ node, className, columnStyleOptions }: CellWithComp
             renderedInTable: true,
           }}
         />
-      </LegacyTableCell>
+      </CellComponent>
     );
   }
 
-  return <LegacyTableCell className={className} />;
+  return <CellComponent className={className} />;
 }
 
-function CellWithText({ children, className, columnStyleOptions, help }: CellWithTextProps) {
+function CellWithText({ children, className, columnStyleOptions, help, isHeader = false }: CellWithTextProps) {
   const columnStyles = columnStyleOptions && getColumnStyles(columnStyleOptions);
   const { elementAsString } = useLanguage();
+  const CellComponent = isHeader ? Table.HeaderCell : Table.Cell;
+
   return (
-    <LegacyTableCell
+    <CellComponent
       className={cn(css.tableCellFormatting, className)}
       style={columnStyles}
     >
@@ -231,11 +235,11 @@ function CellWithText({ children, className, columnStyleOptions, help }: CellWit
           />
         )}
       </span>
-    </LegacyTableCell>
+    </CellComponent>
   );
 }
 
-function CellWithLabel({ className, columnStyleOptions, referenceComponent }: CellWithLabelProps) {
+function CellWithLabel({ className, columnStyleOptions, referenceComponent, isHeader = false }: CellWithLabelProps) {
   const columnStyles = columnStyleOptions && getColumnStyles(columnStyleOptions);
   const refItem = referenceComponent?.item;
   const trb = (refItem && 'textResourceBindings' in refItem ? refItem.textResourceBindings : {}) as
@@ -248,8 +252,10 @@ function CellWithLabel({ className, columnStyleOptions, referenceComponent }: Ce
     (referenceComponent && 'required' in referenceComponent.item && referenceComponent.item.required) ?? false;
   const componentId = referenceComponent?.item.id ?? referenceComponent?.item.baseComponentId;
 
+  const CellComponent = isHeader ? Table.HeaderCell : Table.Cell;
+
   return (
-    <LegacyTableCell
+    <CellComponent
       className={cn(css.tableCellFormatting, className)}
       style={columnStyles}
     >
@@ -270,7 +276,7 @@ function CellWithLabel({ className, columnStyleOptions, referenceComponent }: Ce
           />
         </>
       )}
-    </LegacyTableCell>
+    </CellComponent>
   );
 }
 

--- a/src/layout/Grid/index.tsx
+++ b/src/layout/Grid/index.tsx
@@ -16,9 +16,7 @@ import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 export class Grid extends GridDef {
   private _hierarchyGenerator = new GridHierarchyGenerator();
 
-  render(props: PropsFromGenericComponent<'Grid'>): JSX.Element | null {
-    return <RenderGrid {...props} />;
-  }
+  render = (props: PropsFromGenericComponent<'Grid'>): JSX.Element | null => <RenderGrid {...props} />;
 
   renderSummary(props: SummaryRendererProps<'Grid'>): JSX.Element | null {
     return <GridSummaryComponent {...props} />;

--- a/src/layout/Group/index.tsx
+++ b/src/layout/Group/index.tsx
@@ -27,19 +27,17 @@ export class Group extends GroupDef implements ValidateAny, ValidateComponent {
     return true;
   }
 
-  render(props: PropsFromGenericComponent<'Group'>): JSX.Element | null {
-    return (
-      <GroupComponent
-        groupNode={props.node}
-        renderLayoutNode={(n) => (
-          <GenericComponent
-            key={n.item.id}
-            node={n}
-          />
-        )}
-      />
-    );
-  }
+  render = (props: PropsFromGenericComponent<'Group'>): JSX.Element | null => (
+    <GroupComponent
+      groupNode={props.node}
+      renderLayoutNode={(n) => (
+        <GenericComponent
+          key={n.item.id}
+          node={n}
+        />
+      )}
+    />
+  );
 
   renderSummary({
     onChangeClick,

--- a/src/layout/Header/index.tsx
+++ b/src/layout/Header/index.tsx
@@ -5,7 +5,5 @@ import { HeaderComponent } from 'src/layout/Header/HeaderComponent';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export class Header extends HeaderDef {
-  render(props: PropsFromGenericComponent<'Header'>): JSX.Element | null {
-    return <HeaderComponent {...props} />;
-  }
+  render = (props: PropsFromGenericComponent<'Header'>): JSX.Element | null => <HeaderComponent {...props} />;
 }

--- a/src/layout/IFrame/index.tsx
+++ b/src/layout/IFrame/index.tsx
@@ -5,7 +5,5 @@ import { IFrameComponent } from 'src/layout/IFrame/IFrameComponent';
 import type { IFrameComponentProps } from 'src/layout/IFrame/IFrameComponent';
 
 export class IFrame extends IFrameDef {
-  render(props: IFrameComponentProps): JSX.Element | null {
-    return <IFrameComponent {...props} />;
-  }
+  render = (props: IFrameComponentProps): JSX.Element | null => <IFrameComponent {...props} />;
 }

--- a/src/layout/Image/index.tsx
+++ b/src/layout/Image/index.tsx
@@ -5,7 +5,5 @@ import { ImageComponent } from 'src/layout/Image/ImageComponent';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export class Image extends ImageDef {
-  render(props: PropsFromGenericComponent<'Image'>): JSX.Element | null {
-    return <ImageComponent {...props} />;
-  }
+  render = (props: PropsFromGenericComponent<'Image'>): JSX.Element | null => <ImageComponent {...props} />;
 }

--- a/src/layout/Input/index.tsx
+++ b/src/layout/Input/index.tsx
@@ -14,9 +14,7 @@ import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class Input extends InputDef {
-  render(props: PropsFromGenericComponent<'Input'>): JSX.Element | null {
-    return <InputComponent {...props} />;
-  }
+  render = (props: PropsFromGenericComponent<'Input'>): JSX.Element | null => <InputComponent {...props} />;
 
   getDisplayData(node: LayoutNode<'Input'>, { currentLanguage }: DisplayDataProps): string {
     if (!node.item.dataModelBindings?.simpleBinding) {

--- a/src/layout/InstanceInformation/index.tsx
+++ b/src/layout/InstanceInformation/index.tsx
@@ -5,7 +5,7 @@ import { InstanceInformationComponent } from 'src/layout/InstanceInformation/Ins
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export class InstanceInformation extends InstanceInformationDef {
-  render(props: PropsFromGenericComponent<'InstanceInformation'>): JSX.Element | null {
-    return <InstanceInformationComponent {...props} />;
-  }
+  render = (props: PropsFromGenericComponent<'InstanceInformation'>): JSX.Element | null => (
+    <InstanceInformationComponent {...props} />
+  );
 }

--- a/src/layout/InstantiationButton/index.tsx
+++ b/src/layout/InstantiationButton/index.tsx
@@ -5,7 +5,7 @@ import { InstantiationButtonComponent } from 'src/layout/InstantiationButton/Ins
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export class InstantiationButton extends InstantiationButtonDef {
-  render(props: PropsFromGenericComponent<'InstantiationButton'>): JSX.Element | null {
-    return <InstantiationButtonComponent {...props} />;
-  }
+  render = (props: PropsFromGenericComponent<'InstantiationButton'>): JSX.Element | null => (
+    <InstantiationButtonComponent {...props} />
+  );
 }

--- a/src/layout/LayoutComponent.tsx
+++ b/src/layout/LayoutComponent.tsx
@@ -48,7 +48,9 @@ export abstract class AnyComponent<Type extends CompTypes> {
   /**
    * Given properties from GenericComponent, render this layout component
    */
-  abstract render(props: PropsFromGenericComponent<Type>): JSX.Element | null;
+  abstract render:
+    | ReturnType<typeof React.forwardRef<HTMLElement, PropsFromGenericComponent<Type>>>
+    | ((props: PropsFromGenericComponent<Type>) => JSX.Element | null);
 
   /**
    * Given a node, a list of the node's data, for display in the devtools node inspector

--- a/src/layout/Likert/LikertComponent.test.tsx
+++ b/src/layout/Likert/LikertComponent.test.tsx
@@ -169,7 +169,7 @@ describe('RepeatingGroupsLikertContainer', () => {
     it('should render standard view and use keyboard to navigate', async () => {
       const { formDataMethods } = await render();
       await waitFor(async () => {
-        expect(await screen.findAllByRole('columnheader')).toHaveLength(3);
+        expect(await screen.findAllByRole('columnheader')).toHaveLength(4);
       });
       await validateTableLayout(defaultMockQuestions, defaultMockOptions);
 

--- a/src/layout/Likert/LikertComponent.tsx
+++ b/src/layout/Likert/LikertComponent.tsx
@@ -1,15 +1,11 @@
 import React from 'react';
 
-import {
-  LegacyTable,
-  LegacyTableBody,
-  LegacyTableCell,
-  LegacyTableHeader,
-  LegacyTableRow,
-} from '@digdir/design-system-react';
+import { Table } from '@digdir/design-system-react';
 import { Grid, Typography } from '@material-ui/core';
+import cn from 'classnames';
 
 import { AltinnSpinner } from 'src/components/AltinnSpinner';
+import { Lang } from 'src/features/language/Lang';
 import { useLanguage } from 'src/features/language/useLanguage';
 import { useGetOptions } from 'src/features/options/useGetOptions';
 import { useIsMobileOrTablet } from 'src/hooks/useIsMobile';
@@ -109,33 +105,40 @@ export const LikertComponent = ({ node, ref }: LikertComponentProps) => {
           className={classes.likertTableContainer}
           ref={ref}
         >
-          <LegacyTable
+          <Table
             id={id}
             aria-labelledby={(hasTitle && titleId) || undefined}
             aria-describedby={(hasDescription && descriptionId) || undefined}
+            border
+            className={classes.likertTable}
           >
-            <LegacyTableHeader id={`likert-table-header-${id}`}>
-              <LegacyTableRow>
-                {node?.item.textResourceBindings?.leftColumnHeader ? (
-                  <LegacyTableCell>{lang(node?.item.textResourceBindings?.leftColumnHeader)}</LegacyTableCell>
-                ) : (
-                  <LegacyTableCell />
-                )}
+            <Table.Head id={`likert-table-header-${id}`}>
+              <Table.Row>
+                <Table.HeaderCell>
+                  <span
+                    className={cn({
+                      ['sr-only']: node?.item.textResourceBindings?.leftColumnHeader == null,
+                    })}
+                  >
+                    <Lang
+                      id={node?.item.textResourceBindings?.leftColumnHeader ?? 'likert.left_column_default_header_text'}
+                    />
+                  </span>
+                </Table.HeaderCell>
                 {calculatedOptions.map((option, index) => {
                   const colLabelId = `${id}-likert-columnheader-${index}`;
                   return (
-                    <LegacyTableCell
+                    <Table.HeaderCell
                       key={option.value}
                       id={colLabelId}
-                      className={classes.likertTableHeaderTop}
                     >
                       {lang(option.label)}
-                    </LegacyTableCell>
+                    </Table.HeaderCell>
                   );
                 })}
-              </LegacyTableRow>
-            </LegacyTableHeader>
-            <LegacyTableBody id={`likert-table-body-${id}`}>
+              </Table.Row>
+            </Table.Head>
+            <Table.Body id={`likert-table-body-${id}`}>
               {node?.children().map((comp) => {
                 if (comp.isType('Group') || comp.isType('Summary')) {
                   window.logWarnOnce('Unexpected Group or Summary inside likert container:\n', comp.item.id);
@@ -154,8 +157,8 @@ export const LikertComponent = ({ node, ref }: LikertComponentProps) => {
                   />
                 );
               })}
-            </LegacyTableBody>
-          </LegacyTable>
+            </Table.Body>
+          </Table>
         </div>
       )}
     </>

--- a/src/layout/Likert/LikertComponent.tsx
+++ b/src/layout/Likert/LikertComponent.tsx
@@ -17,10 +17,9 @@ import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 interface LikertComponentProps {
   node: LayoutNode<'Likert'>;
-  ref?: React.Ref<HTMLDivElement>;
 }
 
-export const LikertComponent = ({ node, ref }: LikertComponentProps) => {
+export const LikertComponent = ({ node }: LikertComponentProps) => {
   const firstLikertChild = node?.children((item) => item.type === 'LikertItem') as LayoutNode<'LikertItem'> | undefined;
   const mobileView = useIsMobileOrTablet();
   const { options: calculatedOptions, isFetching } = useGetOptions({
@@ -101,10 +100,7 @@ export const LikertComponent = ({ node, ref }: LikertComponentProps) => {
       {isFetching ? (
         <AltinnSpinner />
       ) : (
-        <div
-          className={classes.likertTableContainer}
-          ref={ref}
-        >
+        <div className={classes.likertTableContainer}>
           <Table
             id={id}
             aria-labelledby={(hasTitle && titleId) || undefined}

--- a/src/layout/Likert/LikertComponent.tsx
+++ b/src/layout/Likert/LikertComponent.tsx
@@ -113,7 +113,7 @@ export const LikertComponent = ({ node }: LikertComponentProps) => {
                 <Table.HeaderCell>
                   <span
                     className={cn({
-                      ['sr-only']: node?.item.textResourceBindings?.leftColumnHeader == null,
+                      'sr-only': node?.item.textResourceBindings?.leftColumnHeader == null,
                     })}
                   >
                     <Lang

--- a/src/layout/Likert/LikertComponent.tsx
+++ b/src/layout/Likert/LikertComponent.tsx
@@ -106,11 +106,15 @@ export const LikertComponent = ({ node }: LikertComponentProps) => {
             aria-labelledby={(hasTitle && titleId) || undefined}
             aria-describedby={(hasDescription && descriptionId) || undefined}
             border
+            role='presentation'
             className={classes.likertTable}
           >
-            <Table.Head id={`likert-table-header-${id}`}>
-              <Table.Row>
-                <Table.HeaderCell>
+            <Table.Head
+              id={`likert-table-header-${id}`}
+              role='presentation'
+            >
+              <Table.Row role='presentation'>
+                <Table.HeaderCell role='presentation'>
                   <span
                     className={cn({
                       'sr-only': node?.item.textResourceBindings?.leftColumnHeader == null,
@@ -127,6 +131,7 @@ export const LikertComponent = ({ node }: LikertComponentProps) => {
                     <Table.HeaderCell
                       key={option.value}
                       id={colLabelId}
+                      role='presentation'
                     >
                       {lang(option.label)}
                     </Table.HeaderCell>
@@ -134,7 +139,10 @@ export const LikertComponent = ({ node }: LikertComponentProps) => {
                 })}
               </Table.Row>
             </Table.Head>
-            <Table.Body id={`likert-table-body-${id}`}>
+            <Table.Body
+              id={`likert-table-body-${id}`}
+              role='presentation'
+            >
               {node?.children().map((comp) => {
                 if (comp.isType('Group') || comp.isType('Summary')) {
                   window.logWarnOnce('Unexpected Group or Summary inside likert container:\n', comp.item.id);

--- a/src/layout/Likert/LikertComponent.tsx
+++ b/src/layout/Likert/LikertComponent.tsx
@@ -106,15 +106,11 @@ export const LikertComponent = ({ node }: LikertComponentProps) => {
             aria-labelledby={(hasTitle && titleId) || undefined}
             aria-describedby={(hasDescription && descriptionId) || undefined}
             border
-            role='presentation'
             className={classes.likertTable}
           >
-            <Table.Head
-              id={`likert-table-header-${id}`}
-              role='presentation'
-            >
-              <Table.Row role='presentation'>
-                <Table.HeaderCell role='presentation'>
+            <Table.Head id={`likert-table-header-${id}`}>
+              <Table.Row>
+                <Table.HeaderCell>
                   <span
                     className={cn({
                       'sr-only': node?.item.textResourceBindings?.leftColumnHeader == null,
@@ -131,7 +127,6 @@ export const LikertComponent = ({ node }: LikertComponentProps) => {
                     <Table.HeaderCell
                       key={option.value}
                       id={colLabelId}
-                      role='presentation'
                     >
                       {lang(option.label)}
                     </Table.HeaderCell>
@@ -139,10 +134,7 @@ export const LikertComponent = ({ node }: LikertComponentProps) => {
                 })}
               </Table.Row>
             </Table.Head>
-            <Table.Body
-              id={`likert-table-body-${id}`}
-              role='presentation'
-            >
+            <Table.Body id={`likert-table-body-${id}`}>
               {node?.children().map((comp) => {
                 if (comp.isType('Group') || comp.isType('Summary')) {
                   window.logWarnOnce('Unexpected Group or Summary inside likert container:\n', comp.item.id);

--- a/src/layout/Likert/LikertComponent.tsx
+++ b/src/layout/Likert/LikertComponent.tsx
@@ -105,7 +105,6 @@ export const LikertComponent = ({ node }: LikertComponentProps) => {
             id={id}
             aria-labelledby={(hasTitle && titleId) || undefined}
             aria-describedby={(hasDescription && descriptionId) || undefined}
-            border
             className={classes.likertTable}
           >
             <Table.Head id={`likert-table-header-${id}`}>

--- a/src/layout/Likert/index.tsx
+++ b/src/layout/Likert/index.tsx
@@ -26,9 +26,7 @@ export class Likert extends LikertDef implements ValidateAny {
     return true;
   }
 
-  render(props: PropsFromGenericComponent<'Likert'>): JSX.Element | null {
-    return <LikertComponent {...props} />;
-  }
+  render = (props: PropsFromGenericComponent<'Likert'>): JSX.Element | null => <LikertComponent {...props} />;
 
   renderSummary({
     onChangeClick,

--- a/src/layout/LikertItem/LikertItemComponent.module.css
+++ b/src/layout/LikertItem/LikertItemComponent.module.css
@@ -1,3 +1,7 @@
+.likertTable {
+  width: 100%;
+}
+
 .likertRadioGroupWrapperMobile {
   padding-top: 12px;
 }
@@ -6,22 +10,4 @@
   display: block;
   width: 100%;
   padding: 12px;
-}
-
-.likertTableHeaderTop {
-  text-align: center !important; /* remove important after https://github.com/Altinn/app-frontend-react/pull/1330*/
-}
-
-.likertTableRowHeader {
-  border-top: 1px solid #dde3e5;
-  border-bottom: 1px solid #dde3e5;
-  background-color: transparent !important; /* remove important after https://github.com/Altinn/app-frontend-react/pull/1330*/
-}
-
-.likertTableCell {
-  padding: 4px 12px;
-}
-
-.likertTableRow:hover {
-  background-color: #e3f7ff;
 }

--- a/src/layout/LikertItem/LikertItemComponent.module.css
+++ b/src/layout/LikertItem/LikertItemComponent.module.css
@@ -2,6 +2,37 @@
   width: 100%;
 }
 
+/* ====
+TODO(1779): Remove these styles after going through all the different Table styles in
+Altinn, and making sure they are consistent. */
+.likertTable {
+  box-shadow:
+    0 1px 1px rgba(0, 0, 0, 0.12),
+    0 2px 2px rgba(0, 0, 0, 0.12);
+}
+
+.likertTable th {
+  background-color: #f5f5f5;
+  border-bottom: 1px solid #dde3e5;
+  padding-top: 15px;
+  padding-bottom: 15px;
+}
+
+.likertTable tr:not(:last-of-type) td {
+  padding-top: 8px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid #dde3e5;
+}
+
+.likertTable tr:last-of-type td {
+  border-bottom: none;
+}
+
+.likertTable tr:hover {
+  background-color: #e3f7ff;
+}
+/* ==== */
+
 .likertRadioGroupWrapperMobile {
   padding-top: 12px;
 }

--- a/src/layout/LikertItem/LikertItemComponent.tsx
+++ b/src/layout/LikertItem/LikertItemComponent.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { LegacyTableCell, LegacyTableRow } from '@digdir/design-system-react';
+import { Table } from '@digdir/design-system-react';
 import { Typography } from '@material-ui/core';
 
 import { RadioButton } from 'src/components/form/RadioButton';
@@ -40,16 +40,12 @@ const RadioGroupTableRow = (props: IControlledRadioGroupProps) => {
   const rowLabelId = `row-label-${id}`;
 
   return (
-    <LegacyTableRow
+    <Table.Row
       aria-labelledby={rowLabelId}
       data-componentid={node.item.id}
       data-is-loading={fetchingOptions ? 'true' : 'false'}
-      className={classes.likertTableRow}
     >
-      <LegacyTableCell
-        id={rowLabelId}
-        className={classes.likertTableRowHeader}
-      >
+      <Table.Cell id={rowLabelId}>
         <Typography component={'div'}>
           <GenericComponentLegend />
           <ComponentValidations
@@ -57,25 +53,24 @@ const RadioGroupTableRow = (props: IControlledRadioGroupProps) => {
             node={node}
           />
         </Typography>
-      </LegacyTableCell>
+      </Table.Cell>
       {calculatedOptions?.map((option, colIndex) => {
         const colLabelId = `${groupContainerId}-likert-columnheader-${colIndex}`;
         const isChecked = selected === option.value;
         return (
-          <LegacyTableCell
-            key={option.value}
-            className={classes.likertTableCell}
-          >
+          <Table.Cell key={option.value}>
             <RadioButton
               aria-labelledby={`${rowLabelId} ${colLabelId}`}
               checked={isChecked}
               onChange={handleChange}
               value={option.value}
               name={rowLabelId}
+              label={option.label}
+              hideLabel
             />
-          </LegacyTableCell>
+          </Table.Cell>
         );
       })}
-    </LegacyTableRow>
+    </Table.Row>
   );
 };

--- a/src/layout/LikertItem/LikertItemComponent.tsx
+++ b/src/layout/LikertItem/LikertItemComponent.tsx
@@ -60,6 +60,7 @@ const RadioGroupTableRow = forwardRef<HTMLTableRowElement, IControlledRadioGroup
           <ComponentValidations
             validations={validations}
             node={node}
+            ariaHide
           />
         </Typography>
       </Table.Cell>
@@ -74,8 +75,6 @@ const RadioGroupTableRow = forwardRef<HTMLTableRowElement, IControlledRadioGroup
               onChange={handleChange}
               value={option.value}
               name={rowLabelId}
-              label={option.label}
-              hideLabel
             />
           </Table.Cell>
         );

--- a/src/layout/LikertItem/LikertItemComponent.tsx
+++ b/src/layout/LikertItem/LikertItemComponent.tsx
@@ -60,7 +60,6 @@ const RadioGroupTableRow = forwardRef<HTMLTableRowElement, IControlledRadioGroup
           <ComponentValidations
             validations={validations}
             node={node}
-            ariaHide
           />
         </Typography>
       </Table.Cell>

--- a/src/layout/LikertItem/LikertItemComponent.tsx
+++ b/src/layout/LikertItem/LikertItemComponent.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import { Table } from '@digdir/design-system-react';
 import { Typography } from '@material-ui/core';
@@ -14,23 +14,31 @@ import { useRadioButtons } from 'src/layout/RadioButtons/radioButtonsUtils';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type { IControlledRadioGroupProps } from 'src/layout/RadioButtons/ControlledRadioGroup';
 
-export const LikertItemComponent = (props: PropsFromGenericComponent<'LikertItem'>) => {
-  const nodeLayout = props.node.item.layout;
-  const overriddenLayout = props.overrideItemProps?.layout;
-  const actualLayout = overriddenLayout || nodeLayout;
+export const LikertItemComponent = forwardRef<HTMLTableRowElement, PropsFromGenericComponent<'LikertItem'>>(
+  (props, ref) => {
+    const nodeLayout = props.node.item.layout;
+    const overriddenLayout = props.overrideItemProps?.layout;
+    const actualLayout = overriddenLayout || nodeLayout;
 
-  if (actualLayout === LayoutStyle.Table) {
-    return <RadioGroupTableRow {...props} />;
-  }
+    if (actualLayout === LayoutStyle.Table) {
+      return (
+        <RadioGroupTableRow
+          {...props}
+          ref={ref}
+        />
+      );
+    }
 
-  return (
-    <div className={classes.likertRadioGroupWrapperMobile}>
-      <ControlledRadioGroup {...props} />
-    </div>
-  );
-};
+    return (
+      <div className={classes.likertRadioGroupWrapperMobile}>
+        <ControlledRadioGroup {...props} />
+      </div>
+    );
+  },
+);
+LikertItemComponent.displayName = 'LikertItemComponent';
 
-const RadioGroupTableRow = (props: IControlledRadioGroupProps) => {
+const RadioGroupTableRow = forwardRef<HTMLTableRowElement, IControlledRadioGroupProps>((props, ref) => {
   const { node } = props;
   const { selected, handleChange, calculatedOptions, fetchingOptions } = useRadioButtons(props);
   const validations = useUnifiedValidationsForNode(node);
@@ -44,6 +52,7 @@ const RadioGroupTableRow = (props: IControlledRadioGroupProps) => {
       aria-labelledby={rowLabelId}
       data-componentid={node.item.id}
       data-is-loading={fetchingOptions ? 'true' : 'false'}
+      ref={ref}
     >
       <Table.Cell id={rowLabelId}>
         <Typography component={'div'}>
@@ -73,4 +82,5 @@ const RadioGroupTableRow = (props: IControlledRadioGroupProps) => {
       })}
     </Table.Row>
   );
-};
+});
+RadioGroupTableRow.displayName = 'RadioGroupTableRow';

--- a/src/layout/LikertItem/index.tsx
+++ b/src/layout/LikertItem/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { getSelectedValueToText } from 'src/features/options/getSelectedValueToText';
@@ -13,9 +13,15 @@ import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class LikertItem extends LikertItemDef {
-  render(props: PropsFromGenericComponent<'LikertItem'>): JSX.Element | null {
-    return <LikertItemComponent {...props} />;
-  }
+  // eslint-disable-next-line react/display-name
+  render = forwardRef<HTMLTableRowElement, PropsFromGenericComponent<'LikertItem'>>(
+    (props, ref): JSX.Element | null => (
+      <LikertItemComponent
+        {...props}
+        ref={ref}
+      />
+    ),
+  );
 
   directRender(props: PropsFromGenericComponent<'LikertItem'>): boolean {
     return props.node.item.layout === LayoutStyle.Table || props.overrideItemProps?.layout === LayoutStyle.Table;

--- a/src/layout/Link/index.tsx
+++ b/src/layout/Link/index.tsx
@@ -6,7 +6,5 @@ import { LinkDef } from 'src/layout/Link/config.def.generated';
 import { LinkComponent } from 'src/layout/Link/LinkComponent';
 
 export class Link extends LinkDef {
-  render(props: PropsFromGenericComponent<'Link'>): JSX.Element | null {
-    return <LinkComponent {...props} />;
-  }
+  render = (props: PropsFromGenericComponent<'Link'>): JSX.Element | null => <LinkComponent {...props} />;
 }

--- a/src/layout/List/index.tsx
+++ b/src/layout/List/index.tsx
@@ -15,9 +15,7 @@ import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class List extends ListDef {
-  render(props: PropsFromGenericComponent<'List'>): JSX.Element | null {
-    return <ListComponent {...props} />;
-  }
+  render = (props: PropsFromGenericComponent<'List'>): JSX.Element | null => <ListComponent {...props} />;
 
   getDisplayData(node: LayoutNode<'List'>): string {
     const formData = node.getFormData();

--- a/src/layout/Map/index.tsx
+++ b/src/layout/Map/index.tsx
@@ -10,9 +10,7 @@ import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class Map extends MapDef {
-  render(props: PropsFromGenericComponent<'Map'>): JSX.Element | null {
-    return <MapComponent {...props} />;
-  }
+  render = (props: PropsFromGenericComponent<'Map'>): JSX.Element | null => <MapComponent {...props} />;
 
   getDisplayData(node: LayoutNode<'Map'>): string {
     if (!node.item.dataModelBindings?.simpleBinding) {

--- a/src/layout/MultipleSelect/index.tsx
+++ b/src/layout/MultipleSelect/index.tsx
@@ -15,9 +15,9 @@ import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class MultipleSelect extends MultipleSelectDef {
-  render(props: PropsFromGenericComponent<'MultipleSelect'>): JSX.Element | null {
-    return <MultipleSelectComponent {...props} />;
-  }
+  render = (props: PropsFromGenericComponent<'MultipleSelect'>): JSX.Element | null => (
+    <MultipleSelectComponent {...props} />
+  );
 
   private getSummaryData(
     node: LayoutNode<'MultipleSelect'>,

--- a/src/layout/NavigationBar/index.tsx
+++ b/src/layout/NavigationBar/index.tsx
@@ -5,7 +5,7 @@ import { NavigationBarComponent } from 'src/layout/NavigationBar/NavigationBarCo
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export class NavigationBar extends NavigationBarDef {
-  render(props: PropsFromGenericComponent<'NavigationBar'>): JSX.Element | null {
-    return <NavigationBarComponent {...props} />;
-  }
+  render = (props: PropsFromGenericComponent<'NavigationBar'>): JSX.Element | null => (
+    <NavigationBarComponent {...props} />
+  );
 }

--- a/src/layout/NavigationButtons/index.tsx
+++ b/src/layout/NavigationButtons/index.tsx
@@ -5,7 +5,7 @@ import { NavigationButtonsComponent } from 'src/layout/NavigationButtons/Navigat
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export class NavigationButtons extends NavigationButtonsDef {
-  render(props: PropsFromGenericComponent<'NavigationButtons'>): JSX.Element | null {
-    return <NavigationButtonsComponent {...props} />;
-  }
+  render = (props: PropsFromGenericComponent<'NavigationButtons'>): JSX.Element | null => (
+    <NavigationButtonsComponent {...props} />
+  );
 }

--- a/src/layout/Panel/index.tsx
+++ b/src/layout/Panel/index.tsx
@@ -5,7 +5,5 @@ import { PanelComponent } from 'src/layout/Panel/PanelComponent';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export class Panel extends PanelDef {
-  render(props: PropsFromGenericComponent<'Panel'>): JSX.Element | null {
-    return <PanelComponent {...props} />;
-  }
+  render = (props: PropsFromGenericComponent<'Panel'>): JSX.Element | null => <PanelComponent {...props} />;
 }

--- a/src/layout/Paragraph/index.tsx
+++ b/src/layout/Paragraph/index.tsx
@@ -5,7 +5,5 @@ import { ParagraphComponent } from 'src/layout/Paragraph/ParagraphComponent';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export class Paragraph extends ParagraphDef {
-  render(props: PropsFromGenericComponent<'Paragraph'>): JSX.Element | null {
-    return <ParagraphComponent {...props} />;
-  }
+  render = (props: PropsFromGenericComponent<'Paragraph'>): JSX.Element | null => <ParagraphComponent {...props} />;
 }

--- a/src/layout/PrintButton/index.tsx
+++ b/src/layout/PrintButton/index.tsx
@@ -6,7 +6,5 @@ import { PrintButtonDef } from 'src/layout/PrintButton/config.def.generated';
 import { PrintButtonComponent } from 'src/layout/PrintButton/PrintButtonComponent';
 
 export class PrintButton extends PrintButtonDef {
-  render(props: PropsFromGenericComponent<'PrintButton'>): JSX.Element | null {
-    return <PrintButtonComponent {...props} />;
-  }
+  render = (props: PropsFromGenericComponent<'PrintButton'>): JSX.Element | null => <PrintButtonComponent {...props} />;
 }

--- a/src/layout/RadioButtons/index.tsx
+++ b/src/layout/RadioButtons/index.tsx
@@ -11,9 +11,9 @@ import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class RadioButtons extends RadioButtonsDef {
-  render(props: PropsFromGenericComponent<'RadioButtons'>): JSX.Element | null {
-    return <RadioButtonContainerComponent {...props} />;
-  }
+  render = (props: PropsFromGenericComponent<'RadioButtons'>): JSX.Element | null => (
+    <RadioButtonContainerComponent {...props} />
+  );
 
   getDisplayData(node: LayoutNode<'RadioButtons'>, { langTools, options }: DisplayDataProps): string {
     const value = String(node.getFormData().simpleBinding ?? '');

--- a/src/layout/RepeatingGroup/RepeatingGroup.module.css
+++ b/src/layout/RepeatingGroup/RepeatingGroup.module.css
@@ -26,7 +26,24 @@
   width: 100%;
 }
 
-.repeatingGroupTable tr:hover {
+/* ====
+TODO(1779): Remove these styles after going through all the different Table styles in
+Altinn, and making sure they are consistent. */
+.repeatingGroupTable > thead > tr > th {
+  background-color: #f5f5f5;
+  border-bottom: 1px solid #dde3e5;
+  padding-top: 15px;
+  padding-bottom: 15px;
+}
+
+.repeatingGroupTable > tbody > tr > td {
+  border-bottom: 1px solid #dde3e5;
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+/* ==== */
+
+.repeatingGroupTable > tbody > tr:hover {
   background-color: unset;
 }
 
@@ -34,12 +51,14 @@
   background-color: var(--fds-semantic-surface-neutral-default);
 }
 
-.nestedTable th {
-  background-color: var(--fds-semantic-background-subtle);
+.nestedTable > thead > tr > th {
+  /*background-color: var(--fds-semantic-background-subtle);*/
+  background-color: #f5f5f5;
 }
 
 .nestedTable thead:not(:first-of-type) th {
-  border-top: 2px solid var(--fds-semantic-border-divider-default);
+  /*border-top: 2px solid var(--fds-semantic-border-divider-default);*/
+  border-top: 1px solid #dde3e5; /* Remove this and uncomment the line above when adjusting the new table component*/
 }
 
 .nestedTable thead:not(:first-of-type) th:first-of-type {
@@ -67,7 +86,7 @@
   background-color: var(--repeating-group-edit-surface-color);
 }
 
-tr.editingRow:hover {
+table > tbody > tr.editingRow:hover {
   background-color: var(--repeating-group-edit-surface-color);
 }
 

--- a/src/layout/RepeatingGroup/RepeatingGroup.module.css
+++ b/src/layout/RepeatingGroup/RepeatingGroup.module.css
@@ -18,7 +18,6 @@
 }
 
 .nestedGroupContainer {
-  overflow-x: auto;
   margin: 0 0 15px 0;
   width: 100%;
 }
@@ -65,6 +64,10 @@
 
 .editingRow {
   border-top: 2px dotted var(--repeating-group-edit-border-color);
+  background-color: var(--repeating-group-edit-surface-color);
+}
+
+tr.editingRow:hover {
   background-color: var(--repeating-group-edit-surface-color);
 }
 

--- a/src/layout/RepeatingGroup/RepeatingGroup.module.css
+++ b/src/layout/RepeatingGroup/RepeatingGroup.module.css
@@ -27,6 +27,10 @@
   width: 100%;
 }
 
+.repeatingGroupTable tr:hover {
+  background-color: unset;
+}
+
 .nestedTable {
   background-color: var(--fds-semantic-surface-neutral-default);
 }

--- a/src/layout/RepeatingGroup/RepeatingGroup.module.css
+++ b/src/layout/RepeatingGroup/RepeatingGroup.module.css
@@ -9,18 +9,41 @@
 
 .groupContainer > table > tbody > tr > td:first-child,
 .groupContainer > table > thead > tr > th:first-child {
-  padding-left: calc(var(--modal-padding-x) - var(--table-input-margin));
+  padding-left: var(--modal-padding-x);
 }
 
 .groupContainer > table > tbody > tr > td:last-child,
 .groupContainer > table > thead > tr > th:last-child {
-  padding-right: calc(var(--modal-padding-x) - var(--table-input-margin));
+  padding-right: var(--modal-padding-x);
 }
 
 .nestedGroupContainer {
   overflow-x: auto;
   margin: 0 0 15px 0;
   width: 100%;
+}
+
+.repeatingGroupTable {
+  width: 100%;
+}
+
+.nestedTable {
+  background-color: var(--fds-semantic-surface-neutral-default);
+}
+
+.nestedTable th {
+  background-color: var(--fds-semantic-background-subtle);
+}
+
+.nestedTable thead:not(:first-of-type) th {
+  border-top: 2px solid var(--fds-semantic-border-divider-default);
+}
+
+.nestedTable thead:not(:first-of-type) th:first-of-type {
+  border-top-left-radius: 0 !important;
+}
+.nestedTable thead:not(:first-of-type) th:last-of-type {
+  border-top-right-radius: 0 !important;
 }
 
 .tableEmpty {

--- a/src/layout/RepeatingGroup/RepeatingGroupTable.tsx
+++ b/src/layout/RepeatingGroup/RepeatingGroupTable.tsx
@@ -1,12 +1,6 @@
 import React from 'react';
 
-import {
-  LegacyTable,
-  LegacyTableBody,
-  LegacyTableCell,
-  LegacyTableHeader,
-  LegacyTableRow,
-} from '@digdir/design-system-react';
+import { Table } from '@digdir/design-system-react';
 import cn from 'classnames';
 
 import { Caption } from 'src/components/form/Caption';
@@ -106,20 +100,20 @@ export function RepeatingGroupTable(): React.JSX.Element | null {
       }
 
       return (
-        <LegacyTableBody>
-          <LegacyTableRow>
-            <LegacyTableCell className={classes.mobileTableCell}>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell className={classes.mobileTableCell}>
               {nodes.map((child) => (
                 <GenericComponent
                   key={child.item.id}
                   node={child}
                 />
               ))}
-            </LegacyTableCell>
+            </Table.Cell>
             {/* One extra cell to make place for edit/delete buttons */}
-            <LegacyTableCell className={classes.mobileTableCell} />
-          </LegacyTableRow>
-        </LegacyTableBody>
+            <Table.Cell className={classes.mobileTableCell} />
+          </Table.Row>
+        </Table.Body>
       );
     }
 
@@ -148,9 +142,15 @@ export function RepeatingGroupTable(): React.JSX.Element | null {
         [classes.tableEmpty]: isEmpty,
       })}
     >
-      <LegacyTable
+      <Table
         id={`group-${id}-table`}
-        className={cn({ [classes.editingBorder]: isNested }, classes.repeatingGroupTable)}
+        className={cn(
+          { [classes.editingBorder]: isNested, [classes.nestedTable]: isNested },
+          classes.repeatingGroupTable,
+        )}
+        // If the list is empty, the border of the table will be visible as a line above
+        // the "Legg til ny" button.
+        border={isNested && visibleRowIndexes.length > 0}
       >
         {textResourceBindings?.title && (
           <Caption
@@ -168,10 +168,10 @@ export function RepeatingGroupTable(): React.JSX.Element | null {
           where={'Before'}
         />
         {showTableHeader && !mobileView && (
-          <LegacyTableHeader id={`group-${id}-table-header`}>
-            <LegacyTableRow className={classes.repeatingGroupRow}>
+          <Table.Head id={`group-${id}-table-header`}>
+            <Table.Row className={classes.repeatingGroupRow}>
               {tableNodes?.map((n) => (
-                <LegacyTableCell
+                <Table.HeaderCell
                   key={n.item.id}
                   className={classes.tableCellFormatting}
                   style={getColumnStylesRepeatingGroups(n, columnSettings)}
@@ -180,26 +180,26 @@ export function RepeatingGroupTable(): React.JSX.Element | null {
                     node={n}
                     columnSettings={columnSettings}
                   />
-                </LegacyTableCell>
+                </Table.HeaderCell>
               ))}
               {displayEditColumn && (
-                <LegacyTableCell style={{ padding: 0, paddingRight: '10px' }}>
+                <Table.HeaderCell style={{ padding: 0, paddingRight: '10px' }}>
                   <span className={classes.visuallyHidden}>
                     <Lang id={'general.edit'} />
                   </span>
-                </LegacyTableCell>
+                </Table.HeaderCell>
               )}
               {displayDeleteColumn && (
-                <LegacyTableCell style={{ padding: 0 }}>
+                <Table.HeaderCell style={{ padding: 0 }}>
                   <span className={classes.visuallyHidden}>
                     <Lang id={'general.delete'} />
                   </span>
-                </LegacyTableCell>
+                </Table.HeaderCell>
               )}
-            </LegacyTableRow>
-          </LegacyTableHeader>
+            </Table.Row>
+          </Table.Head>
         )}
-        <LegacyTableBody id={`group-${id}-table-body`}>
+        <Table.Body id={`group-${id}-table-body`}>
           {visibleRowIndexes.map((index: number) => {
             const isEditingRow = isEditing(index) && edit?.mode !== 'onlyTable';
             return (
@@ -215,12 +215,13 @@ export function RepeatingGroupTable(): React.JSX.Element | null {
                   displayEditColumn={displayEditColumn}
                 />
                 {isEditingRow && (
-                  <LegacyTableRow
+                  <Table.Row
                     key={`edit-container-${index}`}
                     className={classes.editContainerRow}
                   >
-                    <LegacyTableCell
+                    <Table.Cell
                       style={{ padding: 0, borderTop: 0 }}
+                      // @ts-expect-error this will be fixed in v0.48.0 of the design system
                       colSpan={
                         mobileView
                           ? 2
@@ -228,18 +229,18 @@ export function RepeatingGroupTable(): React.JSX.Element | null {
                       }
                     >
                       {edit?.mode !== 'onlyTable' && <RepeatingGroupsEditContainer editIndex={index} />}
-                    </LegacyTableCell>
-                  </LegacyTableRow>
+                    </Table.Cell>
+                  </Table.Row>
                 )}
               </React.Fragment>
             );
           })}
-        </LegacyTableBody>
+        </Table.Body>
         <RenderExtraRows
           rows={rowsAfter}
           where={'After'}
         />
-      </LegacyTable>
+      </Table>
     </div>
   );
 }

--- a/src/layout/RepeatingGroup/RepeatingGroupTableRow.tsx
+++ b/src/layout/RepeatingGroup/RepeatingGroupTableRow.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Button, LegacyTableCell, LegacyTableRow } from '@digdir/design-system-react';
+import { Button, Table } from '@digdir/design-system-react';
 import { Grid } from '@material-ui/core';
 import { Delete as DeleteIcon, Edit as EditIcon, ErrorColored as ErrorIcon } from '@navikt/ds-icons';
 import cn from 'classnames';
@@ -119,7 +119,7 @@ export function RepeatingGroupTableRow({
   const deleteButtonText = langAsString('general.delete');
 
   return (
-    <LegacyTableRow
+    <Table.Row
       key={`repeating-group-row-${index}`}
       className={cn(
         {
@@ -132,7 +132,7 @@ export function RepeatingGroupTableRow({
       {!mobileView ? (
         tableNodes.map((n, idx) =>
           shouldEditInTable(edit, n, columnSettings) ? (
-            <LegacyTableCell
+            <Table.Cell
               key={n.item.id}
               className={classes.tableCell}
             >
@@ -149,9 +149,9 @@ export function RepeatingGroupTableRow({
                   }}
                 />
               </div>
-            </LegacyTableCell>
+            </Table.Cell>
           ) : (
-            <LegacyTableCell
+            <Table.Cell
               key={`${n.item.id}-${index}`}
               className={classes.tableCell}
             >
@@ -161,11 +161,11 @@ export function RepeatingGroupTableRow({
               >
                 {isEditingRow ? null : displayData[idx]}
               </span>
-            </LegacyTableCell>
+            </Table.Cell>
           ),
         )
       ) : (
-        <LegacyTableCell className={classes.mobileTableCell}>
+        <Table.Cell className={classes.mobileTableCell}>
           <Grid
             container={true}
             spacing={3}
@@ -202,20 +202,22 @@ export function RepeatingGroupTableRow({
                 )),
             )}
           </Grid>
-        </LegacyTableCell>
+        </Table.Cell>
       )}
       {!mobileView ? (
         <>
           {edit?.editButton === false && edit?.deleteButton === false && (displayEditColumn || displayDeleteColumn) ? (
-            <LegacyTableCell
+            <Table.Cell
               key={`editDelete-${index}`}
+              // @ts-expect-error this will be fixed in v0.48.0 of the design system
               colSpan={displayEditColumn && displayDeleteColumn ? 2 : 1}
             />
           ) : null}
           {edit?.editButton !== false && displayEditColumn && (
-            <LegacyTableCell
+            <Table.Cell
               key={`edit-${index}`}
               className={classes.buttonCell}
+              // @ts-expect-error this will be fixed in v0.48.0 of the design system
               colSpan={displayDeleteColumn && edit?.deleteButton === false ? 2 : 1}
             >
               <div className={classes.buttonInCellWrapper}>
@@ -235,12 +237,13 @@ export function RepeatingGroupTableRow({
                   {editButtonText}
                 </Button>
               </div>
-            </LegacyTableCell>
+            </Table.Cell>
           )}
           {edit?.deleteButton !== false && displayDeleteColumn && (
-            <LegacyTableCell
+            <Table.Cell
               key={`delete-${index}`}
               className={cn(classes.buttonCell)}
+              // @ts-expect-error this will be fixed in v0.48.0 of the design system
               colSpan={displayEditColumn && edit?.editButton === false ? 2 : 1}
             >
               <div className={classes.buttonInCellWrapper}>
@@ -256,11 +259,11 @@ export function RepeatingGroupTableRow({
                   {deleteButtonText}
                 </DeleteElement>
               </div>
-            </LegacyTableCell>
+            </Table.Cell>
           )}
         </>
       ) : (
-        <LegacyTableCell
+        <Table.Cell
           className={cn(classes.buttonCell, classes.mobileTableCell)}
           style={{ verticalAlign: 'top' }}
         >
@@ -299,9 +302,9 @@ export function RepeatingGroupTableRow({
               </>
             )}
           </div>
-        </LegacyTableCell>
+        </Table.Cell>
       )}
-    </LegacyTableRow>
+    </Table.Row>
   );
 }
 

--- a/src/layout/RepeatingGroup/index.tsx
+++ b/src/layout/RepeatingGroup/index.tsx
@@ -29,15 +29,13 @@ export class RepeatingGroup extends RepeatingGroupDef implements ValidateAny, Va
     return true;
   }
 
-  render(props: PropsFromGenericComponent<'RepeatingGroup'>): JSX.Element | null {
-    return (
-      <RepeatingGroupProvider node={props.node}>
-        <RepeatingGroupsFocusProvider>
-          <RepeatingGroupContainer containerDivRef={props.containerDivRef} />
-        </RepeatingGroupsFocusProvider>
-      </RepeatingGroupProvider>
-    );
-  }
+  render = (props: PropsFromGenericComponent<'RepeatingGroup'>): JSX.Element | null => (
+    <RepeatingGroupProvider node={props.node}>
+      <RepeatingGroupsFocusProvider>
+        <RepeatingGroupContainer containerDivRef={props.containerDivRef} />
+      </RepeatingGroupsFocusProvider>
+    </RepeatingGroupProvider>
+  );
 
   renderSummary({
     onChangeClick,

--- a/src/layout/Summary/index.tsx
+++ b/src/layout/Summary/index.tsx
@@ -10,15 +10,13 @@ export class Summary extends SummaryDef {
     return true;
   }
 
-  render(props: PropsFromGenericComponent<'Summary'>): JSX.Element | null {
-    return (
-      <SummaryComponent
-        summaryNode={props.node}
-        overrides={props.overrideItemProps}
-        ref={props.containerDivRef}
-      />
-    );
-  }
+  render = (props: PropsFromGenericComponent<'Summary'>): JSX.Element | null => (
+    <SummaryComponent
+      summaryNode={props.node}
+      overrides={props.overrideItemProps}
+      ref={props.containerDivRef}
+    />
+  );
 
   renderSummary(): JSX.Element | null {
     // If the code ever ends up with a Summary component referencing another Summary component, we should not end up

--- a/src/layout/TextArea/index.tsx
+++ b/src/layout/TextArea/index.tsx
@@ -10,9 +10,7 @@ import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class TextArea extends TextAreaDef {
-  render(props: PropsFromGenericComponent<'TextArea'>): JSX.Element | null {
-    return <TextAreaComponent {...props} />;
-  }
+  render = (props: PropsFromGenericComponent<'TextArea'>): JSX.Element | null => <TextAreaComponent {...props} />;
 
   getDisplayData(node: LayoutNode<'TextArea'>): string {
     if (!node.item.dataModelBindings?.simpleBinding) {

--- a/test/e2e/integration/frontend-test/grid.ts
+++ b/test/e2e/integration/frontend-test/grid.ts
@@ -163,7 +163,7 @@ describe('Grid component', () => {
 
     cy.get(appFrontend.grid.grid).find('tr:eq(2) td:eq(0)').should('contain.text', 'Dette er en beskrivende tekst');
     cy.get(appFrontend.grid.grid).find('tr:eq(2) td:eq(0)').find(appFrontend.helpText.button).click();
-    cy.get(appFrontend.grid.grid).find('tr:eq(2) td:eq(0) label').click();
+    cy.get(appFrontend.grid.grid).find('tr:eq(2) td:eq(0) label').click({ force: true });
     // eslint-disable-next-line cypress/unsafe-to-chain-command
     cy.focused().should('have.attr', 'id', 'fordeling-studie');
   });

--- a/test/e2e/integration/frontend-test/group.ts
+++ b/test/e2e/integration/frontend-test/group.ts
@@ -448,9 +448,9 @@ describe('Group', () => {
     cy.get(appFrontend.group.subGroup).find(appFrontend.group.delete).click();
     cy.snapshot('group: delete-warning-popup');
 
-    cy.get(appFrontend.group.subGroup).find(appFrontend.group.popOverCancelButton).click();
+    cy.get(appFrontend.group.subGroup).find(appFrontend.group.popOverCancelButton).click({ force: true });
     cy.get(appFrontend.group.subGroup).find(appFrontend.group.delete).click();
-    cy.get(appFrontend.group.subGroup).find(appFrontend.group.popOverDeleteButton).click();
+    cy.get(appFrontend.group.subGroup).find(appFrontend.group.popOverDeleteButton).click({ force: true });
 
     cy.get(appFrontend.group.subGroup).find('tbody > tr > td').should('have.length', 0);
 

--- a/test/e2e/integration/frontend-test/validation.ts
+++ b/test/e2e/integration/frontend-test/validation.ts
@@ -761,5 +761,14 @@ describe('Validation', () => {
       // Content from next page
       cy.findByText('Nåværende navn').should('exist');
     });
+
+    it('Should navigate and focus correct row in Likert component when clicking on error report', () => {
+      cy.goto('likert');
+      cy.findByRole('button', { name: /Send inn/ }).click();
+
+      cy.findByRole('radio', { name: 'Hører skolen på elevenes forslag? * Alltid' }).should('not.be.focused');
+      cy.findByRole('button', { name: /Du må fylle ut hører skolen på elevenes forslag/ }).click();
+      cy.findByRole('radio', { name: 'Hører skolen på elevenes forslag? * Alltid' }).should('be.focused');
+    });
   });
 });

--- a/test/e2e/integration/frontend-test/validation.ts
+++ b/test/e2e/integration/frontend-test/validation.ts
@@ -766,9 +766,13 @@ describe('Validation', () => {
       cy.goto('likert');
       cy.findByRole('button', { name: /Send inn/ }).click();
 
-      cy.findByRole('radio', { name: 'Hører skolen på elevenes forslag? * Alltid' }).should('not.be.focused');
+      cy.findByRole('radio', {
+        name: 'Hører skolen på elevenes forslag? * Du må fylle ut hører skolen på elevenes forslag? Alltid',
+      }).should('not.be.focused');
       cy.findByRole('button', { name: /Du må fylle ut hører skolen på elevenes forslag/ }).click();
-      cy.findByRole('radio', { name: 'Hører skolen på elevenes forslag? * Alltid' }).should('be.focused');
+      cy.findByRole('radio', {
+        name: 'Hører skolen på elevenes forslag? * Du må fylle ut hører skolen på elevenes forslag? Alltid',
+      }).should('be.focused');
     });
   });
 });


### PR DESCRIPTION
## Description
This PR fixes an issue where navigating to the row of a Likert referenced in the `ErrorReport` did not work. I fixed this by updating the `Table` components to the latest version of the design system, and passing along a ref to the `Table.Row` component of the `LikertItem` in question. 

To be able to do this, i had to change the type of the `render` function from being an  instance member function to an instance member property, i.e an arrow function. 

When exchanging the table component of `Likert`, I noticed we had quite a few aria-issues. For one, the `RadioButton`s did not have any content in their label. So I added a label, and hid it with the `hideLabel` prop.

When not providing a ` textResourceBindings.leftColumnHeader` this creates an aria error as the content of this `th` is missing. So I added som generic default values for this column, and visually hid the text if the `leftColumnHeader` property is not set by the user. 

### Code changes: 

- Update all LayoutComponent's render functions to be arrow functions
- Update LikertComponent to use the latest Table components from @digdir/design-system-react.
- Update GridComponent to use the latest Table components from @digdir/design-system-react.
- Update InstanceSelection to use the latest Table components from @digdir/design-system-react.
- Add `likert.left_column_default_header_text` to `LikertComponent`. 

## Related Issue(s)

- closes #1779 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [x] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
