### PR TITLE
Allow `$schema` property in schemas

### DIFF
--- a/schemas/json/layout/footer.schema.v1.json
+++ b/schemas/json/layout/footer.schema.v1.json
@@ -6,7 +6,11 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "$schema": true,
+    "$schema": {
+      "type": "string",
+      "title": "Schema",
+      "description": "The schema that this file adheres to"
+    },
     "footer": {
       "title": "The footer",
       "description": "Array of components to be presented in the footer.",

--- a/schemas/json/validation/validation.schema.v1.json
+++ b/schemas/json/validation/validation.schema.v1.json
@@ -6,6 +6,11 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "$schema": {
+      "type": "string",
+      "title": "Schema",
+      "description": "The schema that this file adheres to"
+    },
     "validations": {
       "type": "object",
       "patternProperties": {

--- a/src/codegen/Common.ts
+++ b/src/codegen/Common.ts
@@ -671,6 +671,7 @@ const common = {
   IPagesSettings: () => new CG.obj().extends(CG.common('GlobalPageSettings')).extends(CG.common('IPagesBaseSettings')),
   ILayoutSettings: () =>
     new CG.obj(
+      new CG.prop('$schema', new CG.str().optional()),
       new CG.prop('pages', CG.common('IPagesSettings')),
       new CG.prop('components', CG.common('IComponentsSettings').optional()),
     )
@@ -680,6 +681,7 @@ const common = {
   // Layout sets:
   ILayoutSets: () =>
     new CG.obj(
+      new CG.prop('$schema', new CG.str().optional()),
       new CG.prop(
         'sets',
         new CG.arr(CG.common('ILayoutSet'))


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

Allow `$schema` property in files where it was missing.
- `Settings.json`
- `layout-sets.json`
- `*.validation.json`

![bilde](https://github.com/Altinn/app-frontend-react/assets/47412359/8b711aa2-fd7f-42c3-8e79-81915ddb8c2e)
