### PR TITLE
Change the screen reader semantics of the Likert component

### DIFF
--- a/src/layout/Likert/LikertComponent.module.css
+++ b/src/layout/Likert/LikertComponent.module.css
@@ -6,6 +6,11 @@
   background-color: var(--fds-semantic-surface-action-second-subtle);
 }
 
+.likertTableHeaderCell:not(:first-of-type) {
+  width: 100px;
+  text-align: center;
+}
+
 .likertTableContainer {
   display: block;
   width: 100%;
@@ -16,13 +21,22 @@
   width: 100%;
 }
 
+.likertRadioButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.likertRadioButton label {
+  margin: 0;
+  gap: 0;
+}
+
 /* ====
 TODO(1779): Remove these styles after going through all the different Table styles in
 Altinn, and making sure they are consistent. */
 .likertTable {
-  box-shadow:
-    0 1px 1px rgba(0, 0, 0, 0.12),
-    0 2px 2px rgba(0, 0, 0, 0.12);
+  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.12), 0 2px 2px rgba(0, 0, 0, 0.12);
 }
 
 .likertTable th {

--- a/src/layout/Likert/LikertComponent.tsx
+++ b/src/layout/Likert/LikertComponent.tsx
@@ -70,6 +70,7 @@ const RadioGroupTableRow = forwardRef<HTMLTableRowElement, IControlledRadioGroup
               checked={isChecked}
               onChange={handleChange}
               value={option.value}
+              className={classes.likertRadioButton}
               name={rowLabelId}
             />
           </Table.Cell>

--- a/src/layout/Likert/LikertComponent.tsx
+++ b/src/layout/Likert/LikertComponent.tsx
@@ -1,10 +1,10 @@
 import React, { forwardRef } from 'react';
 import type { Ref } from 'react';
 
-import { Table } from '@digdir/design-system-react';
+import { Radio, Table } from '@digdir/design-system-react';
 import { Typography } from '@material-ui/core';
 
-import { RadioButton } from 'src/components/form/RadioButton';
+import { useLanguage } from 'src/hooks/useLanguage';
 import { LayoutStyle } from 'src/layout/common.generated';
 import classes from 'src/layout/Likert/LikertComponent.module.css';
 import { ControlledRadioGroup } from 'src/layout/RadioButtons/ControlledRadioGroup';
@@ -38,9 +38,9 @@ LikertComponent.displayName = 'LikertComponent';
 const RadioGroupTableRow = forwardRef<HTMLTableRowElement, IControlledRadioGroupProps>((props, ref) => {
   const { node, componentValidations, legend } = props;
   const { selected, handleChange, calculatedOptions, handleBlur, fetchingOptions } = useRadioButtons(props);
+  const { langAsString } = useLanguage();
 
   const id = node.item.id;
-  const groupContainerId = node.closest((n) => n.type === 'Group')?.item.id;
   const RenderLegend = legend;
   const rowLabelId = `row-label-${id}`;
 
@@ -50,6 +50,7 @@ const RadioGroupTableRow = forwardRef<HTMLTableRowElement, IControlledRadioGroup
       data-componentid={node.item.id}
       data-is-loading={fetchingOptions ? 'true' : 'false'}
       ref={ref}
+      role='radiogroup'
     >
       <Table.Cell id={rowLabelId}>
         <Typography component={'div'}>
@@ -57,22 +58,22 @@ const RadioGroupTableRow = forwardRef<HTMLTableRowElement, IControlledRadioGroup
           {renderValidationMessagesForComponent(componentValidations?.simpleBinding, id)}
         </Typography>
       </Table.Cell>
-      {calculatedOptions?.map((option, colIndex) => {
-        const colLabelId = `${groupContainerId}-likert-columnheader-${colIndex}`;
+      {calculatedOptions?.map((option) => {
         const isChecked = selected === option.value;
         return (
           <Table.Cell
             key={option.value}
             onBlur={handleBlur}
           >
-            <RadioButton
-              aria-labelledby={`${rowLabelId} ${colLabelId}`}
+            <Radio
               checked={isChecked}
               onChange={handleChange}
               value={option.value}
               className={classes.likertRadioButton}
               name={rowLabelId}
-            />
+            >
+              <span className='sr-only'>{langAsString(option.label)}</span>
+            </Radio>
           </Table.Cell>
         );
       })}

--- a/src/layout/Likert/LikertComponent.tsx
+++ b/src/layout/Likert/LikertComponent.tsx
@@ -41,12 +41,16 @@ const RadioGroupTableRow = forwardRef<HTMLTableRowElement, IControlledRadioGroup
   const { langAsString } = useLanguage();
 
   const id = node.item.id;
-  const RenderLegend = legend;
+  const likertId = node.parents((p) => p.item.type === 'Group')?.[0].item.id;
+
   const rowLabelId = `row-label-${id}`;
+  const headerColumnId = `${likertId}-likert-columnheader-left`;
+
+  const RenderLegend = legend;
 
   return (
     <Table.Row
-      aria-labelledby={rowLabelId}
+      aria-labelledby={`${headerColumnId} ${rowLabelId}`}
       data-componentid={node.item.id}
       data-is-loading={fetchingOptions ? 'true' : 'false'}
       ref={ref}

--- a/src/layout/Likert/RepeatingGroupsLikertContainer.test.tsx
+++ b/src/layout/Likert/RepeatingGroupsLikertContainer.test.tsx
@@ -45,9 +45,9 @@ describe('RepeatingGroupsLikertContainer', () => {
         },
       });
       expect(screen.getByText('Test title')).toBeInTheDocument();
-      expect(screen.getByRole('table', { name: 'Test title' })).toBeInTheDocument();
+      expect(screen.getByRole('group', { name: 'Test title' })).toBeInTheDocument();
       expect(screen.getByText('Test description')).toBeInTheDocument();
-      expect(screen.getByRole('columnheader', { name: 'Test left column header' })).toBeInTheDocument();
+      expect(screen.getByText('Test left column header')).toBeInTheDocument();
     });
 
     it('should render table with one selected row', () => {
@@ -127,18 +127,18 @@ describe('RepeatingGroupsLikertContainer', () => {
       const { mockStoreDispatch } = render();
       validateTableLayout(defaultMockQuestions, defaultMockOptions);
 
-      const rad1 = screen.getByRole('row', {
+      const row1 = screen.getByRole('radiogroup', {
         name: /Hvordan trives du på skolen/i,
       });
-      const btn1 = within(rad1).getByRole('radio', {
+      const btn1 = within(row1).getByRole('radio', {
         name: /Bra/i,
       });
 
-      const rad2 = screen.getByRole('row', {
+      const row2 = screen.getByRole('radiogroup', {
         name: /Har du det bra/i,
       });
 
-      const btn2 = within(rad2).getByRole('radio', {
+      const btn2 = within(row2).getByRole('radio', {
         name: /Dårlig/i,
       });
 
@@ -180,9 +180,15 @@ describe('RepeatingGroupsLikertContainer', () => {
       }));
       render({ mockQuestions, extraTextResources });
       validateTableLayout(defaultMockQuestions, defaultMockOptions);
-      screen.getByRole('radio', { name: 'Hvordan trives du på skolen? Bra' });
-      screen.getByRole('radio', { name: 'Hvordan trives du på skolen? Ok' });
-      screen.getByRole('radio', { name: 'Hvordan trives du på skolen? Dårlig' });
+      within(screen.getByRole('radiogroup', { name: 'Hvordan trives du på skolen?' })).getByRole('radio', {
+        name: 'Bra',
+      });
+      within(screen.getByRole('radiogroup', { name: 'Hvordan trives du på skolen?' })).getByRole('radio', {
+        name: 'Ok',
+      });
+      within(screen.getByRole('radiogroup', { name: 'Hvordan trives du på skolen?' })).getByRole('radio', {
+        name: 'Dårlig',
+      });
     });
 
     it('should support nested binding for options label referencing text resources', async () => {
@@ -196,9 +202,15 @@ describe('RepeatingGroupsLikertContainer', () => {
       }));
       render({ mockOptions, extraTextResources });
       validateTableLayout(defaultMockQuestions, mockOptions);
-      screen.getByRole('radio', { name: 'Hvordan trives du på skolen? Bra' });
-      screen.getByRole('radio', { name: 'Hvordan trives du på skolen? Ok' });
-      screen.getByRole('radio', { name: 'Hvordan trives du på skolen? Dårlig' });
+      within(screen.getByRole('radiogroup', { name: 'Hvordan trives du på skolen?' })).getByRole('radio', {
+        name: 'Bra',
+      });
+      within(screen.getByRole('radiogroup', { name: 'Hvordan trives du på skolen?' })).getByRole('radio', {
+        name: 'Ok',
+      });
+      within(screen.getByRole('radiogroup', { name: 'Hvordan trives du på skolen?' })).getByRole('radio', {
+        name: 'Dårlig',
+      });
     });
 
     it('should render error message', async () => {
@@ -224,7 +236,7 @@ describe('RepeatingGroupsLikertContainer', () => {
           },
         },
       });
-      expect(screen.getByRole('table', { name: /Likert test title/i })).toHaveAccessibleDescription(
+      expect(screen.getByRole('group', { name: /Likert test title/i })).toHaveAccessibleDescription(
         'This is a test description',
       );
     });
@@ -258,13 +270,12 @@ describe('RepeatingGroupsLikertContainer', () => {
       validateRadioLayout(
         defaultMockQuestions.map((q) => ({ ...q, Question: `${leftColumnHeader} ${q.Question}` })),
         defaultMockOptions,
-        true,
       );
     });
 
     it('should render mobile view and click radiobuttons', async () => {
       const { mockStoreDispatch } = render({ mobileView: true });
-      validateRadioLayout(defaultMockQuestions, defaultMockOptions, true);
+      validateRadioLayout(defaultMockQuestions, defaultMockOptions);
       const rad1 = screen.getByRole('radiogroup', {
         name: /Hvordan trives du på skolen/i,
       });
@@ -301,7 +312,7 @@ describe('RepeatingGroupsLikertContainer', () => {
       });
 
       render({ mockQuestions: questions, mobileView: true });
-      validateRadioLayout(questions, defaultMockOptions, true);
+      validateRadioLayout(questions, defaultMockOptions);
 
       // Validate that radio is selected
       const selectedRow = screen.getByRole('radiogroup', {
@@ -337,7 +348,7 @@ describe('RepeatingGroupsLikertContainer', () => {
         },
       });
 
-      validateRadioLayout(defaultMockQuestions.slice(1, 3), defaultMockOptions, true);
+      validateRadioLayout(defaultMockQuestions.slice(1, 3), defaultMockOptions);
     });
   });
 });

--- a/src/layout/Likert/RepeatingGroupsLikertContainer.test.tsx
+++ b/src/layout/Likert/RepeatingGroupsLikertContainer.test.tsx
@@ -31,7 +31,7 @@ describe('RepeatingGroupsLikertContainer', () => {
           options: defaultMockOptions,
         },
       });
-      validateTableLayout(defaultMockQuestions, defaultMockOptions);
+      validateTableLayout(defaultMockQuestions, defaultMockOptions, { leftColumnHeader: 'Spørsmål' });
     });
 
     it('should render title, description and left column header', () => {
@@ -57,7 +57,7 @@ describe('RepeatingGroupsLikertContainer', () => {
       });
       render({ mockQuestions: questions });
 
-      validateTableLayout(defaultMockQuestions, defaultMockOptions);
+      validateTableLayout(defaultMockQuestions, defaultMockOptions, { leftColumnHeader: 'Spørsmål' });
     });
 
     it('should render table with two selected row', () => {
@@ -78,7 +78,7 @@ describe('RepeatingGroupsLikertContainer', () => {
       });
 
       render({ mockQuestions: questions });
-      validateTableLayout(defaultMockQuestions, defaultMockOptions);
+      validateTableLayout(defaultMockQuestions, defaultMockOptions, { leftColumnHeader: 'Spørsmål' });
     });
 
     it('should render table with start binding', () => {
@@ -91,7 +91,7 @@ describe('RepeatingGroupsLikertContainer', () => {
         },
       });
 
-      validateTableLayout(defaultMockQuestions.slice(2), defaultMockOptions);
+      validateTableLayout(defaultMockQuestions.slice(2), defaultMockOptions, { leftColumnHeader: 'Spørsmål' });
     });
 
     it('should render table with end binding', () => {
@@ -104,7 +104,7 @@ describe('RepeatingGroupsLikertContainer', () => {
         },
       });
 
-      validateTableLayout(defaultMockQuestions.slice(0, 3), defaultMockOptions);
+      validateTableLayout(defaultMockQuestions.slice(0, 3), defaultMockOptions, { leftColumnHeader: 'Spørsmål' });
     });
 
     it('should render table with start and end binding', () => {
@@ -120,22 +120,22 @@ describe('RepeatingGroupsLikertContainer', () => {
         },
       });
 
-      validateTableLayout(defaultMockQuestions.slice(1, 3), defaultMockOptions);
+      validateTableLayout(defaultMockQuestions.slice(1, 3), defaultMockOptions, { leftColumnHeader: 'Spørsmål' });
     });
 
     it('should render table view and click radiobuttons', async () => {
       const { mockStoreDispatch } = render();
-      validateTableLayout(defaultMockQuestions, defaultMockOptions);
+      validateTableLayout(defaultMockQuestions, defaultMockOptions, { leftColumnHeader: 'Spørsmål' });
 
       const row1 = screen.getByRole('radiogroup', {
-        name: /Hvordan trives du på skolen/i,
+        name: /Spørsmål Hvordan trives du på skolen/i,
       });
       const btn1 = within(row1).getByRole('radio', {
         name: /Bra/i,
       });
 
       const row2 = screen.getByRole('radiogroup', {
-        name: /Har du det bra/i,
+        name: /Spørsmål Har du det bra/i,
       });
 
       const btn2 = within(row2).getByRole('radio', {
@@ -159,7 +159,7 @@ describe('RepeatingGroupsLikertContainer', () => {
 
     it('should render standard view and use keyboard to navigate', async () => {
       const { mockStoreDispatch } = render();
-      validateTableLayout(defaultMockQuestions, defaultMockOptions);
+      validateTableLayout(defaultMockQuestions, defaultMockOptions, { leftColumnHeader: 'Spørsmål' });
 
       await user.tab();
       await user.keyboard('[Space]');
@@ -179,14 +179,14 @@ describe('RepeatingGroupsLikertContainer', () => {
         Question: `nested-question-binding-${i}`,
       }));
       render({ mockQuestions, extraTextResources });
-      validateTableLayout(defaultMockQuestions, defaultMockOptions);
-      within(screen.getByRole('radiogroup', { name: 'Hvordan trives du på skolen?' })).getByRole('radio', {
+      validateTableLayout(defaultMockQuestions, defaultMockOptions, { leftColumnHeader: 'Spørsmål' });
+      within(screen.getByRole('radiogroup', { name: 'Spørsmål Hvordan trives du på skolen?' })).getByRole('radio', {
         name: 'Bra',
       });
-      within(screen.getByRole('radiogroup', { name: 'Hvordan trives du på skolen?' })).getByRole('radio', {
+      within(screen.getByRole('radiogroup', { name: 'Spørsmål Hvordan trives du på skolen?' })).getByRole('radio', {
         name: 'Ok',
       });
-      within(screen.getByRole('radiogroup', { name: 'Hvordan trives du på skolen?' })).getByRole('radio', {
+      within(screen.getByRole('radiogroup', { name: 'Spørsmål Hvordan trives du på skolen?' })).getByRole('radio', {
         name: 'Dårlig',
       });
     });
@@ -201,14 +201,14 @@ describe('RepeatingGroupsLikertContainer', () => {
         label: `nested-option-binding-${i}`,
       }));
       render({ mockOptions, extraTextResources });
-      validateTableLayout(defaultMockQuestions, mockOptions);
-      within(screen.getByRole('radiogroup', { name: 'Hvordan trives du på skolen?' })).getByRole('radio', {
+      validateTableLayout(defaultMockQuestions, mockOptions, { leftColumnHeader: 'Spørsmål' });
+      within(screen.getByRole('radiogroup', { name: 'Spørsmål Hvordan trives du på skolen?' })).getByRole('radio', {
         name: 'Bra',
       });
-      within(screen.getByRole('radiogroup', { name: 'Hvordan trives du på skolen?' })).getByRole('radio', {
+      within(screen.getByRole('radiogroup', { name: 'Spørsmål Hvordan trives du på skolen?' })).getByRole('radio', {
         name: 'Ok',
       });
-      within(screen.getByRole('radiogroup', { name: 'Hvordan trives du på skolen?' })).getByRole('radio', {
+      within(screen.getByRole('radiogroup', { name: 'Spørsmål Hvordan trives du på skolen?' })).getByRole('radio', {
         name: 'Dårlig',
       });
     });
@@ -267,10 +267,7 @@ describe('RepeatingGroupsLikertContainer', () => {
         },
         mobileView: true,
       });
-      validateRadioLayout(
-        defaultMockQuestions.map((q) => ({ ...q, Question: `${leftColumnHeader} ${q.Question}` })),
-        defaultMockOptions,
-      );
+      validateRadioLayout(defaultMockQuestions, defaultMockOptions, { leftColumnHeader });
     });
 
     it('should render mobile view and click radiobuttons', async () => {

--- a/src/layout/Likert/RepeatingGroupsLikertContainer.tsx
+++ b/src/layout/Likert/RepeatingGroupsLikertContainer.tsx
@@ -115,7 +115,10 @@ export const RepeatingGroupsLikertContainer = ({ node }: RepeatingGroupsLikertCo
               className={classes.likertTableHeader}
             >
               <Table.Row>
-                <Table.HeaderCell aria-hidden='true'>
+                <Table.HeaderCell
+                  id={`${id}-likert-columnheader-left`}
+                  aria-hidden={true}
+                >
                   <span className={cn({ 'sr-only': node?.item.textResourceBindings?.leftColumnHeader == null })}>
                     {lang(
                       node?.item.textResourceBindings?.leftColumnHeader ?? 'likert.left_column_default_header_text',

--- a/src/layout/Likert/RepeatingGroupsLikertContainer.tsx
+++ b/src/layout/Likert/RepeatingGroupsLikertContainer.tsx
@@ -108,13 +108,14 @@ export const RepeatingGroupsLikertContainer = ({ node }: RepeatingGroupsLikertCo
             aria-labelledby={(hasTitle && titleId) || undefined}
             aria-describedby={(hasDescription && descriptionId) || undefined}
             className={classes.likertTable}
+            role='group'
           >
             <Table.Head
               id={`likert-table-header-${id}`}
               className={classes.likertTableHeader}
             >
               <Table.Row>
-                <Table.HeaderCell>
+                <Table.HeaderCell aria-hidden='true'>
                   <span className={cn({ 'sr-only': node?.item.textResourceBindings?.leftColumnHeader == null })}>
                     {lang(
                       node?.item.textResourceBindings?.leftColumnHeader ?? 'likert.left_column_default_header_text',
@@ -126,6 +127,7 @@ export const RepeatingGroupsLikertContainer = ({ node }: RepeatingGroupsLikertCo
                   return (
                     <Table.HeaderCell
                       key={option.value}
+                      aria-hidden='true'
                       id={colLabelId}
                       className={classes.likertTableHeaderCell}
                     >

--- a/src/layout/Likert/RepeatingGroupsLikertContainer.tsx
+++ b/src/layout/Likert/RepeatingGroupsLikertContainer.tsx
@@ -127,6 +127,7 @@ export const RepeatingGroupsLikertContainer = ({ node }: RepeatingGroupsLikertCo
                     <Table.HeaderCell
                       key={option.value}
                       id={colLabelId}
+                      className={classes.likertTableHeaderCell}
                     >
                       {lang(option.label)}
                     </Table.HeaderCell>

--- a/src/layout/Likert/RepeatingGroupsLikertContainerTestUtils.tsx
+++ b/src/layout/Likert/RepeatingGroupsLikertContainerTestUtils.tsx
@@ -254,28 +254,23 @@ export function ContainerTester(props: { id: string }) {
 }
 
 export const validateTableLayout = (questions: IQuestion[], options: IOption[]) => {
-  screen.getByRole('table');
+  screen.getByRole('group');
 
   for (const option of defaultMockOptions) {
-    const columnHeader = screen.getByRole('columnheader', {
-      name: new RegExp(option.label),
-    });
-    expect(columnHeader).toBeInTheDocument();
+    const allElements = screen.getAllByRole('radio', { name: option.label });
+    for (const element of allElements) {
+      expect(element).toBeInTheDocument();
+    }
   }
 
   validateRadioLayout(questions, options);
 };
 
-export const validateRadioLayout = (questions: IQuestion[], options: IOption[], mobileView = false) => {
-  if (mobileView) {
-    expect(screen.getAllByRole('radiogroup')).toHaveLength(questions.length);
-  } else {
-    // Header and questions
-    expect(screen.getAllByRole('row')).toHaveLength(questions.length + 1);
-  }
+export const validateRadioLayout = (questions: IQuestion[], options: IOption[]) => {
+  expect(screen.getAllByRole('radiogroup')).toHaveLength(questions.length);
 
   for (const question of questions) {
-    const row = screen.getByRole(mobileView ? 'radiogroup' : 'row', {
+    const row = screen.getByRole('radiogroup', {
       name: question.Question,
     });
 

--- a/src/layout/Likert/RepeatingGroupsLikertContainerTestUtils.tsx
+++ b/src/layout/Likert/RepeatingGroupsLikertContainerTestUtils.tsx
@@ -253,7 +253,11 @@ export function ContainerTester(props: { id: string }) {
   return <RepeatingGroupsLikertContainer node={node} />;
 }
 
-export const validateTableLayout = (questions: IQuestion[], options: IOption[]) => {
+export const validateTableLayout = (
+  questions: IQuestion[],
+  options: IOption[],
+  validateRadioLayoutOptions: ValidateRadioLayoutOptions,
+) => {
   screen.getByRole('group');
 
   for (const option of defaultMockOptions) {
@@ -263,15 +267,23 @@ export const validateTableLayout = (questions: IQuestion[], options: IOption[]) 
     }
   }
 
-  validateRadioLayout(questions, options);
+  validateRadioLayout(questions, options, validateRadioLayoutOptions);
 };
 
-export const validateRadioLayout = (questions: IQuestion[], options: IOption[]) => {
+type ValidateRadioLayoutOptions = {
+  leftColumnHeader?: string;
+};
+
+export const validateRadioLayout = (
+  questions: IQuestion[],
+  options: IOption[],
+  { leftColumnHeader }: ValidateRadioLayoutOptions = {},
+) => {
   expect(screen.getAllByRole('radiogroup')).toHaveLength(questions.length);
 
   for (const question of questions) {
     const row = screen.getByRole('radiogroup', {
-      name: question.Question,
+      name: leftColumnHeader != null ? `${leftColumnHeader} ${question.Question}` : question.Question,
     });
 
     for (const option of options) {

--- a/test/e2e/integration/frontend-test/likert.ts
+++ b/test/e2e/integration/frontend-test/likert.ts
@@ -1,5 +1,3 @@
-import escapeRegex from 'escape-string-regexp';
-
 import { AppFrontend } from 'test/e2e/pageobjects/app-frontend';
 import { Likert } from 'test/e2e/pageobjects/likert';
 
@@ -18,7 +16,7 @@ describe('Likert', () => {
     });
 
     // Check the second required question and take a snapshot
-    likertPage.selectRadio(new RegExp(`^${escapeRegex(likertPage.requiredQuestions[1])}`), likertPage.options[1]);
+    likertPage.selectRadio(likertPage.requiredQuestions[1], likertPage.options[1]);
     cy.findAllByRole('alert').should('have.length', 2);
     cy.snapshot('likert');
   });

--- a/test/e2e/integration/frontend-test/mobile.ts
+++ b/test/e2e/integration/frontend-test/mobile.ts
@@ -106,7 +106,7 @@ function ensureTableHasNumColumns(tableContainer: string, numColumns: number) {
 }
 
 function testLikert() {
-  likertPage.selectRequiredRadiosInMobile();
+  likertPage.selectRequiredRadios();
   sendIn();
 }
 

--- a/test/e2e/integration/frontend-test/validation.ts
+++ b/test/e2e/integration/frontend-test/validation.ts
@@ -695,13 +695,13 @@ describe('Validation', () => {
     cy.findByRole('button', { name: /Send inn/ }).click();
 
     cy.findByRole('radiogroup', {
-      name: 'Hører skolen på elevenes forslag? * Du må fylle ut hører skolen på elevenes forslag?',
+      name: 'Spørsmål Hører skolen på elevenes forslag? * Du må fylle ut hører skolen på elevenes forslag?',
     }).within(() => {
       cy.findByRole('radio', { name: 'Alltid' }).should('not.be.focused');
     });
     cy.findByRole('button', { name: /Du må fylle ut hører skolen på elevenes forslag/ }).click();
     cy.findByRole('radiogroup', {
-      name: 'Hører skolen på elevenes forslag? * Du må fylle ut hører skolen på elevenes forslag?',
+      name: 'Spørsmål Hører skolen på elevenes forslag? * Du må fylle ut hører skolen på elevenes forslag?',
     }).within(() => {
       cy.findByRole('radio', { name: 'Alltid' }).should('be.focused');
     });

--- a/test/e2e/integration/frontend-test/validation.ts
+++ b/test/e2e/integration/frontend-test/validation.ts
@@ -694,12 +694,16 @@ describe('Validation', () => {
     cy.goto('likert');
     cy.findByRole('button', { name: /Send inn/ }).click();
 
-    cy.findByRole('radio', {
-      name: 'Hører skolen på elevenes forslag? * Du må fylle ut hører skolen på elevenes forslag? Alltid',
-    }).should('not.be.focused');
+    cy.findByRole('radiogroup', {
+      name: 'Hører skolen på elevenes forslag? * Du må fylle ut hører skolen på elevenes forslag?',
+    }).within(() => {
+      cy.findByRole('radio', { name: 'Alltid' }).should('not.be.focused');
+    });
     cy.findByRole('button', { name: /Du må fylle ut hører skolen på elevenes forslag/ }).click();
-    cy.findByRole('radio', {
-      name: 'Hører skolen på elevenes forslag? * Du må fylle ut hører skolen på elevenes forslag? Alltid',
-    }).should('be.focused');
+    cy.findByRole('radiogroup', {
+      name: 'Hører skolen på elevenes forslag? * Du må fylle ut hører skolen på elevenes forslag?',
+    }).within(() => {
+      cy.findByRole('radio', { name: 'Alltid' }).should('be.focused');
+    });
   });
 });

--- a/test/e2e/pageobjects/likert.ts
+++ b/test/e2e/pageobjects/likert.ts
@@ -21,7 +21,7 @@ export class Likert {
   }
 
   selectRadio(question, option) {
-    cy.findByRole('radiogroup', { name: question }).within(() => {
+    cy.findByRole('radiogroup', { name: new RegExp(question) }).within(() => {
       cy.findByRole('radio', { name: new RegExp(option) }).check();
     });
   }

--- a/test/e2e/pageobjects/likert.ts
+++ b/test/e2e/pageobjects/likert.ts
@@ -13,37 +13,22 @@ export class Likert {
   public options = ['Alltid', 'Nesten alltid', 'Ofte', 'Noen ganger', 'Sjelden'];
 
   selectRequiredRadios() {
-    cy.findByRole('table', { name: this.requiredTableTitle }).within(() => {
+    cy.findByRole('group', { name: this.requiredTableTitle }).within(() => {
       this.requiredQuestions.forEach((question, index) => {
         this.selectRadio(`${question} *`, this.options[index]);
       });
     });
   }
 
-  selectRequiredRadiosInMobile() {
-    this.requiredQuestions.forEach((question, index) => {
-      this.selectRadioInMobile(`${question} *`, this.options[index]);
-    });
-  }
-
   selectRadio(question, option) {
-    cy.findByRole('row', { name: question }).within(() => {
-      cy.findByRole('radio', { name: new RegExp(option) }).check();
-    });
-  }
-
-  selectRadioInMobile(question, option) {
     cy.findByRole('radiogroup', { name: question }).within(() => {
       cy.findByRole('radio', { name: new RegExp(option) }).check();
     });
   }
 
   assertOptionalLikertColumnHeaders() {
-    cy.findByRole('table', { name: this.optionalTableTitle }).within(() => {
-      cy.findByRole('columnheader', { name: 'Spørsmål' });
-      this.options.forEach((option) => {
-        cy.findByRole('columnheader', { name: option });
-      });
+    cy.findByRole('group', { name: this.optionalTableTitle }).within(() => {
+      cy.findByText('Spørsmål');
     });
   }
 }


### PR DESCRIPTION
## Description
This PR fixes an issue where the label of each individual radio button in the `Likert` was empty. This PR addresses that issue, and also does some other fixes.

**Changes:**
- Add text label to radio buttons which are visible for screen readers only
- Refactor the code such that the `<table>` element which encapsulates the `Likert`, does not behave like a table for screen readers. The TL;DR for why I did this, is that the component is only visually represented as a table, but is in fact just a collection of radio groups. 
![image](https://github.com/Altinn/app-frontend-react/assets/26043795/a7662653-1410-4ce3-8699-989bf562c0b7) This case, for instance will be read by NVDA like this with our current implementation: "Table. Gjør du leksene dine? Nesten Alltid. Gjør du leksene dine? Nesten Alltid Radio button checked 1 of 1", where as changing the implementation such that screen readers ignore the table elements, and designating each table row the `role="radiogroup"`, NVDA reads it like this: "Gjør du leksene dine? Grouping. Nesten Alltid. Radio button checked 2 of 5". This also means that the screen reader behaves the same whether the page is displayed in mobile or desktop view. More information about the reasoning behind this can be fond [here](https://www.washington.edu/accesstech/2021/09/28/online-survey-tools/#:~:text=The%20Likert%20question,this%20interface%20correctly.)
- Changed the styling of the table such that each table header (except for the inital one) takes exactly 100px width. This ensures that the `Likert` options are aligned underneath each other no matter how many `Likert` components a page has. I also centered the text of the header and the radio buttons. (This was altered in `v3.68.2` and introduced by [this change](https://github.com/Altinn/app-frontend-react/pull/1536/files#diff-bccde60356bf20046e273ef206ae1ffb7271d25a29f01278c4ee8839103f0d38L25)). Udir have already implemented this fixed width change in their forms by overwriting our CSS, so changing this should be safe. 

## Related Issue(s)

- closes #1037 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [x] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
