### PR TITLE
Include empty fields in mapping as empty query parameters

### DIFF
--- a/src/features/formData/FormDataWrite.tsx
+++ b/src/features/formData/FormDataWrite.tsx
@@ -354,7 +354,6 @@ export const FD = {
    *      in that sense.
    *   2. The data is fetched from the debounced model, not the fresh/current one. That ensures queries that are
    *      generated from this hook are more stable, and aren't re-fetched on every keystroke.
-   *   3. Values that don't exist in the debounced model are not included in the output at all.
    */
   useMapping: <D extends 'string' | 'raw' = 'string'>(
     mapping: IMapping | undefined,
@@ -367,12 +366,15 @@ export const FD = {
         for (const key of Object.keys(mapping)) {
           const outputKey = mapping[key];
           const value = dot.pick(key, s.debouncedCurrentData);
-          if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
-            out[outputKey] = realDataAs === 'raw' ? value : String(value);
-          } else if (value && realDataAs === 'string') {
-            out[outputKey] = JSON.stringify(value);
-          } else if (value && realDataAs === 'raw') {
+
+          if (realDataAs === 'raw') {
             out[outputKey] = value;
+          } else if (typeof value === 'undefined' || value === null) {
+            out[outputKey] = '';
+          } else if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+            out[outputKey] = String(value);
+          } else {
+            out[outputKey] = JSON.stringify(value);
           }
         }
       }

--- a/src/layout/FileUpload/Summary/AttachmentWithTagSummaryComponent.test.tsx
+++ b/src/layout/FileUpload/Summary/AttachmentWithTagSummaryComponent.test.tsx
@@ -51,7 +51,6 @@ describe('AttachmentWithTagSummaryComponent', () => {
     type: 'FileUploadWithTag',
     textResourceBindings: {},
     optionsId: 'a',
-    mapping: { a: 'b' },
     maxFileSizeInMB: 15,
     displayMode: 'list',
     maxNumberOfAttachments: 12,
@@ -71,11 +70,11 @@ describe('AttachmentWithTagSummaryComponent', () => {
     expect(await screen.findByText('da option value')).toBeInTheDocument();
   });
   test('should render the text resource', async () => {
-    await render({ component: { ...component, optionsId: 'b', mapping: undefined } });
+    await render({ component: { ...component, optionsId: 'b' } });
     expect(await screen.findByText('the result')).toBeInTheDocument();
   });
   test('should not render a text resource', async () => {
-    await render({ component: { ...component, optionsId: 'c', mapping: undefined } });
+    await render({ component: { ...component, optionsId: 'c' } });
     expect(await screen.findByText('ca option value')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

In v3, a `mapping` from an empty field would add the queryParameter `?field=undefined` which is literally sending the value as the string `"undefined"`. If the query parameter is used for filtering on some property this sometimes worked as expected, as long as the filtered property never actually was equal the string `"undefined"`.

Up until now in v4, we have instead ignored and simply not added the query parameter if its value was empty, which is less wrong, and arguably correct. However, now you cannot separate the cases where a mapping parameter is added but empty, or if it is not added to the mapping at all. Since setting the mapping parameter is an active choice you may want a different behavior in the two cases.

This change makes sure to add all mapping parameters to the query string, but treat `null`/`undefined` as empty strings instead of literal `"null"`, `"undefined"` strings.

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
