### PR TITLE
Expression support for number formatting

### DIFF
--- a/src/__mocks__/getHierarchyDataSourcesMock.ts
+++ b/src/__mocks__/getHierarchyDataSourcesMock.ts
@@ -15,7 +15,7 @@ export function getHierarchyDataSourcesMock(): HierarchyDataSources {
     authContext: null,
     devToolsIsOpen: false,
     devToolsHiddenComponents: 'hide',
-    langToolsRef: { current: staticUseLanguageForTests() },
+    langToolsSelector: () => staticUseLanguageForTests(),
     currentLanguage: 'nb',
   };
 }

--- a/src/core/ui/RenderStart.tsx
+++ b/src/core/ui/RenderStart.tsx
@@ -3,7 +3,7 @@ import type { PropsWithChildren } from 'react';
 
 import { DevTools } from 'src/features/devtools/DevTools';
 import { DataModelFetcher } from 'src/features/formData/FormDataReaders';
-import { LangDataSourcesProvider, ProvideUseLanguageRef } from 'src/features/language/LangDataSourcesProvider';
+import { LangDataSourcesProvider } from 'src/features/language/LangDataSourcesProvider';
 
 interface Props extends PropsWithChildren {
   devTools?: boolean;
@@ -18,7 +18,6 @@ interface Props extends PropsWithChildren {
 export function RenderStart({ children, devTools = true, dataModelFetcher = true }: Props) {
   return (
     <LangDataSourcesProvider>
-      <ProvideUseLanguageRef />
       {children}
       {devTools && <DevTools />}
       {dataModelFetcher && <DataModelFetcher />}

--- a/src/features/expressions/ExprContext.ts
+++ b/src/features/expressions/ExprContext.ts
@@ -32,11 +32,7 @@ export interface ContextDataSources {
   options: ReturnType<typeof useAllOptionsSelector>;
   authContext: Partial<IAuthContext> | null;
   isHidden: (nodeId: string) => boolean;
-  langToolsRef: {
-    // We pass langTools as a ref, because it itself re-renders a lot, and we don't want to
-    // re-create the hierarchy every time language stuff changes.
-    current: IUseLanguage;
-  };
+  langToolsSelector: (node: LayoutNode | undefined) => IUseLanguage;
   currentLanguage: string;
 }
 

--- a/src/features/expressions/index.ts
+++ b/src/features/expressions/index.ts
@@ -588,7 +588,7 @@ export const ExprFunctions = {
       return component.def.getDisplayData(component as any, {
         attachments: this.dataSources.attachments,
         optionsSelector: this.dataSources.options,
-        langTools: this.dataSources.langToolsRef.current,
+        langTools: this.dataSources.langToolsSelector(node as LayoutNode),
         currentLanguage: this.dataSources.currentLanguage,
         formDataSelector: this.dataSources.formDataSelector,
       });
@@ -624,7 +624,8 @@ export const ExprFunctions = {
         return null;
       }
 
-      return this.dataSources.langToolsRef.current.langAsNonProcessedString(key);
+      const node = this.node instanceof BaseLayoutNode ? this.node : undefined;
+      return this.dataSources.langToolsSelector(node).langAsNonProcessedString(key);
     },
     args: [ExprVal.String] as const,
     returns: ExprVal.String,

--- a/src/features/expressions/index.ts
+++ b/src/features/expressions/index.ts
@@ -940,6 +940,21 @@ export const ExprConfigForComponent: ExprObjConfig<CompExternal> = {
         defaultValue: '',
         resolvePerRow: false,
       },
+      thousandSeparator: {
+        returnType: ExprVal.Any,
+        defaultValue: '',
+        resolvePerRow: false,
+      },
+      decimalSeparator: {
+        returnType: ExprVal.String,
+        defaultValue: '',
+        resolvePerRow: false,
+      },
+      format: {
+        returnType: ExprVal.String,
+        defaultValue: '',
+        resolvePerRow: false,
+      },
     },
   },
 };

--- a/src/features/expressions/index.ts
+++ b/src/features/expressions/index.ts
@@ -928,6 +928,20 @@ export const ExprConfigForComponent: ExprObjConfig<CompExternal> = {
     defaultValue: false,
     resolvePerRow: false,
   },
+  formatting: {
+    number: {
+      prefix: {
+        returnType: ExprVal.String,
+        defaultValue: '',
+        resolvePerRow: false,
+      },
+      suffix: {
+        returnType: ExprVal.String,
+        defaultValue: '',
+        resolvePerRow: false,
+      },
+    },
+  },
 };
 
 export const ExprConfigForGroup:

--- a/src/features/expressions/shared.test.ts
+++ b/src/features/expressions/shared.test.ts
@@ -93,11 +93,10 @@ describe('Expressions shared function tests', () => {
           instanceDataSources: buildInstanceDataSources(instance),
           applicationSettings: frontendSettings || ({} as IApplicationSettings),
           authContext: buildAuthContext(permissions),
-          langToolsRef: {
-            current: staticUseLanguageForTests({
+          langToolsSelector: () =>
+            staticUseLanguageForTests({
               textResources: textResources ? resourcesAsMap(textResources) : {},
             }),
-          },
           process,
           currentLanguage: profileSettings?.language || 'nb',
           options: (nodeId) => options[nodeId] || [],

--- a/src/features/language/LangDataSourcesProvider.tsx
+++ b/src/features/language/LangDataSourcesProvider.tsx
@@ -5,14 +5,9 @@ import { ContextNotProvided } from 'src/core/contexts/context';
 import { useLaxApplicationSettings } from 'src/features/applicationSettings/ApplicationSettingsProvider';
 import { useDataModelReaders } from 'src/features/formData/FormDataReaders';
 import { useLaxInstanceDataSources } from 'src/features/instance/InstanceContext';
-import {
-  useLangToolsDataSources,
-  useLangToolsRef,
-  useSetLangToolsDataSources,
-} from 'src/features/language/LangToolsStore';
+import { useLangToolsDataSources, useSetLangToolsDataSources } from 'src/features/language/LangToolsStore';
 import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
 import { useTextResources } from 'src/features/language/textResources/TextResourcesProvider';
-import { useLanguageWithForcedNode } from 'src/features/language/useLanguage';
 import { getLanguageFromCode } from 'src/language/languages';
 import type { TextResourceMap } from 'src/features/language/textResources';
 import type { TextResourceVariablesDataSources } from 'src/features/language/useLanguage';
@@ -71,9 +66,3 @@ export const LangDataSourcesProvider = ({ children }: PropsWithChildren) => {
 
   return <>{children}</>;
 };
-
-export function ProvideUseLanguageRef() {
-  const intoRef = useLangToolsRef();
-  intoRef.current = useLanguageWithForcedNode(undefined);
-  return null;
-}

--- a/src/features/language/LangToolsStore.tsx
+++ b/src/features/language/LangToolsStore.tsx
@@ -1,12 +1,10 @@
-import React, { useRef } from 'react';
+import React from 'react';
 
 import { createContext } from 'src/core/contexts/context';
 import { useStateDeepEqual } from 'src/hooks/useStateDeepEqual';
 import type { LangDataSources } from 'src/features/language/LangDataSourcesProvider';
-import type { IUseLanguage } from 'src/features/language/useLanguage';
 
 interface Context {
-  latestRef: React.MutableRefObject<IUseLanguage | undefined>;
   dataSources: LangDataSources | undefined;
   setDataSources: React.Dispatch<React.SetStateAction<LangDataSources | undefined>>;
 }
@@ -18,12 +16,10 @@ const { Provider, useCtx } = createContext<Context>({
 
 export function LangToolsStoreProvider({ children }: React.PropsWithChildren) {
   const [dataSources, setDataSources] = useStateDeepEqual<LangDataSources | undefined>(undefined);
-  const latestRef = useRef<IUseLanguage>();
 
   return (
     <Provider
       value={{
-        latestRef,
         dataSources,
         setDataSources,
       }}
@@ -35,13 +31,3 @@ export function LangToolsStoreProvider({ children }: React.PropsWithChildren) {
 
 export const useLangToolsDataSources = () => useCtx().dataSources;
 export const useSetLangToolsDataSources = () => useCtx().setDataSources;
-
-/**
- * This provides a ref to the result of useLanguage(). It does not have any node locality (so it will not work
- * inside repeating groups, when looking up variables relative to the row index), but it can be used
- * for purposes where it's important not to re-render often (e.g. when creating the node hierarchy), and where
- * rendering language keys is not needed immediately, but in e.g. a callback function.
- *
- * It is set via ProvideUseLanguageRef, which is rendered as soon as possible in the <RenderStart> component.
- */
-export const useLangToolsRef = () => useCtx().latestRef as React.MutableRefObject<IUseLanguage>;

--- a/src/features/language/useLanguage.ts
+++ b/src/features/language/useLanguage.ts
@@ -1,4 +1,4 @@
-import { Children, isValidElement, useMemo } from 'react';
+import { Children, isValidElement, useCallback, useMemo } from 'react';
 import type { JSX, ReactNode } from 'react';
 
 import { ContextNotProvided } from 'src/core/contexts/context';
@@ -110,6 +110,33 @@ export function useLanguageWithForcedNode(node: LayoutNode | undefined) {
       currentDataModelName,
     });
   }, [currentDataModel, currentDataModelName, dataSources, language, node, selectedLanguage, textResources]);
+}
+
+// Exactly the same as above, but returns a function accepting a node
+export function useLanguageWithForcedNodeSelector() {
+  const { textResources, language, selectedLanguage, ...dataSources } = useLangToolsDataSources() || {};
+  const layoutSetId = useCurrentLayoutSetId();
+  const currentDataModelName = useDataTypeByLayoutSetId(layoutSetId);
+  const currentDataModel = FD.useLaxDebouncedSelector();
+
+  return useCallback(
+    (node: LayoutNode | undefined) => {
+      if (!textResources || !language || !selectedLanguage) {
+        throw new Error('useLanguage must be used inside a LangToolsStoreProvider');
+      }
+
+      return staticUseLanguage(textResources, language, selectedLanguage, {
+        ...(dataSources as Omit<
+          TextResourceVariablesDataSources,
+          'node' | 'currentDataModel' | 'currentDataModelName'
+        >),
+        node,
+        currentDataModel,
+        currentDataModelName,
+      });
+    },
+    [currentDataModel, currentDataModelName, dataSources, language, selectedLanguage, textResources],
+  );
 }
 
 interface ILanguageState {

--- a/src/features/validation/expressionValidation/useExpressionValidation.test.ts
+++ b/src/features/validation/expressionValidation/useExpressionValidation.test.ts
@@ -70,7 +70,7 @@ describe('Expression validation shared tests', () => {
       instanceDataSources: buildInstanceDataSources(),
       authContext: buildAuthContext(undefined),
       isHidden: (nodeId: string) => hiddenFields.has(nodeId),
-      langToolsRef: { current: langTools },
+      langToolsSelector: () => langTools,
     };
 
     const customValidation = resolveExpressionValidationConfig(validationConfig);

--- a/src/hooks/useMapToReactNumberConfig.ts
+++ b/src/hooks/useMapToReactNumberConfig.ts
@@ -1,10 +1,13 @@
 import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
 import { useMemoDeepEqual } from 'src/hooks/useStateDeepEqual';
 import { formatNumber } from 'src/utils/formattingUtils';
-import type { IInputFormatting } from 'src/layout/Input/config.generated';
+import type { IInputFormattingInternal } from 'src/layout/Input/config.generated';
 import type { CurrencyFormattingOptions, UnitFormattingOptions } from 'src/utils/formattingUtils';
 
-export const useMapToReactNumberConfig = (formatting: IInputFormatting | undefined, value = ''): IInputFormatting => {
+export const useMapToReactNumberConfig = (
+  formatting: IInputFormattingInternal | undefined,
+  value = '',
+): IInputFormattingInternal => {
   const selectedLanguage = useCurrentLanguage();
   return useMemoDeepEqual(
     () => getMapToReactNumberConfig(formatting, value, selectedLanguage),
@@ -13,15 +16,15 @@ export const useMapToReactNumberConfig = (formatting: IInputFormatting | undefin
 };
 
 export const getMapToReactNumberConfig = (
-  formatting: IInputFormatting | undefined,
+  formatting: IInputFormattingInternal | undefined,
   value = '',
   selectedLanguage: string,
-): IInputFormatting => {
+): IInputFormattingInternal => {
   if (!formatting?.currency && !formatting?.unit) {
     return formatting ?? {};
   }
 
-  const createOptions = (config: IInputFormatting) => {
+  const createOptions = (config: IInputFormattingInternal) => {
     if (config.currency) {
       return { style: 'currency', currency: config.currency } as CurrencyFormattingOptions;
     }

--- a/src/hooks/useSourceOptions.ts
+++ b/src/hooks/useSourceOptions.ts
@@ -38,7 +38,8 @@ export function getSourceOptions({ source, node, dataSources }: IGetSourceOption
     return undefined;
   }
 
-  const { formDataSelector, langToolsRef } = dataSources;
+  const { formDataSelector, langToolsSelector } = dataSources;
+  const langTools = langToolsSelector(node);
   const { group, value, label, helpText, description } = source;
   const cleanValue = getKeyWithoutIndexIndicators(value);
   const cleanGroup = getKeyWithoutIndexIndicators(group);
@@ -67,10 +68,10 @@ export function getSourceOptions({ source, node, dataSources }: IGetSourceOption
           ...dataSources,
           langToolsRef: {
             current: {
-              ...langToolsRef.current,
-              langAsString: (key: string) => langToolsRef.current.langAsStringUsingPathInDataModel(key, path),
+              ...langTools,
+              langAsString: (key: string) => langTools.langAsStringUsingPathInDataModel(key, path),
               langAsNonProcessedString: (key: string) =>
-                langToolsRef.current.langAsNonProcessedStringUsingPathInDataModel(key, path),
+                langTools.langAsNonProcessedStringUsingPathInDataModel(key, path),
             },
           },
         };
@@ -91,19 +92,19 @@ export function getSourceOptions({ source, node, dataSources }: IGetSourceOption
           value: String(formDataSelector(valuePath)),
           label:
             label && !Array.isArray(label)
-              ? langToolsRef.current.langAsStringUsingPathInDataModel(label, path)
+              ? langTools.langAsStringUsingPathInDataModel(label, path)
               : Array.isArray(labelExpression)
                 ? evalExpr(labelExpression, node, modifiedDataSources)
                 : undefined,
           description:
             description && !Array.isArray(description)
-              ? langToolsRef.current.langAsStringUsingPathInDataModel(description, path)
+              ? langTools.langAsStringUsingPathInDataModel(description, path)
               : Array.isArray(descriptionExpression)
                 ? evalExpr(descriptionExpression, node, modifiedDataSources)
                 : undefined,
           helpText:
             helpText && !Array.isArray(helpText)
-              ? langToolsRef.current.langAsStringUsingPathInDataModel(helpText, path)
+              ? langTools.langAsStringUsingPathInDataModel(helpText, path)
               : Array.isArray(helpTextExpression)
                 ? evalExpr(helpTextExpression, node, modifiedDataSources)
                 : undefined,

--- a/src/hooks/useSourceOptions.ts
+++ b/src/hooks/useSourceOptions.ts
@@ -64,16 +64,14 @@ export function getSourceOptions({ source, node, dataSources }: IGetSourceOption
          * langAsString function to actually be langAsStringUsingPathInDataModel partially
          * applied with the correct path in the data model.
          */
-        const modifiedDataSources = {
+        const modifiedDataSources: HierarchyDataSources = {
           ...dataSources,
-          langToolsRef: {
-            current: {
-              ...langTools,
-              langAsString: (key: string) => langTools.langAsStringUsingPathInDataModel(key, path),
-              langAsNonProcessedString: (key: string) =>
-                langTools.langAsNonProcessedStringUsingPathInDataModel(key, path),
-            },
-          },
+          langToolsSelector: () => ({
+            ...langTools,
+            langAsString: (key: string) => langTools.langAsStringUsingPathInDataModel(key, path),
+            langAsNonProcessedString: (key: string) =>
+              langTools.langAsNonProcessedStringUsingPathInDataModel(key, path),
+          }),
         };
 
         const config = {

--- a/src/layout/Input/InputComponent.tsx
+++ b/src/layout/Input/InputComponent.tsx
@@ -19,8 +19,8 @@ import type { TextfieldProps } from '@digdir/designsystemet-react/dist/types/com
 
 interface InputComponentProps extends Omit<TextfieldProps, 'prefix' | 'suffix'> {
   textOnly?: boolean;
-  prefixExternal?: string;
-  suffixExternal?: string;
+  prefixText?: string;
+  suffixText?: string;
 }
 
 const TextOnly: React.FunctionComponent<TextfieldProps> = ({ className, id, value }) => {
@@ -49,7 +49,7 @@ const TextOnly: React.FunctionComponent<TextfieldProps> = ({ className, id, valu
 // of the TextField and the react-number-format components which also have a 'size' prop
 // The prefix/suffix props from the design system also conflicts with react-number-format
 const TextfieldWrapped: React.FunctionComponent<InputComponentProps> = (props) => {
-  const { size: _, textOnly, prefixExternal, suffixExternal, ...customProps } = props;
+  const { size: _, textOnly, prefixText, suffixText, ...customProps } = props;
 
   if (textOnly) {
     return <TextOnly {...customProps}></TextOnly>;
@@ -58,8 +58,8 @@ const TextfieldWrapped: React.FunctionComponent<InputComponentProps> = (props) =
   return (
     <Textfield
       size={'small'}
-      prefix={prefixExternal}
-      suffix={suffixExternal}
+      prefix={prefixText}
+      suffix={suffixText}
       {...customProps}
     ></Textfield>
   );

--- a/src/layout/Input/InputComponent.tsx
+++ b/src/layout/Input/InputComponent.tsx
@@ -11,14 +11,16 @@ import classes from 'src/layout/Input/InputComponent.module.css';
 import { isNumericFormat, isPatternFormat } from 'src/layout/Input/number-format-helpers';
 import { useCharacterLimit } from 'src/utils/inputUtils';
 import type { PropsFromGenericComponent } from 'src/layout';
-import type { IInputFormatting } from 'src/layout/Input/config.generated';
+import type { IInputFormattingInternal } from 'src/layout/Input/config.generated';
 
 export type IInputProps = PropsFromGenericComponent<'Input'>;
 
 import type { TextfieldProps } from '@digdir/designsystemet-react/dist/types/components/form/Textfield/Textfield';
 
-interface InputComponentProps extends TextfieldProps {
+interface InputComponentProps extends Omit<TextfieldProps, 'prefix' | 'suffix'> {
   textOnly?: boolean;
+  prefixExternal?: string;
+  suffixExternal?: string;
 }
 
 const TextOnly: React.FunctionComponent<TextfieldProps> = ({ className, id, value }) => {
@@ -45,8 +47,9 @@ const TextOnly: React.FunctionComponent<TextfieldProps> = ({ className, id, valu
 
 // We need to use this wrapped Textfield component because we have a conflict between the 'size' prop
 // of the TextField and the react-number-format components which also have a 'size' prop
+// The prefix/suffix props from the design system also conflicts with react-number-format
 const TextfieldWrapped: React.FunctionComponent<InputComponentProps> = (props) => {
-  const { size: _, textOnly, ...customProps } = props;
+  const { size: _, textOnly, prefixExternal, suffixExternal, ...customProps } = props;
 
   if (textOnly) {
     return <TextOnly {...customProps}></TextOnly>;
@@ -55,6 +58,8 @@ const TextfieldWrapped: React.FunctionComponent<InputComponentProps> = (props) =
   return (
     <Textfield
       size={'small'}
+      prefix={prefixExternal}
+      suffix={suffixExternal}
       {...customProps}
     ></Textfield>
   );
@@ -82,9 +87,13 @@ export const InputComponent: React.FunctionComponent<IInputProps> = ({ node, isV
 
   const { langAsString } = useLanguage();
 
-  const reactNumberFormatConfig = useMapToReactNumberConfig(formatting as IInputFormatting | undefined, formValue);
+  const reactNumberFormatConfig = useMapToReactNumberConfig(
+    formatting as IInputFormattingInternal | undefined,
+    formValue,
+  );
   const ariaLabel = overrideDisplay?.renderedInTable === true ? langAsString(textResourceBindings?.title) : undefined;
-
+  const prefixExternal = textResourceBindings?.prefix ? langAsString(textResourceBindings.prefix) : undefined;
+  const suffixExternal = textResourceBindings?.suffix ? langAsString(textResourceBindings.suffix) : undefined;
   const characterLimit = useCharacterLimit(maxLength);
 
   const commonProps = {
@@ -100,6 +109,8 @@ export const InputComponent: React.FunctionComponent<IInputProps> = ({ node, isV
     required,
     onBlur: debounce,
     textOnly: overrideDisplay?.rowReadOnly && readOnly,
+    prefixExternal,
+    suffixExternal,
   };
 
   if (variant === 'search') {

--- a/src/layout/Input/InputComponent.tsx
+++ b/src/layout/Input/InputComponent.tsx
@@ -92,8 +92,8 @@ export const InputComponent: React.FunctionComponent<IInputProps> = ({ node, isV
     formValue,
   );
   const ariaLabel = overrideDisplay?.renderedInTable === true ? langAsString(textResourceBindings?.title) : undefined;
-  const prefixExternal = textResourceBindings?.prefix ? langAsString(textResourceBindings.prefix) : undefined;
-  const suffixExternal = textResourceBindings?.suffix ? langAsString(textResourceBindings.suffix) : undefined;
+  const prefixText = textResourceBindings?.prefix ? langAsString(textResourceBindings.prefix) : undefined;
+  const suffixText = textResourceBindings?.suffix ? langAsString(textResourceBindings.suffix) : undefined;
   const characterLimit = useCharacterLimit(maxLength);
 
   const commonProps = {
@@ -109,8 +109,8 @@ export const InputComponent: React.FunctionComponent<IInputProps> = ({ node, isV
     required,
     onBlur: debounce,
     textOnly: overrideDisplay?.rowReadOnly && readOnly,
-    prefixExternal,
-    suffixExternal,
+    prefixText,
+    suffixText,
   };
 
   if (variant === 'search') {

--- a/src/layout/Input/config.ts
+++ b/src/layout/Input/config.ts
@@ -87,14 +87,17 @@ export const Config = new CG.component({
           'number',
           new CG.union(
             new CG.obj(
-              new CG.prop('format', new CG.str()),
+              new CG.prop('format', new CG.expr(ExprVal.String)),
               new CG.prop('mask', new CG.union(new CG.str(), new CG.arr(new CG.str())).optional()),
               new CG.prop('allowEmptyFormatting', new CG.bool().optional()),
               new CG.prop('patternChar', new CG.str().optional()),
             ).exportAs('PatternFormatProps'),
             new CG.obj(
-              new CG.prop('thousandSeparator', new CG.union(new CG.bool(), new CG.str()).optional()),
-              new CG.prop('decimalSeparator', new CG.str().optional()),
+              new CG.prop(
+                'thousandSeparator',
+                new CG.union(new CG.expr(ExprVal.Boolean), new CG.expr(ExprVal.String)).optional(),
+              ),
+              new CG.prop('decimalSeparator', new CG.expr(ExprVal.String).optional()),
               new CG.prop('allowedDecimalSeparators', new CG.arr(new CG.str()).optional()),
               new CG.prop('thousandsGroupStyle', new CG.enum('thousand', 'lakh', 'wan', 'none').optional()),
               new CG.prop('decimalScale', new CG.num().optional()),

--- a/src/layout/Input/config.ts
+++ b/src/layout/Input/config.ts
@@ -1,4 +1,5 @@
 import { CG } from 'src/codegen/CG';
+import { ExprVal } from 'src/features/expressions/types';
 import { CompCategory } from 'src/layout/common';
 
 export const Config = new CG.component({
@@ -11,6 +12,20 @@ export const Config = new CG.component({
     renderInAccordionGroup: false,
   },
 })
+  .addTextResource(
+    new CG.trb({
+      name: 'prefix',
+      title: 'Prefix',
+      description: 'Prefix shown next to the input field',
+    }),
+  )
+  .addTextResource(
+    new CG.trb({
+      name: 'suffix',
+      title: 'Suffix',
+      description: 'Suffix shown next to the input field',
+    }),
+  )
   .addDataModelBinding(CG.common('IDataModelBindingsSimple'))
   .addProperty(new CG.prop('saveWhileTyping', CG.common('SaveWhileTyping').optional({ default: true })))
   .addProperty(
@@ -86,8 +101,8 @@ export const Config = new CG.component({
               new CG.prop('fixedDecimalScale', new CG.bool().optional()),
               new CG.prop('allowNegative', new CG.bool().optional()),
               new CG.prop('allowLeadingZeros', new CG.bool().optional()),
-              new CG.prop('suffix', new CG.str().optional()),
-              new CG.prop('prefix', new CG.str().optional()),
+              new CG.prop('suffix', new CG.expr(ExprVal.String).optional()),
+              new CG.prop('prefix', new CG.expr(ExprVal.String).optional()),
             )
               .exportAs('NumberFormatProps')
               .setTitle('Number formatting options')

--- a/src/layout/Input/config.ts
+++ b/src/layout/Input/config.ts
@@ -16,14 +16,14 @@ export const Config = new CG.component({
     new CG.trb({
       name: 'prefix',
       title: 'Prefix',
-      description: 'Prefix shown next to the input field',
+      description: 'Prefix shown before the input field',
     }),
   )
   .addTextResource(
     new CG.trb({
       name: 'suffix',
       title: 'Suffix',
-      description: 'Suffix shown next to the input field',
+      description: 'Suffix shown after the input field',
     }),
   )
   .addDataModelBinding(CG.common('IDataModelBindingsSimple'))

--- a/src/layout/Input/index.tsx
+++ b/src/layout/Input/index.tsx
@@ -10,7 +10,7 @@ import { SummaryItemSimple } from 'src/layout/Summary/SummaryItemSimple';
 import type { LayoutValidationCtx } from 'src/features/devtools/layoutValidation/types';
 import type { DisplayDataProps } from 'src/features/displayData';
 import type { PropsFromGenericComponent } from 'src/layout';
-import type { IInputFormatting } from 'src/layout/Input/config.generated';
+import type { IInputFormattingInternal } from 'src/layout/Input/config.generated';
 import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
@@ -28,7 +28,7 @@ export class Input extends InputDef {
 
     const text = node.getFormData(formDataSelector).simpleBinding || '';
     const numberFormatting = getMapToReactNumberConfig(
-      node.item.formatting as IInputFormatting | undefined,
+      node.item.formatting as IInputFormattingInternal | undefined,
       text,
       currentLanguage,
     );

--- a/src/utils/layout/hierarchy.ts
+++ b/src/utils/layout/hierarchy.ts
@@ -12,8 +12,8 @@ import { useLayoutSettings } from 'src/features/form/layoutSettings/LayoutSettin
 import { FD } from 'src/features/formData/FormDataWrite';
 import { useLaxInstanceDataSources } from 'src/features/instance/InstanceContext';
 import { useLaxProcessData } from 'src/features/instance/ProcessContext';
-import { useLangToolsRef } from 'src/features/language/LangToolsStore';
 import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
+import { useLanguageWithForcedNodeSelector } from 'src/features/language/useLanguage';
 import { useAllOptionsSelector } from 'src/features/options/useAllOptions';
 import { useCurrentView } from 'src/hooks/useNavigatePage';
 import { getLayoutComponentObject } from 'src/layout';
@@ -158,7 +158,7 @@ export function useExpressionDataSources(isHidden: ReturnType<typeof useIsHidden
   const applicationSettings = useApplicationSettings();
   const devToolsIsOpen = useDevToolsStore((state) => state.isOpen);
   const devToolsHiddenComponents = useDevToolsStore((state) => state.hiddenComponents);
-  const langToolsRef = useLangToolsRef();
+  const langToolsSelector = useLanguageWithForcedNodeSelector();
   const currentLanguage = useCurrentLanguage();
   const pageNavigationConfig = usePageNavigationConfig();
   const authContext = useMemo(() => buildAuthContext(process?.currentTask), [process?.currentTask]);
@@ -177,7 +177,7 @@ export function useExpressionDataSources(isHidden: ReturnType<typeof useIsHidden
       isHidden,
       devToolsIsOpen,
       devToolsHiddenComponents,
-      langToolsRef,
+      langToolsSelector,
       currentLanguage,
     }),
     [
@@ -193,7 +193,7 @@ export function useExpressionDataSources(isHidden: ReturnType<typeof useIsHidden
       isHidden,
       devToolsIsOpen,
       devToolsHiddenComponents,
-      langToolsRef,
+      langToolsSelector,
       currentLanguage,
     ],
   );

--- a/test/e2e/integration/frontend-test/formatting.ts
+++ b/test/e2e/integration/frontend-test/formatting.ts
@@ -1,6 +1,6 @@
 import { AppFrontend } from 'test/e2e/pageobjects/app-frontend';
 
-import type { IInputFormatting } from 'src/layout/Input/config.generated';
+import type { IInputFormattingInternal } from 'src/layout/Input/config.generated';
 
 const appFrontend = new AppFrontend();
 
@@ -46,7 +46,7 @@ describe('Formatting', () => {
     cy.get(appFrontend.group.currentValue).numberFormatClear();
     cy.get(appFrontend.group.currentValue).type('10000');
 
-    const alternatives: { format: IInputFormatting; expected: any }[] = [
+    const alternatives: { format: IInputFormattingInternal; expected: any }[] = [
       {
         format: { currency: 'NOK', number: { prefix: 'SEK ' } },
         expected: { nb: 'SEK 10 000', en: 'SEK 10,000' },


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

Some extensions for the `Input` component's `format` property, as well as adding support for the design-system component's prefix and suffix. https://storybook.designsystemet.no/?path=/docs/komponenter-textfield--docs

Expression support has been added to:
- `formatting.number.prefix`
- `formatting.number.suffix`
- `formatting.number.thousandSeparator`
- `formatting.number.decimalSeparator`

Expressions allow you to refer to text-resources using the `text`-expression, so #717 is solved by #2057.

An example of how to use text-resources with suffix:
```json
"formatting": {
  "number": {
    "suffix": ["text", "some-text-resource"],
  }
}
```

The new prefix/suffix is shown like this next to the input field and is configured in `textResourceBindings`:

`textResourceBindings.prefix`:
![image](https://github.com/Altinn/app-frontend-react/assets/47412359/ea62ad7e-0f9c-49bd-90df-056a6e9c0a9e)

`textResourceBindings.suffix`:
![image](https://github.com/Altinn/app-frontend-react/assets/47412359/23e01447-a57c-4a5b-a7b3-2a69a44d329e)

### Other
When implementing this I noticed that the `text`-expression did not update properly, so I have changed how the language tools are exposed in the expression data sources. It does not seem to cause many more rerenders for now, so I think it is fine performance wise, but we should keep an eye on it. A consequence of these changes is that the `text`-expression (and `displayValue`-expression) now gets the proper node context so it should work better in repeating group rows as well.

## Related Issue(s)

- closes https://github.com/Altinn/app-frontend-react/issues/717
- closes https://github.com/Altinn/app-frontend-react/issues/2057

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
