### PR TITLE
Make map marker visible in PDF and readyForPrint more robust

### DIFF
--- a/src/layout/Map/MapComponentSummary.tsx
+++ b/src/layout/Map/MapComponentSummary.tsx
@@ -13,8 +13,18 @@ export interface IMapComponentSummary {
 }
 
 export const useStyles = makeStyles(() => ({
-  mapMargin: {
+  mapContainer: {
     marginTop: 12,
+    // The marker has role=button, and will therefore be hidden from PDF by default
+    // This makes sure it is visible after all
+    '& img.leaflet-marker-icon': {
+      display: 'block !important',
+    },
+    // The tiles fade in from opacity 0, meaning that they are not fully visible in PDF when print is called
+    // This overrides the opacity so that the tiles are visible immediately
+    '& img.leaflet-tile': {
+      opacity: '1 !important',
+    },
   },
   footer: {
     paddingTop: '12px',
@@ -36,7 +46,7 @@ export function MapComponentSummary({ targetNode }: IMapComponentSummary) {
     <Grid
       item
       xs={12}
-      className={location ? classes.mapMargin : undefined}
+      className={location ? classes.mapContainer : undefined}
     >
       {location ? (
         <>


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

There were a few issues with the Map component in PDF
1. The map marker from leaflet has `role=button` and would therefore get hidden in the PDF. This was solved by overriding styling in the `MapComponentSummary`
2. The map fades in from opacity 0 on load, meaning that when app-frontend thinks everything is loaded the Map is not 100% visible yet. This was also fixed by overriding styling in `MapComponentSummary`, setting tiles to always have opacity 1.
3. The waiting-for-images-to-load part of `ReadyForPrint` turned out to not be very robust, as in most cases none of the map tiles had time to load before print happened. One problem seems to be that it first looks for all of the image elements, and adds promises for the ones that have not loaded yet. But most of the time it would not find any image elements at that time, and therefore add no promises, and so it would be completely unpredictable whether the images are actually loaded or not.

Adding this simple check revealed that when using a Map component, most of the images were not in fact finished loading by the time `ReadyForPrint` was rendered past the `assetsLoaded` check. At least when doing a hard refresh (Ctrl+Shift+R), when allowing the browser to use its cache it would often load them all in time.

<img width="489" alt="bilde" src="https://github.com/Altinn/app-frontend-react/assets/47412359/8848ab75-94f1-4578-a53f-dd75376b6773">


<img width="198" alt="bilde" src="https://github.com/Altinn/app-frontend-react/assets/47412359/39f8e660-ebe3-446b-b6ca-1e99b8a905f7">

To resolve the last issue I added the `waitForImages` function, which will wait for a couple of animation frames before checking for new image elements, then awaiting those promises, and repeating, until there are no more images that are not loaded.

I have not added any tests for this, not sure exactly how I would detect this in cypress, but I have tested manually and it has never failed me so far
<img width="489" alt="bilde" src="https://github.com/Altinn/app-frontend-react/assets/47412359/f2f880a7-4502-4ba5-bd60-7c10a6fddc39">


## Related Issue(s)

- closes #2044 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
