### PR TITLE
Fix hierarchy generation crashing due to missing null check

### DIFF
--- a/src/utils/layout/hierarchy.ts
+++ b/src/utils/layout/hierarchy.ts
@@ -129,12 +129,12 @@ function resolvedNodesInLayouts(
 /**
  * Recursive function to check if a node.item contains other LayoutNode objects somewhere inside
  */
-function containsLayoutNode(obj: any): boolean {
+function containsLayoutNode(obj: unknown): boolean {
   if (obj instanceof BaseLayoutNode) {
     return true;
   }
 
-  if (typeof obj !== 'object') {
+  if (typeof obj !== 'object' || obj === null) {
     return false;
   }
 


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

The Javascript type system is amazing as always, this error was due to the fact that `typeof null === 'object'` returns true, combined with the fact that `any` in Typescript does not do type-narrowing very well. Switching `any` to `unknown` made the mistake more apparent, now warning that `obj` could be either `object | null` which gave a type error in `Object.keys`.

A lesson here is that `unknown` can be more useful in cases like this instead of using `any` explicitly when you dont know the type.

## Related Issue(s)

- https://altinn.slack.com/archives/C02EJ9HKQA3/p1713947469018009

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
