### PR TITLE
Do not show required validation when data is invalid

### DIFF
--- a/src/features/validation/index.ts
+++ b/src/features/validation/index.ts
@@ -164,6 +164,7 @@ export type NodeValidation<Severity extends ValidationSeverity = ValidationSever
 export type ValidationDataSources = {
   currentLanguage: string;
   formData: object;
+  invalidData: object;
   attachments: IAttachments;
   nodes: LayoutPages;
 };

--- a/src/features/validation/nodeValidation/useNodeValidation.ts
+++ b/src/features/validation/nodeValidation/useNodeValidation.ts
@@ -69,6 +69,7 @@ export function useNodeValidation(): ComponentValidations {
  */
 export function useValidationDataSources(): ValidationDataSources {
   const formData = FD.useDebounced();
+  const invalidData = FD.useInvalidDebounced();
   const attachments = useAttachments();
   const currentLanguage = useCurrentLanguage();
   const nodes = useNodes();
@@ -76,10 +77,11 @@ export function useValidationDataSources(): ValidationDataSources {
   return useMemo(
     () => ({
       formData,
+      invalidData,
       attachments,
       currentLanguage,
       nodes,
     }),
-    [attachments, currentLanguage, formData, nodes],
+    [attachments, currentLanguage, formData, invalidData, nodes],
   );
 }

--- a/src/layout/LayoutComponent.tsx
+++ b/src/layout/LayoutComponent.tsx
@@ -286,7 +286,10 @@ export abstract class ActionComponent<Type extends CompTypes> extends AnyCompone
 export abstract class FormComponent<Type extends CompTypes> extends _FormComponent<Type> implements ValidateEmptyField {
   readonly type = CompCategory.Form;
 
-  runEmptyFieldValidation(node: LayoutNode<Type>, { formData }: ValidationDataSources): ComponentValidation[] {
+  runEmptyFieldValidation(
+    node: LayoutNode<Type>,
+    { formData, invalidData }: ValidationDataSources,
+  ): ComponentValidation[] {
     if (!('required' in node.item) || !node.item.required || !node.item.dataModelBindings) {
       return [];
     }
@@ -294,7 +297,7 @@ export abstract class FormComponent<Type extends CompTypes> extends _FormCompone
     const validations: ComponentValidation[] = [];
 
     for (const [bindingKey, field] of Object.entries(node.item.dataModelBindings) as [string, string][]) {
-      const data = dot.pick(field, formData);
+      const data = dot.pick(field, formData) ?? dot.pick(field, invalidData);
       const asString =
         typeof data === 'string' || typeof data === 'number' || typeof data === 'boolean' ? String(data) : '';
       const trb: ITextResourceBindings = 'textResourceBindings' in node.item ? node.item.textResourceBindings : {};

--- a/src/layout/List/index.tsx
+++ b/src/layout/List/index.tsx
@@ -39,7 +39,10 @@ export class List extends ListDef {
     return <SummaryItemSimple formDataAsString={displayData} />;
   }
 
-  runEmptyFieldValidation(node: LayoutNode<'List'>, { formData }: ValidationDataSources): ComponentValidation[] {
+  runEmptyFieldValidation(
+    node: LayoutNode<'List'>,
+    { formData, invalidData }: ValidationDataSources,
+  ): ComponentValidation[] {
     if (!node.item.required || !node.item.dataModelBindings) {
       return [];
     }
@@ -52,7 +55,7 @@ export class List extends ListDef {
 
     let listHasErrors = false;
     for (const field of fields) {
-      const data = dot.pick(field, formData);
+      const data = dot.pick(field, formData) ?? dot.pick(field, invalidData);
       const dataAsString =
         typeof data === 'string' || typeof data === 'number' || typeof data === 'boolean' ? String(data) : undefined;
 


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

This small change makes sure to check the `invalidData` object as well when checking for empty fields, so that required validation is not shown e.g. when an integer is too big. Tested manually on `ssb/ra0439-01` as well.

## Related Issue(s)

- closes #1890

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
