### PR TITLE
Fix repeating group minCount validation visibility

### DIFF
--- a/src/layout/RepeatingGroup/index.tsx
+++ b/src/layout/RepeatingGroup/index.tsx
@@ -78,16 +78,15 @@ export class RepeatingGroup extends RepeatingGroupDef implements ValidateCompone
       (row) => row && !row.groupExpressions?.hiddenRow,
     ).length;
 
-    const repeatingGroupMinCountValid = repeatingGroupMinCount <= repeatingGroupVisibleRows;
-
-    // if not valid, return appropriate error message
-    if (!repeatingGroupMinCountValid) {
+    // Validate minCount
+    if (repeatingGroupVisibleRows < repeatingGroupMinCount) {
       validations.push({
         message: { key: 'validation_errors.minItems', params: [repeatingGroupMinCount] },
         severity: 'error',
         componentId: node.item.id,
         source: FrontendValidationSource.Component,
-        category: ValidationMask.Component,
+        // Treat visibility of minCount the same as required to prevent showing an error immediately
+        category: ValidationMask.Required,
       });
     }
 

--- a/test/e2e/integration/frontend-test/group.ts
+++ b/test/e2e/integration/frontend-test/group.ts
@@ -138,6 +138,9 @@ describe('Group', () => {
     init();
     cy.get(appFrontend.group.showGroupToContinue).findByRole('checkbox', { name: 'Ja' }).check();
 
+    cy.get(appFrontend.group.mainGroup).should('be.visible');
+    cy.get(appFrontend.fieldValidation('mainGroup')).should('not.exist');
+
     const rowsToAdd = [1, 2, 3];
     for (const idx in rowsToAdd) {
       cy.get(appFrontend.group.addNewItem).click();


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

Essentially the same problem as https://github.com/Altinn/app-frontend-react/issues/1920 but for repeating groups.

## Related Issue(s)

- https://altinn.slack.com/archives/C02EJ9HKQA3/p1710316266683829
- https://github.com/Altinn/app-frontend-react/pull/1893

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
