### PR TITLE
Use language in Nets

### DIFF
--- a/src/features/payment/OrderDetailsProvider.tsx
+++ b/src/features/payment/OrderDetailsProvider.tsx
@@ -7,6 +7,7 @@ import { delayedContext } from 'src/core/contexts/delayedContext';
 import { createQueryContext } from 'src/core/contexts/queryContext';
 import { useQueryWithStaleData } from 'src/core/queries/useQueryWithStaleData';
 import { useLaxInstance } from 'src/features/instance/InstanceContext';
+import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
 import { useHasPayment } from 'src/features/payment/utils';
 import type { QueryDefinition } from 'src/core/queries/usePrefetchQuery';
 import type { OrderDetails } from 'src/features/payment/types';
@@ -15,9 +16,10 @@ import type { HttpClientError } from 'src/utils/network/sharedNetworking';
 // Also used for prefetching @see formPrefetcher.ts
 export function useOrderDetailsQueryDef(enabled: boolean, instanceId?: string): QueryDefinition<OrderDetails> {
   const { fetchOrderDetails } = useAppQueries();
+  const selectedLanguage = useCurrentLanguage();
   return {
     queryKey: ['fetchOrderDetails'],
-    queryFn: instanceId ? () => fetchOrderDetails(instanceId) : skipToken,
+    queryFn: instanceId ? () => fetchOrderDetails(instanceId, selectedLanguage) : skipToken,
     enabled: enabled && !!instanceId,
   };
 }

--- a/src/features/payment/PaymentInformationProvider.tsx
+++ b/src/features/payment/PaymentInformationProvider.tsx
@@ -6,6 +6,7 @@ import { useAppQueries } from 'src/core/contexts/AppQueriesProvider';
 import { delayedContext } from 'src/core/contexts/delayedContext';
 import { createQueryContext } from 'src/core/contexts/queryContext';
 import { useLaxInstance } from 'src/features/instance/InstanceContext';
+import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
 import { useIsPayment } from 'src/features/payment/utils';
 import type { QueryDefinition } from 'src/core/queries/usePrefetchQuery';
 import type { PaymentResponsePayload } from 'src/features/payment/types';
@@ -16,10 +17,12 @@ export function usePaymentInformationQueryDef(
   instanceId?: string,
 ): QueryDefinition<PaymentResponsePayload> {
   const { fetchPaymentInformation } = useAppQueries();
+  const selectedLanguage = useCurrentLanguage();
   return {
     queryKey: ['fetchPaymentInfo'],
-    queryFn: instanceId ? () => fetchPaymentInformation(instanceId) : skipToken,
+    queryFn: instanceId ? () => fetchPaymentInformation(instanceId, selectedLanguage) : skipToken,
     enabled: enabled && !!instanceId,
+    gcTime: 0,
   };
 }
 

--- a/src/features/payment/usePerformPaymentMutation.ts
+++ b/src/features/payment/usePerformPaymentMutation.ts
@@ -2,14 +2,16 @@ import { useMutation } from '@tanstack/react-query';
 import type { AxiosError } from 'axios';
 
 import { useAppMutations } from 'src/core/contexts/AppQueriesProvider';
+import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
 
 export const usePerformPayActionMutation = (partyId?: string, instanceGuid?: string) => {
   const { doPerformAction } = useAppMutations();
+  const selectedLanguage = useCurrentLanguage();
   return useMutation({
     mutationKey: ['performPayAction', partyId, instanceGuid],
     mutationFn: async () => {
       if (partyId && instanceGuid) {
-        return await doPerformAction(partyId, instanceGuid, { action: 'pay' });
+        return await doPerformAction(partyId, instanceGuid, { action: 'pay' }, selectedLanguage);
       }
     },
     onError: (error: AxiosError) => {

--- a/src/queries/queries.ts
+++ b/src/queries/queries.ts
@@ -130,8 +130,13 @@ export const doAttachmentAddTag = async (instanceId: string, dataGuid: string, t
   return response.data;
 };
 
-export const doPerformAction = async (partyId: string, dataGuid: string, data: any): Promise<ActionResult> => {
-  const response = await httpPost(getActionsUrl(partyId, dataGuid), undefined, data);
+export const doPerformAction = async (
+  partyId: string,
+  dataGuid: string,
+  data: any,
+  language?: string,
+): Promise<ActionResult> => {
+  const response = await httpPost(getActionsUrl(partyId, dataGuid, language), undefined, data);
   if (response.status !== 200) {
     throw new Error('Failed to perform action');
   }
@@ -223,10 +228,11 @@ export const fetchRuleHandler = (layoutSetId: string): Promise<string | null> =>
 export const fetchTextResources = (selectedLanguage: string): Promise<ITextResourceResult> =>
   httpGet(textResourcesUrl(selectedLanguage));
 
-export const fetchPaymentInformation = (instanceId: string): Promise<PaymentResponsePayload> =>
-  httpGet(getPaymentInformationUrl(instanceId));
+export const fetchPaymentInformation = (instanceId: string, language?: string): Promise<PaymentResponsePayload> =>
+  httpGet(getPaymentInformationUrl(instanceId, language));
 
-export const fetchOrderDetails = (instanceId: string): Promise<OrderDetails> => httpGet(getOrderDetailsUrl(instanceId));
+export const fetchOrderDetails = (instanceId: string, language?: string): Promise<OrderDetails> =>
+  httpGet(getOrderDetailsUrl(instanceId, language));
 
 export const fetchBackendValidations = (
   instanceId: string,

--- a/src/utils/urls/appUrlHelper.ts
+++ b/src/utils/urls/appUrlHelper.ts
@@ -21,12 +21,15 @@ export const getSetCurrentPartyUrl = (partyId: number) => `${appPath}/api/v1/par
 
 export const textResourcesUrl = (language: string) => `${origin}/${org}/${app}/api/v1/texts/${language}`;
 
-export const getPaymentInformationUrl = (instanceId: string) =>
-  `${origin}/${org}/${app}/instances/${instanceId}/payment`;
+export const getPaymentInformationUrl = (instanceId: string, language?: string) => {
+  const queryString = getQueryStringFromObject({ language });
+  return `${origin}/${org}/${app}/instances/${instanceId}/payment${queryString}`;
+};
 
-export const getOrderDetailsUrl = (instanceId: string) =>
-  `${origin}/${org}/${app}/instances/${instanceId}/payment/order-details`;
-
+export const getOrderDetailsUrl = (instanceId: string, language?: string) => {
+  const queryString = getQueryStringFromObject({ language });
+  return `${origin}/${org}/${app}/instances/${instanceId}/payment/order-details${queryString}`;
+};
 export const getFileUploadUrl = (instanceId: string, attachmentType: string) =>
   `${appPath}/instances/${instanceId}/data?dataType=${attachmentType}`;
 
@@ -49,8 +52,10 @@ export const getDataElementUrl = (instanceId: string, dataGuid: string, language
   `${appPath}/instances/${instanceId}/data/${dataGuid}?language=${language}`;
 
 export const getProcessStateUrl = (instanceId: string) => `${appPath}/instances/${instanceId}/process`;
-export const getActionsUrl = (partyId: string, instanceId: string) =>
-  `${appPath}/instances/${partyId}/${instanceId}/actions`;
+export const getActionsUrl = (partyId: string, instanceId: string, language?: string) => {
+  const queryString = getQueryStringFromObject({ language });
+  return `${appPath}/instances/${partyId}/${instanceId}/actions${queryString}`;
+};
 
 export const getCreateInstancesUrl = (partyId: number) => `${appPath}/instances?instanceOwnerPartyId=${partyId}`;
 

--- a/test/e2e/integration/payment-test/payment.ts
+++ b/test/e2e/integration/payment-test/payment.ts
@@ -28,7 +28,7 @@ describe('Payment', () => {
     cy.findByRole('button', { name: /Til betaling/ }).click();
     cy.intercept({
       method: 'GET',
-      url: '**/ttd/payment-test/instances/**/**/payment',
+      url: '**/ttd/payment-test/instances/**/**/payment?langauge=**',
     }).as('paymentInfoRequest');
 
     cy.wait('@paymentInfoRequest').then((_) => {

--- a/test/e2e/integration/payment-test/payment.ts
+++ b/test/e2e/integration/payment-test/payment.ts
@@ -28,7 +28,7 @@ describe('Payment', () => {
     cy.findByRole('button', { name: /Til betaling/ }).click();
     cy.intercept({
       method: 'GET',
-      url: '**/ttd/payment-test/instances/**/**/payment?langauge=**',
+      url: '**/ttd/payment-test/instances/**/**/payment*',
     }).as('paymentInfoRequest');
 
     cy.wait('@paymentInfoRequest').then((_) => {


### PR DESCRIPTION
## Description

Giva current selected language as query parameter to payment endpoints in order to make use of the language functionality in backend.

Also solved an insconsistency with going directly to Nets where it would only work the first time, since the response for paymentInformation would be cached and it would seem like a payment existed even though it had been cleaned up in backend.

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
