### PR TITLE
fix: returning null if input is null or empty string

### DIFF
--- a/src/layout/Input/InputComponent.tsx
+++ b/src/layout/Input/InputComponent.tsx
@@ -21,16 +21,27 @@ interface InputComponentProps extends TextfieldProps {
   textOnly?: boolean;
 }
 
-const TextOnly: React.FunctionComponent<TextfieldProps> = ({ className, id, value }) => (
-  <Paragraph
-    id={id}
-    size='small'
-    className={`${classes['text-padding']} ${classes['focusable']}  ${className}`}
-    tabindex='0'
-  >
-    {value}
-  </Paragraph>
-);
+const TextOnly: React.FunctionComponent<TextfieldProps> = ({ className, id, value }) => {
+  // If the value is null or empty string, we dont render anything to prevent an empty tabbable paragraph
+  if (value === null) {
+    return null;
+  }
+
+  if (typeof value === 'string' && value.length === 0) {
+    return null;
+  }
+
+  return (
+    <Paragraph
+      id={id}
+      size='small'
+      className={`${classes['text-padding']} ${classes['focusable']}  ${className}`}
+      tabindex='0'
+    >
+      {value}
+    </Paragraph>
+  );
+};
 
 // We need to use this wrapped Textfield component because we have a conflict between the 'size' prop
 // of the TextField and the react-number-format components which also have a 'size' prop


### PR DESCRIPTION
## Description

User reports this box being shown when there is not yet any data:

![bug](https://github.com/Altinn/app-frontend-react/assets/1534950/14e753fa-6746-42fe-a6ca-6c717cf4d780)

This fixes the issue by returning null when the input is null or empty string.

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [ x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
