### PR TITLE
Fix validation of minNumberOfAttachments

### DIFF
--- a/src/features/validation/callbacks/onAttachmentSave.ts
+++ b/src/features/validation/callbacks/onAttachmentSave.ts
@@ -12,7 +12,7 @@ export function useOnAttachmentSave() {
 
   return useCallback(
     (node: LayoutNode, attachmentId: string) => {
-      const mask = getVisibilityMask(['Component']);
+      const mask = getVisibilityMask(['All']);
       setAttachmentVisibility(attachmentId, node, mask);
     },
     [setAttachmentVisibility],

--- a/src/features/validation/utils.ts
+++ b/src/features/validation/utils.ts
@@ -1,6 +1,5 @@
 import { ValidationMask } from 'src/features/validation';
 import { implementsValidationFilter } from 'src/layout';
-import type { IAttachments, UploadedAttachment } from 'src/features/attachments';
 import type {
   BaseValidation,
   ComponentValidation,
@@ -14,7 +13,6 @@ import type {
 } from 'src/features/validation';
 import type { ValidationSelector } from 'src/features/validation/validationContext';
 import type { ValidationFilterFunction } from 'src/layout';
-import type { CompInternal } from 'src/layout/layout';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 import type { LayoutPage } from 'src/utils/layout/LayoutPage';
 
@@ -196,24 +194,4 @@ export function getVisibilityMask(maskKeys?: ValidationMaskKeys[]): number {
     mask |= ValidationMask[maskKey];
   }
   return mask;
-}
-
-export function attachmentsValid(
-  attachments: IAttachments,
-  component: CompInternal<'FileUpload' | 'FileUploadWithTag'>,
-): boolean {
-  if (component.minNumberOfAttachments === 0) {
-    return true;
-  }
-
-  const attachmentsForComponent = attachments[component.id];
-  if (!attachmentsForComponent) {
-    return false;
-  }
-
-  return attachmentsForComponent.length >= component.minNumberOfAttachments;
-}
-
-export function attachmentIsMissingTag(attachment: UploadedAttachment): boolean {
-  return attachment.data.tags === undefined || attachment.data.tags.length === 0;
 }

--- a/src/layout/FileUpload/index.tsx
+++ b/src/layout/FileUpload/index.tsx
@@ -2,7 +2,6 @@ import React, { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { FrontendValidationSource, ValidationMask } from 'src/features/validation';
-import { attachmentsValid } from 'src/features/validation/utils';
 import { FileUploadDef } from 'src/layout/FileUpload/config.def.generated';
 import { FileUploadComponent } from 'src/layout/FileUpload/FileUploadComponent';
 import { AttachmentSummaryComponent } from 'src/layout/FileUpload/Summary/AttachmentSummaryComponent';
@@ -44,7 +43,11 @@ export class FileUpload extends FileUploadDef implements ValidateComponent {
   ): ComponentValidation[] {
     const validations: ComponentValidation[] = [];
 
-    if (!attachmentsValid(attachments, node.item)) {
+    // Validate minNumberOfAttachments
+    if (
+      node.item.minNumberOfAttachments > 0 &&
+      (!attachments[node.item.id] || attachments[node.item.id]!.length < node.item.minNumberOfAttachments)
+    ) {
       validations.push({
         message: {
           key: 'form_filler.file_uploader_validation_error_file_number',
@@ -53,7 +56,8 @@ export class FileUpload extends FileUploadDef implements ValidateComponent {
         severity: 'error',
         source: FrontendValidationSource.Component,
         componentId: node.item.id,
-        category: ValidationMask.Component,
+        // Treat visibility of minNumberOfAttachments the same as required to prevent showing an error immediately
+        category: ValidationMask.Required,
       });
     }
 

--- a/src/layout/FileUploadWithTag/index.tsx
+++ b/src/layout/FileUploadWithTag/index.tsx
@@ -84,7 +84,8 @@ export class FileUploadWithTag extends FileUploadWithTagDef implements ValidateC
           componentId: node.item.id,
           source: FrontendValidationSource.Component,
           meta: { attachmentId: attachment.data.id },
-          category: ValidationMask.Component,
+          // Treat visibility of missing tag the same as required to prevent showing an error immediately
+          category: ValidationMask.Required,
         });
       }
     }

--- a/src/layout/FileUploadWithTag/index.tsx
+++ b/src/layout/FileUploadWithTag/index.tsx
@@ -2,7 +2,6 @@ import React, { forwardRef } from 'react';
 
 import { isAttachmentUploaded } from 'src/features/attachments';
 import { FrontendValidationSource, ValidationMask } from 'src/features/validation';
-import { attachmentIsMissingTag, attachmentsValid } from 'src/features/validation/utils';
 import { FileUploadComponent } from 'src/layout/FileUpload/FileUploadComponent';
 import { AttachmentSummaryComponent } from 'src/layout/FileUpload/Summary/AttachmentSummaryComponent';
 import { FileUploadWithTagDef } from 'src/layout/FileUploadWithTag/config.def.generated';
@@ -44,49 +43,52 @@ export class FileUploadWithTag extends FileUploadWithTagDef implements ValidateC
   ): ComponentValidation[] {
     const validations: ComponentValidation[] = [];
 
-    if (attachmentsValid(attachments, node.item)) {
-      const missingTagAttachmentIds: string[] = [];
-      for (const attachment of attachments[node.item.id] || []) {
-        if (isAttachmentUploaded(attachment) && attachmentIsMissingTag(attachment)) {
-          missingTagAttachmentIds.push(attachment.data.id);
-        }
-      }
-
-      if (missingTagAttachmentIds?.length > 0) {
-        missingTagAttachmentIds.forEach((attachmentId) => {
-          const tagKey = node.item.textResourceBindings?.tagTitle;
-          const tagReference = tagKey
-            ? {
-                key: tagKey,
-                makeLowerCase: true,
-              }
-            : 'tag';
-
-          validations.push({
-            message: {
-              key: 'form_filler.file_uploader_validation_error_no_chosen_tag',
-              params: [tagReference],
-            },
-            severity: 'error',
-            componentId: node.item.id,
-            source: FrontendValidationSource.Component,
-            meta: { attachmentId },
-            category: ValidationMask.Component,
-          });
-        });
-      }
-    } else {
+    // Validate minNumberOfAttachments
+    if (
+      node.item.minNumberOfAttachments > 0 &&
+      (!attachments[node.item.id] || attachments[node.item.id]!.length < node.item.minNumberOfAttachments)
+    ) {
       validations.push({
         message: {
           key: 'form_filler.file_uploader_validation_error_file_number',
           params: [node.item.minNumberOfAttachments],
         },
         severity: 'error',
-        componentId: node.item.id,
         source: FrontendValidationSource.Component,
-        category: ValidationMask.Component,
+        componentId: node.item.id,
+        // Treat visibility of minNumberOfAttachments the same as required to prevent showing an error immediately
+        category: ValidationMask.Required,
       });
     }
+
+    // Validate missing tags
+    for (const attachment of attachments[node.item.id] || []) {
+      if (
+        isAttachmentUploaded(attachment) &&
+        (attachment.data.tags === undefined || attachment.data.tags.length === 0)
+      ) {
+        const tagKey = node.item.textResourceBindings?.tagTitle;
+        const tagReference = tagKey
+          ? {
+              key: tagKey,
+              makeLowerCase: true,
+            }
+          : 'tag';
+
+        validations.push({
+          message: {
+            key: 'form_filler.file_uploader_validation_error_no_chosen_tag',
+            params: [tagReference],
+          },
+          severity: 'error',
+          componentId: node.item.id,
+          source: FrontendValidationSource.Component,
+          meta: { attachmentId: attachment.data.id },
+          category: ValidationMask.Component,
+        });
+      }
+    }
+
     return validations;
   }
 

--- a/test/e2e/integration/frontend-test/components.ts
+++ b/test/e2e/integration/frontend-test/components.ts
@@ -104,6 +104,12 @@ describe('UI Components', () => {
       force: true,
     });
     cy.get(appFrontend.changeOfName.uploadWithTag.editWindow).should('be.visible');
+    cy.get(appFrontend.fieldValidation(appFrontend.changeOfName.uploadWithTag.uploadZone)).should('not.exist');
+    cy.get(appFrontend.changeOfName.uploadWithTag.saveTag).click();
+    cy.get(appFrontend.fieldValidation(appFrontend.changeOfName.uploadWithTag.uploadZone)).should(
+      'contain.text',
+      'Du må velge file type',
+    );
     cy.dsSelect(appFrontend.changeOfName.uploadWithTag.tagsDropDown, 'Adresse');
     cy.get(appFrontend.changeOfName.uploadWithTag.saveTag).click();
     cy.wait('@saveTags');

--- a/test/e2e/integration/frontend-test/components.ts
+++ b/test/e2e/integration/frontend-test/components.ts
@@ -176,6 +176,29 @@ describe('UI Components', () => {
     }
   });
 
+  it('minNumberOfAttachments should validate like required', () => {
+    cy.interceptLayout('changename', (component) => {
+      if (component.type === 'FileUpload' || component.type === 'FileUploadWithTag') {
+        component.minNumberOfAttachments = 1;
+      }
+    });
+    cy.goto('changename');
+    cy.get(appFrontend.changeOfName.newFirstName).type('Per');
+    cy.get(appFrontend.errorReport).should('not.exist');
+    cy.gotoNavPage('grid');
+    cy.get(appFrontend.sendinButton).click();
+    cy.get(appFrontend.errorReport).should('contain.text', 'For å fortsette må du laste opp 1 vedlegg');
+    cy.gotoNavPage('form');
+    cy.get(appFrontend.fieldValidation(appFrontend.changeOfName.upload)).should(
+      'contain.text',
+      'For å fortsette må du laste opp 1 vedlegg',
+    );
+    cy.get(appFrontend.fieldValidation(appFrontend.changeOfName.uploadWithTag.uploadZone)).should(
+      'contain.text',
+      'For å fortsette må du laste opp 1 vedlegg',
+    );
+  });
+
   it('is possible to navigate between pages using navigation bar', () => {
     cy.goto('changename');
     cy.get(appFrontend.navMenuButtons).should('have.length', 3);


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

Since https://github.com/Altinn/app-frontend-react/pull/1893 was merged it has become apparent that minimum number of attachments is essentially the same as required validation, and should therefore not be immediately visible, but rather follow the same pattern as required. This also applies to missing tags for FileUploadWithTag.

## Related Issue(s)

- closes #1920 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
