### PR TITLE
Fix/2000 empty headers and description

### DIFF
--- a/src/components/atoms/AltinnAttachment.tsx
+++ b/src/components/atoms/AltinnAttachment.tsx
@@ -23,15 +23,16 @@ export function AltinnAttachment({ attachments, id, title }: IAltinnAttachmentPr
   const filteredAndSortedAttachments = attachments
     ?.filter((attachment) => attachment.name)
     .sort((a, b) => (a.name && b.name ? a.name.localeCompare(b.name, selectedLanguage, { numeric: true }) : 0));
-
   return (
     <List.Root
       id={id}
       data-testid='attachment-list'
     >
-      <List.Heading>
-        <Lang id={title} />
-      </List.Heading>
+      {title && (
+        <List.Heading>
+          <Lang id={title} />
+        </List.Heading>
+      )}
       <List.Unordered className={classes.attachmentList}>
         {filteredAndSortedAttachments?.map((attachment, index) => (
           <List.Item key={index}>

--- a/src/layout/Panel/PanelComponent.tsx
+++ b/src/layout/Panel/PanelComponent.tsx
@@ -35,7 +35,7 @@ export const PanelComponent = ({ node }: IPanelProps) => {
       )}
     >
       <Panel
-        title={<Lang id={textResourceBindings.title} />}
+        title={textResourceBindings.title ? <Lang id={textResourceBindings.title} /> : null}
         showIcon={showIcon}
         variant={getVariant({ variant })}
         forceMobileLayout={!fullWidth}

--- a/src/layout/TextArea/TextAreaComponent.test.tsx
+++ b/src/layout/TextArea/TextAreaComponent.test.tsx
@@ -64,7 +64,19 @@ describe('TextAreaComponent', () => {
     expect(formDataMethods.setLeafValue).not.toHaveBeenCalled();
   });
 
-  it('should have aria-describedby attribute if textResourceBindings is present', async () => {
+  it('should have aria-describedby attribute if textResourceBindings.description is present', async () => {
+    await render({
+      component: {
+        id: 'id',
+        textResourceBindings: { description: 'tekst' },
+      },
+    });
+
+    const textarea = screen.getByRole('textbox');
+    expect(textarea).toHaveAttribute('aria-describedby', 'description-id');
+  });
+
+  it('should not have aria-describedby attribute if textResourceBindings is present without description', async () => {
     await render({
       component: {
         id: 'id',
@@ -73,7 +85,7 @@ describe('TextAreaComponent', () => {
     });
 
     const textarea = screen.getByRole('textbox');
-    expect(textarea).toHaveAttribute('aria-describedby', 'description-id');
+    expect(textarea).not.toHaveAttribute('aria-describedby');
   });
 
   it('should not have aria-describedby attribute if textResourceBindings is not present', async () => {

--- a/src/layout/TextArea/TextAreaComponent.tsx
+++ b/src/layout/TextArea/TextAreaComponent.tsx
@@ -33,7 +33,7 @@ export function TextAreaComponent({ node, isValid, overrideDisplay }: ITextAreaP
       value={value}
       data-testid={id}
       aria-describedby={
-        overrideDisplay?.renderedInTable !== true && textResourceBindings ? `description-${id}` : undefined
+        overrideDisplay?.renderedInTable !== true && textResourceBindings?.description ? `description-${id}` : undefined
       }
       aria-label={overrideDisplay?.renderedInTable === true ? langAsString(textResourceBindings?.title) : undefined}
       autoComplete={autocomplete}


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes #2000 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [x] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  [<!--- insert link to issue(s) here -->](https://github.com/orgs/Altinn/projects/39/views/2?pane=issue&itemId=58637289)
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
