### PR TITLE
Fix axios error logging

### DIFF
--- a/src/features/logging.ts
+++ b/src/features/logging.ts
@@ -38,9 +38,14 @@ export function parseErrorArgs(args: any[]): string {
   return args
     .map((arg) => {
       if (isAxiosError(arg)) {
-        return `Message: ${arg.message}\nRequest: ${arg.config?.method?.toUpperCase()} '${
-          arg.config?.url
-        }'\nResponse: ${arg.response?.data}`;
+        const message = arg.message;
+        const method = arg.config?.method?.toUpperCase();
+        const url = arg.config?.url;
+        const data = arg.response?.data;
+        const stringData = typeof data === 'object' ? JSON.stringify(data) : String(data);
+        return `Message: ${message}\nRequest: ${method ?? '<method not found>'} '${
+          url ?? '<url not found>'
+        }'\nResponse: ${stringData}`;
       }
       if (arg instanceof Error) {
         return `${arg.name}: ${arg.message}`;


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

Stringify objects in axios error response to avoid getting `[Object object]`:

```
Process next failed:
Message: Request failed with status code 409
Request: PUT 'http://local.altinn.cloud/staf/rusarbeid/instances/500800/45c202cc-bb7f-44ce-8e9e-664f12c31f7a/process/next?language=nn'
Response: [object Object]
```