### PR TITLE
Add function select to dynamic expressions

### DIFF
--- a/schemas/json/layout/expression.schema.v1.json
+++ b/schemas/json/layout/expression.schema.v1.json
@@ -77,6 +77,7 @@
         { "$ref": "#/definitions/func-language" },
         { "$ref": "#/definitions/func-lowerCase" },
         { "$ref": "#/definitions/func-upperCase" },
+        { "$ref": "#/definitions/func-_experimentalSelectAndMap" },
         { "$ref": "#/definitions/func-argv"}
       ]
     },
@@ -465,6 +466,20 @@
       "items": [
         { "const":  "upperCase" },
         { "$ref": "#/definitions/string" }
+      ],
+      "additionalItems": false
+    },
+    "func-_experimentalSelectAndMap": {
+      "title": "Experimental Select and map function",
+      "description": "This function takes a data model path which points to an array in the data model, and selects a specific property from the object in the containing array. It then concatenates the selected values into a single string separated by a space. The values can be prepended and appended with a string constant. This function is experimental and will be removed in future versions. Do not use unless you know what you're doing.",
+      "type": "array",
+      "items": [
+        { "const":  "_experimentalSelectAndMap" },
+        { "$ref": "#/definitions/string" },
+        { "$ref": "#/definitions/string" },
+        { "$ref": "#/definitions/string" },
+        { "$ref": "#/definitions/string" },
+        { "$ref": "#/definitions/boolean" }
       ],
       "additionalItems": false
     },

--- a/src/features/expressions/index.ts
+++ b/src/features/expressions/index.ts
@@ -760,6 +760,30 @@ export const ExprFunctions = {
     args: [ExprVal.String] as const,
     returns: ExprVal.String,
   }),
+  _experimentalSelectAndMap: defineFunc({
+    args: [ExprVal.String, ExprVal.String, ExprVal.String, ExprVal.String, ExprVal.Boolean] as const,
+    impl(path, propertyToSelect, prepend, append, appendToLastElement = true) {
+      if (path === null || propertyToSelect == null) {
+        throw new ExprRuntimeError(this, `Cannot lookup dataModel null`);
+      }
+      const array = this.dataSources.formDataSelector(path);
+      if (typeof array != 'object' || !Array.isArray(array)) {
+        return '';
+      }
+      return array
+        .map((x, i) => {
+          const hideLastElement = i == array.length - 1 && !appendToLastElement;
+
+          const valueToPrepend = prepend == null ? '' : prepend;
+          const valueToAppend = append == null || hideLastElement ? '' : append;
+
+          return `${valueToPrepend}${x[propertyToSelect]}${valueToAppend}`;
+        })
+        .join(' ');
+    },
+    minArguments: 2,
+    returns: ExprVal.String,
+  }),
 };
 
 function asNumber(arg: string) {

--- a/src/features/expressions/shared-tests/functions/_experimentalSelectAndMap/_experimentalSelectAndMap-with-append-without-last-element.json
+++ b/src/features/expressions/shared-tests/functions/_experimentalSelectAndMap/_experimentalSelectAndMap-with-append-without-last-element.json
@@ -1,0 +1,25 @@
+{
+  "name": "Should return a string with selected property",
+  "expression": ["_experimentalSelectAndMap", "path.to.arrayOfObjects", "name", "", ",", false],
+  "expects": "Prop1, Prop2, Prop3",
+  "dataModel": {
+    "path": {
+      "to": {
+        "arrayOfObjects": [
+          {
+            "name": "Prop1",
+            "value": "Value1"
+          },
+          {
+            "name": "Prop2",
+            "value": "Value2"
+          },
+          {
+            "name": "Prop3",
+            "value": "Value3"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/features/expressions/shared-tests/functions/_experimentalSelectAndMap/_experimentalSelectAndMap-with-prepend-and-append.json
+++ b/src/features/expressions/shared-tests/functions/_experimentalSelectAndMap/_experimentalSelectAndMap-with-prepend-and-append.json
@@ -1,0 +1,25 @@
+{
+  "name": "Should return a string with selected property",
+  "expression": ["_experimentalSelectAndMap", "path.to.arrayOfObjects", "name", "<li>", "</li>"],
+  "expects": "<li>Prop1</li> <li>Prop2</li> <li>Prop3</li>",
+  "dataModel": {
+    "path": {
+      "to": {
+        "arrayOfObjects": [
+          {
+            "name": "Prop1",
+            "value": "Value1"
+          },
+          {
+            "name": "Prop2",
+            "value": "Value2"
+          },
+          {
+            "name": "Prop3",
+            "value": "Value3"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/features/expressions/shared-tests/functions/_experimentalSelectAndMap/_experimentalSelectAndMap.json
+++ b/src/features/expressions/shared-tests/functions/_experimentalSelectAndMap/_experimentalSelectAndMap.json
@@ -1,0 +1,25 @@
+{
+  "name": "Should return a string with selected property",
+  "expression": ["_experimentalSelectAndMap", "path.to.arrayOfObjects", "name"],
+  "expects": "Prop1 Prop2 Prop3",
+  "dataModel": {
+    "path": {
+      "to": {
+        "arrayOfObjects": [
+          {
+            "name": "Prop1",
+            "value": "Value1"
+          },
+          {
+            "name": "Prop2",
+            "value": "Value2"
+          },
+          {
+            "name": "Prop3",
+            "value": "Value3"
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

_This is a feature request, and I would like some feedback as to whether you think this should be implemented or not._

This PR introduces a new function `_experimentalSelectAndMap` to the dynamic expression language. The function selects string properties in objects of an array in the data model and concatenates them to a single string. The reason for this is to be able to create a list of something in a form's data model. 

Usage: 

Say you have this underlying data structure: 
```json 
{
  "path": {
    "to": {
      "arrayOfObjects": [
        {
          "name": "Prop1",
          "value": "Value1"
        },
        {
          "name": "Prop2",
          "value": "Value2"
        },
        {
          "name": "Prop3",
          "value": "Value3"
        }
      ]
    }
  }
}
```

```json 
["_experimentalSelectAndMap", "path.to.arrayOfObjects", "name"]
``` 
Would result in the string `Prop1 Prop2 Prop3`

The function accepts two optional parameters that are string constants to prepend and append to each item in the list. 

```json 
["_experimentalSelectAndMap", "path.to.arrayOfObjects", "name", "<li>", "</li>"]
``` 
Would result in the string `<li>Prop1</li> <li>Prop2</li> <li>Prop3</li>`

Appending to the last element in the list is optional but on by default. 


```json 
["_experimentalSelectAndMap", "path.to.arrayOfObjects", "name", "", ",", false]
``` 
Would result in the string `Prop1, Prop2, Prop3`

A typical use case for this would be to show a list of names from some data structure. The need arose in Digital gravferdsmelding, where there is a need to be able to list deceased people who already have somebody to take care of their funeral. 

![image](https://github.com/Altinn/app-frontend-react/assets/26043795/a24e665e-fe56-450c-803b-c51d3ac80d5c)

I realize I can probably already achieve this by creating the output string on the backend and show the string in clear text in the form. However, I think it would be nice to have this kind of function as this would allow service owners to implement something like this in Altinn Studio without having to write C# code. 


## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [x] I will do that later/have created an issue - This feature will be undocumented as it is not intended to be removed in the future. It will be replaced by a more comprehensive list operation workflow in the dynamic expression language. 
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
