### PR TITLE
Fix infinite loop in `useAllOptions`

### DIFF
--- a/src/features/options/useAllOptions.tsx
+++ b/src/features/options/useAllOptions.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import type { PropsWithChildren } from 'react';
 
 import deepEqual from 'fast-deep-equal';
@@ -147,6 +147,17 @@ export function AllOptionsProvider({ children }: PropsWithChildren) {
     }
   }, [currentTaskType, nodes, setNodesFound]);
 
+  const loadingDone = useCallback(
+    (id: string, options: IOptionInternal[]) => {
+      setNodeOptions(id, options);
+    },
+    [setNodeOptions],
+  );
+
+  const onError = useCallback(() => {
+    setError(true);
+  }, [setError]);
+
   const dummies = nodes
     ?.allNodes()
     .filter((n) => isNodeOptionBased(n))
@@ -156,12 +167,8 @@ export function AllOptionsProvider({ children }: PropsWithChildren) {
       <DummyOptionsSaver
         key={node.item.id}
         node={node}
-        loadingDone={(options) => {
-          setNodeOptions(node.item.id, options);
-        }}
-        onError={() => {
-          setError(true);
-        }}
+        loadingDone={loadingDone}
+        onError={onError}
       />
     ));
 
@@ -192,7 +199,7 @@ function DummyOptionsSaver({
   onError,
 }: {
   node: LayoutNode;
-  loadingDone: (options: IOptionInternal[]) => void;
+  loadingDone: (id: string, options: IOptionInternal[]) => void;
   onError: () => void;
 }) {
   const {
@@ -212,7 +219,7 @@ function DummyOptionsSaver({
 
   useEffect(() => {
     if (!isFetching) {
-      loadingDone(calculatedOptions);
+      loadingDone(node.item.id, calculatedOptions);
     }
   }, [isFetching, node.item.id, calculatedOptions, loadingDone]);
 


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

While looking into #1685 I got some 500 internal server errors from the options API, and this somehow caused an infinite render loop in allOptions. The loadingDone function ran in a loop, probably because the function gets recreated every single render, and it is a dependency in the useEffect. Not sure why this doesn't happen in other cases though 🤷 but using a callback hook fixed the problem.

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
