### PR TITLE
Fixes for flaky tests, separate configs for docker/podman

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -33,8 +33,7 @@ module.exports = defineConfig({
         }
       });
 
-      const validEnvironments = ['local', 'at21', 'at22', 'tt02'];
-
+      const validEnvironments = ['docker', 'podman', 'tt02'];
       if (validEnvironments.includes(config.env.environment)) {
         return getConfigurationByFile(config.env.environment);
       }

--- a/src/layout/Checkboxes/CheckboxesContainerComponent.tsx
+++ b/src/layout/Checkboxes/CheckboxesContainerComponent.tsx
@@ -6,7 +6,6 @@ import cn from 'classnames';
 import { AltinnSpinner } from 'src/components/AltinnSpinner';
 import { OptionalIndicator } from 'src/components/form/OptionalIndicator';
 import { RequiredIndicator } from 'src/components/form/RequiredIndicator';
-import { FD } from 'src/features/formData/FormDataWrite';
 import { Lang } from 'src/features/language/Lang';
 import { useLanguage } from 'src/features/language/useLanguage';
 import { useGetOptions } from 'src/features/options/useGetOptions';
@@ -20,8 +19,6 @@ export type ICheckboxContainerProps = PropsFromGenericComponent<'Checkboxes'>;
 export const CheckboxContainerComponent = ({ node, isValid, overrideDisplay }: ICheckboxContainerProps) => {
   const { id, layout, readOnly, textResourceBindings, required, labelSettings, alertOnChange } = node.item;
   const { langAsString } = useLanguage();
-
-  const debounce = FD.useDebounceImmediately();
 
   const {
     options: calculatedOptions,
@@ -64,7 +61,6 @@ export const CheckboxContainerComponent = ({ node, isValid, overrideDisplay }: I
     <div
       id={id}
       key={`checkboxes_group_${id}`}
-      onBlur={debounce}
     >
       <Checkbox.Group
         className={cn({ [classes.horizontal]: horizontal }, classes.checkboxGroup)}

--- a/test/e2e/config/docker.json
+++ b/test/e2e/config/docker.json
@@ -3,6 +3,8 @@
   "baseUrl": "http://local.altinn.cloud",
   "frontendUrl": "http://localhost:8080",
   "env": {
+    "type": "localtest",
+
     "defaultFullName": "Ola Nordmann",
     "defaultFirstName": "Ola",
     "defaultPartyId": "12345.512345",

--- a/test/e2e/config/podman.json
+++ b/test/e2e/config/podman.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://on.cypress.io/cypress.schema.json",
+  "baseUrl": "http://local.altinn.cloud:8000",
+  "frontendUrl": "http://localhost:8080",
+  "env": {
+    "type": "localtest",
+
+    "defaultFullName": "Ola Nordmann",
+    "defaultFirstName": "Ola",
+    "defaultPartyId": "12345.512345",
+
+    "accountantFullName": "Pengelens Partner",
+    "accountantFirstName": "Pengelens",
+    "accountantPartyId": "1001.500000",
+
+    "managerFullName": "Sophie Salt",
+    "managerFirstName": "Sophie",
+    "managerPartyId": "1337.500000",
+
+    "auditorFullName": "Gjentagende Forelder",
+    "auditorFirstName": "Gjentagende",
+    "auditorPartyId": "1002.500000"
+  }
+}

--- a/test/e2e/config/tt02.json
+++ b/test/e2e/config/tt02.json
@@ -3,6 +3,8 @@
   "baseUrl": "https://tt02.altinn.no",
   "frontendUrl": "http://localhost:8080",
   "env": {
+    "type": "production-like",
+
     "defaultFullName": "RISHAUG JULIUS",
     "defaultFirstName": "JULIUS",
     "defaultUserName": "testuserexternal",

--- a/test/e2e/integration/frontend-test/all-process-steps.ts
+++ b/test/e2e/integration/frontend-test/all-process-steps.ts
@@ -142,7 +142,7 @@ function testInstanceData() {
     const maybeInstanceId = getInstanceIdRegExp().exec(url);
     const instanceId = maybeInstanceId ? maybeInstanceId[1] : 'instance-id-not-found';
 
-    const host = Cypress.env('environment') === 'local' ? urlParsed.origin : 'https://ttd.apps.tt02.altinn.no';
+    const host = Cypress.env('type') === 'localtest' ? urlParsed.origin : 'https://ttd.apps.tt02.altinn.no';
     const instanceUrl = [host, urlParsed.pathname, `/instances/`, instanceId].join('');
 
     cy.request({ url: instanceUrl }).then((response) => {
@@ -151,7 +151,7 @@ function testInstanceData() {
         if (dataElement.contentType === 'application/xml') {
           const dataModelUrlParsed = new URL(dataElement.selfLinks!.apps);
           const dataModelUrl =
-            Cypress.env('environment') === 'local' ? dataModelUrlParsed.pathname : dataElement.selfLinks!.apps;
+            Cypress.env('type') === 'localtest' ? dataModelUrlParsed.pathname : dataElement.selfLinks!.apps;
           cy.request({
             url: dataModelUrl,
           }).then((response) => {

--- a/test/e2e/integration/frontend-test/group.ts
+++ b/test/e2e/integration/frontend-test/group.ts
@@ -582,6 +582,10 @@ describe('Group', () => {
     cy.get(appFrontend.group.prefill.enorm).check();
     cy.gotoNavPage('repeating');
     cy.get(appFrontend.group.showGroupToContinue).findByRole('checkbox', { name: 'Ja' }).check();
+
+    // Make sure the new row is added last, and that the last few things we did has been saved
+    // (and thus that the new rows have been received from the backend)
+    cy.waitUntilSaved();
     cy.get(appFrontend.group.addNewItem).click();
 
     cy.get('#group-mainGroup table th').eq(0).should('have.text', 'currentValue tableTitle');
@@ -752,6 +756,7 @@ describe('Group', () => {
     cy.gotoNavPage('prefill');
     cy.get('#prefill-enabled').findByRole('radio', { name: 'Nei' }).click();
     cy.get(appFrontend.group.prefill.middels).check();
+    cy.waitUntilSaved();
 
     cy.gotoNavPage('repeating');
     cy.get(appFrontend.group.mainGroupTableBody).find('tr').should('have.length', 1);

--- a/test/e2e/integration/frontend-test/hide-row-in-group.ts
+++ b/test/e2e/integration/frontend-test/hide-row-in-group.ts
@@ -4,10 +4,9 @@ const appFrontend = new AppFrontend();
 
 it('should be possible to hide rows when "Endre fra" is greater or equals to [...]', () => {
   cy.goto('group');
-  cy.intercept('PATCH', '**/data/**').as('saveFormData');
   for (const prefill of Object.values(appFrontend.group.prefill)) {
     cy.get(prefill).check();
-    cy.wait('@saveFormData');
+    cy.waitUntilSaved();
   }
   const headerRow = 1;
 
@@ -22,6 +21,13 @@ it('should be possible to hide rows when "Endre fra" is greater or equals to [..
 
   // When hiding every row with value over 1, all rows including the header should be hidden
   cy.get(appFrontend.group.hideRepeatingGroupRow).numberFormatClear();
+
+  // By waiting until this is saved, we ensure that a previous flaky bug is not reproduced. The `hideRowValue` field
+  // in the data model used to have a default value of 99999+, but a default value in a numeric field like this
+  // means it will be reset back to the default value once you clear it. Prefill is the more appropriate solution
+  // for such fields in the data model.
+  cy.waitUntilSaved();
+
   cy.get(appFrontend.group.hideRepeatingGroupRow).type('1');
   cy.get(appFrontend.group.mainGroup).find('tr').should('not.exist');
   cy.get(appFrontend.group.hiddenRowsInfoMsg).should('exist');

--- a/test/e2e/integration/frontend-test/message.ts
+++ b/test/e2e/integration/frontend-test/message.ts
@@ -32,7 +32,7 @@ describe('Message', () => {
       });
     cy.url().then((url) => {
       const instantiateUrl =
-        Cypress.env('environment') === 'local'
+        Cypress.env('type') === 'localtest'
           ? 'http://local.altinn.cloud/ttd/frontend-test'
           : 'https://ttd.apps.tt02.altinn.no/ttd/frontend-test/';
       const maybeInstanceId = instanceIdExpr.exec(url);

--- a/test/e2e/integration/frontend-test/summary.ts
+++ b/test/e2e/integration/frontend-test/summary.ts
@@ -184,27 +184,24 @@ describe('Summary', () => {
 
     cy.fillOut('group');
 
-    cy.get(appFrontend.group.mainGroupSummaryContent)
-      .should('have.length', 1)
-      .first()
-      .children(mui.gridItem)
-      .should('have.length', 7)
-      .then((item) => {
-        cy.wrap(item).find('button').should('have.length', 7);
-        cy.wrap(item).eq(2).should('contain.text', 'attachment-in-single.pdf');
-        cy.wrap(item).eq(3).should('contain.text', 'attachment-in-multi1.pdf');
-        cy.wrap(item).eq(3).should('contain.text', 'attachment-in-multi2.pdf');
-        cy.wrap(item).eq(4).should('contain.text', 'attachment-in-nested.pdf');
-        cy.wrap(item).eq(4).should('contain.text', 'automation');
-        cy.wrap(item).eq(4).should('contain.text', texts.nestedOptionsToggle);
-        cy.wrap(item).eq(4).should('not.contain.text', texts.nestedOptions);
-        cy.wrap(item).eq(4).should('contain.text', 'hvor fikk du vite om skjemaet? : Annet');
-        cy.wrap(item).eq(4).should('contain.text', 'Referanse : Test');
-        cy.wrap(item).eq(5).should('contain.text', 'Digitaliseringsdirektoratet');
-        cy.wrap(item).eq(6).should('contain.text', 'Sophie Salt');
+    cy.get(appFrontend.group.mainGroupSummaryContent).should('have.length', 1);
+    const groupElements = () => cy.get(appFrontend.group.mainGroupSummaryContent).first().children(mui.gridItem);
 
-        cy.wrap(item).eq(4).find('button').first().should('contain.text', texts.change);
-      });
+    groupElements().should('have.length', 7);
+    groupElements().find('button').should('have.length', 7);
+
+    groupElements().eq(2).should('contain.text', 'attachment-in-single.pdf');
+    groupElements().eq(3).should('contain.text', 'attachment-in-multi1.pdf');
+    groupElements().eq(3).should('contain.text', 'attachment-in-multi2.pdf');
+    groupElements().eq(4).should('contain.text', 'attachment-in-nested.pdf');
+    groupElements().eq(4).should('contain.text', 'automation');
+    groupElements().eq(4).should('contain.text', texts.nestedOptionsToggle);
+    groupElements().eq(4).should('not.contain.text', texts.nestedOptions);
+    groupElements().eq(4).should('contain.text', 'hvor fikk du vite om skjemaet? : Annet');
+    groupElements().eq(4).should('contain.text', 'Referanse : Test');
+    groupElements().eq(5).should('contain.text', 'Digitaliseringsdirektoratet');
+    groupElements().eq(6).should('contain.text', 'Sophie Salt');
+    groupElements().eq(4).find('button').first().should('contain.text', texts.change);
 
     // Go back to the repeating group in order to set nested options
     cy.get(appFrontend.group.mainGroupSummaryContent)
@@ -222,16 +219,11 @@ describe('Summary', () => {
     cy.get(appFrontend.group.row(0).nestedGroup.row(0).nestedOptions[2]).check();
     cy.get(appFrontend.backToSummaryButton).click();
 
-    cy.get(appFrontend.group.mainGroupSummaryContent)
-      .should('have.length', 1)
-      .first()
-      .children(mui.gridItem)
-      .should('have.length', 7)
-      .then((item) => {
-        cy.wrap(item).eq(4).should('contain.text', texts.nestedOptionsToggle);
-        cy.wrap(item).eq(4).should('contain.text', texts.nestedOptions);
-        cy.wrap(item).eq(4).should('contain.text', `${texts.nestedOption2}, ${texts.nestedOption3}`);
-      });
+    cy.get(appFrontend.group.mainGroupSummaryContent).should('have.length', 1);
+    groupElements().should('have.length', 7);
+    groupElements().eq(4).should('contain.text', texts.nestedOptionsToggle);
+    groupElements().eq(4).should('contain.text', texts.nestedOptions);
+    groupElements().eq(4).should('contain.text', `${texts.nestedOption2}, ${texts.nestedOption3}`);
 
     cy.gotoNavPage('prefill');
     cy.get(appFrontend.group.prefill.liten).check();

--- a/test/e2e/integration/frontend-test/validation.ts
+++ b/test/e2e/integration/frontend-test/validation.ts
@@ -581,9 +581,11 @@ describe('Validation', () => {
     cy.fillOut('changename');
 
     cy.get(appFrontend.grid.bolig.percent).numberFormatClear();
-    cy.get(appFrontend.grid.studie.percent).numberFormatClear();
+
     cy.get(appFrontend.grid.kredittkort.percent).numberFormatClear();
     cy.get(appFrontend.grid.kredittkort.percent).type('44');
+
+    cy.get(appFrontend.grid.studie.percent).numberFormatClear();
     cy.get(appFrontend.grid.studie.percent).type('56');
 
     // When filling out the credit card field with 44%, there is a special validation that triggers and is added to
@@ -592,6 +594,7 @@ describe('Validation', () => {
     // the dreaded 'unknown error' message to appear.
     cy.get(appFrontend.sendinButton).click();
     cy.get(appFrontend.errorReport).should('contain.text', 'Valideringsmelding på felt som aldri vises');
+    cy.navPage('grid').should('have.attr', 'aria-current', 'page');
   });
 
   it('Submitting should be rejected if validation fails on field hidden using expression', () => {

--- a/test/e2e/support/custom.ts
+++ b/test/e2e/support/custom.ts
@@ -408,7 +408,7 @@ Cypress.Commands.add('moveProcessNext', () => {
     const maybeInstanceId = getInstanceIdRegExp().exec(url);
     const instanceId = maybeInstanceId ? maybeInstanceId[1] : 'instance-id-not-found';
     const baseUrl =
-      Cypress.env('environment') === 'local'
+      Cypress.env('type') === 'localtest'
         ? Cypress.config().baseUrl || ''
         : `https://ttd.apps.${Cypress.config('baseUrl')?.slice(8)}`;
     const urlPath = url.replace(baseUrl, '');

--- a/test/e2e/support/custom.ts
+++ b/test/e2e/support/custom.ts
@@ -51,7 +51,12 @@ Cypress.Commands.add('dsSelect', (selector, value) => {
   cy.log(`Selecting ${value} in ${selector}`);
   cy.get(selector).should('not.be.disabled');
   cy.get(selector).click();
-  cy.findByRole('option', { name: value }).click();
+
+  // It is tempting to just use findByRole('option', { name: value }) here, but that's flakier than using findByText()
+  // as it never retries if the element re-renders. More information here:
+  // https://github.com/testing-library/cypress-testing-library/issues/205#issuecomment-974688283
+  cy.get('[id^="fds-select-"] [aria-expanded=true]').findByText(value).click();
+
   cy.get('body').click();
 });
 

--- a/test/e2e/support/formFiller.ts
+++ b/test/e2e/support/formFiller.ts
@@ -59,12 +59,15 @@ function fillOutChangeName() {
 }
 
 function fillOutGroup() {
-  const mkFile = (fileName) => ({
-    fileName,
-    mimeType: 'application/pdf',
-    lastModified: Date.now(),
-    contents: Cypress.Buffer.from('hello world'),
-  });
+  const mkFile = (fileName: string) => {
+    cy.log(`Making new file: ${fileName}`);
+    return {
+      fileName,
+      mimeType: 'application/pdf',
+      lastModified: Date.now(),
+      contents: Cypress.Buffer.from('hello world'),
+    };
+  };
 
   cy.get(appFrontend.nextButton).click();
   cy.get(appFrontend.group.showGroupToContinue).findByRole('checkbox', { name: 'Ja' }).check();
@@ -74,13 +77,16 @@ function fillOutGroup() {
   cy.get(appFrontend.group.row(0).uploadSingle.dropZone).selectFile(mkFile('attachment-in-single.pdf'), {
     force: true,
   });
+  cy.get(appFrontend.group.row(0).uploadSingle.attachments(0).name).should('have.text', 'attachment-in-single.pdf');
   cy.get(appFrontend.group.row(0).uploadMulti.dropZone).selectFile(mkFile('attachment-in-multi1.pdf'), {
     force: true,
   });
+  cy.get(appFrontend.group.row(0).uploadMulti.attachments(0).name).should('have.text', 'attachment-in-multi1.pdf');
   cy.get(appFrontend.group.row(0).uploadMulti.addMoreBtn).click();
   cy.get(appFrontend.group.row(0).uploadMulti.dropZone).selectFile(mkFile('attachment-in-multi2.pdf'), {
     force: true,
   });
+  cy.get(appFrontend.group.row(0).uploadMulti.attachments(1).name).should('have.text', 'attachment-in-multi2.pdf');
   cy.get(appFrontend.group.row(0).nestedGroup.row(0).editBtn).click();
   cy.get(appFrontend.group.row(0).nestedGroup.row(0).uploadTagMulti.dropZone).selectFile(
     mkFile('attachment-in-nested.pdf'),

--- a/test/e2e/support/start-app-instance.ts
+++ b/test/e2e/support/start-app-instance.ts
@@ -8,7 +8,7 @@ import Response = Cypress.Response;
 function login(user: CyUser) {
   cy.clearCookies();
 
-  if (Cypress.env('environment') === 'local') {
+  if (Cypress.env('type') === 'localtest') {
     const { localPartyId } = cyUserCredentials[user];
 
     const formData = new FormData();
@@ -50,7 +50,7 @@ Cypress.Commands.add('startAppInstance', (appName, options) => {
   }
 
   // You can override the host we load css/js from, using multiple methods:
-  //   1. Start Cypress with --env environment=<local|tt02>,host=<host>
+  //   1. Start Cypress with --env environment=<docker|podman|tt02>,host=<host>
   //   2. Set CYPRESS_HOST=<host> in your .env file
   // This is useful, for example if you want to run a Cypress test locally in the background while working on
   // other things. Build the app-frontend with `yarn build` and serve it with `yarn serve 8081`, then run
@@ -77,7 +77,7 @@ Cypress.Commands.add('startAppInstance', (appName, options) => {
     },
   };
 
-  // Run this using --env environment=<local|tt02>,responseFuzzing=on to simulate an unreliable network. This might
+  // Run this using --env environment=<docker|podman|tt02>,responseFuzzing=on to simulate an unreliable network. This might
   // help us find bugs (usually race conditions) that only occur requests/responses arrive out of order.
   if (Cypress.env('responseFuzzing') === 'on') {
     const [min, max] = [10, 1000];
@@ -137,7 +137,7 @@ Cypress.Commands.add('startAppInstance', (appName, options) => {
 });
 
 export function getTargetUrl(appName: string) {
-  return Cypress.env('environment') === 'local'
+  return Cypress.env('type') === 'localtest'
     ? `${Cypress.config('baseUrl')}/ttd/${appName}`
     : `https://ttd.apps.${Cypress.config('baseUrl')?.slice(8)}/ttd/${appName}`;
 }


### PR DESCRIPTION
## Description

- Adding flaky test fixes originally applied to the `fix/1696-decimal-separator-stripped` branch
- Removing debounce onBlur for checkboxes. It turns out this forces a save immediately when clicking a checkbox, which is absolutely not what we wanted to do.
- Adding different configurations for docker/podman

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [x] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
