### PR TITLE
Issue labeler ported from app-lib-dotnet

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,3 @@
+# Add 'triage' label to all new issues
+'status/triage':
+  - '/.*/'

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -1,0 +1,18 @@
+name: "Issue Labeler"
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  apply-labels:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: github/issue-labeler@v3.4
+      with:
+        configuration-path: .github/labeler.yml
+        enable-versioned-regex: 0
+        repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

This PR only modifies the GitHub workflow settings of the repository, no other code changes have been made.

The [issue labeler](https://github.com/github/issue-labeler) has been configured to add the `status/triage` tag to all new (opened) issues.

Unfortunately the functionality of this patch can only be validated from the `main` branch.