### PR TITLE
Align helptext with legend

### DIFF
--- a/src/layout/Checkboxes/CheckboxesContainerComponent.module.css
+++ b/src/layout/Checkboxes/CheckboxesContainerComponent.module.css
@@ -23,3 +23,8 @@
   gap: var(--fds-spacing-1);
   align-items: center;
 }
+
+.labelContent {
+  font-size: '1rem';
+  word-break: 'break-word';
+}

--- a/src/layout/Checkboxes/CheckboxesContainerComponent.tsx
+++ b/src/layout/Checkboxes/CheckboxesContainerComponent.tsx
@@ -33,13 +33,15 @@ export const CheckboxContainerComponent = ({ node, isValid, overrideDisplay }: I
   });
 
   const labelTextGroup = (
-    <span className={classes.checkBoxLabelContainer}>
-      <Lang id={node.item.textResourceBindings?.title} />
-      <RequiredIndicator required={required} />
-      <OptionalIndicator
-        labelSettings={labelSettings}
-        required={required}
-      />
+    <span className={classes.checkboxLabelContainer}>
+      <span className={classes.labelContent}>
+        <Lang id={node.item.textResourceBindings?.title} />
+        <RequiredIndicator required={required} />
+        <OptionalIndicator
+          labelSettings={labelSettings}
+          required={required}
+        />
+      </span>
       {textResourceBindings?.help && (
         <HelpText title={langAsString(textResourceBindings?.help)}>
           <Lang id={textResourceBindings?.help} />


### PR DESCRIPTION
## Description

Implements the Helptext in the same way as radiogroup, which aligns the helptext with the legend for checkboxes.

<img width="513" alt="image" src="https://github.com/Altinn/app-frontend-react/assets/32294735/1d77ef2b-5f89-49ae-bf44-ca51d77e716f">


<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes #1972 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [x] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
