### PR TITLE
Fix backToSummary getting stuck

### DIFF
--- a/src/components/presentation/NavBar.tsx
+++ b/src/components/presentation/NavBar.tsx
@@ -26,7 +26,7 @@ const expandIconStyle = { transform: 'rotate(45deg)' };
 export const NavBar = ({ type }: INavBarProps) => {
   const { langAsString } = useLanguage();
   const { navigateToPage, previous } = useNavigatePage();
-  const returnToView = useReturnToView();
+  const { returnToView } = useReturnToView();
   const party = useCurrentParty();
   const { expandedWidth, toggleExpandedWidth } = useUiConfigContext();
   const { hideCloseButton, showLanguageSelector, showExpandWidthButton } = usePageSettings();

--- a/src/features/form/layout/PageNavigationContext.tsx
+++ b/src/features/form/layout/PageNavigationContext.tsx
@@ -71,8 +71,8 @@ export const useHiddenPages = () => {
 export const useReturnToView = () => {
   const ctx = useLaxCtx();
   if (ctx === ContextNotProvided) {
-    return undefined;
+    return {};
   }
 
-  return ctx.returnToView;
+  return { returnToView: ctx.returnToView, setReturnToView: ctx.setReturnToView };
 };

--- a/src/hooks/useNavigatePage.ts
+++ b/src/hooks/useNavigatePage.ts
@@ -1,9 +1,9 @@
 import { useCallback, useEffect, useMemo } from 'react';
 import { useLocation, useMatch, useNavigate } from 'react-router-dom';
-import type { NavigateOptions } from 'react-router-dom';
+import type { NavigateFunction, NavigateOptions } from 'react-router-dom';
 
 import { ContextNotProvided } from 'src/core/contexts/context';
-import { useHiddenPages } from 'src/features/form/layout/PageNavigationContext';
+import { useHiddenPages, useReturnToView } from 'src/features/form/layout/PageNavigationContext';
 import { useLaxLayoutSettings, usePageSettings } from 'src/features/form/layoutSettings/LayoutSettingsContext';
 import { FD } from 'src/features/formData/FormDataWrite';
 import { useLaxProcessData, useTaskType } from 'src/features/instance/ProcessContext';
@@ -56,7 +56,6 @@ export const useOrder = () => {
 };
 
 export const useNavigatePage = () => {
-  const navigate = useNavigate();
   const isStatelessApp = useIsStatelessApp();
   const currentTaskId = useLaxProcessData()?.currentTask?.elementId;
   const processTasks = useLaxProcessData()?.processTasks;
@@ -72,6 +71,20 @@ export const useNavigatePage = () => {
   const currentPageIndex = order?.indexOf(currentPageId) ?? -1;
   const nextPageIndex = currentPageIndex !== -1 ? currentPageIndex + 1 : -1;
   const previousPageIndex = currentPageIndex !== -1 ? currentPageIndex - 1 : -1;
+
+  /**
+   * Navigation function for react-router-dom
+   * Make sure to clear returnToView on navigation
+   */
+  const { setReturnToView } = useReturnToView();
+  const _navigate = useNavigate();
+  const navigate = useCallback(
+    (...args: Parameters<NavigateFunction>) => {
+      setReturnToView && setReturnToView(undefined);
+      return _navigate(...args);
+    },
+    [_navigate, setReturnToView],
+  ) as NavigateFunction;
 
   const isValidPageId = useCallback(
     (pageId: string) => {

--- a/src/layout/NavigationButtons/NavigationButtonsComponent.tsx
+++ b/src/layout/NavigationButtons/NavigationButtonsComponent.tsx
@@ -97,7 +97,6 @@ export function NavigationButtonsComponent({ node }: INavigationButtons) {
       }
     }
 
-    setReturnToView(undefined);
     navigateToPage(goToView, { skipAutoSave: true });
   };
 

--- a/src/layout/Summary/SummaryComponent.tsx
+++ b/src/layout/Summary/SummaryComponent.tsx
@@ -52,8 +52,8 @@ export function SummaryComponent({ summaryNode, overrides, ref }: ISummaryCompon
       return;
     }
 
-    setReturnToView(currentPageId);
     await navigateTo(targetNode, true);
+    setReturnToView(currentPageId);
   };
 
   if (!targetNode || !targetItem || targetNode.isHidden() || targetItem.type === 'Summary') {

--- a/test/e2e/integration/frontend-test/summary.ts
+++ b/test/e2e/integration/frontend-test/summary.ts
@@ -572,6 +572,67 @@ describe('Summary', () => {
       });
     }
   });
+
+  it('backToSummary should disappear when navigating away from the current page', () => {
+    cy.goto('changename');
+
+    cy.get(appFrontend.changeOfName.newLastName).type('Hansen');
+    cy.get(appFrontend.changeOfName.confirmChangeName).find('label').click();
+    cy.get(appFrontend.nextButton).should('be.visible');
+    cy.get(appFrontend.backToSummaryButton).should('not.exist');
+    // Get some validation messages
+    cy.gotoNavPage('grid');
+    cy.get(appFrontend.sendinButton).click();
+
+    /**
+     * test() should return true if backToSummary should be gone, and false if it should still be visible
+     */
+    function testNavigationMethod(test: () => boolean) {
+      cy.gotoNavPage('summary');
+      cy.get('[data-componentid="summary3"] button').click();
+      cy.navPage('form').should('have.attr', 'aria-current', 'page');
+      cy.get(appFrontend.backToSummaryButton).should('be.visible');
+      cy.get(appFrontend.nextButton).should('not.exist');
+
+      if (test()) {
+        cy.get(appFrontend.nextButton).should('be.visible');
+        cy.get(appFrontend.backToSummaryButton).should('not.exist');
+      } else {
+        cy.get(appFrontend.backToSummaryButton).should('be.visible');
+        cy.get(appFrontend.nextButton).should('not.exist');
+      }
+    }
+
+    // Navigation bare should clear backToSummary
+    testNavigationMethod(() => {
+      cy.gotoNavPage('summary');
+      return true;
+    });
+
+    // Error report on the same page should not clear backToSummary
+    testNavigationMethod(() => {
+      cy.get(appFrontend.errorReport).find(`li:contains("${texts.requiredFieldFromBackend}")`).find('button').click();
+      cy.get(appFrontend.changeOfName.newFirstName).should('be.focused');
+      return false;
+    });
+
+    // Clicking backToSummary should clear it
+    testNavigationMethod(() => {
+      cy.get(appFrontend.backToSummaryButton).click();
+      cy.navPage('summary').should('have.attr', 'aria-current', 'page');
+      return true;
+    });
+
+    // Error report to different page shoud clear backToSummary
+    cy.gotoNavPage('summary');
+    cy.get('[data-testid="summary-fordeling-bolig"] button').click();
+    cy.navPage('grid').should('have.attr', 'aria-current', 'page');
+    cy.get(appFrontend.errorReport).find(`li:contains("${texts.requiredFieldFromBackend}")`).find('button').click();
+    cy.navPage('form').should('have.attr', 'aria-current', 'page');
+    cy.get(appFrontend.changeOfName.newFirstName).should('be.focused');
+    cy.get(appFrontend.nextButton).should('be.visible');
+    cy.get(appFrontend.backToSummaryButton).should('not.exist');
+  });
 });
 
 /**


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

`returnToView` now gets clear whenever navigation happens

## Related Issue(s)

- closes #1878

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
