### PR TITLE
Give certain schema validations `Required` visibility, and filter duplicates

### DIFF
--- a/src/features/devtools/DevTools.module.css
+++ b/src/features/devtools/DevTools.module.css
@@ -45,7 +45,7 @@
   height: 32px;
   width: 32px;
   position: absolute;
-  top: 10px;
+  top: 11px;
   right: 0;
   z-index: 1001;
 }

--- a/src/features/devtools/components/LayoutInspector/LayoutInspector.module.css
+++ b/src/features/devtools/components/LayoutInspector/LayoutInspector.module.css
@@ -128,3 +128,30 @@
 .error {
   color: red;
 }
+
+.tabs {
+  height: 100%;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.closeButton {
+  position: relative;
+}
+
+.closeButton > button {
+  height: 32px;
+  width: 32px;
+  position: absolute;
+  top: 1px;
+  right: 0;
+  z-index: 1001;
+}
+
+.scrollable {
+  height: 100%;
+  overflow-y: auto;
+  width: 100%;
+  background-color: white;
+}

--- a/src/features/devtools/components/LayoutInspector/LayoutInspector.tsx
+++ b/src/features/devtools/components/LayoutInspector/LayoutInspector.tsx
@@ -121,7 +121,7 @@ export const LayoutInspector = () => {
       {selectedComponent && (
         <div className={classes.properties}>
           <div className={classes.header}>
-            <h3>Egenskaper</h3>
+            <h3>Konfigurasjon</h3>
             {validationErrorsForPage[selectedComponent] && validationErrorsForPage[selectedComponent].length > 0 && (
               <Alert
                 className={classes.errorAlert}

--- a/src/features/devtools/components/NodeInspector/NodeInspector.tsx
+++ b/src/features/devtools/components/NodeInspector/NodeInspector.tsx
@@ -1,14 +1,16 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import React from 'react';
 
-import { Button } from '@digdir/design-system-react';
+import { Button, Tabs } from '@digdir/design-system-react';
 import { Close } from '@navikt/ds-icons';
 
 import reusedClasses from 'src/features/devtools/components/LayoutInspector/LayoutInspector.module.css';
 import { NodeHierarchy } from 'src/features/devtools/components/NodeInspector/NodeHierarchy';
 import { NodeInspectorContextProvider } from 'src/features/devtools/components/NodeInspector/NodeInspectorContext';
+import { ValidationInspector } from 'src/features/devtools/components/NodeInspector/ValidationInspector';
 import { SplitView } from 'src/features/devtools/components/SplitView/SplitView';
 import { useDevToolsStore } from 'src/features/devtools/data/DevToolsStore';
+import { implementsAnyValidation } from 'src/layout';
 import { useNodes } from 'src/utils/layout/NodesContext';
 
 export const NodeInspector = () => {
@@ -32,20 +34,8 @@ export const NodeInspector = () => {
         />
       </div>
       {selectedId && selectedNode && (
-        <div className={reusedClasses.properties}>
-          <div className={reusedClasses.header}>
-            <h3>Egenskaper for {selectedId}</h3>
-            <div className={reusedClasses.headerLink}>
-              <a
-                href='#'
-                onClick={(e) => {
-                  e.preventDefault();
-                  focusLayoutInspector(selectedNode?.item.baseComponentId || selectedNode?.item.id);
-                }}
-              >
-                Rediger konfigurasjonen i Layout-fanen
-              </a>
-            </div>
+        <>
+          <div className={reusedClasses.closeButton}>
             <Button
               onClick={() => setSelected(undefined)}
               size='small'
@@ -64,9 +54,39 @@ export const NodeInspector = () => {
               selectNode: setSelected,
             }}
           >
-            {selectedNode.def.renderDevToolsInspector(selectedNode as any)}
+            <Tabs
+              size='small'
+              defaultValue='properties'
+              className={reusedClasses.tabs}
+            >
+              <Tabs.List>
+                <Tabs.Tab value='properties'>Egenskaper</Tabs.Tab>
+                {implementsAnyValidation(selectedNode.def) && <Tabs.Tab value='validation'>Validering</Tabs.Tab>}
+              </Tabs.List>
+              <Tabs.Content value='properties'>
+                <div className={reusedClasses.properties}>
+                  <div className={reusedClasses.headerLink}>
+                    <a
+                      href='#'
+                      onClick={(e) => {
+                        e.preventDefault();
+                        focusLayoutInspector(selectedNode?.item.baseComponentId || selectedNode?.item.id);
+                      }}
+                    >
+                      Rediger konfigurasjonen i Layout-fanen
+                    </a>
+                  </div>
+                  {selectedNode.def.renderDevToolsInspector(selectedNode as any)}
+                </div>
+              </Tabs.Content>
+              <Tabs.Content value='validation'>
+                <div className={reusedClasses.scrollable}>
+                  <ValidationInspector node={selectedNode} />
+                </div>
+              </Tabs.Content>
+            </Tabs>
           </NodeInspectorContextProvider>
-        </div>
+        </>
       )}
     </SplitView>
   );

--- a/src/features/devtools/components/NodeInspector/ValidationInspector.module.css
+++ b/src/features/devtools/components/NodeInspector/ValidationInspector.module.css
@@ -1,0 +1,29 @@
+.categoryList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 12px;
+}
+
+.category {
+  border-radius: 4px;
+  padding: 2px 6px;
+}
+
+.listItem {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  border-radius: 4px;
+  background-color: #eee;
+  padding: 0px 0px 0px 4px;
+  list-style: none;
+  margin-bottom: 4px;
+}
+
+.listItemCategory {
+  text-align: center;
+  border-radius: 4px;
+  color: black;
+  padding: 0px 4px;
+}

--- a/src/features/devtools/components/NodeInspector/ValidationInspector.tsx
+++ b/src/features/devtools/components/NodeInspector/ValidationInspector.tsx
@@ -1,0 +1,194 @@
+import React from 'react';
+
+import { EyeSlashIcon } from '@navikt/aksel-icons';
+
+import classes from 'src/features/devtools/components/NodeInspector/ValidationInspector.module.css';
+import { Lang } from 'src/features/language/Lang';
+import { type NodeValidation, ValidationMask, type ValidationSeverity } from 'src/features/validation';
+import { buildNodeValidation, isValidationVisible } from 'src/features/validation/utils';
+import { Validation } from 'src/features/validation/validationContext';
+import { getVisibilityForNode } from 'src/features/validation/visibility/visibilityUtils';
+import { implementsAnyValidation, implementsValidationFilter } from 'src/layout';
+import type { ValidationFilterFunction } from 'src/layout';
+import type { LayoutNode } from 'src/utils/layout/LayoutNode';
+
+interface ValidationInspectorProps {
+  node: LayoutNode;
+}
+
+const categories = [
+  { name: 'Schema', category: ValidationMask.Schema },
+  { name: 'Component', category: ValidationMask.Component },
+  { name: 'Expression', category: ValidationMask.Expression },
+  { name: 'Custom backend', category: ValidationMask.CustomBackend },
+  { name: 'Required', category: ValidationMask.Required },
+  { name: 'Standard backend', category: ValidationMask.Backend },
+] as const;
+
+export const ValidationInspector = ({ node }: ValidationInspectorProps) => {
+  const fieldSelector = Validation.useFieldSelector();
+  const componentSelector = Validation.useComponentSelector();
+  const visibilitySelector = Validation.useVisibilitySelector();
+
+  if (!implementsAnyValidation(node.def)) {
+    return (
+      <div style={{ padding: 4 }}>
+        <b>{node.item.type}</b> implementerer ikke validering.
+      </div>
+    );
+  }
+
+  const mask = getVisibilityForNode(node, visibilitySelector);
+  const filters = implementsValidationFilter(node.def) ? node.def.getValidationFilters(node as any) : [];
+
+  const component = componentSelector(node.item.id, (components) => components[node.item.id]);
+  const componentValidations = component?.component?.map((validation) => buildNodeValidation(node, validation));
+  const bindingValidations: { [key: string]: NodeValidation[] } = {};
+  for (const [bindingKey, field] of Object.entries(node.item.dataModelBindings ?? {})) {
+    bindingValidations[bindingKey] = [];
+
+    const fieldValidation = fieldSelector(field, (fields) => fields[field]);
+    if (fieldValidation) {
+      bindingValidations[bindingKey].push(
+        ...fieldValidation.map((validation) => buildNodeValidation(node, validation, bindingKey)),
+      );
+    }
+    if (component?.bindingKeys?.[bindingKey]) {
+      bindingValidations[bindingKey].push(
+        ...component.bindingKeys[bindingKey].map((validation) => buildNodeValidation(node, validation, bindingKey)),
+      );
+    }
+  }
+
+  return (
+    <div style={{ padding: 4 }}>
+      <CategoryVisibility mask={mask} />
+      <ValidationItems
+        binding='Uten datamodell-tilknytning'
+        validations={componentValidations}
+        node={node}
+        mask={mask}
+        filters={filters}
+      />
+      {Object.entries(bindingValidations).map(([binding, validations]) => (
+        <ValidationItems
+          key={binding}
+          binding={binding}
+          validations={validations}
+          node={node}
+          mask={mask}
+          filters={filters}
+        />
+      ))}
+    </div>
+  );
+};
+
+const CategoryVisibility = ({ mask }: { mask: number }) => (
+  <>
+    <b>Synlige valideringstyper på noden:</b>
+    <div className={classes.categoryList}>
+      {categories.map(({ name, category }) => {
+        const isVisible = (mask & category) > 0;
+        return (
+          <div
+            key={name}
+            className={classes.category}
+            style={{ backgroundColor: isVisible ? 'lightgreen' : 'lightgray' }}
+            title={isVisible ? 'Valideringstypen er synlig' : 'Valideringstypen er skjult'}
+          >
+            {name}
+          </div>
+        );
+      })}
+    </div>
+  </>
+);
+
+interface ValidationItemsProps {
+  binding: string;
+  validations: NodeValidation[];
+  node: LayoutNode;
+  mask: number;
+  filters: ValidationFilterFunction[];
+}
+const ValidationItems = ({ binding, validations, node, mask, filters }: ValidationItemsProps) => {
+  if (!validations?.length) {
+    return null;
+  }
+
+  return (
+    <>
+      <b>{binding}:</b>
+      <ul style={{ padding: 0 }}>
+        {validations.map((validation) => (
+          <ValidationItem
+            key={`${validation.source}-${validation.message.key}-${validation.severity}`}
+            validation={validation}
+            node={node}
+            nodeVisibility={mask}
+            filters={filters}
+          />
+        ))}
+      </ul>
+    </>
+  );
+};
+
+interface ValidationItemProps {
+  validation: NodeValidation;
+  node: LayoutNode;
+  nodeVisibility: number;
+  filters: ValidationFilterFunction[];
+}
+const ValidationItem = ({ validation, node, nodeVisibility, filters }: ValidationItemProps) => {
+  const color = getColor(validation.severity);
+
+  const isVisible = isValidationVisible(validation, nodeVisibility);
+  const category = categories.find((c) => validation.category === c.category);
+
+  const isFiltered = filters.some((filter) => !filter(validation, 0, [validation]));
+  return (
+    <li
+      className={classes.listItem}
+      style={{ color, textDecoration: isFiltered ? 'line-through' : 'none' }}
+      title={isFiltered ? 'Denne valideringen er filtrert bort' : undefined}
+    >
+      <div>
+        {!isVisible && (
+          <EyeSlashIcon
+            style={{ marginRight: '6px' }}
+            title='Denne valideringen er skjult'
+          />
+        )}
+        <Lang
+          id={validation.message.key}
+          params={validation.message.params}
+          node={node}
+        />
+      </div>
+      {category && (
+        <span
+          className={classes.listItemCategory}
+          style={{ backgroundColor: isVisible ? 'lightgreen' : 'lightgray' }}
+          title={isVisible ? 'Valideringstypen er synlig' : 'Valideringstypen er skjult'}
+        >
+          {category.name}
+        </span>
+      )}
+    </li>
+  );
+};
+
+function getColor(severity: ValidationSeverity) {
+  switch (severity) {
+    case 'error':
+      return 'red';
+    case 'warning':
+      return 'orange';
+    case 'info':
+      return 'blue';
+    case 'success':
+      return 'green';
+  }
+}

--- a/src/features/devtools/components/NodeInspector/ValidationInspector.tsx
+++ b/src/features/devtools/components/NodeInspector/ValidationInspector.tsx
@@ -151,10 +151,9 @@ const ValidationItem = ({ validation, node, nodeVisibility, filters }: Validatio
   return (
     <li
       className={classes.listItem}
-      style={{ color, textDecoration: isFiltered ? 'line-through' : 'none' }}
       title={isFiltered ? 'Denne valideringen er filtrert bort' : undefined}
     >
-      <div>
+      <div style={{ color, textDecoration: isFiltered ? 'line-through' : 'none' }}>
         {!isVisible && (
           <EyeSlashIcon
             style={{ marginRight: '6px' }}

--- a/src/features/devtools/components/NodeInspector/ValidationInspector.tsx
+++ b/src/features/devtools/components/NodeInspector/ValidationInspector.tsx
@@ -2,12 +2,17 @@ import React from 'react';
 
 import { EyeSlashIcon } from '@navikt/aksel-icons';
 
+import { isAttachmentUploaded } from 'src/features/attachments';
+import { useAttachments } from 'src/features/attachments/AttachmentsContext';
 import classes from 'src/features/devtools/components/NodeInspector/ValidationInspector.module.css';
 import { Lang } from 'src/features/language/Lang';
 import { type NodeValidation, ValidationMask, type ValidationSeverity } from 'src/features/validation';
 import { buildNodeValidation, isValidationVisible } from 'src/features/validation/utils';
 import { Validation } from 'src/features/validation/validationContext';
-import { getVisibilityForNode } from 'src/features/validation/visibility/visibilityUtils';
+import {
+  getResolvedVisibilityForAttachment,
+  getVisibilityForNode,
+} from 'src/features/validation/visibility/visibilityUtils';
 import { implementsAnyValidation, implementsValidationFilter } from 'src/layout';
 import type { ValidationFilterFunction } from 'src/layout';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
@@ -29,6 +34,7 @@ export const ValidationInspector = ({ node }: ValidationInspectorProps) => {
   const fieldSelector = Validation.useFieldSelector();
   const componentSelector = Validation.useComponentSelector();
   const visibilitySelector = Validation.useVisibilitySelector();
+  const attachments = useAttachments();
 
   if (!implementsAnyValidation(node.def)) {
     return (
@@ -38,23 +44,46 @@ export const ValidationInspector = ({ node }: ValidationInspectorProps) => {
     );
   }
 
-  const mask = getVisibilityForNode(node, visibilitySelector);
+  const nodeVisibility = getVisibilityForNode(node, visibilitySelector);
   const filters = implementsValidationFilter(node.def) ? node.def.getValidationFilters(node as any) : [];
-
   const component = componentSelector(node.item.id, (components) => components[node.item.id]);
-  const componentValidations = component?.component?.map((validation) => buildNodeValidation(node, validation));
+  const componentValidations = component?.component?.map((validation) => buildNodeValidation(node, validation)) ?? [];
+
+  // Validations that are not bound to any datamodel field or attachment
+  const unboundComponentValidations = componentValidations.filter((validation) => !validation.meta?.attachmentId);
+
+  // Validations for attachments
+  const attachmentValidations: { [key: string]: { attachmentVisibility: number; validations: NodeValidation[] } } =
+    componentValidations.reduce((obj, val) => {
+      const attachmentId = val.meta?.attachmentId;
+      if (attachmentId) {
+        const attachment = attachments[node.item.id]?.find(
+          (a) => isAttachmentUploaded(a) && a.data.id === attachmentId,
+        );
+        const key = `Vedlegg ${attachment?.data.filename ?? attachmentId}`;
+        if (!obj[key]) {
+          const attachmentVisibility = getResolvedVisibilityForAttachment(attachmentId, node, visibilitySelector);
+          obj[key] = { attachmentVisibility, validations: [] };
+        }
+        obj[key].validations.push(val);
+      }
+      return obj;
+    }, {});
+
+  // Validations for datamodel bindings
   const bindingValidations: { [key: string]: NodeValidation[] } = {};
   for (const [bindingKey, field] of Object.entries(node.item.dataModelBindings ?? {})) {
-    bindingValidations[bindingKey] = [];
+    const key = `Datamodell ${bindingKey}`;
+    bindingValidations[key] = [];
 
     const fieldValidation = fieldSelector(field, (fields) => fields[field]);
     if (fieldValidation) {
-      bindingValidations[bindingKey].push(
+      bindingValidations[key].push(
         ...fieldValidation.map((validation) => buildNodeValidation(node, validation, bindingKey)),
       );
     }
     if (component?.bindingKeys?.[bindingKey]) {
-      bindingValidations[bindingKey].push(
+      bindingValidations[key].push(
         ...component.bindingKeys[bindingKey].map((validation) => buildNodeValidation(node, validation, bindingKey)),
       );
     }
@@ -62,21 +91,31 @@ export const ValidationInspector = ({ node }: ValidationInspectorProps) => {
 
   return (
     <div style={{ padding: 4 }}>
-      <CategoryVisibility mask={mask} />
+      <CategoryVisibility mask={nodeVisibility} />
       <ValidationItems
-        binding='Uten datamodell-tilknytning'
-        validations={componentValidations}
+        grouping='Komponent'
+        validations={unboundComponentValidations}
         node={node}
-        mask={mask}
+        visibility={nodeVisibility}
         filters={filters}
       />
       {Object.entries(bindingValidations).map(([binding, validations]) => (
         <ValidationItems
           key={binding}
-          binding={binding}
+          grouping={binding}
           validations={validations}
           node={node}
-          mask={mask}
+          visibility={nodeVisibility}
+          filters={filters}
+        />
+      ))}
+      {Object.entries(attachmentValidations).map(([attachment, { attachmentVisibility, validations }]) => (
+        <ValidationItems
+          key={attachment}
+          grouping={attachment}
+          validations={validations}
+          node={node}
+          visibility={attachmentVisibility}
           filters={filters}
         />
       ))}
@@ -106,27 +145,27 @@ const CategoryVisibility = ({ mask }: { mask: number }) => (
 );
 
 interface ValidationItemsProps {
-  binding: string;
+  grouping: string;
   validations: NodeValidation[];
   node: LayoutNode;
-  mask: number;
+  visibility: number;
   filters: ValidationFilterFunction[];
 }
-const ValidationItems = ({ binding, validations, node, mask, filters }: ValidationItemsProps) => {
+const ValidationItems = ({ grouping, validations, node, visibility, filters }: ValidationItemsProps) => {
   if (!validations?.length) {
     return null;
   }
 
   return (
     <>
-      <b>{binding}:</b>
+      <b>{grouping}:</b>
       <ul style={{ padding: 0 }}>
         {validations.map((validation) => (
           <ValidationItem
             key={`${validation.source}-${validation.message.key}-${validation.severity}`}
             validation={validation}
             node={node}
-            nodeVisibility={mask}
+            visibility={visibility}
             filters={filters}
           />
         ))}
@@ -138,13 +177,18 @@ const ValidationItems = ({ binding, validations, node, mask, filters }: Validati
 interface ValidationItemProps {
   validation: NodeValidation;
   node: LayoutNode;
-  nodeVisibility: number;
+  visibility: number;
   filters: ValidationFilterFunction[];
 }
-const ValidationItem = ({ validation, node, nodeVisibility, filters }: ValidationItemProps) => {
+const ValidationItem = ({ validation, node, visibility, filters }: ValidationItemProps) => {
+  // Ignore old severities which are no longer supported
+  if (!['error', 'warning', 'info', 'success'].includes(validation.severity)) {
+    return null;
+  }
+
   const color = getColor(validation.severity);
 
-  const isVisible = isValidationVisible(validation, nodeVisibility);
+  const isVisible = isValidationVisible(validation, visibility);
   const category = categories.find((c) => validation.category === c.category);
 
   const isFiltered = filters.some((filter) => !filter(validation, 0, [validation]));

--- a/src/features/validation/schemaValidation/schemaValidationUtils.ts
+++ b/src/features/validation/schemaValidation/schemaValidationUtils.ts
@@ -5,6 +5,9 @@ import addAdditionalFormats from 'ajv-formats-draft2019';
 import type { ErrorObject, Options } from 'ajv';
 import type { JSONSchema7 } from 'json-schema';
 
+import { ValidationMask } from '..';
+import type { ValidationCategory } from '..';
+
 /**
  * Create a new ajv validator for a given schema.
  */
@@ -159,4 +162,17 @@ export function getErrorParams(error: ErrorObject): string | null {
   }
   const errorParams = error.params[errorType.paramKey];
   return Array.isArray(errorParams) ? errorParams.join(', ') : errorParams;
+}
+
+/**
+ * Get the category of an error object.
+ */
+export function getErrorCategory(error: ErrorObject): ValidationCategory {
+  switch (error.keyword) {
+    case 'required':
+    case 'minItems':
+      return ValidationMask.Required;
+    default:
+      return ValidationMask.Schema;
+  }
 }

--- a/src/features/validation/schemaValidation/schemaValidationUtils.ts
+++ b/src/features/validation/schemaValidation/schemaValidationUtils.ts
@@ -5,8 +5,8 @@ import addAdditionalFormats from 'ajv-formats-draft2019';
 import type { ErrorObject, Options } from 'ajv';
 import type { JSONSchema7 } from 'json-schema';
 
-import { ValidationMask } from '..';
-import type { ValidationCategory } from '..';
+import { ValidationMask } from 'src/features/validation';
+import type { ValidationCategory } from 'src/features/validation';
 
 /**
  * Create a new ajv validator for a given schema.

--- a/src/features/validation/schemaValidation/schemaValidationUtils.ts
+++ b/src/features/validation/schemaValidation/schemaValidationUtils.ts
@@ -166,6 +166,8 @@ export function getErrorParams(error: ErrorObject): string | null {
 
 /**
  * Get the category of an error object.
+ * Validation types that act essentially like required should be treated as such
+ * so they do not give errors before the user has an opportunity to fill anything out.
  */
 export function getErrorCategory(error: ErrorObject): ValidationCategory {
   switch (error.keyword) {

--- a/src/features/validation/schemaValidation/useSchemaValidation.ts
+++ b/src/features/validation/schemaValidation/useSchemaValidation.ts
@@ -3,9 +3,10 @@ import { useMemo } from 'react';
 import { useCurrentDataModelSchema } from 'src/features/datamodel/DataModelSchemaProvider';
 import { useCurrentDataModelType } from 'src/features/datamodel/useBindingSchema';
 import { FD } from 'src/features/formData/FormDataWrite';
-import { type FieldValidations, FrontendValidationSource, ValidationMask } from 'src/features/validation';
+import { type FieldValidations, FrontendValidationSource } from 'src/features/validation';
 import {
   createValidator,
+  getErrorCategory,
   getErrorParams,
   getErrorTextKey,
 } from 'src/features/validation/schemaValidation/schemaValidationUtils';
@@ -58,13 +59,7 @@ export function useSchemaValidation(): FieldValidations {
        * These can be ignored, as there will be other, specific validation errors that actually
        * from the specified sub-schemas that will trigger validation errors where relevant.
        */
-      if (
-        error.data == null ||
-        error.data === '' ||
-        error.keyword === 'required' || // TODO(Validation): Check if this can be filtered out later
-        error.keyword === 'oneOf' ||
-        error.params?.type === 'null'
-      ) {
+      if (error.data == null || error.data === '' || error.keyword === 'oneOf' || error.params?.type === 'null') {
         continue;
       }
 
@@ -85,6 +80,8 @@ export function useSchemaValidation(): FieldValidations {
         : {
             key: getErrorTextKey(error),
           };
+
+      const category = getErrorCategory(error);
 
       /**
        * Extract error parameters and add to message if available.
@@ -107,7 +104,7 @@ export function useSchemaValidation(): FieldValidations {
         message,
         field,
         source: FrontendValidationSource.Schema,
-        category: ValidationMask.Schema,
+        category,
         severity: 'error',
       });
     }

--- a/src/features/validation/schemaValidation/useSchemaValidation.ts
+++ b/src/features/validation/schemaValidation/useSchemaValidation.ts
@@ -53,13 +53,21 @@ export function useSchemaValidation(): FieldValidations {
 
     for (const error of validator.errors || []) {
       /**
-       * Skip schema validation for empty fields and ignore required errors. Let component validation handle these.
+       * Skip schema validation for empty fields and ignore required errors.
+       * JSON schema required does not work too well for our use case. The expectation that a missing field should give an error is not necessarily true,
+       * since it will not work in nested objects if the parent is also missing.
        * Check if AVJ validation error is a oneOf error ("must match exactly one schema in oneOf").
        * We don't currently support oneOf validation.
        * These can be ignored, as there will be other, specific validation errors that actually
        * from the specified sub-schemas that will trigger validation errors where relevant.
        */
-      if (error.data == null || error.data === '' || error.keyword === 'oneOf' || error.params?.type === 'null') {
+      if (
+        error.data == null ||
+        error.data === '' ||
+        error.keyword === 'required' ||
+        error.keyword === 'oneOf' ||
+        error.params?.type === 'null'
+      ) {
         continue;
       }
 

--- a/src/features/validation/selectors/attachmentValidations.ts
+++ b/src/features/validation/selectors/attachmentValidations.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 
 import type { NodeValidation } from '..';
 
-import { buildNodeValidation, selectValidations, validationNodeFilter } from 'src/features/validation/utils';
+import { buildNodeValidation, filterValidations, selectValidations } from 'src/features/validation/utils';
 import { Validation } from 'src/features/validation/validationContext';
 import { getResolvedVisibilityForAttachment } from 'src/features/validation/visibility/visibilityUtils';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
@@ -19,13 +19,15 @@ export function useAttachmentValidations(node: LayoutNode, attachmentId: string 
     if (!component?.component || !attachmentId) {
       return [];
     }
-    const validations = selectValidations(
-      component.component!,
-      getResolvedVisibilityForAttachment(attachmentId, node, visibilitySelector),
+    const validations = filterValidations(
+      selectValidations(
+        component.component!,
+        getResolvedVisibilityForAttachment(attachmentId, node, visibilitySelector),
+      ),
+      node,
     );
     return validations
       .filter((validation) => validation.meta?.attachmentId === attachmentId)
-      .filter(validationNodeFilter(node))
       .map((validation) => buildNodeValidation(node, validation));
   }, [componentSelector, node, attachmentId, visibilitySelector]);
 }

--- a/src/features/validation/selectors/bindingValidationsForNode.ts
+++ b/src/features/validation/selectors/bindingValidationsForNode.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 
 import type { NodeValidation } from '..';
 
-import { buildNodeValidation, selectValidations, validationNodeFilter } from 'src/features/validation/utils';
+import { buildNodeValidation, filterValidations, selectValidations } from 'src/features/validation/utils';
 import { Validation } from 'src/features/validation/validationContext';
 import { getVisibilityForNode } from 'src/features/validation/visibility/visibilityUtils';
 import type { CompTypes, IDataModelBindings } from 'src/layout/layout';
@@ -31,20 +31,16 @@ export function useBindingValidationsForNode<
 
       const fieldValidation = fieldSelector(field, (fields) => fields[field]);
       if (fieldValidation) {
-        const validations = selectValidations(fieldValidation, mask);
+        const validations = filterValidations(selectValidations(fieldValidation, mask), node);
         bindingValidations[bindingKey].push(
-          ...validations
-            .filter(validationNodeFilter(node))
-            .map((validation) => buildNodeValidation(node, validation, bindingKey)),
+          ...validations.map((validation) => buildNodeValidation(node, validation, bindingKey)),
         );
       }
       const component = componentSelector(node.item.id, (components) => components[node.item.id]);
       if (component?.bindingKeys?.[bindingKey]) {
-        const validations = selectValidations(component.bindingKeys[bindingKey], mask);
+        const validations = filterValidations(selectValidations(component.bindingKeys[bindingKey], mask), node);
         bindingValidations[bindingKey].push(
-          ...validations
-            .filter(validationNodeFilter(node))
-            .map((validation) => buildNodeValidation(node, validation, bindingKey)),
+          ...validations.map((validation) => buildNodeValidation(node, validation, bindingKey)),
         );
       }
     }

--- a/src/features/validation/selectors/componentValidationsForNode.ts
+++ b/src/features/validation/selectors/componentValidationsForNode.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 
 import type { NodeValidation } from '..';
 
-import { buildNodeValidation, selectValidations, validationNodeFilter } from 'src/features/validation/utils';
+import { buildNodeValidation, filterValidations, selectValidations } from 'src/features/validation/utils';
 import { Validation } from 'src/features/validation/validationContext';
 import { getVisibilityForNode } from 'src/features/validation/visibility/visibilityUtils';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
@@ -19,7 +19,10 @@ export function useComponentValidationsForNode(node: LayoutNode): NodeValidation
     if (!component?.component) {
       return [];
     }
-    const validations = selectValidations(component.component!, getVisibilityForNode(node, visibilitySelector));
-    return validations.filter(validationNodeFilter(node)).map((validation) => buildNodeValidation(node, validation));
+    const validations = filterValidations(
+      selectValidations(component.component!, getVisibilityForNode(node, visibilitySelector)),
+      node,
+    );
+    return validations.map((validation) => buildNodeValidation(node, validation));
   }, [componentSelector, node, visibilitySelector]);
 }

--- a/src/features/validation/utils.ts
+++ b/src/features/validation/utils.ts
@@ -104,7 +104,7 @@ export function shouldValidateNode(node: LayoutNode): boolean {
   return !node.isHidden({ respectTracks: true }) && !('renderAsSummary' in node.item && node.item.renderAsSummary);
 }
 
-function isValidationVisible<T extends BaseValidation>(validation: T, mask: number): boolean {
+export function isValidationVisible<T extends BaseValidation>(validation: T, mask: number): boolean {
   if (validation.category === 0) {
     return true;
   }

--- a/src/features/validation/utils.ts
+++ b/src/features/validation/utils.ts
@@ -12,7 +12,6 @@ import type {
   ValidationState,
 } from 'src/features/validation';
 import type { ValidationSelector } from 'src/features/validation/validationContext';
-import type { ValidationFilterFunction } from 'src/layout';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 import type { LayoutPage } from 'src/utils/layout/LayoutPage';
 
@@ -52,14 +51,33 @@ export function hasValidationErrors<V extends BaseValidation>(validations: V[] |
   return validations?.some((validation: any) => validation.severity === 'error') ?? false;
 }
 
-function __default_filter__() {
-  return true;
-}
-export function validationNodeFilter(node: LayoutNode): ValidationFilterFunction {
-  if (implementsValidationFilter(node.def)) {
-    return node.def.getValidationFilter(node as any) ?? __default_filter__;
+/**
+ * Filters a list of validations based on the validation filters of a node
+ */
+export function filterValidations<Validation extends BaseValidation>(
+  validations: Validation[],
+  node: LayoutNode,
+): Validation[] {
+  if (!implementsValidationFilter(node.def)) {
+    return validations;
   }
-  return __default_filter__;
+
+  const filters = node.def.getValidationFilters(node as any);
+  if (filters.length == 0) {
+    return validations;
+  }
+
+  const out: Validation[] = [];
+  validationsLoop: for (let i = 0; i < validations.length; i++) {
+    for (const filter of filters) {
+      if (!filter(validations[i], i, validations)) {
+        // Skip validation if any filter returns false
+        continue validationsLoop;
+      }
+    }
+    out.push(validations[i]);
+  }
+  return out;
 }
 
 /**
@@ -139,12 +157,8 @@ export function getValidationsForNode(
     for (const [bindingKey, field] of Object.entries(node.item.dataModelBindings)) {
       const fieldValidations = selector(`field-${field}`, (state) => state.state.fields[field]);
       if (fieldValidations) {
-        const validations = selectValidations(fieldValidations, mask, severity);
-        validationMessages.push(
-          ...validations
-            .filter(validationNodeFilter(node))
-            .map((validation) => buildNodeValidation(node, validation, bindingKey)),
-        );
+        const validations = filterValidations(selectValidations(fieldValidations, mask, severity), node);
+        validationMessages.push(...validations.map((validation) => buildNodeValidation(node, validation, bindingKey)));
       }
 
       const cacheKey = ['binding', node.item.id, bindingKey].join('-');
@@ -153,22 +167,16 @@ export function getValidationsForNode(
         (state) => state.state.components[node.item.id]?.bindingKeys?.[bindingKey],
       );
       if (bindingValidations) {
-        const validations = selectValidations(bindingValidations, mask, severity);
-        validationMessages.push(
-          ...validations
-            .filter(validationNodeFilter(node))
-            .map((validation) => buildNodeValidation(node, validation, bindingKey)),
-        );
+        const validations = filterValidations(selectValidations(bindingValidations, mask, severity), node);
+        validationMessages.push(...validations.map((validation) => buildNodeValidation(node, validation, bindingKey)));
       }
     }
   }
 
   const componentValidations = selector(node.item.id, (state) => state.state.components[node.item.id]?.component);
   if (componentValidations) {
-    const validations = selectValidations(componentValidations, mask, severity);
-    validationMessages.push(
-      ...validations.filter(validationNodeFilter(node)).map((validation) => buildNodeValidation(node, validation)),
-    );
+    const validations = filterValidations(selectValidations(componentValidations, mask, severity), node);
+    validationMessages.push(...validations.map((validation) => buildNodeValidation(node, validation)));
   }
   return validationMessages;
 }

--- a/src/layout/Datepicker/index.tsx
+++ b/src/layout/Datepicker/index.tsx
@@ -103,7 +103,7 @@ export class Datepicker extends DatepickerDef implements ValidateComponent, Vali
    * Datepicker has a custom format validation which give a better error message than what the schema provides.
    * Filter out the schema format vaildation to avoid duplicate error messages.
    */
-  schemaFormatFilter(validation: BaseValidation): boolean {
+  private schemaFormatFilter(validation: BaseValidation): boolean {
     return !(
       validation.source === FrontendValidationSource.Schema && validation.message.key === 'validation_errors.pattern'
     );

--- a/src/layout/Datepicker/index.tsx
+++ b/src/layout/Datepicker/index.tsx
@@ -103,14 +103,17 @@ export class Datepicker extends DatepickerDef implements ValidateComponent, Vali
    * Datepicker has a custom format validation which give a better error message than what the schema provides.
    * Filter out the schema format vaildation to avoid duplicate error messages.
    */
-  formatFilter(validation: BaseValidation): boolean {
+  schemaFormatFilter(validation: BaseValidation): boolean {
     return !(
       validation.source === FrontendValidationSource.Schema && validation.message.key === 'validation_errors.pattern'
     );
   }
 
-  getValidationFilter(_node: LayoutNode): ValidationFilterFunction | null {
-    return this.formatFilter;
+  getValidationFilters(_node: LayoutNode): ValidationFilterFunction[] {
+    if ('required' in _node.item && _node.item.required === true) {
+      return [this.schemaRequiredFilter, this.schemaFormatFilter];
+    }
+    return [this.schemaFormatFilter];
   }
 
   validateDataModelBindings(ctx: LayoutValidationCtx<'Datepicker'>): string[] {

--- a/src/layout/Datepicker/index.tsx
+++ b/src/layout/Datepicker/index.tsx
@@ -110,9 +110,6 @@ export class Datepicker extends DatepickerDef implements ValidateComponent, Vali
   }
 
   getValidationFilters(_node: LayoutNode): ValidationFilterFunction[] {
-    if ('required' in _node.item && _node.item.required === true) {
-      return [this.schemaRequiredFilter, this.schemaFormatFilter];
-    }
     return [this.schemaFormatFilter];
   }
 

--- a/src/layout/LayoutComponent.tsx
+++ b/src/layout/LayoutComponent.tsx
@@ -15,14 +15,8 @@ import { SimpleComponentHierarchyGenerator } from 'src/utils/layout/HierarchyGen
 import { BaseLayoutNode } from 'src/utils/layout/LayoutNode';
 import type { LayoutValidationCtx } from 'src/features/devtools/layoutValidation/types';
 import type { DisplayData, DisplayDataProps } from 'src/features/displayData';
-import type { BaseValidation, ComponentValidation, ValidationDataSources } from 'src/features/validation';
-import type {
-  FormDataSelector,
-  PropsFromGenericComponent,
-  ValidateEmptyField,
-  ValidationFilter,
-  ValidationFilterFunction,
-} from 'src/layout/index';
+import type { ComponentValidation, ValidationDataSources } from 'src/features/validation';
+import type { FormDataSelector, PropsFromGenericComponent, ValidateEmptyField } from 'src/layout/index';
 import type {
   CompExternalExact,
   CompInternal,
@@ -289,10 +283,7 @@ export abstract class ActionComponent<Type extends CompTypes> extends AnyCompone
   }
 }
 
-export abstract class FormComponent<Type extends CompTypes>
-  extends _FormComponent<Type>
-  implements ValidateEmptyField, ValidationFilter
-{
+export abstract class FormComponent<Type extends CompTypes> extends _FormComponent<Type> implements ValidateEmptyField {
   readonly type = CompCategory.Form;
 
   runEmptyFieldValidation(node: LayoutNode<Type>, { formData }: ValidationDataSources): ComponentValidation[] {
@@ -326,22 +317,6 @@ export abstract class FormComponent<Type extends CompTypes>
       }
     }
     return validations;
-  }
-
-  /**
-   * If required is true on the component, we should filter out the required validation from schema.
-   */
-  schemaRequiredFilter(validation: BaseValidation): boolean {
-    return !(
-      validation.source === FrontendValidationSource.Schema && validation.message.key === 'validation_errors.required'
-    );
-  }
-
-  getValidationFilters(_node: LayoutNode<Type>): ValidationFilterFunction[] {
-    if ('required' in _node.item && _node.item.required === true) {
-      return [this.schemaRequiredFilter];
-    }
-    return [];
   }
 }
 

--- a/src/layout/RepeatingGroup/index.tsx
+++ b/src/layout/RepeatingGroup/index.tsx
@@ -96,7 +96,7 @@ export class RepeatingGroup extends RepeatingGroupDef implements ValidateCompone
   /**
    * Repeating group has its own minCount property, so if set, we should filter out the minItems validation from schema.
    */
-  schemaMinItemsFilter(validation: BaseValidation): boolean {
+  private schemaMinItemsFilter(validation: BaseValidation): boolean {
     return !(
       validation.source === FrontendValidationSource.Schema && validation.message.key === 'validation_errors.minItems'
     );

--- a/src/layout/RepeatingGroup/index.tsx
+++ b/src/layout/RepeatingGroup/index.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import type { JSX } from 'react';
 
-import type { PropsFromGenericComponent, ValidateComponent } from '..';
+import type { PropsFromGenericComponent, ValidateComponent, ValidationFilter, ValidationFilterFunction } from '..';
 
 import { FrontendValidationSource, ValidationMask } from 'src/features/validation';
 import { RepeatingGroupDef } from 'src/layout/RepeatingGroup/config.def.generated';
@@ -11,12 +11,12 @@ import { RepeatingGroupProvider } from 'src/layout/RepeatingGroup/RepeatingGroup
 import { RepeatingGroupsFocusProvider } from 'src/layout/RepeatingGroup/RepeatingGroupFocusContext';
 import { SummaryRepeatingGroup } from 'src/layout/RepeatingGroup/Summary/SummaryRepeatingGroup';
 import type { LayoutValidationCtx } from 'src/features/devtools/layoutValidation/types';
-import type { ComponentValidation } from 'src/features/validation';
+import type { BaseValidation, ComponentValidation } from 'src/features/validation';
 import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { ComponentHierarchyGenerator } from 'src/utils/layout/HierarchyGenerator';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
-export class RepeatingGroup extends RepeatingGroupDef implements ValidateComponent {
+export class RepeatingGroup extends RepeatingGroupDef implements ValidateComponent, ValidationFilter {
   private _hierarchyGenerator = new GroupHierarchyGenerator();
 
   directRender(): boolean {
@@ -91,6 +91,22 @@ export class RepeatingGroup extends RepeatingGroupDef implements ValidateCompone
     }
 
     return validations;
+  }
+
+  /**
+   * Repeating group has its own minCount property, so if set, we should filter out the minItems validation from schema.
+   */
+  schemaMinItemsFilter(validation: BaseValidation): boolean {
+    return !(
+      validation.source === FrontendValidationSource.Schema && validation.message.key === 'validation_errors.minItems'
+    );
+  }
+
+  getValidationFilters(_node: LayoutNode<'RepeatingGroup'>): ValidationFilterFunction[] {
+    if ((_node.item.minCount ?? 0) > 0) {
+      return [this.schemaMinItemsFilter];
+    }
+    return [];
   }
 
   isDataModelBindingsRequired(): boolean {

--- a/src/layout/index.ts
+++ b/src/layout/index.ts
@@ -84,7 +84,7 @@ export type ValidationFilterFunction = (
 ) => boolean;
 
 export interface ValidationFilter {
-  getValidationFilter: (node: LayoutNode) => ValidationFilterFunction | null;
+  getValidationFilters: (node: LayoutNode) => ValidationFilterFunction[];
 }
 
 export type FormDataSelector = (path: string, postProcessor?: (data: unknown) => unknown) => unknown;
@@ -92,7 +92,7 @@ export type FormDataSelector = (path: string, postProcessor?: (data: unknown) =>
 export function implementsValidationFilter<Type extends CompTypes>(
   component: AnyComponent<Type>,
 ): component is typeof component & ValidationFilter {
-  return 'getValidationFilter' in component;
+  return 'getValidationFilters' in component;
 }
 
 export function implementsDisplayData<Type extends CompTypes>(


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

Give `minItems` errors from schema validation the same visibility as required. Make sure to filter out duplicate errors if both `minItems` is defined in schema and `minCount` is defined on the repeating group.

I added a tab in the node inspector to more easily observe the validation state of nodes. This will show validations for each dataModel binding, which type of validation it is, if it is visible and or filtered out as a duplicate. It also shows which validation types are visible for the node at the top (Schema, Component, CustomBackend,  etc.).

**A small digression**
I also explored the possibility of doing the same with required validations from the data model, as it would be nice to show these even if the component is not marked as required. Required validations in schema are currently ignored in the frontend but can occur in the backend. There were two main problems with this:
1. In JSON schema, required is actually defined on the parent object, not the field itself, so we would need to add a special case when figuring out what field the error should map to. This is trivial to solve, as the error object returned from AJV contains this information.
2. Data models often have their fields deeply nested, and whether or not a field is required is defined in the parent object. If the parent object that contains the definition of what is required does not exist, then the missing field is not really an error in the JSON schema world. This can easily occur since intermediate objects are not created before the datamodel is written to.
3. (Even more digression here, by @olemartinorg) Also, the form data context will remove properties when clearing fields, as the backend may define non-obvious default values, which will only be set when the property is removed (i.e. not when the field is set to empty string, `0` anything else - technically setting `null` may even cause problems if the field cannot be `null` according to the backend). We remove the property to avoid dealing with this, and the backend will respond with the default value for the field immediately when saving.
4. (Yet more digressions by @olemartinorg). Lastly, required on a property in JsonSchema is not the same as our required-validation for form fields. We produce en error if the value is "empty" (i.e. empty string), but technically an empty string is still a value and thus fully valid (and the requirement is fulfilled) according to JsonSchema.

## Related Issue(s)

- https://altinn.slack.com/archives/C02EJ9HKQA3/p1710332770814879?thread_ts=1710320934.677599&cid=C02EJ9HKQA3

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
