### PR TITLE
fix: styled the text-only focus state to look more like the input state

### DIFF
--- a/src/layout/Input/InputComponent.module.css
+++ b/src/layout/Input/InputComponent.module.css
@@ -15,4 +15,13 @@
 
 .text-padding {
   padding: 0 var(--fds-spacing-2);
+  line-height: 32px;
+}
+
+.focusable:focus-visible {
+  --fds-focus-border-width: 3px;
+  outline: var(--fds-focus-border-width) solid var(--fds-semantic-border-focus-outline);
+  outline-offset: var(--fds-focus-border-width);
+  box-shadow: 0 0 0 var(--fds-focus-border-width) var(--fds-semantic-border-focus-boxshadow);
+  border-radius: var(--fds-border_radius-medium);
 }

--- a/src/layout/Input/InputComponent.tsx
+++ b/src/layout/Input/InputComponent.tsx
@@ -25,7 +25,7 @@ const TextOnly: React.FunctionComponent<TextfieldProps> = ({ className, id, valu
   <Paragraph
     id={id}
     size='small'
-    className={`${classes['text-padding']} ${className}`}
+    className={`${classes['text-padding']} ${classes['focusable']}  ${className}`}
     tabindex='0'
   >
     {value}


### PR DESCRIPTION
## Description

This is in response to this comment:

https://github.com/Altinn/app-frontend-react/issues/1833#issuecomment-2012475986

The styling is now updatet as suggested in the comment:

<img width="855" alt="Screenshot 2024-04-02 at 16 46 16" src="https://github.com/Altinn/app-frontend-react/assets/1534950/9c02e723-6177-4e8c-b59a-b755ca791da3">

## Related Issue(s)

- closes #{1833}

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
