### PR TITLE
Fix PDF generator crashing when having Grid inside Group

### DIFF
--- a/src/layout/Grid/GridSummaryComponent.tsx
+++ b/src/layout/Grid/GridSummaryComponent.tsx
@@ -18,11 +18,11 @@ export function GridSummaryComponent({
           key={node.item.id}
           summaryNode={summaryNode}
           overrides={{
-            targetNode: node,
             ...overrides,
+            targetNode: node,
             display: {
-              hideBottomBorder: idx === nodes.length - 1,
               ...overrides?.display,
+              hideBottomBorder: idx === nodes.length - 1,
             },
           }}
         />

--- a/test/e2e/integration/frontend-test/pdf.ts
+++ b/test/e2e/integration/frontend-test/pdf.ts
@@ -222,4 +222,41 @@ describe('PDF', () => {
       cy.findByRole('heading', { name: /this is a custom pdf/i }).should('be.visible');
     });
   });
+
+  // Used to cause a crash, @see https://github.com/Altinn/app-frontend-react/pull/2019
+  it('Grid in Group should display correctly', () => {
+    cy.intercept('GET', '**/layouts/**', (req) => {
+      req.continue((res) => {
+        const body = JSON.parse(res.body);
+        res.body = JSON.stringify({
+          ...body,
+          grid: {
+            ...body.grid,
+            data: {
+              ...body.grid.data,
+              layout: [
+                {
+                  id: 'gridGroup',
+                  type: 'Group',
+                  textResourceBindings: {
+                    title: 'Grid gruppe',
+                  },
+                  children: ['page3-grid'],
+                },
+                ...body.grid.data.layout,
+              ],
+            },
+          },
+        });
+      });
+    });
+
+    cy.goto('changename');
+
+    cy.testPdf(() => {
+      cy.findByRole('heading', { name: /grid gruppe/i }).should('be.visible');
+      cy.findByText('Prosentandel av gjeld i boliglån').should('be.visible');
+      cy.findByText('Utregnet totalprosent').should('be.visible');
+    });
+  });
 });


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

The problem was caused by the targetNode in GridSummaryComponent not overriding the existing value from overrides, causing it to refer to itself recursively, since the existing value was from the group component above.

## Related Issue(s)

- slack https://altinn.slack.com/archives/C02EJ9HKQA3/p1712827090911089

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
