### PR TITLE
Render linkToComponent and linkToPage as pure text if hidden/does not exist

### DIFF
--- a/src/components/form/LinkToPotentialNode.tsx
+++ b/src/components/form/LinkToPotentialNode.tsx
@@ -26,9 +26,7 @@ export const LinkToPotentialNode = (props: Props) => {
   const shouldShowLink = nodeExists && !isNodeHidden;
 
   if (shouldShowLink) {
-    return (
-      <Link {...props} />
-    );
+    return <Link {...props} />;
   }
 
   if (!nodeExists) {

--- a/src/components/form/LinkToPotentialNode.tsx
+++ b/src/components/form/LinkToPotentialNode.tsx
@@ -27,10 +27,7 @@ export const LinkToPotentialNode = (props: Props) => {
 
   if (shouldShowLink) {
     return (
-      <Link
-        {...props}
-        replace={!nodeExists}
-      ></Link>
+      <Link {...props} />
     );
   }
 

--- a/src/components/form/LinkToPotentialNode.tsx
+++ b/src/components/form/LinkToPotentialNode.tsx
@@ -5,22 +5,44 @@ import type { LinkProps } from 'react-router-dom';
 import { SearchParams } from 'src/hooks/useNavigatePage';
 import { useResolvedNode } from 'src/utils/layout/NodesContext';
 
+type Props = LinkProps & { children?: React.ReactNode };
+
 /**
  * This component is used to navigate to a potential node. If the node it is supposed
- * to navigate to does not exist, the link will not replace the current page with the
- * page it is supposed to navigate to.
+ * to navigate to does not exist or the node is hidden, the link will render as pure
+ * text instead of a link.
  * @param props
  * @constructor
  */
-export const LinkToPotentialNode = (props: LinkProps) => {
+export const LinkToPotentialNode = (props: Props) => {
   const [_url, queryParams] = props.to.toString().split('?') ?? [];
+
   const url = new URLSearchParams(queryParams);
-  const resolvedNode = useResolvedNode(url.get(SearchParams.FocusComponentId));
+  const componentId = url.get(SearchParams.FocusComponentId);
+  const resolvedNode = useResolvedNode(componentId);
+
   const nodeExists = resolvedNode != null;
-  return (
-    <Link
-      {...props}
-      replace={!nodeExists}
-    ></Link>
-  );
+  const isNodeHidden = resolvedNode?.isHidden();
+  const shouldShowLink = nodeExists && !isNodeHidden;
+
+  if (shouldShowLink) {
+    return (
+      <Link
+        {...props}
+        replace={!nodeExists}
+      ></Link>
+    );
+  }
+
+  if (!nodeExists) {
+    window.logWarnOnce(
+      `linkToComponent points to a component that does not exist. The link is therefore rendered as pure text. Component ID you tried to link to: ${componentId}`,
+    );
+  } else if (isNodeHidden) {
+    window.logWarnOnce(
+      `linkToComponent points to a component that is hidden. The link is therefore rendered as pure text. Component ID you tried to link to: ${componentId}`,
+    );
+  }
+
+  return <>{props.children}</>;
 };

--- a/src/components/form/LinkToPotentialPage.tsx
+++ b/src/components/form/LinkToPotentialPage.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import type { LinkProps } from 'react-router-dom';
+
+import { useIsHiddenPage } from 'src/features/form/layout/PageNavigationContext';
+import { useNavigatePage } from 'src/hooks/useNavigatePage';
+
+type Props = LinkProps & { children?: React.ReactNode };
+
+/**
+ * This component is used to navigate to a potential page. If the page it is supposed
+ * to navigate to does not exist or the page is hidden, the link will turn into pure text.
+ * @param props
+ * @constructor
+ */
+export const LinkToPotentialPage = (props: Props) => {
+  const parts = props.to.toString().split('/') ?? [];
+  const page = parts[parts.length - 1];
+
+  const isHiddenPage = useIsHiddenPage();
+  const { isValidPageId } = useNavigatePage();
+
+  const shouldShowLink = isValidPageId(page) && !isHiddenPage(page);
+
+  if (shouldShowLink) {
+    return <Link {...props} />;
+  }
+
+  if (isHiddenPage(page)) {
+    window.logWarnOnce(
+      `linkToPage points to a page that is hidden. The link is therefore rendered as pure text. Page you tried to link to: ${page}`,
+    );
+  } else if (!isValidPageId(page)) {
+    window.logWarnOnce(
+      `linkToPage points to a page that does not exist. The link is therefore rendered as pure text. Page you tried to link to: ${page}`,
+    );
+  }
+
+  return <>{props.children}</>;
+};

--- a/src/features/expressions/index.ts
+++ b/src/features/expressions/index.ts
@@ -664,11 +664,11 @@ export const ExprFunctions = {
 
       let url = '';
       if (taskId && instanceId) {
-        url = `#/instance/${instanceId}/${taskId}/${pageId}`;
+        url = `/instance/${instanceId}/${taskId}/${pageId}`;
       } else {
-        url = `#/${pageId}`;
+        url = `/${pageId}`;
       }
-      return `<a href="${url}" class="same-window">${linkText}</a>`;
+      return `<a href="${url}" data-link-type="LinkToPotentialPage">${linkText}</a>`;
     },
     args: [ExprVal.String, ExprVal.String] as const,
     minArguments: 2,

--- a/src/features/expressions/shared-tests/functions/linkToPage/linkToPage-stateless.json
+++ b/src/features/expressions/shared-tests/functions/linkToPage/linkToPage-stateless.json
@@ -1,5 +1,5 @@
 {
   "name": "Should create a link with reference to a page when no instance is provided",
   "expression": ["linkToPage", "Klikk på meg", "grid"],
-  "expects": "<a href=\"#/grid\" class=\"same-window\">Klikk på meg</a>"
+  "expects": "<a href=\"/grid\" data-link-type=\"LinkToPotentialPage\">Klikk på meg</a>"
 }

--- a/src/features/expressions/shared-tests/functions/linkToPage/linkToPage.json
+++ b/src/features/expressions/shared-tests/functions/linkToPage/linkToPage.json
@@ -1,7 +1,7 @@
 {
   "name": "Should create a link with reference to a page when instance is provided",
   "expression": ["linkToPage", "Klikk på meg", "grid"],
-  "expects": "<a href=\"#/instance/510001/d00ce51c-800b-416a-a906-ccab55f597e9/Task_3/grid\" class=\"same-window\">Klikk på meg</a>",
+  "expects": "<a href=\"/instance/510001/d00ce51c-800b-416a-a906-ccab55f597e9/Task_3/grid\" data-link-type=\"LinkToPotentialPage\">Klikk på meg</a>",
   "instance": {
     "id": "510001/d00ce51c-800b-416a-a906-ccab55f597e9",
     "appId": "org/app-name",

--- a/src/language/sharedLanguage.ts
+++ b/src/language/sharedLanguage.ts
@@ -8,6 +8,7 @@ import { mangle } from 'marked-mangle';
 import type { DOMNode, Element, HTMLReactParserOptions } from 'html-react-parser';
 
 import { LinkToPotentialNode } from 'src/components/form/LinkToPotentialNode';
+import { LinkToPotentialPage } from 'src/components/form/LinkToPotentialPage';
 import { cachedFunction } from 'src/utils/cachedFunction';
 
 marked.use(mangle());
@@ -108,6 +109,13 @@ const parserOptions: HTMLReactParserOptions = {
     if (isElement(domNode) && domNode.name === 'a' && domNode.attribs['data-link-type'] === 'LinkToPotentialNode') {
       return React.createElement(
         LinkToPotentialNode,
+        { to: domNode.attribs.href, preventScrollReset: true },
+        domToReact(domNode.children as DOMNode[], parserOptions),
+      );
+    }
+    if (isElement(domNode) && domNode.name === 'a' && domNode.attribs['data-link-type'] === 'LinkToPotentialPage') {
+      return React.createElement(
+        LinkToPotentialPage,
         { to: domNode.attribs.href, preventScrollReset: true },
         domToReact(domNode.children as DOMNode[], parserOptions),
       );

--- a/test/e2e/integration/frontend-test/navigation.ts
+++ b/test/e2e/integration/frontend-test/navigation.ts
@@ -194,7 +194,7 @@ describe('Navigation', () => {
     cy.url().should('satisfy', (url) => url.endsWith('/Task_3/prefill'));
   });
 
-  it('should navigate back to previous page when using browser back after trying to navigate to a non-existent component', () => {
+  it('Should render link as text and not link if it points to a non exisiting component', () => {
     cy.interceptLayout(
       'group',
       (component) => component,
@@ -212,15 +212,10 @@ describe('Navigation', () => {
     );
     cy.goto('group');
 
-    cy.findByRole('button', { name: /hide/ }).click();
-    cy.url().should('satisfy', (url) => url.endsWith('/Task_3/hide'));
-    cy.findByRole('button', { name: /prefill/ }).click();
     cy.url().should('satisfy', (url) => url.endsWith('/Task_3/prefill'));
 
-    cy.findByRole('link', { name: 'Klikk på meg' }).click();
-
-    cy.go('back');
-    cy.url().should('satisfy', (url) => url.endsWith('/Task_3/hide'));
+    cy.findByRole('link', { name: 'Klikk på meg' }).should('not.exist');
+    cy.findByText('Klikk på meg').should('exist');
   });
 
   it('should navigate back to previous page when using browser back after trying to navigate to a non-existent component', () => {


### PR DESCRIPTION
## Description

When `linkToComponent` or `linkToPage` points to components or pages that are either hidden or does not exist, the functions render the link ass pure text. A warning will also be logged to the developer tools that the link pointed to a component or page that did not exist. 

## Related Issue(s)

- closes #1648

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
