### PR TITLE
Fix edge case where validations may not show up

### DIFF
--- a/src/features/validation/ComponentValidations.tsx
+++ b/src/features/validation/ComponentValidations.tsx
@@ -6,6 +6,7 @@ import { Lang } from 'src/features/language/Lang';
 import { useLanguage } from 'src/features/language/useLanguage';
 import { validationsOfSeverity } from 'src/features/validation/utils';
 import { AlertBaseComponent } from 'src/layout/Alert/AlertBaseComponent';
+import { useGetUniqueKeyFromObject } from 'src/utils/useGetKeyFromObject';
 import type { NodeValidation } from 'src/features/validation';
 import type { AlertSeverity } from 'src/layout/Alert/config.generated';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
@@ -58,10 +59,12 @@ export function ComponentValidations({ validations, node }: Props) {
 }
 
 function ErrorValidations({ validations, node }: { validations: NodeValidation<'error'>[]; node?: LayoutNode }) {
+  const getUniqueKeyFromObject = useGetUniqueKeyFromObject();
+
   return (
     <ol style={{ padding: 0, margin: 0, listStyleType: 'none' }}>
       {validations.map((validation) => (
-        <li key={`validationMessage-${validation.message.key}`}>
+        <li key={getUniqueKeyFromObject(validation)}>
           <ErrorMessage
             role='alert'
             size='small'
@@ -87,6 +90,7 @@ function SoftValidations({
   variant: AlertSeverity;
   node?: LayoutNode;
 }) {
+  const getUniqueKeyFromObject = useGetUniqueKeyFromObject();
   const { langAsString } = useLanguage();
 
   /**
@@ -106,7 +110,7 @@ function SoftValidations({
           {validations.map((validation) => (
             <li
               role='alert'
-              key={`validationMessage-${validation.message.key}`}
+              key={getUniqueKeyFromObject(validation)}
             >
               <Lang
                 id={validation.message.key}

--- a/src/features/validation/selectors/deepValidationsForNode.ts
+++ b/src/features/validation/selectors/deepValidationsForNode.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 
 import type { NodeValidation } from '..';
 
-import { getValidationsForNode } from 'src/features/validation/utils';
+import { getValidationsForNode, shouldValidateNode } from 'src/features/validation/utils';
 import { Validation } from 'src/features/validation/validationContext';
 import { getVisibilityForNode } from 'src/features/validation/visibility/visibilityUtils';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
@@ -24,9 +24,9 @@ export function useDeepValidationsForNode(
     }
 
     const restriction = onlyInRowUuid ? { onlyInRowUuid } : undefined;
-    const nodesToValidate = onlyChildren ? node.flat(true, restriction) : [node, ...node.flat(true, restriction)];
-    return nodesToValidate.flatMap((node) =>
-      getValidationsForNode(node, selector, getVisibilityForNode(node, visibilitySelector)),
-    );
+    const deepNodes = onlyChildren ? node.flat(true, restriction) : [node, ...node.flat(true, restriction)];
+    return deepNodes
+      .filter(shouldValidateNode)
+      .flatMap((node) => getValidationsForNode(node, selector, getVisibilityForNode(node, visibilitySelector)));
   }, [node, onlyChildren, onlyInRowUuid, selector, visibilitySelector]);
 }

--- a/src/features/validation/utils.ts
+++ b/src/features/validation/utils.ts
@@ -142,9 +142,6 @@ export function getValidationsForNode(
   severity?: ValidationSeverity,
 ): NodeValidation[] {
   const validationMessages: NodeValidation[] = [];
-  if (!shouldValidateNode(node)) {
-    return validationMessages;
-  }
 
   const selector: ValidationSelector = (cacheKey, selector) => {
     if (typeof findIn === 'function') {

--- a/src/layout/GenericComponent.tsx
+++ b/src/layout/GenericComponent.tsx
@@ -167,7 +167,7 @@ function ActualGenericComponent<Type extends CompTypes = CompTypes>({
     return (
       <SummaryComponent
         summaryNode={node as LayoutNode<'Summary'>}
-        overrides={{ display: { hideChangeButton: true } }}
+        overrides={{ display: { hideChangeButton: true, hideValidationMessages: true } }}
       />
     );
   }

--- a/src/layout/RepeatingGroup/RepeatingGroupPagination.tsx
+++ b/src/layout/RepeatingGroup/RepeatingGroupPagination.tsx
@@ -6,7 +6,7 @@ import deepEqual from 'fast-deep-equal';
 
 import { ConditionalWrapper } from 'src/components/ConditionalWrapper';
 import { useLanguage } from 'src/features/language/useLanguage';
-import { getValidationsForNode, hasValidationErrors } from 'src/features/validation/utils';
+import { getValidationsForNode, hasValidationErrors, shouldValidateNode } from 'src/features/validation/utils';
 import { Validation } from 'src/features/validation/validationContext';
 import { getVisibilityForNode } from 'src/features/validation/visibility/visibilityUtils';
 import { useIsMini, useIsMobile, useIsMobileOrTablet } from 'src/hooks/useIsMobile';
@@ -249,6 +249,10 @@ function usePagesWithErrors(rowsPerPage: number | undefined, node: BaseLayoutNod
       const deepNodes = visibleRows[i].items.flatMap((node) => [node, ...node.flat(true)]);
 
       for (const node of deepNodes) {
+        if (!shouldValidateNode(node)) {
+          continue;
+        }
+
         if (
           hasValidationErrors(getValidationsForNode(node, selector, getVisibilityForNode(node, visibilitySelector)))
         ) {


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

The culprit turned out to be checking `shouldValidateNode` inside of `getValidationsForNode`. The result of this could somehow change without the node reference updating. This may be due to reusing nodes when they supposedly have not changed? Needed to add back the filter on `shouldValidateNode` the few places that were missing it, most users of `getValdiationsForNode` were already using it anyway.

The changes in `ComponentValidations` are not related, but noticed that the key was a bit fragile.

## Related Issue(s)

- https://altinn.slack.com/archives/C02EJ9HKQA3/p1716540609951709

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
