### PR TITLE
Several performace improvements

### DIFF
--- a/src/core/contexts/zustandContext.tsx
+++ b/src/core/contexts/zustandContext.tsx
@@ -20,10 +20,7 @@ type DelayedSelectorFunc<T> = <U>(selector: Selector<T, U>, postProcessor?: (dat
 type DelayedSelectorFuncWithArg<Arg, U> = (lookup: Arg, postProcessor?: (data: unknown) => U) => U;
 type SelectorFuncLax<T> = <U>(selector: Selector<T, U>) => U | typeof ContextNotProvided;
 
-type DelayedSelectorState<T> = {
-  selector: Selector<T, any>;
-  prevValue: any;
-}[];
+type DelayedSelectorState<T> = Map<Selector<T, any>, { selector: Selector<T, any>; value: any }>;
 
 interface DelayedSelectorFactory<Param, RetVal, T> {
   selector: (lookup: Param) => Selector<T, RetVal>;
@@ -126,7 +123,7 @@ export function createZustandContext<Store extends StoreApi<Type>, Type = Extrac
    * will not be able to be used as a cache key.
    */
   const useDelayedMemoSelectorProto = (store: Store | typeof ContextNotProvided): DelayedSelectorFunc<Type> => {
-    const selectorsCalled = useRef<DelayedSelectorState<Type>>([]);
+    const selectorsCalled = useRef<DelayedSelectorState<Type>>(new Map());
     const [renderCount, forceRerender] = useState(0);
 
     useEffect(() => {
@@ -138,9 +135,15 @@ export function createZustandContext<Store extends StoreApi<Type>, Type = Extrac
         // When the state changes, we run all the known selectors again to figure out if anything changed. If it
         // did change, we'll clear the list of selectors to force a re-render.
         const selectors = selectorsCalled.current;
-        const changed = selectors.some((s) => !deepEqual(s.prevValue, s.selector(state)));
+        let changed = false;
+        for (const { selector, value } of selectors.values()) {
+          if (!deepEqual(value, selector(state))) {
+            changed = true;
+            break;
+          }
+        }
         if (changed) {
-          selectorsCalled.current = [];
+          selectorsCalled.current = new Map();
           forceRerender((prev) => prev + 1);
         }
       });
@@ -165,14 +168,14 @@ export function createZustandContext<Store extends StoreApi<Type>, Type = Extrac
 
         // Check if this function has been called before, and if the value has not changed since the last time it
         // was called we can return the previous value and prevent re-rendering.
-        const prev = selectorsCalled.current.find((s) => s.selector === selector);
-        if (prev && !deepEqual(prev.prevValue, value)) {
-          return prev.prevValue;
+        const prev = selectorsCalled.current.get(selector);
+        if (prev && deepEqual(prev.value, value)) {
+          return prev.value;
         }
 
         // The value has changed, or the callback is new to us. No need to re-render the component now, because
         // this is always the first render where this value is referenced, and we're always selecting from fresh state.
-        selectorsCalled.current.push({ selector, prevValue: value });
+        selectorsCalled.current.set(selector, { selector, value });
         return value;
       },
       [store, renderCount],

--- a/src/features/devtools/layoutValidation/useLayoutValidation.tsx
+++ b/src/features/devtools/layoutValidation/useLayoutValidation.tsx
@@ -117,20 +117,14 @@ function useNodesStructureMemo() {
   const nodes = useNodes();
   const nodesRef = useRef(nodes);
 
-  const allNodes = useMemo(() => nodes.allNodes(), [nodes]);
-  const allNodesRef = useRef(allNodes);
+  const allNodesIds = useMemo(() => nodes.allNodes().map((n) => n.item.id), [nodes]);
+  const allNodeIdsRef = useRef(allNodesIds);
 
-  if (
-    allNodes === allNodesRef.current ||
-    deepEqual(
-      allNodes.map((n) => n.item.id),
-      allNodesRef.current.map((n) => n.item.id),
-    )
-  ) {
+  if (allNodesIds === allNodeIdsRef.current || deepEqual(allNodesIds, allNodeIdsRef.current)) {
     return nodesRef.current;
   } else {
     nodesRef.current = nodes;
-    allNodesRef.current = allNodes;
+    allNodeIdsRef.current = allNodesIds;
     return nodes;
   }
 }

--- a/src/features/devtools/layoutValidation/useLayoutValidation.tsx
+++ b/src/features/devtools/layoutValidation/useLayoutValidation.tsx
@@ -21,6 +21,7 @@ import type { LayoutValidationErrors } from 'src/features/devtools/layoutValidat
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export interface LayoutValidationProps {
+  enabled: boolean;
   logErrors?: boolean;
 }
 
@@ -60,7 +61,7 @@ function mergeValidationErrors(a: LayoutValidationErrors, b: LayoutValidationErr
  */
 function useDataModelBindingsValidation(props: LayoutValidationProps) {
   const layoutSetId = useCurrentLayoutSetId() || 'default';
-  const { logErrors = false } = props;
+  const { logErrors = false, enabled } = props;
   const schema = useCurrentDataModelSchema();
   const dataType = useCurrentDataModelType();
   const nodes = useNodes();
@@ -69,7 +70,7 @@ function useDataModelBindingsValidation(props: LayoutValidationProps) {
     const failures: LayoutValidationErrors = {
       [layoutSetId]: {},
     };
-    if (!schema) {
+    if (!enabled || !schema) {
       return failures;
     }
     const rootElementPath = getRootElementPath(schema, dataType);
@@ -104,7 +105,7 @@ function useDataModelBindingsValidation(props: LayoutValidationProps) {
     }
 
     return failures;
-  }, [layoutSetId, schema, dataType, nodes, logErrors]);
+  }, [layoutSetId, enabled, schema, dataType, nodes, logErrors]);
 }
 
 interface Context {
@@ -171,7 +172,7 @@ export function Generator() {
   const enabled = isDev || panelOpen;
 
   const layoutSchemaValidations = useLayoutSchemaValidation(enabled);
-  const dataModelBindingsValidations = useDataModelBindingsValidation({ logErrors: true });
+  const dataModelBindingsValidations = useDataModelBindingsValidation({ enabled, logErrors: true });
 
   const update = useSelector((state) => state.update);
 

--- a/src/features/form/layout/PageNavigationContext.tsx
+++ b/src/features/form/layout/PageNavigationContext.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 
 import { createStore } from 'zustand';
 
@@ -92,10 +92,13 @@ export const useHiddenPages = () => {
 
 export const useIsHiddenPage = () => {
   const hidden = useLaxSelectorAsRef((state) => state.hidden);
-  return (pageId: string) => {
-    const current = hidden.current;
-    return current === ContextNotProvided ? false : current.has(pageId);
-  };
+  return useCallback(
+    (pageId: string) => {
+      const current = hidden.current;
+      return current === ContextNotProvided ? false : current.has(pageId);
+    },
+    [hidden],
+  );
 };
 
 export const useSetHiddenPages = () => {

--- a/src/features/formData/FormDataWrite.tsx
+++ b/src/features/formData/FormDataWrite.tsx
@@ -322,6 +322,9 @@ const useWaitForSave = () => {
 
 const emptyObject: any = {};
 
+const debouncedSelector = (path: string) => (state: FormDataContext) => dot.pick(path, state.debouncedCurrentData);
+const makeCacheKey = (path: string) => path;
+
 export const FD = {
   /**
    * Gives you a selector function that can be used to look up paths in the data model. This is similar to
@@ -331,8 +334,8 @@ export const FD = {
    */
   useDebouncedSelector(): FormDataSelector {
     return useDelayedMemoSelectorFactory({
-      selector: (path: string) => (state) => dot.pick(path, state.debouncedCurrentData),
-      makeCacheKey: (path: string) => path,
+      selector: debouncedSelector,
+      makeCacheKey,
     });
   },
 
@@ -350,8 +353,8 @@ export const FD = {
    */
   useLaxDebouncedSelector(): FormDataSelector | typeof ContextNotProvided {
     return useLaxDelayedMemoSelectorFactory({
-      selector: (path: string) => (state) => dot.pick(path, state.debouncedCurrentData),
-      makeCacheKey: (path: string) => path,
+      selector: debouncedSelector,
+      makeCacheKey,
     });
   },
 

--- a/src/features/options/useAllOptions.tsx
+++ b/src/features/options/useAllOptions.tsx
@@ -108,14 +108,24 @@ const { Provider, useSelector, useDelayedMemoSelectorFactory } = createZustandCo
 
 const emptyArray: IOptionInternal[] = [];
 export function useAllOptionsSelector(onlyWhenAllLoaded = false) {
-  return useDelayedMemoSelectorFactory({
-    selector: (nodeId: string) => (state) => {
+  const selector = useCallback(
+    (nodeId: string) => (state: State) => {
       if (onlyWhenAllLoaded && !state.allInitiallyLoaded) {
         return emptyArray;
       }
       return state.nodes[nodeId] || emptyArray;
     },
-    makeCacheKey: (nodeId: string) => nodeId + (onlyWhenAllLoaded ? '|onlyWhenAllLoaded' : ''),
+    [onlyWhenAllLoaded],
+  );
+
+  const makeCacheKey = useCallback(
+    (nodeId: string) => nodeId + (onlyWhenAllLoaded ? '|onlyWhenAllLoaded' : ''),
+    [onlyWhenAllLoaded],
+  );
+
+  return useDelayedMemoSelectorFactory({
+    selector,
+    makeCacheKey,
   });
 }
 

--- a/src/utils/layout/NodesContext.tsx
+++ b/src/utils/layout/NodesContext.tsx
@@ -97,10 +97,13 @@ export function useNodesMemoSelector<U>(selector: (s: LayoutPages) => U) {
   return useMemoSelector((state) => selector(state.nodes!));
 }
 
+const isHiddenComponentSelector = (nodeId: string) => (state: NodesContext) => state.hiddenComponents.has(nodeId);
+const makeCacheKey = (nodeId: string) => nodeId;
+
 export function useIsHiddenComponent() {
   return useDelayedMemoSelectorFactory({
-    selector: (nodeId: string) => (state) => state.hiddenComponents.has(nodeId),
-    makeCacheKey: (nodeId) => nodeId,
+    selector: isHiddenComponentSelector,
+    makeCacheKey,
   });
 }
 


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

These performance improvements were identified by testing `ssb/ra0255-01` with 250 rows in a repeating group. Specifically, by adding an artificial pagination set-up so only 10/250 rows were visible. That way, performance issues that were not directly tied to rendering many components could be found more easily.

1. **Problem**: In `useDelayedMemoSelectorProto`, checking if a selector had changed was slow due to having to call `find` on the list of selectors, which would be very large for an app with hundreds of rows. This would also have to be called for every selector when rendering.
  **Solution**: Store previously accessed selectors in a `Map` instead of an array, to be able to find a selector in constant time.
2. In `useDelayedMemoSelectorProto`, when checking if a selector had changed, it would not reuse the previous value even if it had not changed due to a mistaken `!deepEqual`, causing unecessary rerenders.
3. **Problem**: `useTaskErrors` had to get validations for all nodes very often, which is slow for apps with many nodes, and also causing many rerenders in the `ErrorReport` due to being dependent on `useNodes` which changed a lot. 
  **Solution**: The only practical dependency to nodes was which nodes actually exist and are visible, since the actual validations and validation visibility is stored elsewhere. Therefore, a `useVisibleNodes` hook was introduced which only updates whenever nodes are added, removed, or changes their hidden state.
4. `useDataModelBindingsValidation` had a similar problem to `useTaskErrors`. It showed up during profiling as it was running almost continually. This was solved in a similar way by introducing a hook which only updates when nodes are added or removed, since `dataModelBindings` are static for any node.
5. **Problem**: The hierarchy was regenerated for each key-press, slowing things down significantly when the app had many nodes, regardless of whether the components were rendered or not. This was due to expression datasources changing on every render.
  **Solutions**:
    - Add `useCallback`s to `useAllOptionsSelector` as it was updated every render.
    - Wrap `useIsHiddenPage` in a `useCallback` as this caused `usePageNavigationConfig` to update on every render.
    - Move selector- and cacheKey-functions outside of `useDebouncedSelector` to prevent it from being created on every render, causing `useDelayedMemoSelectorFactory` to update on every render.
    - Same as above but for `useIsHiddenComponent`.
    - In `useDelayedMemoSelectorProto`, store the raw value of the selector as well as the value after post-processing. Use the raw values when checking if the selectors needs to be cleared and re-rendered. Previously, the post-processed value was compared with the raw output from the selector, causing it to clear for every render even if no selectors had changed.

**Note**: The optimizations for `useTaskErrors` and `useDataModelBindingsValidation` may have been made redundant by reducing the no. of times the hierarchy has to be generated, as these optimizations were made because the `useNodes`-hook was updated so often.

## Related Issue(s)

- In preparation for #581 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
