### PR TITLE
fix: make all layout componenst support receiving refs

### DIFF
--- a/src/layout/Accordion/index.tsx
+++ b/src/layout/Accordion/index.tsx
@@ -11,10 +11,11 @@ import type { ComponentHierarchyGenerator } from 'src/utils/layout/HierarchyGene
 export class Accordion extends AccordionDef {
   private _hierarchyGenerator = new AccordionHierarchyGenerator();
 
-  // eslint-disable-next-line react/display-name
-  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Accordion'>>((props, _): React.JSX.Element | null => (
-    <AccordionComponent {...props} />
-  ));
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Accordion'>>(
+    function LayoutComponentAccordionRender(props, _): React.JSX.Element | null {
+      return <AccordionComponent {...props} />;
+    },
+  );
 
   hierarchyGenerator(): ComponentHierarchyGenerator<'Accordion'> {
     return this._hierarchyGenerator;

--- a/src/layout/Accordion/index.tsx
+++ b/src/layout/Accordion/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import { Accordion as AccordionComponent } from 'src/layout/Accordion/Accordion';
 import { AccordionDef } from 'src/layout/Accordion/config.def.generated';
@@ -11,9 +11,10 @@ import type { ComponentHierarchyGenerator } from 'src/utils/layout/HierarchyGene
 export class Accordion extends AccordionDef {
   private _hierarchyGenerator = new AccordionHierarchyGenerator();
 
-  render = (props: PropsFromGenericComponent<'Accordion'>): React.JSX.Element | null => (
+  // eslint-disable-next-line react/display-name
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Accordion'>>((props, _): React.JSX.Element | null => (
     <AccordionComponent {...props} />
-  );
+  ));
 
   hierarchyGenerator(): ComponentHierarchyGenerator<'Accordion'> {
     return this._hierarchyGenerator;

--- a/src/layout/AccordionGroup/index.tsx
+++ b/src/layout/AccordionGroup/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { AccordionGroup as AccordionGroupComponent } from 'src/layout/AccordionGroup/AccordionGroup';
@@ -13,9 +13,10 @@ import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 export class AccordionGroup extends AccordionGroupDef {
   private _hierarchyGenerator = new AccordionGroupHierarchyGenerator();
 
-  render = (props: PropsFromGenericComponent<'AccordionGroup'>): JSX.Element | null => (
+  // eslint-disable-next-line react/display-name
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'AccordionGroup'>>((props, _): JSX.Element | null => (
     <AccordionGroupComponent {...props} />
-  );
+  ));
 
   hierarchyGenerator(): ComponentHierarchyGenerator<'AccordionGroup'> {
     return this._hierarchyGenerator;

--- a/src/layout/AccordionGroup/index.tsx
+++ b/src/layout/AccordionGroup/index.tsx
@@ -13,10 +13,11 @@ import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 export class AccordionGroup extends AccordionGroupDef {
   private _hierarchyGenerator = new AccordionGroupHierarchyGenerator();
 
-  // eslint-disable-next-line react/display-name
-  render = forwardRef<HTMLElement, PropsFromGenericComponent<'AccordionGroup'>>((props, _): JSX.Element | null => (
-    <AccordionGroupComponent {...props} />
-  ));
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'AccordionGroup'>>(
+    function LayoutComponentAccordionGroupRender(props, _): JSX.Element | null {
+      return <AccordionGroupComponent {...props} />;
+    },
+  );
 
   hierarchyGenerator(): ComponentHierarchyGenerator<'AccordionGroup'> {
     return this._hierarchyGenerator;

--- a/src/layout/ActionButton/index.tsx
+++ b/src/layout/ActionButton/index.tsx
@@ -5,8 +5,9 @@ import { ActionButtonDef } from 'src/layout/ActionButton/config.def.generated';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export class ActionButton extends ActionButtonDef {
-  // eslint-disable-next-line react/display-name
-  render = forwardRef<HTMLElement, PropsFromGenericComponent<'ActionButton'>>((props, _): JSX.Element | null => (
-    <ActionButtonComponent {...props} />
-  ));
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'ActionButton'>>(
+    function LayoutComponentActionButtonRender(props, _): JSX.Element | null {
+      return <ActionButtonComponent {...props} />;
+    },
+  );
 }

--- a/src/layout/ActionButton/index.tsx
+++ b/src/layout/ActionButton/index.tsx
@@ -1,11 +1,12 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import { ActionButtonComponent } from 'src/layout/ActionButton/ActionButtonComponent';
 import { ActionButtonDef } from 'src/layout/ActionButton/config.def.generated';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export class ActionButton extends ActionButtonDef {
-  render = (props: PropsFromGenericComponent<'ActionButton'>): JSX.Element | null => (
+  // eslint-disable-next-line react/display-name
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'ActionButton'>>((props, _): JSX.Element | null => (
     <ActionButtonComponent {...props} />
-  );
+  ));
 }

--- a/src/layout/Address/index.tsx
+++ b/src/layout/Address/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import dot from 'dot-object';
@@ -14,7 +14,10 @@ import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class Address extends AddressDef implements ValidateComponent {
-  render = (props: PropsFromGenericComponent<'Address'>): JSX.Element | null => <AddressComponent {...props} />;
+  // eslint-disable-next-line react/display-name
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Address'>>((props, _): JSX.Element | null => (
+    <AddressComponent {...props} />
+  ));
 
   getDisplayData(node: LayoutNode<'Address'>): string {
     const data = node.getFormData();

--- a/src/layout/Address/index.tsx
+++ b/src/layout/Address/index.tsx
@@ -14,10 +14,11 @@ import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class Address extends AddressDef implements ValidateComponent {
-  // eslint-disable-next-line react/display-name
-  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Address'>>((props, _): JSX.Element | null => (
-    <AddressComponent {...props} />
-  ));
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Address'>>(
+    function LayoutComponentAddressRender(props, _): JSX.Element | null {
+      return <AddressComponent {...props} />;
+    },
+  );
 
   getDisplayData(node: LayoutNode<'Address'>): string {
     const data = node.getFormData();

--- a/src/layout/Alert/index.tsx
+++ b/src/layout/Alert/index.tsx
@@ -5,8 +5,9 @@ import { AlertDef } from 'src/layout/Alert/config.def.generated';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export class Alert extends AlertDef {
-  // eslint-disable-next-line react/display-name
-  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Alert'>>((props, _): JSX.Element | null => (
-    <AlertComponent {...props} />
-  ));
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Alert'>>(
+    function LayoutComponentAlertRender(props, _): JSX.Element | null {
+      return <AlertComponent {...props} />;
+    },
+  );
 }

--- a/src/layout/Alert/index.tsx
+++ b/src/layout/Alert/index.tsx
@@ -1,9 +1,12 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import { Alert as AlertComponent } from 'src/layout/Alert/Alert';
 import { AlertDef } from 'src/layout/Alert/config.def.generated';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export class Alert extends AlertDef {
-  render = (props: PropsFromGenericComponent<'Alert'>): JSX.Element | null => <AlertComponent {...props} />;
+  // eslint-disable-next-line react/display-name
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Alert'>>((props, _): JSX.Element | null => (
+    <AlertComponent {...props} />
+  ));
 }

--- a/src/layout/AttachmentList/index.tsx
+++ b/src/layout/AttachmentList/index.tsx
@@ -1,11 +1,12 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import { AttachmentListComponent } from 'src/layout/AttachmentList/AttachmentListComponent';
 import { AttachmentListDef } from 'src/layout/AttachmentList/config.def.generated';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export class AttachmentList extends AttachmentListDef {
-  render = (props: PropsFromGenericComponent<'AttachmentList'>): JSX.Element | null => (
+  // eslint-disable-next-line react/display-name
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'AttachmentList'>>((props, _): JSX.Element | null => (
     <AttachmentListComponent {...props} />
-  );
+  ));
 }

--- a/src/layout/AttachmentList/index.tsx
+++ b/src/layout/AttachmentList/index.tsx
@@ -5,8 +5,9 @@ import { AttachmentListDef } from 'src/layout/AttachmentList/config.def.generate
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export class AttachmentList extends AttachmentListDef {
-  // eslint-disable-next-line react/display-name
-  render = forwardRef<HTMLElement, PropsFromGenericComponent<'AttachmentList'>>((props, _): JSX.Element | null => (
-    <AttachmentListComponent {...props} />
-  ));
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'AttachmentList'>>(
+    function LayoutComponentAttachmentListRender(props, _): JSX.Element | null {
+      return <AttachmentListComponent {...props} />;
+    },
+  );
 }

--- a/src/layout/Button/index.tsx
+++ b/src/layout/Button/index.tsx
@@ -1,9 +1,12 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import { ButtonComponent } from 'src/layout/Button/ButtonComponent';
 import { ButtonDef } from 'src/layout/Button/config.def.generated';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export class Button extends ButtonDef {
-  render = (props: PropsFromGenericComponent<'Button'>): JSX.Element | null => <ButtonComponent {...props} />;
+  // eslint-disable-next-line react/display-name
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Button'>>((props, _): JSX.Element | null => (
+    <ButtonComponent {...props} />
+  ));
 }

--- a/src/layout/Button/index.tsx
+++ b/src/layout/Button/index.tsx
@@ -5,8 +5,9 @@ import { ButtonDef } from 'src/layout/Button/config.def.generated';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export class Button extends ButtonDef {
-  // eslint-disable-next-line react/display-name
-  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Button'>>((props, _): JSX.Element | null => (
-    <ButtonComponent {...props} />
-  ));
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Button'>>(
+    function LayoutComponentButtonRender(props, _): JSX.Element | null {
+      return <ButtonComponent {...props} />;
+    },
+  );
 }

--- a/src/layout/ButtonGroup/index.tsx
+++ b/src/layout/ButtonGroup/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import type { PropsFromGenericComponent } from '..';
@@ -12,7 +12,10 @@ import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 export class ButtonGroup extends ButtonGroupDef {
   private _hierarchyGenerator = new ButtonGroupHierarchyGenerator();
 
-  render = (props: PropsFromGenericComponent<'ButtonGroup'>): JSX.Element | null => <ButtonGroupComponent {...props} />;
+  // eslint-disable-next-line react/display-name
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'ButtonGroup'>>((props, _): JSX.Element | null => (
+    <ButtonGroupComponent {...props} />
+  ));
 
   shouldRenderInAutomaticPDF() {
     return false;

--- a/src/layout/ButtonGroup/index.tsx
+++ b/src/layout/ButtonGroup/index.tsx
@@ -12,10 +12,11 @@ import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 export class ButtonGroup extends ButtonGroupDef {
   private _hierarchyGenerator = new ButtonGroupHierarchyGenerator();
 
-  // eslint-disable-next-line react/display-name
-  render = forwardRef<HTMLElement, PropsFromGenericComponent<'ButtonGroup'>>((props, _): JSX.Element | null => (
-    <ButtonGroupComponent {...props} />
-  ));
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'ButtonGroup'>>(
+    function LayoutComponentButtonGroupRender(props, _): JSX.Element | null {
+      return <ButtonGroupComponent {...props} />;
+    },
+  );
 
   shouldRenderInAutomaticPDF() {
     return false;

--- a/src/layout/Checkboxes/index.tsx
+++ b/src/layout/Checkboxes/index.tsx
@@ -15,10 +15,11 @@ import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class Checkboxes extends CheckboxesDef {
-  // eslint-disable-next-line react/display-name
-  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Checkboxes'>>((props, _): JSX.Element | null => (
-    <CheckboxContainerComponent {...props} />
-  ));
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Checkboxes'>>(
+    function LayoutComponentCheckboxesRender(props, _): JSX.Element | null {
+      return <CheckboxContainerComponent {...props} />;
+    },
+  );
 
   private getSummaryData(
     node: LayoutNode<'Checkboxes'>,

--- a/src/layout/Checkboxes/index.tsx
+++ b/src/layout/Checkboxes/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { useLanguage } from 'src/features/language/useLanguage';
@@ -15,9 +15,10 @@ import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class Checkboxes extends CheckboxesDef {
-  render = (props: PropsFromGenericComponent<'Checkboxes'>): JSX.Element | null => (
+  // eslint-disable-next-line react/display-name
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Checkboxes'>>((props, _): JSX.Element | null => (
     <CheckboxContainerComponent {...props} />
-  );
+  ));
 
   private getSummaryData(
     node: LayoutNode<'Checkboxes'>,

--- a/src/layout/Custom/index.tsx
+++ b/src/layout/Custom/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { CustomDef } from 'src/layout/Custom/config.def.generated';
@@ -9,7 +9,10 @@ import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class Custom extends CustomDef {
-  render = (props: PropsFromGenericComponent<'Custom'>): JSX.Element | null => <CustomWebComponent {...props} />;
+  // eslint-disable-next-line react/display-name
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Custom'>>((props, _): JSX.Element | null => (
+    <CustomWebComponent {...props} />
+  ));
 
   getDisplayData(node: LayoutNode<'Custom'>): string {
     const data = node.getFormData();

--- a/src/layout/Custom/index.tsx
+++ b/src/layout/Custom/index.tsx
@@ -9,10 +9,11 @@ import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class Custom extends CustomDef {
-  // eslint-disable-next-line react/display-name
-  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Custom'>>((props, _): JSX.Element | null => (
-    <CustomWebComponent {...props} />
-  ));
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Custom'>>(
+    function LayoutComponentCustomRender(props, _): JSX.Element | null {
+      return <CustomWebComponent {...props} />;
+    },
+  );
 
   getDisplayData(node: LayoutNode<'Custom'>): string {
     const data = node.getFormData();

--- a/src/layout/CustomButton/index.tsx
+++ b/src/layout/CustomButton/index.tsx
@@ -7,10 +7,11 @@ import type { PropsFromGenericComponent } from 'src/layout';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class CustomButton extends CustomButtonDef {
-  // eslint-disable-next-line react/display-name
-  render = forwardRef<HTMLElement, PropsFromGenericComponent<'CustomButton'>>((props, _): JSX.Element | null => (
-    <CustomButtonComponent {...props} />
-  ));
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'CustomButton'>>(
+    function LayoutComponentCustomButtonRender(props, _): JSX.Element | null {
+      return <CustomButtonComponent {...props} />;
+    },
+  );
 
   renderSummaryBoilerplate(): boolean {
     return false;

--- a/src/layout/CustomButton/index.tsx
+++ b/src/layout/CustomButton/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { CustomButtonDef } from 'src/layout/CustomButton/config.def.generated';
@@ -7,9 +7,10 @@ import type { PropsFromGenericComponent } from 'src/layout';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class CustomButton extends CustomButtonDef {
-  render = (props: PropsFromGenericComponent<'CustomButton'>): JSX.Element | null => (
+  // eslint-disable-next-line react/display-name
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'CustomButton'>>((props, _): JSX.Element | null => (
     <CustomButtonComponent {...props} />
-  );
+  ));
 
   renderSummaryBoilerplate(): boolean {
     return false;

--- a/src/layout/Datepicker/index.tsx
+++ b/src/layout/Datepicker/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import dot from 'dot-object';
 import moment from 'moment';
@@ -21,7 +21,10 @@ import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class Datepicker extends DatepickerDef implements ValidateComponent {
-  render = (props: PropsFromGenericComponent<'Datepicker'>): JSX.Element | null => <DatepickerComponent {...props} />;
+  // eslint-disable-next-line react/display-name
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Datepicker'>>((props, _): JSX.Element | null => (
+    <DatepickerComponent {...props} />
+  ));
 
   getDisplayData(node: LayoutNode<'Datepicker'>, { currentLanguage }: DisplayDataProps): string {
     if (!node.item.dataModelBindings?.simpleBinding) {

--- a/src/layout/Datepicker/index.tsx
+++ b/src/layout/Datepicker/index.tsx
@@ -21,10 +21,11 @@ import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class Datepicker extends DatepickerDef implements ValidateComponent {
-  // eslint-disable-next-line react/display-name
-  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Datepicker'>>((props, _): JSX.Element | null => (
-    <DatepickerComponent {...props} />
-  ));
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Datepicker'>>(
+    function LayoutComponentDatepickerRender(props, _): JSX.Element | null {
+      return <DatepickerComponent {...props} />;
+    },
+  );
 
   getDisplayData(node: LayoutNode<'Datepicker'>, { currentLanguage }: DisplayDataProps): string {
     if (!node.item.dataModelBindings?.simpleBinding) {

--- a/src/layout/Dropdown/index.tsx
+++ b/src/layout/Dropdown/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { getSelectedValueToText } from 'src/features/options/getSelectedValueToText';
@@ -11,7 +11,10 @@ import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class Dropdown extends DropdownDef {
-  render = (props: PropsFromGenericComponent<'Dropdown'>): JSX.Element | null => <DropdownComponent {...props} />;
+  // eslint-disable-next-line react/display-name
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Dropdown'>>((props, _): JSX.Element | null => (
+    <DropdownComponent {...props} />
+  ));
 
   getDisplayData(node: LayoutNode<'Dropdown'>, { langTools, options }: DisplayDataProps): string {
     if (!node.item.dataModelBindings?.simpleBinding) {

--- a/src/layout/Dropdown/index.tsx
+++ b/src/layout/Dropdown/index.tsx
@@ -11,10 +11,11 @@ import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class Dropdown extends DropdownDef {
-  // eslint-disable-next-line react/display-name
-  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Dropdown'>>((props, _): JSX.Element | null => (
-    <DropdownComponent {...props} />
-  ));
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Dropdown'>>(
+    function LayoutComponentDropdownRender(props, _): JSX.Element | null {
+      return <DropdownComponent {...props} />;
+    },
+  );
 
   getDisplayData(node: LayoutNode<'Dropdown'>, { langTools, options }: DisplayDataProps): string {
     if (!node.item.dataModelBindings?.simpleBinding) {

--- a/src/layout/FileUpload/index.tsx
+++ b/src/layout/FileUpload/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { FrontendValidationSource, ValidationMask } from 'src/features/validation';
@@ -14,7 +14,10 @@ import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class FileUpload extends FileUploadDef implements ValidateComponent {
-  render = (props: PropsFromGenericComponent<'FileUpload'>): JSX.Element | null => <FileUploadComponent {...props} />;
+  // eslint-disable-next-line react/display-name
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'FileUpload'>>((props, _): JSX.Element | null => (
+    <FileUploadComponent {...props} />
+  ));
 
   renderDefaultValidations(): boolean {
     return false;

--- a/src/layout/FileUpload/index.tsx
+++ b/src/layout/FileUpload/index.tsx
@@ -14,10 +14,11 @@ import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class FileUpload extends FileUploadDef implements ValidateComponent {
-  // eslint-disable-next-line react/display-name
-  render = forwardRef<HTMLElement, PropsFromGenericComponent<'FileUpload'>>((props, _): JSX.Element | null => (
-    <FileUploadComponent {...props} />
-  ));
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'FileUpload'>>(
+    function LayoutComponentFileUploadRender(props, _): JSX.Element | null {
+      return <FileUploadComponent {...props} />;
+    },
+  );
 
   renderDefaultValidations(): boolean {
     return false;

--- a/src/layout/FileUploadWithTag/index.tsx
+++ b/src/layout/FileUploadWithTag/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import { isAttachmentUploaded } from 'src/features/attachments';
 import { FrontendValidationSource, ValidationMask } from 'src/features/validation';
@@ -14,9 +14,10 @@ import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class FileUploadWithTag extends FileUploadWithTagDef implements ValidateComponent {
-  render = (props: PropsFromGenericComponent<'FileUploadWithTag'>): JSX.Element | null => (
+  // eslint-disable-next-line react/display-name
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'FileUploadWithTag'>>((props, _): JSX.Element | null => (
     <FileUploadComponent {...props} />
-  );
+  ));
 
   renderDefaultValidations(): boolean {
     return false;

--- a/src/layout/FileUploadWithTag/index.tsx
+++ b/src/layout/FileUploadWithTag/index.tsx
@@ -14,10 +14,11 @@ import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class FileUploadWithTag extends FileUploadWithTagDef implements ValidateComponent {
-  // eslint-disable-next-line react/display-name
-  render = forwardRef<HTMLElement, PropsFromGenericComponent<'FileUploadWithTag'>>((props, _): JSX.Element | null => (
-    <FileUploadComponent {...props} />
-  ));
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'FileUploadWithTag'>>(
+    function LayoutComponentFileUploadWithTagRender(props, _): JSX.Element | null {
+      return <FileUploadComponent {...props} />;
+    },
+  );
 
   renderDefaultValidations(): boolean {
     return false;

--- a/src/layout/Grid/index.tsx
+++ b/src/layout/Grid/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import type { ErrorObject } from 'ajv';
@@ -16,7 +16,10 @@ import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 export class Grid extends GridDef {
   private _hierarchyGenerator = new GridHierarchyGenerator();
 
-  render = (props: PropsFromGenericComponent<'Grid'>): JSX.Element | null => <RenderGrid {...props} />;
+  // eslint-disable-next-line react/display-name
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Grid'>>((props, _): JSX.Element | null => (
+    <RenderGrid {...props} />
+  ));
 
   renderSummary(props: SummaryRendererProps<'Grid'>): JSX.Element | null {
     return <GridSummaryComponent {...props} />;

--- a/src/layout/Grid/index.tsx
+++ b/src/layout/Grid/index.tsx
@@ -16,10 +16,11 @@ import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 export class Grid extends GridDef {
   private _hierarchyGenerator = new GridHierarchyGenerator();
 
-  // eslint-disable-next-line react/display-name
-  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Grid'>>((props, _): JSX.Element | null => (
-    <RenderGrid {...props} />
-  ));
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Grid'>>(
+    function LayoutComponentGridRender(props, _): JSX.Element | null {
+      return <RenderGrid {...props} />;
+    },
+  );
 
   renderSummary(props: SummaryRendererProps<'Grid'>): JSX.Element | null {
     return <GridSummaryComponent {...props} />;

--- a/src/layout/Group/index.tsx
+++ b/src/layout/Group/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { runAllValidations } from 'src/layout/componentValidation';
@@ -27,7 +27,8 @@ export class Group extends GroupDef implements ValidateAny, ValidateComponent {
     return true;
   }
 
-  render = (props: PropsFromGenericComponent<'Group'>): JSX.Element | null => (
+  // eslint-disable-next-line react/display-name
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Group'>>((props, _): JSX.Element | null => (
     <GroupComponent
       groupNode={props.node}
       renderLayoutNode={(n) => (
@@ -37,7 +38,7 @@ export class Group extends GroupDef implements ValidateAny, ValidateComponent {
         />
       )}
     />
-  );
+  ));
 
   renderSummary({
     onChangeClick,

--- a/src/layout/Group/index.tsx
+++ b/src/layout/Group/index.tsx
@@ -27,18 +27,21 @@ export class Group extends GroupDef implements ValidateAny, ValidateComponent {
     return true;
   }
 
-  // eslint-disable-next-line react/display-name
-  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Group'>>((props, _): JSX.Element | null => (
-    <GroupComponent
-      groupNode={props.node}
-      renderLayoutNode={(n) => (
-        <GenericComponent
-          key={n.item.id}
-          node={n}
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Group'>>(
+    function LayoutComponentGroupRender(props, _): JSX.Element | null {
+      return (
+        <GroupComponent
+          groupNode={props.node}
+          renderLayoutNode={(n) => (
+            <GenericComponent
+              key={n.item.id}
+              node={n}
+            />
+          )}
         />
-      )}
-    />
-  ));
+      );
+    },
+  );
 
   renderSummary({
     onChangeClick,

--- a/src/layout/Header/index.tsx
+++ b/src/layout/Header/index.tsx
@@ -1,9 +1,12 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import { HeaderDef } from 'src/layout/Header/config.def.generated';
 import { HeaderComponent } from 'src/layout/Header/HeaderComponent';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export class Header extends HeaderDef {
-  render = (props: PropsFromGenericComponent<'Header'>): JSX.Element | null => <HeaderComponent {...props} />;
+  // eslint-disable-next-line react/display-name
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Header'>>((props, _): JSX.Element | null => (
+    <HeaderComponent {...props} />
+  ));
 }

--- a/src/layout/Header/index.tsx
+++ b/src/layout/Header/index.tsx
@@ -5,8 +5,9 @@ import { HeaderComponent } from 'src/layout/Header/HeaderComponent';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export class Header extends HeaderDef {
-  // eslint-disable-next-line react/display-name
-  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Header'>>((props, _): JSX.Element | null => (
-    <HeaderComponent {...props} />
-  ));
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Header'>>(
+    function LayoutComponentHeaderRender(props, _): JSX.Element | null {
+      return <HeaderComponent {...props} />;
+    },
+  );
 }

--- a/src/layout/IFrame/index.tsx
+++ b/src/layout/IFrame/index.tsx
@@ -5,6 +5,9 @@ import { IFrameComponent } from 'src/layout/IFrame/IFrameComponent';
 import type { IFrameComponentProps } from 'src/layout/IFrame/IFrameComponent';
 
 export class IFrame extends IFrameDef {
-  // eslint-disable-next-line react/display-name
-  render = forwardRef<HTMLElement, IFrameComponentProps>((props): JSX.Element | null => <IFrameComponent {...props} />);
+  render = forwardRef<HTMLElement, IFrameComponentProps>(
+    function LayoutComponentIFrameRender(props): JSX.Element | null {
+      return <IFrameComponent {...props} />;
+    },
+  );
 }

--- a/src/layout/IFrame/index.tsx
+++ b/src/layout/IFrame/index.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import { IFrameDef } from 'src/layout/IFrame/config.def.generated';
 import { IFrameComponent } from 'src/layout/IFrame/IFrameComponent';
 import type { IFrameComponentProps } from 'src/layout/IFrame/IFrameComponent';
 
 export class IFrame extends IFrameDef {
-  render = (props: IFrameComponentProps): JSX.Element | null => <IFrameComponent {...props} />;
+  // eslint-disable-next-line react/display-name
+  render = forwardRef<HTMLElement, IFrameComponentProps>((props): JSX.Element | null => <IFrameComponent {...props} />);
 }

--- a/src/layout/Image/index.tsx
+++ b/src/layout/Image/index.tsx
@@ -5,8 +5,9 @@ import { ImageComponent } from 'src/layout/Image/ImageComponent';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export class Image extends ImageDef {
-  // eslint-disable-next-line react/display-name
-  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Image'>>((props, _): JSX.Element | null => (
-    <ImageComponent {...props} />
-  ));
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Image'>>(
+    function LayoutComponentImageRender(props, _): JSX.Element | null {
+      return <ImageComponent {...props} />;
+    },
+  );
 }

--- a/src/layout/Image/index.tsx
+++ b/src/layout/Image/index.tsx
@@ -1,9 +1,12 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import { ImageDef } from 'src/layout/Image/config.def.generated';
 import { ImageComponent } from 'src/layout/Image/ImageComponent';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export class Image extends ImageDef {
-  render = (props: PropsFromGenericComponent<'Image'>): JSX.Element | null => <ImageComponent {...props} />;
+  // eslint-disable-next-line react/display-name
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Image'>>((props, _): JSX.Element | null => (
+    <ImageComponent {...props} />
+  ));
 }

--- a/src/layout/Input/index.tsx
+++ b/src/layout/Input/index.tsx
@@ -14,10 +14,11 @@ import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class Input extends InputDef {
-  // eslint-disable-next-line react/display-name
-  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Input'>>((props, _): JSX.Element | null => (
-    <InputComponent {...props} />
-  ));
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Input'>>(
+    function LayoutComponentInputRender(props, _): JSX.Element | null {
+      return <InputComponent {...props} />;
+    },
+  );
 
   getDisplayData(node: LayoutNode<'Input'>, { currentLanguage }: DisplayDataProps): string {
     if (!node.item.dataModelBindings?.simpleBinding) {

--- a/src/layout/Input/index.tsx
+++ b/src/layout/Input/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { formatNumericText } from '@digdir/design-system-react';
@@ -14,7 +14,10 @@ import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class Input extends InputDef {
-  render = (props: PropsFromGenericComponent<'Input'>): JSX.Element | null => <InputComponent {...props} />;
+  // eslint-disable-next-line react/display-name
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Input'>>((props, _): JSX.Element | null => (
+    <InputComponent {...props} />
+  ));
 
   getDisplayData(node: LayoutNode<'Input'>, { currentLanguage }: DisplayDataProps): string {
     if (!node.item.dataModelBindings?.simpleBinding) {

--- a/src/layout/InstanceInformation/index.tsx
+++ b/src/layout/InstanceInformation/index.tsx
@@ -5,8 +5,9 @@ import { InstanceInformationComponent } from 'src/layout/InstanceInformation/Ins
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export class InstanceInformation extends InstanceInformationDef {
-  // eslint-disable-next-line react/display-name
-  render = forwardRef<HTMLElement, PropsFromGenericComponent<'InstanceInformation'>>((props, _): JSX.Element | null => (
-    <InstanceInformationComponent {...props} />
-  ));
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'InstanceInformation'>>(
+    function LayoutComponentInstanceInformationRender(props, _): JSX.Element | null {
+      return <InstanceInformationComponent {...props} />;
+    },
+  );
 }

--- a/src/layout/InstanceInformation/index.tsx
+++ b/src/layout/InstanceInformation/index.tsx
@@ -1,11 +1,12 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import { InstanceInformationDef } from 'src/layout/InstanceInformation/config.def.generated';
 import { InstanceInformationComponent } from 'src/layout/InstanceInformation/InstanceInformationComponent';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export class InstanceInformation extends InstanceInformationDef {
-  render = (props: PropsFromGenericComponent<'InstanceInformation'>): JSX.Element | null => (
+  // eslint-disable-next-line react/display-name
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'InstanceInformation'>>((props, _): JSX.Element | null => (
     <InstanceInformationComponent {...props} />
-  );
+  ));
 }

--- a/src/layout/InstantiationButton/index.tsx
+++ b/src/layout/InstantiationButton/index.tsx
@@ -5,8 +5,9 @@ import { InstantiationButtonComponent } from 'src/layout/InstantiationButton/Ins
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export class InstantiationButton extends InstantiationButtonDef {
-  // eslint-disable-next-line react/display-name
-  render = forwardRef<HTMLElement, PropsFromGenericComponent<'InstantiationButton'>>((props, _): JSX.Element | null => (
-    <InstantiationButtonComponent {...props} />
-  ));
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'InstantiationButton'>>(
+    function LayoutComponentInstantiationButtonRender(props, _): JSX.Element | null {
+      return <InstantiationButtonComponent {...props} />;
+    },
+  );
 }

--- a/src/layout/InstantiationButton/index.tsx
+++ b/src/layout/InstantiationButton/index.tsx
@@ -1,11 +1,12 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import { InstantiationButtonDef } from 'src/layout/InstantiationButton/config.def.generated';
 import { InstantiationButtonComponent } from 'src/layout/InstantiationButton/InstantiationButtonComponent';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export class InstantiationButton extends InstantiationButtonDef {
-  render = (props: PropsFromGenericComponent<'InstantiationButton'>): JSX.Element | null => (
+  // eslint-disable-next-line react/display-name
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'InstantiationButton'>>((props, _): JSX.Element | null => (
     <InstantiationButtonComponent {...props} />
-  );
+  ));
 }

--- a/src/layout/Likert/index.tsx
+++ b/src/layout/Likert/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import type { PropsFromGenericComponent, ValidateAny } from '..';
@@ -26,7 +26,10 @@ export class Likert extends LikertDef implements ValidateAny {
     return true;
   }
 
-  render = (props: PropsFromGenericComponent<'Likert'>): JSX.Element | null => <LikertComponent {...props} />;
+  // eslint-disable-next-line react/display-name
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Likert'>>((props, _): JSX.Element | null => (
+    <LikertComponent {...props} />
+  ));
 
   renderSummary({
     onChangeClick,

--- a/src/layout/Likert/index.tsx
+++ b/src/layout/Likert/index.tsx
@@ -26,10 +26,11 @@ export class Likert extends LikertDef implements ValidateAny {
     return true;
   }
 
-  // eslint-disable-next-line react/display-name
-  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Likert'>>((props, _): JSX.Element | null => (
-    <LikertComponent {...props} />
-  ));
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Likert'>>(
+    function LayoutComponentLikertRender(props, _): JSX.Element | null {
+      return <LikertComponent {...props} />;
+    },
+  );
 
   renderSummary({
     onChangeClick,

--- a/src/layout/LikertItem/index.tsx
+++ b/src/layout/LikertItem/index.tsx
@@ -13,14 +13,15 @@ import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class LikertItem extends LikertItemDef {
-  // eslint-disable-next-line react/display-name
   render = forwardRef<HTMLTableRowElement, PropsFromGenericComponent<'LikertItem'>>(
-    (props, ref): JSX.Element | null => (
-      <LikertItemComponent
-        {...props}
-        ref={ref}
-      />
-    ),
+    function LayoutComponentLikertItemRender(props, ref): JSX.Element | null {
+      return (
+        <LikertItemComponent
+          {...props}
+          ref={ref}
+        />
+      );
+    },
   );
 
   directRender(props: PropsFromGenericComponent<'LikertItem'>): boolean {

--- a/src/layout/Link/index.tsx
+++ b/src/layout/Link/index.tsx
@@ -6,8 +6,9 @@ import { LinkDef } from 'src/layout/Link/config.def.generated';
 import { LinkComponent } from 'src/layout/Link/LinkComponent';
 
 export class Link extends LinkDef {
-  // eslint-disable-next-line react/display-name
-  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Link'>>((props, _): JSX.Element | null => (
-    <LinkComponent {...props} />
-  ));
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Link'>>(
+    function LayoutComponentLinkRender(props, _): JSX.Element | null {
+      return <LinkComponent {...props} />;
+    },
+  );
 }

--- a/src/layout/Link/index.tsx
+++ b/src/layout/Link/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import type { PropsFromGenericComponent } from '..';
 
@@ -6,5 +6,8 @@ import { LinkDef } from 'src/layout/Link/config.def.generated';
 import { LinkComponent } from 'src/layout/Link/LinkComponent';
 
 export class Link extends LinkDef {
-  render = (props: PropsFromGenericComponent<'Link'>): JSX.Element | null => <LinkComponent {...props} />;
+  // eslint-disable-next-line react/display-name
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Link'>>((props, _): JSX.Element | null => (
+    <LinkComponent {...props} />
+  ));
 }

--- a/src/layout/List/index.tsx
+++ b/src/layout/List/index.tsx
@@ -15,10 +15,11 @@ import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class List extends ListDef {
-  // eslint-disable-next-line react/display-name
-  render = forwardRef<HTMLElement, PropsFromGenericComponent<'List'>>((props, _): JSX.Element | null => (
-    <ListComponent {...props} />
-  ));
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'List'>>(
+    function LayoutComponentListRender(props, _): JSX.Element | null {
+      return <ListComponent {...props} />;
+    },
+  );
 
   getDisplayData(node: LayoutNode<'List'>): string {
     const formData = node.getFormData();

--- a/src/layout/List/index.tsx
+++ b/src/layout/List/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import dot from 'dot-object';
@@ -15,7 +15,10 @@ import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class List extends ListDef {
-  render = (props: PropsFromGenericComponent<'List'>): JSX.Element | null => <ListComponent {...props} />;
+  // eslint-disable-next-line react/display-name
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'List'>>((props, _): JSX.Element | null => (
+    <ListComponent {...props} />
+  ));
 
   getDisplayData(node: LayoutNode<'List'>): string {
     const formData = node.getFormData();

--- a/src/layout/Map/index.tsx
+++ b/src/layout/Map/index.tsx
@@ -10,10 +10,11 @@ import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class Map extends MapDef {
-  // eslint-disable-next-line react/display-name
-  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Map'>>((props, _): JSX.Element | null => (
-    <MapComponent {...props} />
-  ));
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Map'>>(
+    function LayoutComponentMapRender(props, _): JSX.Element | null {
+      return <MapComponent {...props} />;
+    },
+  );
 
   getDisplayData(node: LayoutNode<'Map'>): string {
     if (!node.item.dataModelBindings?.simpleBinding) {

--- a/src/layout/Map/index.tsx
+++ b/src/layout/Map/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { MapDef } from 'src/layout/Map/config.def.generated';
@@ -10,7 +10,10 @@ import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class Map extends MapDef {
-  render = (props: PropsFromGenericComponent<'Map'>): JSX.Element | null => <MapComponent {...props} />;
+  // eslint-disable-next-line react/display-name
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Map'>>((props, _): JSX.Element | null => (
+    <MapComponent {...props} />
+  ));
 
   getDisplayData(node: LayoutNode<'Map'>): string {
     if (!node.item.dataModelBindings?.simpleBinding) {

--- a/src/layout/MultipleSelect/index.tsx
+++ b/src/layout/MultipleSelect/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { useLanguage } from 'src/features/language/useLanguage';
@@ -15,9 +15,10 @@ import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class MultipleSelect extends MultipleSelectDef {
-  render = (props: PropsFromGenericComponent<'MultipleSelect'>): JSX.Element | null => (
+  // eslint-disable-next-line react/display-name
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'MultipleSelect'>>((props, _): JSX.Element | null => (
     <MultipleSelectComponent {...props} />
-  );
+  ));
 
   private getSummaryData(
     node: LayoutNode<'MultipleSelect'>,

--- a/src/layout/MultipleSelect/index.tsx
+++ b/src/layout/MultipleSelect/index.tsx
@@ -15,10 +15,11 @@ import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class MultipleSelect extends MultipleSelectDef {
-  // eslint-disable-next-line react/display-name
-  render = forwardRef<HTMLElement, PropsFromGenericComponent<'MultipleSelect'>>((props, _): JSX.Element | null => (
-    <MultipleSelectComponent {...props} />
-  ));
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'MultipleSelect'>>(
+    function LayoutComponentMultipleSelectRender(props, _): JSX.Element | null {
+      return <MultipleSelectComponent {...props} />;
+    },
+  );
 
   private getSummaryData(
     node: LayoutNode<'MultipleSelect'>,

--- a/src/layout/NavigationBar/index.tsx
+++ b/src/layout/NavigationBar/index.tsx
@@ -5,8 +5,9 @@ import { NavigationBarComponent } from 'src/layout/NavigationBar/NavigationBarCo
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export class NavigationBar extends NavigationBarDef {
-  // eslint-disable-next-line react/display-name
-  render = forwardRef<HTMLElement, PropsFromGenericComponent<'NavigationBar'>>((props, _): JSX.Element | null => (
-    <NavigationBarComponent {...props} />
-  ));
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'NavigationBar'>>(
+    function LayoutComponentNavigationBarRender(props, _): JSX.Element | null {
+      return <NavigationBarComponent {...props} />;
+    },
+  );
 }

--- a/src/layout/NavigationBar/index.tsx
+++ b/src/layout/NavigationBar/index.tsx
@@ -1,11 +1,12 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import { NavigationBarDef } from 'src/layout/NavigationBar/config.def.generated';
 import { NavigationBarComponent } from 'src/layout/NavigationBar/NavigationBarComponent';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export class NavigationBar extends NavigationBarDef {
-  render = (props: PropsFromGenericComponent<'NavigationBar'>): JSX.Element | null => (
+  // eslint-disable-next-line react/display-name
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'NavigationBar'>>((props, _): JSX.Element | null => (
     <NavigationBarComponent {...props} />
-  );
+  ));
 }

--- a/src/layout/NavigationButtons/index.tsx
+++ b/src/layout/NavigationButtons/index.tsx
@@ -5,8 +5,9 @@ import { NavigationButtonsComponent } from 'src/layout/NavigationButtons/Navigat
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export class NavigationButtons extends NavigationButtonsDef {
-  // eslint-disable-next-line react/display-name
-  render = forwardRef<HTMLElement, PropsFromGenericComponent<'NavigationButtons'>>((props, _): JSX.Element | null => (
-    <NavigationButtonsComponent {...props} />
-  ));
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'NavigationButtons'>>(
+    function LayoutComponentNavigationButtonRender(props, _): JSX.Element | null {
+      return <NavigationButtonsComponent {...props} />;
+    },
+  );
 }

--- a/src/layout/NavigationButtons/index.tsx
+++ b/src/layout/NavigationButtons/index.tsx
@@ -1,11 +1,12 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import { NavigationButtonsDef } from 'src/layout/NavigationButtons/config.def.generated';
 import { NavigationButtonsComponent } from 'src/layout/NavigationButtons/NavigationButtonsComponent';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export class NavigationButtons extends NavigationButtonsDef {
-  render = (props: PropsFromGenericComponent<'NavigationButtons'>): JSX.Element | null => (
+  // eslint-disable-next-line react/display-name
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'NavigationButtons'>>((props, _): JSX.Element | null => (
     <NavigationButtonsComponent {...props} />
-  );
+  ));
 }

--- a/src/layout/Panel/index.tsx
+++ b/src/layout/Panel/index.tsx
@@ -1,9 +1,12 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import { PanelDef } from 'src/layout/Panel/config.def.generated';
 import { PanelComponent } from 'src/layout/Panel/PanelComponent';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export class Panel extends PanelDef {
-  render = (props: PropsFromGenericComponent<'Panel'>): JSX.Element | null => <PanelComponent {...props} />;
+  // eslint-disable-next-line react/display-name
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Panel'>>((props, _): JSX.Element | null => (
+    <PanelComponent {...props} />
+  ));
 }

--- a/src/layout/Panel/index.tsx
+++ b/src/layout/Panel/index.tsx
@@ -5,8 +5,9 @@ import { PanelComponent } from 'src/layout/Panel/PanelComponent';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export class Panel extends PanelDef {
-  // eslint-disable-next-line react/display-name
-  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Panel'>>((props, _): JSX.Element | null => (
-    <PanelComponent {...props} />
-  ));
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Panel'>>(
+    function LayoutComponentPanelRender(props, _): JSX.Element | null {
+      return <PanelComponent {...props} />;
+    },
+  );
 }

--- a/src/layout/Paragraph/index.tsx
+++ b/src/layout/Paragraph/index.tsx
@@ -1,9 +1,12 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import { ParagraphDef } from 'src/layout/Paragraph/config.def.generated';
 import { ParagraphComponent } from 'src/layout/Paragraph/ParagraphComponent';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export class Paragraph extends ParagraphDef {
-  render = (props: PropsFromGenericComponent<'Paragraph'>): JSX.Element | null => <ParagraphComponent {...props} />;
+  // eslint-disable-next-line react/display-name
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Paragraph'>>((props, _): JSX.Element | null => (
+    <ParagraphComponent {...props} />
+  ));
 }

--- a/src/layout/Paragraph/index.tsx
+++ b/src/layout/Paragraph/index.tsx
@@ -5,8 +5,9 @@ import { ParagraphComponent } from 'src/layout/Paragraph/ParagraphComponent';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export class Paragraph extends ParagraphDef {
-  // eslint-disable-next-line react/display-name
-  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Paragraph'>>((props, _): JSX.Element | null => (
-    <ParagraphComponent {...props} />
-  ));
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Paragraph'>>(
+    function LayoutComponentParagraphRender(props, _): JSX.Element | null {
+      return <ParagraphComponent {...props} />;
+    },
+  );
 }

--- a/src/layout/PrintButton/index.tsx
+++ b/src/layout/PrintButton/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import type { PropsFromGenericComponent } from '..';
 
@@ -6,5 +6,8 @@ import { PrintButtonDef } from 'src/layout/PrintButton/config.def.generated';
 import { PrintButtonComponent } from 'src/layout/PrintButton/PrintButtonComponent';
 
 export class PrintButton extends PrintButtonDef {
-  render = (props: PropsFromGenericComponent<'PrintButton'>): JSX.Element | null => <PrintButtonComponent {...props} />;
+  // eslint-disable-next-line react/display-name
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'PrintButton'>>((props, _): JSX.Element | null => (
+    <PrintButtonComponent {...props} />
+  ));
 }

--- a/src/layout/PrintButton/index.tsx
+++ b/src/layout/PrintButton/index.tsx
@@ -6,8 +6,9 @@ import { PrintButtonDef } from 'src/layout/PrintButton/config.def.generated';
 import { PrintButtonComponent } from 'src/layout/PrintButton/PrintButtonComponent';
 
 export class PrintButton extends PrintButtonDef {
-  // eslint-disable-next-line react/display-name
-  render = forwardRef<HTMLElement, PropsFromGenericComponent<'PrintButton'>>((props, _): JSX.Element | null => (
-    <PrintButtonComponent {...props} />
-  ));
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'PrintButton'>>(
+    function LayoutComponentPrintRender(props, _): JSX.Element | null {
+      return <PrintButtonComponent {...props} />;
+    },
+  );
 }

--- a/src/layout/RadioButtons/index.tsx
+++ b/src/layout/RadioButtons/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { getSelectedValueToText } from 'src/features/options/getSelectedValueToText';
@@ -11,9 +11,10 @@ import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class RadioButtons extends RadioButtonsDef {
-  render = (props: PropsFromGenericComponent<'RadioButtons'>): JSX.Element | null => (
+  // eslint-disable-next-line react/display-name
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'RadioButtons'>>((props, _): JSX.Element | null => (
     <RadioButtonContainerComponent {...props} />
-  );
+  ));
 
   getDisplayData(node: LayoutNode<'RadioButtons'>, { langTools, options }: DisplayDataProps): string {
     const value = String(node.getFormData().simpleBinding ?? '');

--- a/src/layout/RadioButtons/index.tsx
+++ b/src/layout/RadioButtons/index.tsx
@@ -11,10 +11,11 @@ import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class RadioButtons extends RadioButtonsDef {
-  // eslint-disable-next-line react/display-name
-  render = forwardRef<HTMLElement, PropsFromGenericComponent<'RadioButtons'>>((props, _): JSX.Element | null => (
-    <RadioButtonContainerComponent {...props} />
-  ));
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'RadioButtons'>>(
+    function LayoutComponentRadioButtonsRender(props, _): JSX.Element | null {
+      return <RadioButtonContainerComponent {...props} />;
+    },
+  );
 
   getDisplayData(node: LayoutNode<'RadioButtons'>, { langTools, options }: DisplayDataProps): string {
     const value = String(node.getFormData().simpleBinding ?? '');

--- a/src/layout/RepeatingGroup/index.tsx
+++ b/src/layout/RepeatingGroup/index.tsx
@@ -30,15 +30,13 @@ export class RepeatingGroup extends RepeatingGroupDef implements ValidateAny, Va
   }
 
   // eslint-disable-next-line react/display-name
-  render = forwardRef<HTMLDivElement, PropsFromGenericComponent<'RepeatingGroup'>>(
-    (props, ref: React.ForwardedRef<HTMLDivElement>): JSX.Element | null => (
-      <RepeatingGroupProvider node={props.node}>
-        <RepeatingGroupsFocusProvider>
-          <RepeatingGroupContainer ref={ref} />
-        </RepeatingGroupsFocusProvider>
-      </RepeatingGroupProvider>
-    ),
-  );
+  render = forwardRef<HTMLDivElement, PropsFromGenericComponent<'RepeatingGroup'>>((props, ref): JSX.Element | null => (
+    <RepeatingGroupProvider node={props.node}>
+      <RepeatingGroupsFocusProvider>
+        <RepeatingGroupContainer ref={ref} />
+      </RepeatingGroupsFocusProvider>
+    </RepeatingGroupProvider>
+  ));
 
   renderSummary({
     onChangeClick,

--- a/src/layout/RepeatingGroup/index.tsx
+++ b/src/layout/RepeatingGroup/index.tsx
@@ -29,14 +29,17 @@ export class RepeatingGroup extends RepeatingGroupDef implements ValidateAny, Va
     return true;
   }
 
-  // eslint-disable-next-line react/display-name
-  render = forwardRef<HTMLDivElement, PropsFromGenericComponent<'RepeatingGroup'>>((props, ref): JSX.Element | null => (
-    <RepeatingGroupProvider node={props.node}>
-      <RepeatingGroupsFocusProvider>
-        <RepeatingGroupContainer ref={ref} />
-      </RepeatingGroupsFocusProvider>
-    </RepeatingGroupProvider>
-  ));
+  render = forwardRef<HTMLDivElement, PropsFromGenericComponent<'RepeatingGroup'>>(
+    function LayoutComponentRepeatingGroupRender(props, ref): JSX.Element | null {
+      return (
+        <RepeatingGroupProvider node={props.node}>
+          <RepeatingGroupsFocusProvider>
+            <RepeatingGroupContainer ref={ref} />
+          </RepeatingGroupsFocusProvider>
+        </RepeatingGroupProvider>
+      );
+    },
+  );
 
   renderSummary({
     onChangeClick,

--- a/src/layout/Summary/index.tsx
+++ b/src/layout/Summary/index.tsx
@@ -10,14 +10,17 @@ export class Summary extends SummaryDef {
     return true;
   }
 
-  // eslint-disable-next-line react/display-name
-  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Summary'>>((props, _): JSX.Element | null => (
-    <SummaryComponent
-      summaryNode={props.node}
-      overrides={props.overrideItemProps}
-      ref={props.containerDivRef}
-    />
-  ));
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Summary'>>(
+    function LayoutComponentSummaryRender(props, _): JSX.Element | null {
+      return (
+        <SummaryComponent
+          summaryNode={props.node}
+          overrides={props.overrideItemProps}
+          ref={props.containerDivRef}
+        />
+      );
+    },
+  );
 
   renderSummary(): JSX.Element | null {
     // If the code ever ends up with a Summary component referencing another Summary component, we should not end up

--- a/src/layout/Summary/index.tsx
+++ b/src/layout/Summary/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { SummaryDef } from 'src/layout/Summary/config.def.generated';
@@ -10,13 +10,14 @@ export class Summary extends SummaryDef {
     return true;
   }
 
-  render = (props: PropsFromGenericComponent<'Summary'>): JSX.Element | null => (
+  // eslint-disable-next-line react/display-name
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Summary'>>((props, _): JSX.Element | null => (
     <SummaryComponent
       summaryNode={props.node}
       overrides={props.overrideItemProps}
       ref={props.containerDivRef}
     />
-  );
+  ));
 
   renderSummary(): JSX.Element | null {
     // If the code ever ends up with a Summary component referencing another Summary component, we should not end up

--- a/src/layout/TextArea/index.tsx
+++ b/src/layout/TextArea/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { SummaryItemSimple } from 'src/layout/Summary/SummaryItemSimple';
@@ -10,7 +10,10 @@ import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class TextArea extends TextAreaDef {
-  render = (props: PropsFromGenericComponent<'TextArea'>): JSX.Element | null => <TextAreaComponent {...props} />;
+  // eslint-disable-next-line react/display-name
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'TextArea'>>((props, _): JSX.Element | null => (
+    <TextAreaComponent {...props} />
+  ));
 
   getDisplayData(node: LayoutNode<'TextArea'>): string {
     if (!node.item.dataModelBindings?.simpleBinding) {

--- a/src/layout/TextArea/index.tsx
+++ b/src/layout/TextArea/index.tsx
@@ -10,10 +10,11 @@ import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class TextArea extends TextAreaDef {
-  // eslint-disable-next-line react/display-name
-  render = forwardRef<HTMLElement, PropsFromGenericComponent<'TextArea'>>((props, _): JSX.Element | null => (
-    <TextAreaComponent {...props} />
-  ));
+  render = forwardRef<HTMLElement, PropsFromGenericComponent<'TextArea'>>(
+    function LayoutComponentTextAreaRender(props, _): JSX.Element | null {
+      return <TextAreaComponent {...props} />;
+    },
+  );
 
   getDisplayData(node: LayoutNode<'TextArea'>): string {
     if (!node.item.dataModelBindings?.simpleBinding) {


### PR DESCRIPTION
## Description
Fixes an issue with a warning: `Warning: Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()?`. I thought I had fixed this, but it needs to be implemented for all `LayoutComponents`. This is because all of our components potentially receive a `ref` if the `directRender` function retruns `true`. 

```tsx
  if (layoutComponent.directRender(componentProps) || overrideDisplay?.directRender) {
    return (
      <FormComponentContextProvider value={formComponentContext}>
        <RenderComponent
          {...componentProps}
          ref={containerDivRef}
        />
      </FormComponentContextProvider>
    );
  }

```

I refactored the code such that all `LayoutComponents` use `forwardRef` an such can receive refs even though they might not use the ref. One issue with this is that our lint rules now complain about the render function not having a display name. I've fixed this simply by disabling the lint-rule for these cases:
```tsx

export class Alert extends AlertDef {
  // eslint-disable-next-line react/display-name
  render = forwardRef<HTMLElement, PropsFromGenericComponent<'Alert'>>((props): JSX.Element | null => (
    <AlertComponent {...props} />
  ));
}

```

This could also be solved by placing the component outside of the class, and giving it a displayName there:
```tsx
const RenderComponent = forwardRef<HTMLElement, PropsFromGenericComponent<'Alert'>>((props): JSX.Element | null => (
  <AlertComponent {...props} />
));
RenderComponent.displayName = 'LayoutComponentAlertRender';

export class Alert extends AlertDef {
  render = RenderComponent;
}
```

What do you think we should go for? In option 1, the code looks a little cleaner, but the component becomes `Anonymous` in dev tools. However this is not a huge issue, as the render "component" ever only renders the equivalent react component. In the case of `Alert`, the hierarchy would be `Anonymous` -> `AlertComponent` vs `LayoutComponentAlertRender` -> `AlertComponent` in the react dev tools. 


## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
