### PR TITLE
Use proper readOnly state for Checkboxes, Radiobuttons, and Likert

### DIFF
--- a/src/components/form/Legend.module.css
+++ b/src/components/form/Legend.module.css
@@ -2,3 +2,13 @@
   display: flex;
   flex-direction: row;
 }
+
+.legendSpan {
+  display: inline-flex;
+}
+
+.padlock {
+  margin-top: 0.2em;
+  margin-right: 0.2em;
+  flex-shrink: 0;
+}

--- a/src/components/form/Legend.tsx
+++ b/src/components/form/Legend.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { PadlockLockedFillIcon } from '@navikt/aksel-icons';
+
 import { Description } from 'src/components/form/Description';
 import { HelpTextContainer } from 'src/components/form/HelpTextContainer';
 import classes from 'src/components/form/Legend.module.css';
@@ -13,13 +15,23 @@ export interface IFormLegendProps {
   label: React.ReactNode;
   description: React.ReactNode;
   required?: boolean;
+  readOnly?: boolean;
   labelSettings?: ILabelSettings;
   helpText: React.ReactNode;
   id: string;
   layout?: LayoutStyle;
 }
 
-export function Legend({ label, required, labelSettings, id, helpText, description, layout }: IFormLegendProps) {
+export function Legend({
+  label,
+  required,
+  readOnly,
+  labelSettings,
+  id,
+  helpText,
+  description,
+  layout,
+}: IFormLegendProps) {
   const { elementAsString } = useLanguage();
   const labelAsText = elementAsString(label);
   if (!label || !labelAsText) {
@@ -27,14 +39,22 @@ export function Legend({ label, required, labelSettings, id, helpText, descripti
   }
 
   const LabelText = (
-    <>
-      {label}
-      <RequiredIndicator required={required} />
-      <OptionalIndicator
-        labelSettings={labelSettings}
-        required={required}
-      />
-    </>
+    <span className={classes.legendSpan}>
+      {readOnly && (
+        <PadlockLockedFillIcon
+          aria-hidden={true}
+          className={classes.padlock}
+        />
+      )}
+      <span>
+        {label}
+        <RequiredIndicator required={required} />
+        <OptionalIndicator
+          labelSettings={labelSettings}
+          required={required}
+        />
+      </span>
+    </span>
   );
 
   if (layout === LayoutStyle.Table) {

--- a/src/layout/Checkboxes/CheckboxesContainerComponent.tsx
+++ b/src/layout/Checkboxes/CheckboxesContainerComponent.tsx
@@ -68,7 +68,7 @@ export const CheckboxContainerComponent = ({ node, isValid, overrideDisplay }: I
         className={cn({ [classes.horizontal]: horizontal }, classes.checkboxGroup)}
         legend={labelTextGroup}
         description={textResourceBindings?.description && <Lang id={textResourceBindings?.description} />}
-        disabled={readOnly}
+        readOnly={readOnly}
         hideLegend={overrideDisplay?.renderLegend === false}
         error={!isValid}
         aria-label={ariaLabel}

--- a/src/layout/GenericComponentUtils.tsx
+++ b/src/layout/GenericComponentUtils.tsx
@@ -69,6 +69,7 @@ export function GenericComponentLegend() {
       required={'required' in node.item ? node.item.required : false}
       labelSettings={'labelSettings' in node.item ? node.item.labelSettings : undefined}
       layout={('layout' in node.item && node.item.layout) || undefined}
+      readOnly={'readOnly' in node.item ? node.item.readOnly : false}
     />
   );
 }

--- a/src/layout/LikertItem/LikertItemComponent.tsx
+++ b/src/layout/LikertItem/LikertItemComponent.tsx
@@ -43,7 +43,7 @@ const RadioGroupTableRow = forwardRef<HTMLTableRowElement, IControlledRadioGroup
   const { selected, handleChange, calculatedOptions, fetchingOptions } = useRadioButtons(props);
   const validations = useUnifiedValidationsForNode(node);
 
-  const id = node.item.id;
+  const { id, readOnly } = node.item;
   const groupContainerId = node.closest((n) => n.type === 'Likert')?.item.id;
 
   const headerColumnId = `${groupContainerId}-likert-columnheader-left`;
@@ -72,6 +72,7 @@ const RadioGroupTableRow = forwardRef<HTMLTableRowElement, IControlledRadioGroup
           <Table.Cell key={option.value}>
             <Radio
               checked={isChecked}
+              readOnly={readOnly}
               onChange={handleChange}
               value={option.value}
               className={classes.likertRadioButton}

--- a/src/layout/RadioButtons/ControlledRadioGroup.tsx
+++ b/src/layout/RadioButtons/ControlledRadioGroup.tsx
@@ -78,7 +78,7 @@ export const ControlledRadioGroup = (props: IControlledRadioGroupProps) => {
         hideLegend={overrideDisplay?.renderLegend === false}
         description={<Lang id={textResourceBindings?.description} />}
         error={!isValid}
-        disabled={readOnly}
+        readOnly={readOnly}
         inline={shouldDisplayHorizontally}
         role='radiogroup'
       >
@@ -92,7 +92,7 @@ export const ControlledRadioGroup = (props: IControlledRadioGroupProps) => {
             key={option.value}
             checked={option.value === selected}
             showAsCard={showAsCard}
-            disabled={readOnly}
+            readOnly={readOnly}
             onChange={handleChange}
             hideLabel={hideLabel}
             size='small'

--- a/test/e2e/integration/frontend-test/components.ts
+++ b/test/e2e/integration/frontend-test/components.ts
@@ -337,8 +337,8 @@ describe('UI Components', () => {
     // Make all components on the page readOnly, and snapshot the effect
     cy.get(appFrontend.changeOfName.newMiddleName).clear();
     cy.get(appFrontend.changeOfName.newMiddleName).type('all_readOnly');
-    cy.get(appFrontend.changeOfName.confirmChangeName).find('input').should('be.disabled');
-    cy.get(appFrontend.changeOfName.reasons).find('input').should('be.disabled');
+    cy.get(appFrontend.changeOfName.confirmChangeName).find('input').should('have.attr', 'readonly');
+    cy.get(appFrontend.changeOfName.reasons).find('input').should('have.attr', 'readonly');
     cy.snapshot('components:read-only');
   });
 


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

Apparently we are already using the new versions of checkboxes and radiobuttons from the design-system, so we may as well use the nicer readOnly state instead of the disabled state. I also added the padlock icon for readonly in our legend, which is used in the Likert component on desktop, so its more consistent with the mobile design.

![image](https://github.com/Altinn/app-frontend-react/assets/47412359/e750c136-0f05-4bb7-8e6d-7531ce7cc5d3)


## Related Issue(s)

- https://altinn.slack.com/archives/C02EJ9HKQA3/p1717583480896679

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
