### PR TITLE
Fix/navigation main content

### DIFF
--- a/src/components/wrappers/Presentation.module.css
+++ b/src/components/wrappers/Presentation.module.css
@@ -21,3 +21,7 @@
 .modalBody {
   padding: var(--modal-padding-y) var(--modal-padding-x);
 }
+
+.modal:focus-visible {
+  outline: none;
+}

--- a/src/features/formData/submit/submitFormDataSagas.ts
+++ b/src/features/formData/submit/submitFormDataSagas.ts
@@ -11,6 +11,7 @@ import { staticUseLanguageFromState } from 'src/hooks/useLanguage';
 import { makeGetAllowAnonymousSelector } from 'src/selectors/getAllowAnonymous';
 import { getCurrentDataTypeForApplication, getCurrentTaskDataElementId, isStatelessApp } from 'src/utils/appMetadata';
 import { convertDataBindingToModel, convertModelToDataBinding, filterOutInvalidData } from 'src/utils/databindings';
+import { focusMainContent } from 'src/utils/formLayout';
 import { ResolvedNodesSelector } from 'src/utils/layout/hierarchy';
 import { httpPost } from 'src/utils/network/networking';
 import { httpGet, httpPut } from 'src/utils/network/sharedNetworking';
@@ -52,6 +53,7 @@ export function* submitFormSaga(): SagaIterator {
     yield call(putFormData, {});
     yield call(submitComplete, state, resolvedNodes);
     yield put(FormDataActions.submitFulfilled());
+    focusMainContent();
   } catch (error) {
     window.logError('Submit form data failed:\n', error);
     yield put(FormDataActions.submitRejected({ error }));

--- a/src/features/layout/fetch/fetchFormLayoutSagas.test.ts
+++ b/src/features/layout/fetch/fetchFormLayoutSagas.test.ts
@@ -103,6 +103,7 @@ describe('fetchFormLayoutSagas', () => {
           FormLayoutActions.updateCurrentView({
             newView: 'page1',
             skipPageCaching: true,
+            skipFocusMainContent: true,
           }),
         )
         .run();
@@ -129,6 +130,7 @@ describe('fetchFormLayoutSagas', () => {
           FormLayoutActions.updateCurrentView({
             newView: 'FormLayout',
             skipPageCaching: true,
+            skipFocusMainContent: true,
           }),
         )
         .run();
@@ -179,6 +181,7 @@ describe('fetchFormLayoutSagas', () => {
           FormLayoutActions.updateCurrentView({
             newView: 'page2',
             skipPageCaching: true,
+            skipFocusMainContent: true,
           }),
         )
         .run();
@@ -211,6 +214,7 @@ describe('fetchFormLayoutSagas', () => {
           FormLayoutActions.updateCurrentView({
             newView: 'page1',
             skipPageCaching: true,
+            skipFocusMainContent: true,
           }),
         )
         .run();
@@ -237,6 +241,7 @@ describe('fetchFormLayoutSagas', () => {
           FormLayoutActions.updateCurrentView({
             newView: 'page1',
             skipPageCaching: true,
+            skipFocusMainContent: true,
           }),
         )
         .run();
@@ -263,6 +268,7 @@ describe('fetchFormLayoutSagas', () => {
           FormLayoutActions.updateCurrentView({
             newView: 'page1',
             skipPageCaching: true,
+            skipFocusMainContent: true,
           }),
         )
         .run();

--- a/src/features/layout/fetch/fetchFormLayoutSagas.ts
+++ b/src/features/layout/fetch/fetchFormLayoutSagas.ts
@@ -126,6 +126,7 @@ export function* fetchLayoutSaga(): SagaIterator {
       FormLayoutActions.updateCurrentView({
         newView: firstLayoutKey,
         skipPageCaching: true,
+        skipFocusMainContent: true,
       }),
     );
   } catch (error) {

--- a/src/features/layout/formLayoutSlice.ts
+++ b/src/features/layout/formLayoutSlice.ts
@@ -24,6 +24,7 @@ import {
 } from 'src/features/layout/update/updateFormLayoutSagas';
 import { OptionsActions } from 'src/features/options/optionsSlice';
 import { createSagaSlice } from 'src/redux/sagaSlice';
+import { focusMainContent } from 'src/utils/formLayout';
 import type * as LayoutTypes from 'src/features/layout/formLayoutTypes';
 import type { ILayouts } from 'src/layout/layout';
 import type { ActionsFromSlice, MkActionType } from 'src/redux/sagaSlice';
@@ -169,8 +170,8 @@ export const formLayoutSlice = () => {
           takeEvery: (action) => {
             if (!action.payload.focusComponentId) {
               window.scrollTo({ top: 0 });
-              if (action.payload.skipFocusMainContent !== false) {
-                document.getElementById('main-content')?.focus({ preventScroll: true });
+              if (action.payload.skipFocusMainContent !== true) {
+                focusMainContent();
               }
             }
           },

--- a/src/features/layout/formLayoutSlice.ts
+++ b/src/features/layout/formLayoutSlice.ts
@@ -169,7 +169,9 @@ export const formLayoutSlice = () => {
           takeEvery: (action) => {
             if (!action.payload.focusComponentId) {
               window.scrollTo({ top: 0 });
-              document.getElementById('main-content')?.focus({ preventScroll: true });
+              if (action.payload.skipFocusMainContent !== false) {
+                document.getElementById('main-content')?.focus({ preventScroll: true });
+              }
             }
           },
           reducer: (state, action) => {

--- a/src/features/layout/formLayoutTypes.ts
+++ b/src/features/layout/formLayoutTypes.ts
@@ -38,6 +38,7 @@ export interface IUpdateCurrentView {
   returnToView?: string;
   runValidations?: TriggersPageValidation;
   skipPageCaching?: boolean;
+  skipFocusMainContent?: boolean;
   focusComponentId?: string;
   keepScrollPos?: IKeepComponentScrollPos;
   allowNavigationToHidden?: boolean;
@@ -47,6 +48,7 @@ export interface IUpdateCurrentViewFulfilled {
   newView: string;
   returnToView?: string;
   focusComponentId?: string;
+  skipFocusMainContent?: boolean;
 }
 
 export interface IUpdateCurrentViewRejected extends IFormLayoutActionRejected {

--- a/src/features/layout/update/updateFormLayoutSagas.ts
+++ b/src/features/layout/update/updateFormLayoutSagas.ts
@@ -53,6 +53,7 @@ export function* updateCurrentViewSaga({
     keepScrollPos,
     focusComponentId,
     allowNavigationToHidden,
+    skipFocusMainContent,
   },
 }: PayloadAction<IUpdateCurrentView>): SagaIterator {
   try {
@@ -102,6 +103,7 @@ export function* updateCurrentViewSaga({
           newView,
           returnToView,
           focusComponentId,
+          skipFocusMainContent,
         }),
       );
     } else {

--- a/src/utils/formLayout.ts
+++ b/src/utils/formLayout.ts
@@ -408,3 +408,7 @@ export function getRepeatingGroupFilteredIndices(formData: IFormData, filter?: I
   }
   return null;
 }
+
+export function focusMainContent() {
+  document.getElementById('main-content')?.focus({ preventScroll: true });
+}


### PR DESCRIPTION
## Description

I discovered that focus was placed on main-content when loading a specific page the first time. This is not wanted behaviour, as this skips some of the content for screen reader users. 

I also removed the `:focus-visible` outline when focusing this element. After [a long read](https://github.com/w3c/wcag/issues/1001), I am confident that we aren't breaking [WCAG SC 2.4.7](https://www.w3.org/WAI/WCAG21/Understanding/focus-visible.html), because the element is not "keyboard operable". 

## Related Issue(s)

- closes #1408 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [x] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
