### PR TITLE
Allowing project references in version numbers

### DIFF
--- a/src/features/applicationMetadata/ApplicationMetadataProvider.tsx
+++ b/src/features/applicationMetadata/ApplicationMetadataProvider.tsx
@@ -36,7 +36,14 @@ const { Provider, useCtx, useLaxCtx, useHasProvider } = delayedContext(() =>
 
 function VerifyMinimumVersion({ children }: PropsWithChildren) {
   const { altinnNugetVersion } = useApplicationMetadata();
-  if (!altinnNugetVersion || !isAtLeastVersion(altinnNugetVersion, MINIMUM_APPLICATION_VERSION.build, true)) {
+  if (
+    !altinnNugetVersion ||
+    !isAtLeastVersion({
+      actualVersion: altinnNugetVersion,
+      minimumVersion: MINIMUM_APPLICATION_VERSION.build,
+      allowZeroInLast: true,
+    })
+  ) {
     return <OldVersionError minVer={MINIMUM_APPLICATION_VERSION.name} />;
   }
 

--- a/src/features/applicationMetadata/ApplicationMetadataProvider.tsx
+++ b/src/features/applicationMetadata/ApplicationMetadataProvider.tsx
@@ -36,7 +36,7 @@ const { Provider, useCtx, useLaxCtx, useHasProvider } = delayedContext(() =>
 
 function VerifyMinimumVersion({ children }: PropsWithChildren) {
   const { altinnNugetVersion } = useApplicationMetadata();
-  if (!altinnNugetVersion || !isAtLeastVersion(altinnNugetVersion, MINIMUM_APPLICATION_VERSION.build)) {
+  if (!altinnNugetVersion || !isAtLeastVersion(altinnNugetVersion, MINIMUM_APPLICATION_VERSION.build, true)) {
     return <OldVersionError minVer={MINIMUM_APPLICATION_VERSION.name} />;
   }
 

--- a/src/utils/versionCompare.test.ts
+++ b/src/utils/versionCompare.test.ts
@@ -24,4 +24,9 @@ describe('versionCompare', () => {
   test.each(testCases)('isAtLeastVersion($version, $minVersion) returns $expected', (testCase) => {
     expect(isAtLeastVersion(testCase.version, testCase.minVersion)).toBe(testCase.expected);
   });
+
+  test('should allow zero in last part', () => {
+    expect(isAtLeastVersion('1.2.0', '1.2.3', false)).toBe(false);
+    expect(isAtLeastVersion('1.2.0', '1.2.3', true)).toBe(true);
+  });
 });

--- a/src/utils/versionCompare.test.ts
+++ b/src/utils/versionCompare.test.ts
@@ -22,11 +22,13 @@ describe('versionCompare', () => {
   ];
 
   test.each(testCases)('isAtLeastVersion($version, $minVersion) returns $expected', (testCase) => {
-    expect(isAtLeastVersion(testCase.version, testCase.minVersion)).toBe(testCase.expected);
+    expect(isAtLeastVersion({ actualVersion: testCase.version, minimumVersion: testCase.minVersion })).toBe(
+      testCase.expected,
+    );
   });
 
   test('should allow zero in last part', () => {
-    expect(isAtLeastVersion('1.2.0', '1.2.3', false)).toBe(false);
-    expect(isAtLeastVersion('1.2.0', '1.2.3', true)).toBe(true);
+    expect(isAtLeastVersion({ actualVersion: '1.2.0', minimumVersion: '1.2.3', allowZeroInLast: false })).toBe(false);
+    expect(isAtLeastVersion({ actualVersion: '1.2.0', minimumVersion: '1.2.3', allowZeroInLast: true })).toBe(true);
   });
 });

--- a/src/utils/versionCompare.ts
+++ b/src/utils/versionCompare.ts
@@ -1,3 +1,9 @@
+interface VersionCompareProps {
+  actualVersion: string;
+  minimumVersion: string;
+  allowZeroInLast?: boolean;
+}
+
 /**
  * Checks if the given version is at least the given minimum version. Expects the version numbers to be
  * dot-separated numbers, e.g. "1.0.15". String parts, such as 'preview', 'alpha', 'rc' are not supported.
@@ -5,9 +11,9 @@
  * The allowZeroInLast parameter is used to allow the last part of the version to be zero. This is useful
  * when running the backend with project references, as the build number is set to zero in that case.
  */
-export function isAtLeastVersion(version: string, minVersion: string, allowZeroInLast = false): boolean {
-  const parts = version.split('.');
-  const expectedParts = minVersion.split('.');
+export function isAtLeastVersion({ actualVersion, minimumVersion, allowZeroInLast }: VersionCompareProps): boolean {
+  const parts = actualVersion.split('.');
+  const expectedParts = minimumVersion.split('.');
   if (parts.length !== expectedParts.length) {
     return false;
   }

--- a/src/utils/versionCompare.ts
+++ b/src/utils/versionCompare.ts
@@ -1,13 +1,23 @@
 /**
  * Checks if the given version is at least the given minimum version. Expects the version numbers to be
  * dot-separated numbers, e.g. "1.0.15". String parts, such as 'preview', 'alpha', 'rc' are not supported.
+ *
+ * The allowZeroInLast parameter is used to allow the last part of the version to be zero. This is useful
+ * when running the backend with project references, as the build number is set to zero in that case.
  */
-export function isAtLeastVersion(version: string, minVersion: string): boolean {
+export function isAtLeastVersion(version: string, minVersion: string, allowZeroInLast = false): boolean {
   const parts = version.split('.');
   const expectedParts = minVersion.split('.');
+  if (parts.length !== expectedParts.length) {
+    return false;
+  }
   for (const i in expectedParts) {
     const expected = parseInt(expectedParts[i], 10);
     const actual = parseInt(parts[i], 10);
+    const isLast = parseInt(i) === expectedParts.length - 1;
+    if (isLast && allowZeroInLast && actual === 0) {
+      return true;
+    }
     if (actual > expected) {
       return true;
     }


### PR DESCRIPTION
## Description

This should allow running the backend with project reference instead of nuget packages.

## Related Issue(s)

- closes #1801

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
