### PR TITLE
Fix options loading and clearing

### DIFF
--- a/src/features/options/useAllOptions.tsx
+++ b/src/features/options/useAllOptions.tsx
@@ -143,7 +143,8 @@ export function AllOptionsProvider({ children }: PropsWithChildren) {
   const dummies = nodes
     ?.allNodes()
     .filter((n) => isNodeOptionBased(n))
-    .filter((n) => Object.keys(allOptions).includes(n.item.id))
+    // Until allInitiallyLoaded is true, we want to wait for nodesFound to be set before we start fetching options
+    .filter((n) => allInitiallyLoaded || Object.keys(allOptions).includes(n.item.id))
     .map((node) => (
       <DummyOptionsSaver
         key={node.item.id}

--- a/src/features/options/useAllOptions.tsx
+++ b/src/features/options/useAllOptions.tsx
@@ -117,6 +117,7 @@ export function AllOptionsProvider({ children }: PropsWithChildren) {
   const setNodesFound = useSelector((state) => state.setNodesFound);
   const setNodeOptions = useSelector((state) => state.setNodeOptions);
   const allInitiallyLoaded = useAllOptionsInitiallyLoaded();
+  const allOptions = useAllOptions();
 
   useEffect(() => {
     setCurrentTaskId(currentTaskId);
@@ -142,6 +143,7 @@ export function AllOptionsProvider({ children }: PropsWithChildren) {
   const dummies = nodes
     ?.allNodes()
     .filter((n) => isNodeOptionBased(n))
+    .filter((n) => Object.keys(allOptions).includes(n.item.id))
     .map((node) => (
       <DummyOptionsSaver
         key={node.item.id}

--- a/src/features/options/useGetOptions.ts
+++ b/src/features/options/useGetOptions.ts
@@ -79,7 +79,7 @@ interface EffectProps<T extends ValueType> {
   disable: boolean;
   valueType: T;
   preselectedOption: IOptionInternal | undefined;
-  currentValue: CurrentValue<T>;
+  currentValue: CurrentValueAsString<T>;
   setValue: ValueSetter<T>;
 }
 
@@ -188,10 +188,10 @@ export function useGetOptions<T extends ValueType>(props: Props<T>): OptionsResu
       disable: !(props.dataModelBindings && 'simpleBinding' in props.dataModelBindings),
       valueType,
       preselectedOption,
-      currentValue: current,
+      currentValue: currentStringy,
       setValue: setData,
     }),
-    [calculatedOptions, current, preselectedOption, props.dataModelBindings, setData, valueType],
+    [calculatedOptions, currentStringy, preselectedOption, props.dataModelBindings, setData, valueType],
   );
 
   usePreselectedOptionIndex(effectProps);
@@ -242,12 +242,12 @@ function useRemoveStaleValues<T extends ValueType>(props: EffectProps<T>) {
 
     if (options && isSingle(props)) {
       const { currentValue, setValue } = props;
-      if (currentValue && !options.find((option) => option.value === currentValue.value)) {
+      if (currentValue && !options.find((option) => option.value === currentValue)) {
         setValue('');
       }
     } else if (options && isMulti(props)) {
       const { currentValue, setValue } = props;
-      const itemsToRemove = currentValue.filter((v) => !options.find((option) => option.value === v.value));
+      const itemsToRemove = currentValue.filter((v) => !options.find((option) => option.value === v));
       if (itemsToRemove.length > 0) {
         setValue(currentValue.filter((v) => !itemsToRemove.includes(v)));
       }

--- a/test/e2e/pageobjects/app-frontend.ts
+++ b/test/e2e/pageobjects/app-frontend.ts
@@ -176,6 +176,7 @@ export class AppFrontend {
     uploadDropZone: '#altinn-drop-zone-fileUpload-changename',
     componentSummary: '[data-testid="summary-item-simple"]',
     uploadError: '#error_fileUpload-changename',
+    summaryReference: '[data-componentid="summary-reference"]',
   };
 
   //group - task 3


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

1. `useAllOptions` will now wait until a node is added to the state through `setNodesFound` before it starts to fetch options. This makes sure that it will not think everything is loaded when the first option is loaded.
2. Clearing options did not work as expected. Since it checked the current (from the options-list) instead of the currentStringy, the value would always be undefined if the string-value was not present in the options list, and so it would not see that it needed clearing. Added a test to make sure it does not clear the value while fetching new options in case the value is still valid in the new option list.

## Related Issue(s)

- closes #1556 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
