### PR TITLE
Adding cypress test for validation + saving `onChangePage`

### DIFF
--- a/test/e2e/integration/frontend-test/auto-save-behavior.ts
+++ b/test/e2e/integration/frontend-test/auto-save-behavior.ts
@@ -14,9 +14,9 @@ describe('Auto save behavior', () => {
     cy.goto('group').then(() => {
       cy.intercept('PATCH', '**/data/**', () => {
         formDataReqCounter++;
-      }).as('putFormData');
+      }).as('saveFormData');
       cy.get(appFrontend.group.prefill.liten).check();
-      cy.wait('@putFormData').then(() => {
+      cy.wait('@saveFormData').then(() => {
         expect(formDataReqCounter).to.be.eq(1);
       });
       cy.get(appFrontend.nextButton).clickAndGone();
@@ -36,7 +36,7 @@ describe('Auto save behavior', () => {
     cy.goto('group').then(() => {
       cy.intercept('PATCH', '**/data/**', () => {
         formDataReqCounter++;
-      }).as('putFormData');
+      }).as('saveFormData');
       cy.get(appFrontend.group.prefill.liten).check();
       // Doing a hard wait to be sure no request is sent to backend
       // eslint-disable-next-line cypress/no-unnecessary-waiting
@@ -46,7 +46,7 @@ describe('Auto save behavior', () => {
 
       // NavigationButtons
       cy.get(appFrontend.nextButton).clickAndGone();
-      cy.wait('@putFormData').then(() => {
+      cy.wait('@saveFormData').then(() => {
         expect(formDataReqCounter).to.be.eq(1);
       });
 
@@ -59,21 +59,21 @@ describe('Auto save behavior', () => {
       cy.get(appFrontend.nextButton).clickAndGone();
       cy.get(appFrontend.group.showGroupToContinue).findByRole('checkbox', { name: 'Ja' }).check();
       cy.get(appFrontend.backButton).clickAndGone();
-      cy.wait('@putFormData').then(() => {
+      cy.wait('@saveFormData').then(() => {
         expect(formDataReqCounter).to.be.eq(2);
       });
 
       // NavigationBar
       cy.get(appFrontend.group.prefill.middels).check();
       cy.get(appFrontend.navMenu).findByRole('button', { name: '2. repeating' }).click();
-      cy.wait('@putFormData').then(() => {
+      cy.wait('@saveFormData').then(() => {
         expect(formDataReqCounter).to.be.eq(3);
       });
 
       // Icon previous button
       cy.get(appFrontend.group.showGroupToContinue).findByRole('checkbox', { name: 'Ja' }).uncheck();
       cy.get(appFrontend.prevButton).clickAndGone();
-      cy.wait('@putFormData').then(() => {
+      cy.wait('@saveFormData').then(() => {
         expect(formDataReqCounter).to.be.eq(4);
       });
     });
@@ -96,7 +96,7 @@ describe('Auto save behavior', () => {
       let formDataReqCounter = 0;
       cy.intercept('PATCH', '**/data/**', () => {
         formDataReqCounter++;
-      }).as('putFormData');
+      }).as('saveFormData');
 
       // The newFirstName field has a trigger for single field validation, and it should cause a very specific error
       // message to appear if the field is set to 'test'. Regardless of the trigger on page navigation, if we're saving
@@ -115,7 +115,7 @@ describe('Auto save behavior', () => {
       cy.get(mui.selectedDate).click();
 
       cy.get(appFrontend.nextButton).clickAndGone();
-      cy.wait('@putFormData').then(() => {
+      cy.wait('@saveFormData').then(() => {
         expect(formDataReqCounter).to.be.eq(1);
       });
 
@@ -127,6 +127,83 @@ describe('Auto save behavior', () => {
       if (pages == 'current') {
         expectedErrors = ['Du må fylle ut nytt etternavn', texts.testIsNotValidValue];
       } else if (pages == 'all') {
+        expectedErrors = [
+          'Du må fylle ut nytt etternavn',
+          texts.testIsNotValidValue,
+          'Må summeres opp til 100%', // Validation on the future 'grid' page
+        ];
+      } else {
+        expectedErrors = [
+          // We don't validate the whole page, but the first name field has a trigger for single field validation,
+          // so that should be triggered when we're saving the data on page navigation.
+          texts.testIsNotValidValue,
+        ];
+      }
+
+      cy.get(appFrontend.errorReport).findAllByRole('listitem').should('have.length', expectedErrors.length);
+      for (const error of expectedErrors) {
+        cy.get(appFrontend.errorReport).should('contain.text', error);
+      }
+
+      cy.get(appFrontend.fieldValidation(appFrontend.changeOfName.newFirstName))
+        .should('have.text', texts.testIsNotValidValue)
+        .then((error) => {
+          cy.wrap(error).find('a[href="https://www.altinn.no/"]').should('exist');
+        });
+    });
+  });
+
+  ([undefined, 'current', 'currentAndPrevious', 'all'] as const).forEach((validateOnNext) => {
+    it(`should run save before single field validation with validateOnNext = ${validateOnNext || 'undefined'}`, () => {
+      cy.interceptLayoutSetsUiSettings({ autoSaveBehavior: 'onChangePage' });
+      cy.interceptLayout('changename', (component) => {
+        if (component.type === 'NavigationButtons') {
+          component.validateOnNext = validateOnNext
+            ? {
+                page: validateOnNext,
+                show: ['All'],
+              }
+            : undefined;
+        }
+      });
+
+      cy.goto('changename');
+      let saveFormDataCounter = 0;
+      cy.intercept('PATCH', '**/data/**', () => {
+        saveFormDataCounter++;
+      }).as('saveFormData');
+
+      // The newFirstName field has a trigger for single field validation, and it should cause a very specific error
+      // message to appear if the field is set to 'test'. Regardless of the trigger on page navigation, if we're saving
+      // the data on page navigation, the error message should appear (because the field is set to trigger it).
+      cy.get(appFrontend.changeOfName.newFirstName).type('test');
+
+      cy.get(appFrontend.changeOfName.newMiddleName).type('Kråka');
+      cy.get(appFrontend.changeOfName.confirmChangeName).find('input').dsCheck();
+      cy.get(appFrontend.changeOfName.reasonRelationship).click();
+      cy.get(appFrontend.changeOfName.reasonRelationship).type('hello world');
+      cy.get(appFrontend.changeOfName.dateOfEffect).siblings().findByRole('button').click();
+      cy.get(mui.selectedDate).click();
+
+      cy.get(appFrontend.nextButton).click();
+      cy.wait('@saveFormData').then(() => {
+        expect(saveFormDataCounter).to.be.eq(1);
+      });
+
+      if (validateOnNext === undefined) {
+        // We moved to the next page here, as there was nothing stopping it
+        cy.navPage('summary').should('have.attr', 'aria-current', 'page');
+        cy.gotoNavPage('form');
+      } else {
+        // None of the triggers should cause the page to change, because all of them should be triggered validation
+        // and stopped by the error message.
+        cy.navPage('form').should('have.attr', 'aria-current', 'page');
+      }
+
+      let expectedErrors: string[] = [];
+      if (validateOnNext == 'current' || validateOnNext === 'currentAndPrevious') {
+        expectedErrors = ['Du må fylle ut nytt etternavn', texts.testIsNotValidValue];
+      } else if (validateOnNext == 'all') {
         expectedErrors = [
           'Du må fylle ut nytt etternavn',
           texts.testIsNotValidValue,


### PR DESCRIPTION
## Description

This merely adds the Cypress test from #1257, adjusted to the realities of v4

## Related Issue(s)

- closes #1257

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [x] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
