### PR TITLE
Avoid 401 in anonymous apps due to prefetching

### DIFF
--- a/src/features/language/LanguageProvider.tsx
+++ b/src/features/language/LanguageProvider.tsx
@@ -6,6 +6,7 @@ import type { IProfile } from 'src/types/shared';
 
 interface LanguageCtx {
   current: string;
+  profileLoaded: boolean;
   updateProfile: (profile: IProfile) => void;
   setWithLanguageSelector: (language: string) => void;
 }
@@ -15,6 +16,7 @@ const { Provider, useCtx } = createContext<LanguageCtx>({
   required: false,
   default: {
     current: 'nb',
+    profileLoaded: false,
     updateProfile: () => {
       throw new Error('LanguageProvider not initialized');
     },
@@ -26,10 +28,12 @@ const { Provider, useCtx } = createContext<LanguageCtx>({
 
 export const LanguageProvider = ({ children }: PropsWithChildren) => {
   const [current, setCurrent] = useState('nb');
+  const [profileLoaded, setProfileLoaded] = useState(false);
   const [userId, setUserId] = useState<number | undefined>(undefined);
 
   const updateProfile = (profile: IProfile) => {
     setUserId(profile.userId);
+    setProfileLoaded(true);
     const localStorageKey = `selectedAppLanguage${window.app}${profile.userId ?? ''}`;
     let localStorageValue = localStorage.getItem(localStorageKey);
     if (localStorageValue === 'null' || localStorageValue === 'undefined') {
@@ -47,10 +51,11 @@ export const LanguageProvider = ({ children }: PropsWithChildren) => {
     localStorage.setItem(`selectedAppLanguage${window.app}${userId}`, language);
   };
 
-  return <Provider value={{ current, updateProfile, setWithLanguageSelector }}>{children}</Provider>;
+  return <Provider value={{ current, profileLoaded, updateProfile, setWithLanguageSelector }}>{children}</Provider>;
 };
 
 export const useCurrentLanguage = () => useCtx().current;
+export const useIsProfileLanguageLoaded = () => useCtx().profileLoaded;
 export const useSetCurrentLanguage = () => {
   const { setWithLanguageSelector, updateProfile } = useCtx();
   return { setWithLanguageSelector, updateProfile };

--- a/src/features/language/textResources/TextResourcesProvider.tsx
+++ b/src/features/language/textResources/TextResourcesProvider.tsx
@@ -4,9 +4,8 @@ import { useAppQueries } from 'src/core/contexts/AppQueriesProvider';
 import { delayedContext } from 'src/core/contexts/delayedContext';
 import { createQueryContext } from 'src/core/contexts/queryContext';
 import { useQueryWithStaleData } from 'src/core/queries/useQueryWithStaleData';
-import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
+import { useCurrentLanguage, useIsProfileLanguageLoaded } from 'src/features/language/LanguageProvider';
 import { resourcesAsMap } from 'src/features/language/textResources/resourcesAsMap';
-import { useProfile } from 'src/features/profile/ProfileProvider';
 import { useAllowAnonymousIs } from 'src/features/stateless/getAllowAnonymous';
 import type { ITextResourceResult, TextResourceMap } from 'src/features/language/textResources/index';
 import type { HttpClientError } from 'src/utils/network/sharedNetworking';
@@ -21,9 +20,9 @@ const useTextResourcesQuery = () => {
   const selectedLanguage = useCurrentLanguage();
 
   // This makes sure to await potential profile fetching before fetching text resources
-  const profile = useProfile();
+  const profileLanguageLoaded = useIsProfileLanguageLoaded();
   const isAnonymous = useAllowAnonymousIs(true);
-  const enabled = isAnonymous || profile !== undefined;
+  const enabled = isAnonymous || profileLanguageLoaded;
 
   const utils = {
     ...useQueryWithStaleData<ITextResourceResult, HttpClientError>({

--- a/src/features/party/PartiesProvider.tsx
+++ b/src/features/party/PartiesProvider.tsx
@@ -14,7 +14,7 @@ import { useShouldFetchProfile } from 'src/features/profile/ProfileProvider';
 import type { IParty } from 'src/types/shared';
 import type { HttpClientError } from 'src/utils/network/sharedNetworking';
 
-// Also used for prefetching @see appPrefetcher.ts
+// Also used for prefetching @see appPrefetcher.ts, partyPrefetcher.ts
 export function usePartiesQueryDef(enabled: boolean) {
   const { fetchParties } = useAppQueries();
   return {
@@ -39,7 +39,7 @@ const usePartiesQuery = () => {
   };
 };
 
-// Also used for prefetching @see appPrefetcher.ts
+// Also used for prefetching @see appPrefetcher.ts, partyPrefetcher.ts
 export function useCurrentPartyQueryDef(enabled: boolean) {
   const { fetchCurrentParty } = useAppQueries();
   return {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -34,6 +34,7 @@ import { OrgsProvider } from 'src/features/orgs/OrgsProvider';
 import { PartyProvider } from 'src/features/party/PartiesProvider';
 import { ProfileProvider } from 'src/features/profile/ProfileProvider';
 import { AppPrefetcher } from 'src/queries/appPrefetcher';
+import { PartyPrefetcher } from 'src/queries/partyPrefetcher';
 import * as queries from 'src/queries/queries';
 
 import 'react-toastify/dist/ReactToastify.css';
@@ -106,6 +107,7 @@ function Root() {
                 </OrgsProvider>
               </TextResourcesProvider>
             </ProfileProvider>
+            <PartyPrefetcher />
           </LayoutSetsProvider>
         </GlobalFormDataReadersProvider>
       </ApplicationMetadataProvider>

--- a/src/queries/appPrefetcher.ts
+++ b/src/queries/appPrefetcher.ts
@@ -13,20 +13,22 @@ import { useProfileQueryDef } from 'src/features/profile/ProfileProvider';
 
 /**
  * Prefetches requests that require no processed data to determine the url
+ * Only prefetches profile, parties, and current party if a partyId is present in the URL, this is to avoid 401 errors for anonymous apps
+ * Only prefetches instance and process if a party- and instanceid is present in the URL
  */
 export function AppPrefetcher() {
-  usePrefetchQuery(useApplicationMetadataQueryDef());
-  usePrefetchQuery(useLayoutSetsQueryDef());
-  usePrefetchQuery(useProfileQueryDef(true));
-  usePrefetchQuery(useOrgsQueryDef());
-  usePrefetchQuery(useApplicationSettingsQueryDef());
-  usePrefetchQuery(useFooterLayoutQueryDef());
-  usePrefetchQuery(usePartiesQueryDef(true));
-  usePrefetchQuery(useCurrentPartyQueryDef(true));
-
   const { partyId, instanceGuid } =
     matchPath({ path: '/instance/:partyId/:instanceGuid/*' }, window.location.hash.slice(1))?.params ?? {};
   const instanceId = partyId && instanceGuid ? `${partyId}/${instanceGuid}` : undefined;
+
+  usePrefetchQuery(useApplicationMetadataQueryDef());
+  usePrefetchQuery(useLayoutSetsQueryDef());
+  usePrefetchQuery(useProfileQueryDef(true), Boolean(partyId));
+  usePrefetchQuery(useOrgsQueryDef());
+  usePrefetchQuery(useApplicationSettingsQueryDef());
+  usePrefetchQuery(useFooterLayoutQueryDef());
+  usePrefetchQuery(usePartiesQueryDef(true), Boolean(partyId));
+  usePrefetchQuery(useCurrentPartyQueryDef(true), Boolean(partyId));
 
   usePrefetchQuery(useInstanceDataQueryDef(true, partyId, instanceGuid));
   usePrefetchQuery(useProcessQueryDef(instanceId));

--- a/src/queries/partyPrefetcher.ts
+++ b/src/queries/partyPrefetcher.ts
@@ -1,0 +1,15 @@
+import { usePrefetchQuery } from 'src/core/queries/usePrefetchQuery';
+import { useCurrentPartyQueryDef, usePartiesQueryDef } from 'src/features/party/PartiesProvider';
+import { useShouldFetchProfile } from 'src/features/profile/ProfileProvider';
+
+/**
+ * Prefetches parties and current party if applicable
+ */
+export function PartyPrefetcher() {
+  const enabled = useShouldFetchProfile();
+
+  usePrefetchQuery(usePartiesQueryDef(true), enabled);
+  usePrefetchQuery(useCurrentPartyQueryDef(true), enabled);
+
+  return null;
+}


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

This slightly alters the prefetching behavior for profile, parties, and currentParty. In the original implementation, it would prefetch profile, parties and currentparty immediately. This would lead to 401 errors for anonymous apps. This is not a problem in and of itself, but would create noise in the logs as every time an anonymous app is opened it would fail the same requests. To avoid app-owners getting annoyed at this, I changed it so that parties and current party gets its own prefetcher, which runs immediately after applicationmetadata and layoutsets have loaded, which is what is needed to determine if its anonymous. And since profile is next in line anyway, this is no longer prefetched.

However, all of these are still prefetched if there is an instance id in the url. So opening an existing instance and generating PDFs will still load as fast as the original implementation. This will only make loading a new instance of an app slightly slower.

## Related Issue(s)

- https://github.com/Altinn/app-frontend-react/pull/2092

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
