### PR TITLE
Sticky header for repeating groups

### DIFF
--- a/src/layout/RepeatingGroup/RepeatingGroup.module.css
+++ b/src/layout/RepeatingGroup/RepeatingGroup.module.css
@@ -25,8 +25,13 @@
   width: 100%;
 }
 
-.onTopOfStickyHeader {
+.editContainerOnTopOfStickyHeader {
   z-index: 2;
+  position: relative;
+}
+
+.editRowOnTopOfStickyHeader {
+  z-index: 3;
   position: relative;
 }
 
@@ -93,8 +98,6 @@ Altinn, and making sure they are consistent. */
 .editingRow {
   border-top: 2px dotted var(--repeating-group-edit-border-color);
   background-color: var(--repeating-group-edit-surface-color);
-  z-index: 2;
-  position: relative;
 }
 
 table > tbody > tr.editingRow:hover {
@@ -198,8 +201,6 @@ table > tbody > tr.editingRow:hover {
   display: inline-block;
   padding: var(--modal-padding-y) var(--modal-padding-x);
   box-sizing: border-box;
-  z-index: 2;
-  position: relative;
 }
 
 .nestedEditContainer {
@@ -208,8 +209,6 @@ table > tbody > tr.editingRow:hover {
   display: inline-block;
   padding: 12px 24px;
   box-sizing: border-box;
-  z-index: 2;
-  position: relative;
 }
 
 .hideTable {

--- a/src/layout/RepeatingGroup/RepeatingGroup.module.css
+++ b/src/layout/RepeatingGroup/RepeatingGroup.module.css
@@ -72,6 +72,10 @@ Altinn, and making sure they are consistent. */
   border-top-right-radius: 0 !important;
 }
 
+.nestedNonSticky > thead > tr > th {
+  position: static !important;
+}
+
 .tableEmpty {
   margin: 0;
 }

--- a/src/layout/RepeatingGroup/RepeatingGroup.module.css
+++ b/src/layout/RepeatingGroup/RepeatingGroup.module.css
@@ -73,6 +73,7 @@ Altinn, and making sure they are consistent. */
 }
 
 .nestedNonSticky > thead > tr > th {
+  /*needed !important to override sticky-header css from design system for nested repeating-groups*/
   position: static !important;
 }
 

--- a/src/layout/RepeatingGroup/RepeatingGroup.module.css
+++ b/src/layout/RepeatingGroup/RepeatingGroup.module.css
@@ -3,7 +3,6 @@
   margin-right: calc(var(--modal-padding-x) * -1);
   width: calc(100% + 2 * var(--modal-padding-x));
 
-  overflow-x: auto;
   margin-bottom: 15px;
 }
 

--- a/src/layout/RepeatingGroup/RepeatingGroup.module.css
+++ b/src/layout/RepeatingGroup/RepeatingGroup.module.css
@@ -26,6 +26,11 @@
   width: 100%;
 }
 
+.onTopOfStickyHeader {
+  z-index: 2;
+  position: relative;
+}
+
 /* ====
 TODO(1779): Remove these styles after going through all the different Table styles in
 Altinn, and making sure they are consistent. */
@@ -84,6 +89,8 @@ Altinn, and making sure they are consistent. */
 .editingRow {
   border-top: 2px dotted var(--repeating-group-edit-border-color);
   background-color: var(--repeating-group-edit-surface-color);
+  z-index: 2;
+  position: relative;
 }
 
 table > tbody > tr.editingRow:hover {
@@ -187,6 +194,8 @@ table > tbody > tr.editingRow:hover {
   display: inline-block;
   padding: var(--modal-padding-y) var(--modal-padding-x);
   box-sizing: border-box;
+  z-index: 2;
+  position: relative;
 }
 
 .nestedEditContainer {
@@ -195,6 +204,8 @@ table > tbody > tr.editingRow:hover {
   display: inline-block;
   padding: 12px 24px;
   box-sizing: border-box;
+  z-index: 2;
+  position: relative;
 }
 
 .hideTable {

--- a/src/layout/RepeatingGroup/RepeatingGroupTable.tsx
+++ b/src/layout/RepeatingGroup/RepeatingGroupTable.tsx
@@ -146,7 +146,11 @@ export function RepeatingGroupTable(): React.JSX.Element | null {
         id={`group-${id}-table`}
         stickyHeader={stickyHeader}
         className={cn(
-          { [classes.editingBorder]: isNested, [classes.nestedTable]: isNested },
+          {
+            [classes.editingBorder]: isNested,
+            [classes.nestedTable]: isNested,
+            [classes.nestedNonSticky]: isNested && !stickyHeader,
+          },
           classes.repeatingGroupTable,
         )}
         // If the list is empty, the border of the table will be visible as a line above
@@ -208,7 +212,7 @@ export function RepeatingGroupTable(): React.JSX.Element | null {
                 <RepeatingGroupTableRow
                   className={cn({
                     [classes.editingRow]: isEditingRow,
-                    [classes.onTopOfStickyHeader]: stickyHeader,
+                    [classes.onTopOfStickyHeader]: isEditingRow && stickyHeader,
                   })}
                   index={index}
                   getTableNodes={getTableNodes}

--- a/src/layout/RepeatingGroup/RepeatingGroupTable.tsx
+++ b/src/layout/RepeatingGroup/RepeatingGroupTable.tsx
@@ -25,7 +25,7 @@ export function RepeatingGroupTable(): React.JSX.Element | null {
   const rowsAfter = node.item.rowsAfter;
 
   const container = node.item;
-  const { textResourceBindings, labelSettings, id, edit, minCount } = container;
+  const { textResourceBindings, labelSettings, id, edit, minCount, stickyHeader } = container;
 
   const required = !!minCount && minCount > 0;
 
@@ -207,6 +207,7 @@ export function RepeatingGroupTable(): React.JSX.Element | null {
                 <RepeatingGroupTableRow
                   className={cn({
                     [classes.editingRow]: isEditingRow,
+                    [classes.onTopOfStickyHeader]: stickyHeader,
                   })}
                   index={index}
                   getTableNodes={getTableNodes}
@@ -228,7 +229,12 @@ export function RepeatingGroupTable(): React.JSX.Element | null {
                           : tableNodes.length + 3 + (displayEditColumn ? 1 : 0) + (displayDeleteColumn ? 1 : 0)
                       }
                     >
-                      {edit?.mode !== 'onlyTable' && <RepeatingGroupsEditContainer editIndex={index} />}
+                      {edit?.mode !== 'onlyTable' && (
+                        <RepeatingGroupsEditContainer
+                          editIndex={index}
+                          className={cn({ [classes.onTopOfStickyHeader]: stickyHeader })}
+                        />
+                      )}
                     </Table.Cell>
                   </Table.Row>
                 )}

--- a/src/layout/RepeatingGroup/RepeatingGroupTable.tsx
+++ b/src/layout/RepeatingGroup/RepeatingGroupTable.tsx
@@ -212,7 +212,7 @@ export function RepeatingGroupTable(): React.JSX.Element | null {
                 <RepeatingGroupTableRow
                   className={cn({
                     [classes.editingRow]: isEditingRow,
-                    [classes.onTopOfStickyHeader]: isEditingRow && stickyHeader,
+                    [classes.editRowOnTopOfStickyHeader]: isEditingRow && stickyHeader,
                   })}
                   index={index}
                   getTableNodes={getTableNodes}
@@ -223,7 +223,10 @@ export function RepeatingGroupTable(): React.JSX.Element | null {
                 {isEditingRow && (
                   <Table.Row
                     key={`edit-container-${index}`}
-                    className={classes.editContainerRow}
+                    className={cn(
+                      { [classes.editContainerOnTopOfStickyHeader]: isEditingRow && stickyHeader },
+                      classes.editContainerRow,
+                    )}
                   >
                     <Table.Cell
                       style={{ padding: 0, borderTop: 0 }}
@@ -234,12 +237,7 @@ export function RepeatingGroupTable(): React.JSX.Element | null {
                           : tableNodes.length + 3 + (displayEditColumn ? 1 : 0) + (displayDeleteColumn ? 1 : 0)
                       }
                     >
-                      {edit?.mode !== 'onlyTable' && (
-                        <RepeatingGroupsEditContainer
-                          editIndex={index}
-                          className={cn({ [classes.onTopOfStickyHeader]: stickyHeader })}
-                        />
-                      )}
+                      {edit?.mode !== 'onlyTable' && <RepeatingGroupsEditContainer editIndex={index} />}
                     </Table.Cell>
                   </Table.Row>
                 )}

--- a/src/layout/RepeatingGroup/RepeatingGroupTable.tsx
+++ b/src/layout/RepeatingGroup/RepeatingGroupTable.tsx
@@ -144,6 +144,7 @@ export function RepeatingGroupTable(): React.JSX.Element | null {
     >
       <Table
         id={`group-${id}-table`}
+        stickyHeader={stickyHeader}
         className={cn(
           { [classes.editingBorder]: isNested, [classes.nestedTable]: isNested },
           classes.repeatingGroupTable,

--- a/src/layout/RepeatingGroup/config.ts
+++ b/src/layout/RepeatingGroup/config.ts
@@ -288,6 +288,15 @@ export const Config = new CG.component({
         ),
     ),
   )
+  .addProperty(
+    new CG.prop(
+      'stickyHeader',
+      new CG.bool()
+        .optional({ default: false })
+        .setTitle('Sticky header')
+        .setDescription('If set to true, the header of the repeating group will be sticky'),
+    ),
+  )
   .addProperty(new CG.prop('rowsBefore', CG.common('GridRows').optional()))
   .addProperty(new CG.prop('rowsAfter', CG.common('GridRows').optional()))
   .addProperty(new CG.prop('labelSettings', CG.common('ILabelSettings').optional()));


### PR DESCRIPTION
## Description

Adds a new config option to repeating groups; `stickyHeader` which makes the Tables header stick to the top of the page when scrolling below the header.


```
{
  "id": "myRepeatingGroup",
  "type": "RepeatingGroup",
  "stickyHeader": true,
  ...
}
```
## Related Issue(s)

- closes #1492 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [x] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [x] Has been added/updated
  https://github.com/Altinn/altinn-studio-docs/pull/1413
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
