### PR TITLE
Fix alertOnChange for RadioButtons so it does not alert when empty

### DIFF
--- a/src/language/texts/en.ts
+++ b/src/language/texts/en.ts
@@ -93,7 +93,6 @@ export function en() {
       placeholder_receipt_header: 'The form has been submitted',
       placeholder_user: 'OLA PRIVATPERSON',
       radiobutton_alert_label: 'Are you sure you want to change from {0}?',
-      radiobutton_alert: 'Are you sure you want to change?',
       required_description: 'Required fields are marked with *',
       required_label: '*',
       summary_item_change: 'Change',

--- a/src/language/texts/nb.ts
+++ b/src/language/texts/nb.ts
@@ -93,7 +93,6 @@ export function nb(): FixedLanguageList {
       placeholder_receipt_header: 'Skjemaet er nå fullført og sendt inn.',
       placeholder_user: 'OLA PRIVATPERSON',
       radiobutton_alert_label: 'Er du sikker på at du vil endre fra {0}?',
-      radiobutton_alert: 'Er du sikker på at du vil endre?',
       required_description: 'Obligatoriske felter er markert med *',
       required_label: '*',
       summary_item_change: 'Endre',

--- a/src/language/texts/nn.ts
+++ b/src/language/texts/nn.ts
@@ -93,7 +93,6 @@ export function nn(): FixedLanguageList {
       placeholder_receipt_header: 'Skjemaet er no fullført og sendt inn.',
       placeholder_user: 'OLA PRIVATPERSON',
       radiobutton_alert_label: 'Er du sikker på at du vil endre frå {0}?',
-      radiobutton_alert: 'Er du sikker på at du vil endre?',
       required_description: 'Obligatoriske felt er markerte med *',
       required_label: '*',
       summary_item_change: 'Endre',

--- a/src/layout/RadioButtons/ControlledRadioGroup.tsx
+++ b/src/layout/RadioButtons/ControlledRadioGroup.tsx
@@ -18,15 +18,15 @@ export type IControlledRadioGroupProps = IRadioButtonsContainerProps;
 export const ControlledRadioGroup = (props: IControlledRadioGroupProps) => {
   const { node, isValid, overrideDisplay } = props;
   const { id, layout, readOnly, textResourceBindings, required, showAsCard } = node.item;
-  const alertOnChange = 'alertOnChange' in node.item ? node.item.alertOnChange : undefined;
-  const labelSettings = 'labelSettings' in node.item ? node.item.labelSettings : undefined;
   const { selectedValues, handleChange, fetchingOptions, calculatedOptions } = useRadioButtons(props);
+  const alertOnChange = 'alertOnChange' in node.item ? node.item.alertOnChange && !!selectedValues[0] : undefined;
+  const labelSettings = 'labelSettings' in node.item ? node.item.labelSettings : undefined;
   const { lang, langAsString } = useLanguage();
   const selectedLabel = calculatedOptions.find((option) => option.value === selectedValues[0])?.label;
   const selectedLabelTranslated = langAsString(selectedLabel);
   const alertText = selectedLabel
     ? lang('form_filler.radiobutton_alert_label', [`<strong>${selectedLabelTranslated}</strong>`])
-    : lang('form_filler.radiobutton_alert');
+    : null;
   const confirmChangeText = langAsString('form_filler.alert_confirm');
 
   const getLabelPrefixForLikert = () => {

--- a/test/e2e/integration/frontend-test/components.ts
+++ b/test/e2e/integration/frontend-test/components.ts
@@ -370,6 +370,7 @@ describe('UI Components', () => {
     cy.interceptLayout('changename', (component) => {
       if (component.id === 'reason' && component.type === 'RadioButtons') {
         component.alertOnChange = true;
+        component.preselectedOptionIndex = undefined;
       }
     });
 
@@ -378,6 +379,8 @@ describe('UI Components', () => {
     cy.get(appFrontend.changeOfName.newFirstName).blur();
     cy.get(appFrontend.changeOfName.confirmChangeName).find('label').click();
 
+    cy.findByRole('radio', { name: /Slektskap/ }).should('not.be.checked');
+    cy.findByRole('radio', { name: /Slektskap/ }).click();
     cy.findByRole('radio', { name: /Slektskap/ }).should('be.checked');
 
     cy.findByRole('radio', { name: /Gårdsbruk/ }).click();


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- https://altinn.slack.com/archives/C02EJ9HKQA3/p1718872640474839

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
