### PR TITLE
feat: added support for label for Address component

### DIFF
--- a/src/layout/Address/AddressComponent.test.tsx
+++ b/src/layout/Address/AddressComponent.test.tsx
@@ -373,6 +373,71 @@ describe('AddressComponent', () => {
     expect(screen.getByTestId('label-address_address_address-title')).toHaveTextContent('TEST TITLE');
   });
 
+  it('should display care-of title when set', async () => {
+    const ID = 'care-of-title';
+    const TITLE = 'CARE OF TITLE';
+    await render({
+      component: {
+        required: true,
+        simplified: false,
+        id: ID,
+        textResourceBindings: {
+          careOfTitle: TITLE,
+        },
+      },
+    });
+    expect(screen.getByTestId(`label-address_care_of_${ID}`)).toHaveTextContent(TITLE);
+  });
+
+  it('should display zip code title when set', async () => {
+    const ID = 'zip_code';
+    const TITLE = 'ZIP CODE TITLE';
+
+    await render({
+      component: {
+        required: true,
+        simplified: false,
+        id: ID,
+        textResourceBindings: {
+          zipCodeTitle: TITLE,
+        },
+      },
+    });
+    expect(screen.getByTestId(`label-address_zip_code_${ID}`)).toHaveTextContent(TITLE);
+  });
+
+  it('should display post place title when set', async () => {
+    const ID = 'post-place-title';
+    const TITLE = 'POST PLACE TITLE';
+    await render({
+      component: {
+        required: true,
+        simplified: false,
+        id: ID,
+        textResourceBindings: {
+          postPlaceTitle: TITLE,
+        },
+      },
+    });
+    expect(screen.getByTestId(`label-address_post_place_${ID}`)).toHaveTextContent(TITLE);
+  });
+
+  it('should display house number title when set', async () => {
+    const ID = 'house-number-title';
+    const TITLE = 'HOUSE NUMBER TITLE';
+    await render({
+      component: {
+        required: true,
+        simplified: false,
+        id: ID,
+        textResourceBindings: {
+          houseNumberTitle: TITLE,
+        },
+      },
+    });
+    expect(screen.getByTestId(`label-address_house_number_${ID}`)).toHaveTextContent(TITLE);
+  });
+
   it('should display default title when title is not set', async () => {
     await render({
       component: {

--- a/src/layout/Address/AddressComponent.test.tsx
+++ b/src/layout/Address/AddressComponent.test.tsx
@@ -358,4 +358,29 @@ describe('AddressComponent', () => {
     ).not.toBeInTheDocument();
     expect(screen.queryByRole('textbox', { name: 'Bolignummer (Valgfri)' })).not.toBeInTheDocument();
   });
+
+  it('should display optional title when set', async () => {
+    await render({
+      component: {
+        required: true,
+        simplified: false,
+        id: 'address-title',
+        textResourceBindings: {
+          title: 'TEST TITLE',
+        },
+      },
+    });
+    expect(screen.getByTestId('label-address_address_address-title')).toHaveTextContent('TEST TITLE');
+  });
+
+  it('should display default title when title is not set', async () => {
+    await render({
+      component: {
+        required: true,
+        simplified: false,
+        id: 'address-title',
+      },
+    });
+    expect(screen.getByTestId('label-address_address_address-title')).toHaveTextContent('Gateadresse');
+  });
 });

--- a/src/layout/Address/AddressComponent.tsx
+++ b/src/layout/Address/AddressComponent.tsx
@@ -20,6 +20,7 @@ export type IAddressProps = PropsFromGenericComponent<'Address'>;
 export function AddressComponent({ node }: IAddressProps) {
   const { id, required, readOnly, labelSettings, simplified, saveWhileTyping } = node.item;
 
+  const { textResourceBindings } = node.item;
   const bindingValidations = useBindingValidationsForNode(node);
   const componentValidations = useComponentValidationsForNode(node);
 
@@ -44,7 +45,7 @@ export function AddressComponent({ node }: IAddressProps) {
     >
       <div>
         <Label
-          label={<Lang id={'address_component.address'} />}
+          label={<Lang id={textResourceBindings?.title || 'address_component.address'} />}
           helpText={undefined}
           id={`address_address_${id}`}
           required={required}

--- a/src/layout/Address/AddressComponent.tsx
+++ b/src/layout/Address/AddressComponent.tsx
@@ -71,7 +71,7 @@ export function AddressComponent({ node }: IAddressProps) {
       {!simplified && (
         <div>
           <Label
-            label={<Lang id={'address_component.care_of'} />}
+            label={<Lang id={textResourceBindings?.careOfTitle || 'address_component.care_of'} />}
             helpText={undefined}
             id={`address_care_of_${id}`}
             required={required}
@@ -97,7 +97,7 @@ export function AddressComponent({ node }: IAddressProps) {
       <div className={classes.addressComponentPostplaceZipCode}>
         <div className={classes.addressComponentZipCode}>
           <Label
-            label={<Lang id={'address_component.zip_code'} />}
+            label={<Lang id={textResourceBindings?.zipCodeTitle || 'address_component.zip_code'} />}
             helpText={undefined}
             id={`address_zip_code_${id}`}
             required={required}
@@ -121,7 +121,7 @@ export function AddressComponent({ node }: IAddressProps) {
 
         <div className={classes.addressComponentPostplace}>
           <Label
-            label={<Lang id={'address_component.post_place'} />}
+            label={<Lang id={textResourceBindings?.postPlaceTitle || 'address_component.post_place'} />}
             helpText={undefined}
             id={`address_post_place_${id}`}
             required={required}
@@ -150,7 +150,7 @@ export function AddressComponent({ node }: IAddressProps) {
       {!simplified && (
         <div>
           <Label
-            label={<Lang id={'address_component.house_number'} />}
+            label={<Lang id={textResourceBindings?.houseNumberTitle || 'address_component.house_number'} />}
             helpText={undefined}
             id={`address_house_number_${id}`}
             required={required}

--- a/src/layout/Address/config.ts
+++ b/src/layout/Address/config.ts
@@ -15,7 +15,35 @@ export const Config = new CG.component({
     new CG.trb({
       name: 'title',
       title: 'Title from Summary',
-      description: 'Title of the component (currently only used when referenced from a Summary component)',
+      description: 'Title of the component',
+    }),
+  )
+  .addTextResource(
+    new CG.trb({
+      name: 'careOfTitle',
+      title: 'Care Of Title',
+      description: 'Title for care-of',
+    }),
+  )
+  .addTextResource(
+    new CG.trb({
+      name: 'zipCodeTitle',
+      title: 'Zip Code Title',
+      description: 'Title for the zip code',
+    }),
+  )
+  .addTextResource(
+    new CG.trb({
+      name: 'postPlaceTitle',
+      title: 'Post place Title',
+      description: 'Title for post place',
+    }),
+  )
+  .addTextResource(
+    new CG.trb({
+      name: 'houseNumberTitle',
+      title: 'House number Title',
+      description: 'Title for house number',
     }),
   )
   .addDataModelBinding(

--- a/src/layout/Address/config.ts
+++ b/src/layout/Address/config.ts
@@ -14,7 +14,7 @@ export const Config = new CG.component({
   .addTextResource(
     new CG.trb({
       name: 'title',
-      title: 'Title from Summary',
+      title: 'Title',
       description: 'Title of the component',
     }),
   )

--- a/test/e2e/integration/frontend-test/all-process-steps.ts
+++ b/test/e2e/integration/frontend-test/all-process-steps.ts
@@ -298,7 +298,9 @@ const knownDataModels: { [key: string]: any } = {
     Radioknapp: '1',
     BegrunnelseFrivillig: '1',
     Adresse: {
+      CareOf: null,
       Gateadresse_æøå: null,
+      HouseNumber: null,
       Postnr: null,
       Poststed: null,
       Kommune: null,

--- a/test/e2e/integration/frontend-test/pdf.ts
+++ b/test/e2e/integration/frontend-test/pdf.ts
@@ -31,10 +31,10 @@ describe('PDF', () => {
     cy.get(appFrontend.changeOfName.reference2).should('have.value', '');
     cy.dsSelect(appFrontend.changeOfName.reference, 'Sophie Salt');
     cy.dsSelect(appFrontend.changeOfName.reference2, 'Dole');
-    cy.findByRole('textbox', { name: /gateadresse/i }).type('Økern 1');
-    cy.findByRole('textbox', { name: /postnr/i }).type('0101');
+    cy.findByRole('textbox', { name: /Adresse/i }).type('Økern 1');
+    cy.findByRole('textbox', { name: /Zip Code/i }).type('0101');
 
-    cy.findByRole('textbox', { name: /poststed/i }).should('have.value', 'OSLO');
+    cy.findByRole('textbox', { name: /Post Place/i }).should('have.value', 'OSLO');
 
     cy.testPdf(() => {
       cy.findByRole('table').should('contain.text', 'Mottaker:Testdepartementet');


### PR DESCRIPTION
## Description

Address component now supports a custom label if you add config to ie:

```
     {
        "id": "adresse",
        "type": "Address",
        "textResourceBindings": {
          "title": "Adresse"
        },
        "dataModelBindings": {
          "address": "Adresse.Gateadresse_æøå",
          "zipCode": "Adresse.Postnr",
          "postPlace": "Adresse.Poststed"
        },
        "simplified": true,
        "readOnly": false,
        "required": false
      },
```

## Related Issue(s)

- closes #{36}

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
