### PR TITLE
Make AllExceptRequired validations default

### DIFF
--- a/src/features/validation/utils.ts
+++ b/src/features/validation/utils.ts
@@ -175,12 +175,16 @@ export function getValidationsForNode(
   return validationMessages;
 }
 
+/**
+ * Gets the initial validation mask for a component using its showValidations property
+ * If the value is not set, it will default to all validations except required
+ */
 export function getInitialMaskFromNode(node: LayoutNode | LayoutPage): number {
-  let mask = 0;
-  if ('showValidations' in node.item) {
-    mask = getVisibilityMask(node.item.showValidations);
+  // If not set, null, or undefined, default to all validations except required
+  if (!('showValidations' in node.item) || node.item.showValidations == null) {
+    return ValidationMask.AllExceptRequired;
   }
-  return mask || ValidationMask.AllExceptRequired;
+  return getVisibilityMask(node.item.showValidations);
 }
 
 export function getVisibilityMask(maskKeys?: ValidationMaskKeys[]): number {

--- a/src/features/validation/utils.ts
+++ b/src/features/validation/utils.ts
@@ -176,10 +176,11 @@ export function getValidationsForNode(
 }
 
 export function getInitialMaskFromNode(node: LayoutNode | LayoutPage): number {
+  let mask = 0;
   if ('showValidations' in node.item) {
-    return getVisibilityMask(node.item.showValidations);
+    mask = getVisibilityMask(node.item.showValidations);
   }
-  return 0;
+  return mask || ValidationMask.AllExceptRequired;
 }
 
 export function getVisibilityMask(maskKeys?: ValidationMaskKeys[]): number {

--- a/src/layout/RepeatingGroup/OpenByDefaultProvider.test.tsx
+++ b/src/layout/RepeatingGroup/OpenByDefaultProvider.test.tsx
@@ -92,6 +92,7 @@ describe('openByDefault', () => {
         dataModelBindings: {
           simpleBinding: 'MyGroup.name',
         },
+        showValidations: [],
       },
     ];
 

--- a/src/layout/RepeatingGroup/RepeatingGroupContainer.test.tsx
+++ b/src/layout/RepeatingGroup/RepeatingGroupContainer.test.tsx
@@ -41,6 +41,7 @@ async function render({ container, numRows = 3, validationIssues = [] }: IRender
       dataModelBindings: {
         simpleBinding: 'Group.prop1',
       },
+      showValidations: [],
       textResourceBindings: {
         title: 'Title1',
       },
@@ -53,6 +54,7 @@ async function render({ container, numRows = 3, validationIssues = [] }: IRender
       dataModelBindings: {
         simpleBinding: 'Group.prop2',
       },
+      showValidations: [],
       textResourceBindings: {
         title: 'Title2',
       },
@@ -65,6 +67,7 @@ async function render({ container, numRows = 3, validationIssues = [] }: IRender
       dataModelBindings: {
         simpleBinding: 'Group.prop3',
       },
+      showValidations: [],
       textResourceBindings: {
         title: 'Title3',
       },
@@ -77,6 +80,7 @@ async function render({ container, numRows = 3, validationIssues = [] }: IRender
       dataModelBindings: {
         simpleBinding: 'Group.checkboxBinding',
       },
+      showValidations: [],
       textResourceBindings: {
         title: 'Title4',
       },

--- a/src/layout/RepeatingGroup/RepeatingGroupTable.test.tsx
+++ b/src/layout/RepeatingGroup/RepeatingGroupTable.test.tsx
@@ -46,6 +46,7 @@ describe('RepeatingGroupTable', () => {
       dataModelBindings: {
         simpleBinding: 'some-group.prop1',
       },
+      showValidations: [],
       textResourceBindings: {
         title: 'Title1',
       },
@@ -58,6 +59,7 @@ describe('RepeatingGroupTable', () => {
       dataModelBindings: {
         simpleBinding: 'some-group.prop2',
       },
+      showValidations: [],
       textResourceBindings: {
         title: 'Title2',
       },
@@ -70,6 +72,7 @@ describe('RepeatingGroupTable', () => {
       dataModelBindings: {
         simpleBinding: 'some-group.prop3',
       },
+      showValidations: [],
       textResourceBindings: {
         title: 'Title3',
       },
@@ -82,6 +85,7 @@ describe('RepeatingGroupTable', () => {
       dataModelBindings: {
         simpleBinding: 'some-group.checkboxBinding',
       },
+      showValidations: [],
       textResourceBindings: {
         title: 'Title4',
       },

--- a/test/e2e/integration/frontend-test/auto-save-behavior.ts
+++ b/test/e2e/integration/frontend-test/auto-save-behavior.ts
@@ -88,7 +88,7 @@ describe('Auto save behavior', () => {
         }
         if (component.id === 'newFirstName') {
           // TODO(Validation): Once it is possible to treat custom validations as required, this can be removed.
-          (component as CompInputExternal).showValidations = undefined;
+          (component as CompInputExternal).showValidations = [];
         }
       });
 
@@ -114,7 +114,7 @@ describe('Auto save behavior', () => {
       cy.get(appFrontend.changeOfName.dateOfEffect).siblings().findByRole('button').click();
       cy.get(mui.selectedDate).click();
 
-      cy.get(appFrontend.nextButton).clickAndGone();
+      cy.get(appFrontend.nextButton).click();
       cy.wait('@saveFormData').then(() => {
         expect(formDataReqCounter).to.be.eq(1);
       });

--- a/test/e2e/integration/frontend-test/components.ts
+++ b/test/e2e/integration/frontend-test/components.ts
@@ -53,7 +53,7 @@ describe('UI Components', () => {
     cy.interceptLayout('changename', (component) => {
       if (component.id === 'newFirstName') {
         // TODO(Validation): Once it is possible to treat custom validations as required, this can be removed.
-        (component as CompInputExternal).showValidations = undefined;
+        (component as CompInputExternal).showValidations = [];
       }
     });
     cy.goto('changename');
@@ -94,7 +94,7 @@ describe('UI Components', () => {
     cy.interceptLayout('changename', (component) => {
       if (component.id === 'newFirstName') {
         // TODO(Validation): Once it is possible to treat custom validations as required, this can be removed.
-        (component as CompInputExternal).showValidations = undefined;
+        (component as CompInputExternal).showValidations = [];
       }
     });
     cy.goto('changename');

--- a/test/e2e/integration/frontend-test/footer.ts
+++ b/test/e2e/integration/frontend-test/footer.ts
@@ -11,7 +11,7 @@ describe('Footer', () => {
       .eq(1)
       .children('a')
       .invoke('attr', 'href')
-      .should('eq', 'https://www.altinn.no/om-altinn/tilgjengelighet/');
+      .should('eq', 'https://info.altinn.no/om-altinn/tilgjengelighet/');
     cy.get('footer > div > div').eq(2).children('a').invoke('attr', 'href').should('eq', 'mailto:hjelp@etaten.no');
     cy.get('footer > div > div').eq(3).children('a').invoke('attr', 'href').should('eq', 'tel:+4798765432');
     cy.snapshot('footer');

--- a/test/e2e/integration/frontend-test/group.ts
+++ b/test/e2e/integration/frontend-test/group.ts
@@ -162,7 +162,7 @@ describe('Group', () => {
     const layoutMutator = (component: CompExternal) => {
       // Remove component triggers and set required
       if (['currentValue', 'newValue'].includes(component.id) && component.type === 'Input') {
-        component.showValidations = undefined;
+        component.showValidations = [];
         component.required = true;
       }
     };


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

Make the default for `showValidations` more similar to the default in v3 to make migration easier. `showValidations` can still be empty by setting it as an empty array `[]` instead of `undefined`.

## Related Issue(s)

- closes https://github.com/Altinn/app-frontend-react/issues/1892

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [x] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
