### PR TITLE
Make sure patch requests sets the correct `language` param

### DIFF
--- a/src/features/datamodel/useBindingSchema.tsx
+++ b/src/features/datamodel/useBindingSchema.tsx
@@ -14,11 +14,10 @@ import { useLayoutSets } from 'src/features/form/layoutSets/LayoutSetsProvider';
 import { useCurrentLayoutSetId } from 'src/features/form/layoutSets/useCurrentLayoutSetId';
 import { useLaxInstanceData } from 'src/features/instance/InstanceContext';
 import { useProcessTaskId } from 'src/features/instance/useProcessTaskId';
-import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
 import { useAllowAnonymous } from 'src/features/stateless/getAllowAnonymous';
 import {
   getAnonymousStatelessDataModelUrl,
-  getDataElementUrl,
+  getDataModelUrl,
   getStatelessDataModelUrl,
 } from 'src/utils/urls/appUrlHelper';
 import { useIsStatelessApp } from 'src/utils/useIsStatelessApp';
@@ -44,7 +43,6 @@ export function useCurrentDataModelUrl(includeRowIds: boolean) {
   const dataType = useDataTypeByLayoutSetId(layoutSetId);
   const dataElementUuid = useCurrentDataModelGuid();
   const isStateless = useIsStatelessApp();
-  const language = useCurrentLanguage();
 
   if (isStateless && isAnonymous && dataType) {
     return getAnonymousStatelessDataModelUrl(dataType, includeRowIds);
@@ -55,7 +53,7 @@ export function useCurrentDataModelUrl(includeRowIds: boolean) {
   }
 
   if (instance?.id && dataElementUuid) {
-    return getDataElementUrl(instance.id, dataElementUuid, language, includeRowIds);
+    return getDataModelUrl(instance.id, dataElementUuid, includeRowIds);
   }
 
   return undefined;
@@ -65,7 +63,6 @@ export function useDataModelUrl(includeRowIds: boolean, dataType: string | undef
   const isAnonymous = useAllowAnonymous();
   const isStateless = useIsStatelessApp();
   const instance = useLaxInstanceData();
-  const language = useCurrentLanguage();
 
   if (isStateless && isAnonymous && dataType) {
     return getAnonymousStatelessDataModelUrl(dataType, includeRowIds);
@@ -78,7 +75,7 @@ export function useDataModelUrl(includeRowIds: boolean, dataType: string | undef
   if (instance?.id && dataType) {
     const uuid = getFirstDataElementId(instance, dataType);
     if (uuid) {
-      return getDataElementUrl(instance.id, uuid, language, includeRowIds);
+      return getDataModelUrl(instance.id, uuid, includeRowIds);
     }
   }
 

--- a/src/features/formData/FormDataReaders.test.tsx
+++ b/src/features/formData/FormDataReaders.test.tsx
@@ -88,7 +88,7 @@ async function render(props: TestProps) {
     for (const [uuid, name] of Object.entries(idToNameMap)) {
       if (name === dataModelName) {
         const isDefault = dataModelName === props.defaultDataModel;
-        return `https://local.altinn.cloud/ttd/test/instances/${instanceId}/data/${uuid}?language=nb&includeRowId=${isDefault.toString()}`;
+        return `https://local.altinn.cloud/ttd/test/instances/${instanceId}/data/${uuid}?includeRowId=${isDefault.toString()}&language=nb`;
       }
     }
     return false;

--- a/src/features/formData/FormDataReaders.tsx
+++ b/src/features/formData/FormDataReaders.tsx
@@ -7,8 +7,10 @@ import { ContextNotProvided, createContext } from 'src/core/contexts/context';
 import { useAvailableDataModels } from 'src/features/datamodel/useAvailableDataModels';
 import { useDataModelUrl } from 'src/features/datamodel/useBindingSchema';
 import { useFormDataQuery } from 'src/features/formData/useFormDataQuery';
+import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
 import { useAsRef } from 'src/hooks/useAsRef';
 import { useNavigationParams } from 'src/hooks/useNavigatePage';
+import { getUrlWithLanguage } from 'src/utils/urls/urlHelper';
 
 type ReaderMap = { [name: string]: DataModelReader };
 
@@ -191,7 +193,7 @@ export function DataModelFetcher() {
 }
 
 function SpecificDataModelFetcher({ reader, isAvailable }: { reader: DataModelReader; isAvailable: boolean }) {
-  const url = useDataModelUrl(false, reader.getName());
+  const url = getUrlWithLanguage(useDataModelUrl(false, reader.getName()), useCurrentLanguage());
   const enabled = isAvailable && reader.isLoading();
   const { data, error } = useFormDataQuery(enabled ? url : undefined);
   const { updateModel } = useCtx();

--- a/src/features/formData/FormDataWrite.tsx
+++ b/src/features/formData/FormDataWrite.tsx
@@ -14,8 +14,10 @@ import { useRuleConnections } from 'src/features/form/dynamics/DynamicsContext';
 import { useFormDataWriteProxies } from 'src/features/formData/FormDataWriteProxies';
 import { createFormDataWriteStore } from 'src/features/formData/FormDataWriteStateMachine';
 import { createPatch } from 'src/features/formData/jsonPatch/createPatch';
+import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
 import { useAsRef } from 'src/hooks/useAsRef';
 import { useWaitForState } from 'src/hooks/useWaitForState';
+import { getUrlWithLanguage } from 'src/utils/urls/urlHelper';
 import { useIsStatelessApp } from 'src/utils/useIsStatelessApp';
 import type { SchemaLookupTool } from 'src/features/datamodel/DataModelSchemaProvider';
 import type { IRuleConnections } from 'src/features/form/dynamics';
@@ -67,6 +69,7 @@ const {
 function useFormDataSaveMutation() {
   const { doPatchFormData, doPostStatelessFormData } = useAppMutations();
   const dataModelUrl = useSelector((s) => s.controlState.saveUrl);
+  const currentLanguageRef = useAsRef(useCurrentLanguage());
   const saveFinished = useSelector((s) => s.saveFinished);
   const cancelSave = useSelector((s) => s.cancelSave);
   const isStateless = useIsStatelessApp();
@@ -97,8 +100,11 @@ function useFormDataSaveMutation() {
         return;
       }
 
+      // Add current language as a query parameter
+      const urlWithLanguage = getUrlWithLanguage(dataModelUrl, currentLanguageRef.current);
+
       if (isStateless) {
-        const newDataModel = await doPostStatelessFormData(dataModelUrl, next);
+        const newDataModel = await doPostStatelessFormData(urlWithLanguage, next);
         return { newDataModel, savedData: next, validationIssues: undefined };
       } else {
         const patch = createPatch({ prev, next });
@@ -106,7 +112,7 @@ function useFormDataSaveMutation() {
           return;
         }
 
-        const result = await doPatchFormData(dataModelUrl, {
+        const result = await doPatchFormData(urlWithLanguage, {
           patch,
           ignoredValidators: [],
         });

--- a/src/features/formData/InitialFormData.tsx
+++ b/src/features/formData/InitialFormData.tsx
@@ -8,8 +8,10 @@ import { usePageSettings } from 'src/features/form/layoutSettings/LayoutSettings
 import { FormDataWriteProvider } from 'src/features/formData/FormDataWrite';
 import { useFormDataQuery } from 'src/features/formData/useFormDataQuery';
 import { MissingRolesError } from 'src/features/instantiate/containers/MissingRolesError';
+import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
 import { isAxiosError } from 'src/utils/isAxiosError';
 import { HttpStatusCodes } from 'src/utils/network/networking';
+import { getUrlWithLanguage } from 'src/utils/urls/urlHelper';
 
 /**
  * This provider loads the initial form data for a data task, and then provides a FormDataWriteProvider with that
@@ -17,7 +19,7 @@ import { HttpStatusCodes } from 'src/utils/network/networking';
  */
 export function InitialFormDataProvider({ children }: PropsWithChildren) {
   const url = useCurrentDataModelUrl(true);
-  const { error, isLoading, data } = useFormDataQuery(url);
+  const { error, isLoading, data } = useFormDataQuery(getUrlWithLanguage(url, useCurrentLanguage()));
   const autoSaveBehaviour = usePageSettings().autoSaveBehavior;
 
   if (!url) {

--- a/src/layout/FileUpload/FileUploadTable/AttachmentFileName.tsx
+++ b/src/layout/FileUpload/FileUploadTable/AttachmentFileName.tsx
@@ -17,7 +17,7 @@ export const AttachmentFileName = ({ attachment, mobileView }: { attachment: IAt
   const instanceId = useLaxInstanceData()?.id;
   const url =
     isAttachmentUploaded(attachment) && instanceId
-      ? makeUrlRelativeIfSameDomain(getDataElementUrl(instanceId, attachment.data.id, language, false))
+      ? makeUrlRelativeIfSameDomain(getDataElementUrl(instanceId, attachment.data.id, language))
       : undefined;
 
   const fileName = (

--- a/src/queries/queries.ts
+++ b/src/queries/queries.ts
@@ -136,7 +136,7 @@ export const doPerformAction = async (partyId: string, dataGuid: string, data: a
 };
 
 export const doAttachmentRemove = async (instanceId: string, dataGuid: string, language: string): Promise<void> => {
-  const response = await httpDelete(getDataElementUrl(instanceId, dataGuid, language, false));
+  const response = await httpDelete(getDataElementUrl(instanceId, dataGuid, language));
   if (response.status !== 200) {
     throw new Error('Failed to remove attachment');
   }

--- a/src/utils/urls/appUrlHelper.ts
+++ b/src/utils/urls/appUrlHelper.ts
@@ -33,13 +33,14 @@ export const getFileTagUrl = (instanceId: string, dataGuid: string, tag: string 
 };
 
 export const getAnonymousStatelessDataModelUrl = (dataType: string, includeRowIds: boolean) =>
-  `${appPath}/v1/data/anonymous?dataType=${dataType}&includeRowId=${includeRowIds.toString()}}`;
+  `${appPath}/v1/data/anonymous?dataType=${dataType}&includeRowId=${includeRowIds.toString()}`;
 export const getStatelessDataModelUrl = (dataType: string, includeRowIds: boolean) =>
-  `${appPath}/v1/data?dataType=${dataType}&includeRowId=${includeRowIds.toString()}}`;
-export const getDataElementUrl = (instanceId: string, dataGuid: string, language: string, includeRowIds: boolean) => {
-  const queryString = getQueryStringFromObject({ language, includeRowId: includeRowIds.toString() });
-  return `${appPath}/instances/${instanceId}/data/${dataGuid}${queryString}`;
-};
+  `${appPath}/v1/data?dataType=${dataType}&includeRowId=${includeRowIds.toString()}`;
+export const getDataModelUrl = (instanceId: string, dataGuid: string, includeRowIds: boolean) =>
+  `${appPath}/instances/${instanceId}/data/${dataGuid}?includeRowId=${includeRowIds.toString()}`;
+
+export const getDataElementUrl = (instanceId: string, dataGuid: string, language: string) =>
+  `${appPath}/instances/${instanceId}/data/${dataGuid}?language=${language}`;
 
 export const getProcessStateUrl = (instanceId: string) => `${appPath}/instances/${instanceId}/process`;
 export const getActionsUrl = (partyId: string, instanceId: string) =>

--- a/src/utils/urls/urlHelper.test.ts
+++ b/src/utils/urls/urlHelper.test.ts
@@ -1,5 +1,6 @@
 import {
   customEncodeURI,
+  getUrlWithLanguage,
   logoutUrlAltinn,
   makeUrlRelativeIfSameDomain,
   returnBaseUrlToAltinn,
@@ -121,5 +122,49 @@ describe('Shared urlHelper.ts', () => {
         hostname: 'altinn3local.no',
       } as Location),
     ).toBe('/');
+  });
+
+  describe('getUrlWithLanguage', () => {
+    const testCases = [
+      {
+        url: 'https://local.altinn.cloud/ttd/test/instances/12345/123-123-123/data/456-456-456?includeRowId=true',
+        language: 'nb',
+        expected:
+          'https://local.altinn.cloud/ttd/test/instances/12345/123-123-123/data/456-456-456?includeRowId=true&language=nb',
+      },
+      {
+        url: 'https://local.altinn.cloud/ttd/test/instances/12345/123-123-123/data/456-456-456',
+        language: 'en',
+        expected: 'https://local.altinn.cloud/ttd/test/instances/12345/123-123-123/data/456-456-456?language=en',
+      },
+      {
+        url: 'https://local.altinn.cloud/ttd/test/instances/12345/123-123-123/data/456-456-456?language=en',
+        language: 'nb',
+        expected: 'https://local.altinn.cloud/ttd/test/instances/12345/123-123-123/data/456-456-456?language=nb',
+      },
+      {
+        url: undefined,
+        language: 'nb',
+        expected: undefined,
+      },
+      {
+        url: 'https://local.altinn.cloud/ttd/test/instances/12345/123-123-123/data/456-456-456?language=en',
+        language: undefined,
+        expected: 'https://local.altinn.cloud/ttd/test/instances/12345/123-123-123/data/456-456-456',
+      },
+      {
+        url: 'https://local.altinn.cloud/ttd/test/instances/12345/123-123-123/data/456-456-456?language=nb&includeRowId=true',
+        language: undefined,
+        expected: 'https://local.altinn.cloud/ttd/test/instances/12345/123-123-123/data/456-456-456?includeRowId=true',
+      },
+      {
+        url: 'https://local.altinn.cloud/ttd/test/instances/12345/123-123-123/data/456-456-456',
+        language: undefined,
+        expected: 'https://local.altinn.cloud/ttd/test/instances/12345/123-123-123/data/456-456-456',
+      },
+    ];
+    it.each(testCases)('url: $url, language: $language should result in $expected', ({ url, language, expected }) => {
+      expect(getUrlWithLanguage(url, language)).toBe(expected);
+    });
   });
 });

--- a/src/utils/urls/urlHelper.ts
+++ b/src/utils/urls/urlHelper.ts
@@ -120,3 +120,19 @@ export function getQueryStringFromObject(obj: Record<string, string | null | und
   const queryString = queryParams.toString();
   return queryString ? `?${queryString}` : '';
 }
+
+export function getUrlWithLanguage<T extends string | undefined, R = T extends string ? string : undefined>(
+  url: T,
+  language: string | undefined,
+): R {
+  if (typeof url === 'undefined') {
+    return undefined as R;
+  }
+  const urlObj = new URL(url);
+  if (typeof language === 'string') {
+    urlObj.searchParams.set('language', language);
+  } else {
+    urlObj.searchParams.delete('language');
+  }
+  return urlObj.toString() as R;
+}


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

Added a new method called `getDataModelUrl` instead of using `getDataElementUrl` for stateful apps. The difference being that the former has the `includeRowIds` and the latter has `language` as before. The reason for not including the language in the data model urls is that we store the url in formDataWrite to be able to check in tanstack whether or not we are currently saving, and we do not want the language to be included in the cache key. The current language is now therefore added only right before the patch request gets sent. I added a utility function for adding the query-parameter in a way where it does not matter if it already has any parameters set, to avoid checking if `?` or `&` should be used etc.

## Related Issue(s)

- closes #2037 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
