### PR TITLE
fix: we can now render previous task summaries in pdf

### DIFF
--- a/src/features/pdf/PdfView2.tsx
+++ b/src/features/pdf/PdfView2.tsx
@@ -16,8 +16,10 @@ import { usePdfFormatQuery } from 'src/features/pdf/usePdfFormatQuery';
 import { InstanceInformation } from 'src/layout/InstanceInformation/InstanceInformationComponent';
 import { SummaryComponent } from 'src/layout/Summary/SummaryComponent';
 import { ComponentSummary } from 'src/layout/Summary2/SummaryComponent2/ComponentSummary';
+import { SummaryComponent2 } from 'src/layout/Summary2/SummaryComponent2/SummaryComponent2';
 import { useNodes } from 'src/utils/layout/NodesContext';
-import type { LayoutNode } from 'src/utils/layout/LayoutNode';
+import type { CompSummary2Internal } from 'src/layout/Summary2/config.generated';
+import type { BaseLayoutNode, LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export const PDFView2 = () => {
   const nodes = useNodes();
@@ -84,6 +86,15 @@ export const PDFView2 = () => {
             .filter((node) => !pdfSettings?.excludedComponents.includes(node.item.id))
             .filter((node) => node.def.shouldRenderInAutomaticPDF(node as any))
             .map((node) => {
+              if (node.item.type === 'Summary2' && node.item.target?.taskId) {
+                return (
+                  <SummaryComponent2
+                    key={node.item.id}
+                    summaryNode={node as BaseLayoutNode<CompSummary2Internal, 'Summary2'>}
+                  />
+                );
+              }
+
               if (node.def.renderSummary2) {
                 return (
                   <ComponentSummary

--- a/src/layout/Summary2/index.tsx
+++ b/src/layout/Summary2/index.tsx
@@ -33,7 +33,7 @@ export class Summary2 extends Summary2Def {
     return null;
   }
   shouldRenderInAutomaticPDF() {
-    return false;
+    return true;
   }
 
   getDisplayData(): string {


### PR DESCRIPTION
## Description

Now rendering SummaryComponent2 in the PDF component so that previous tasks are resolved correctly.

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes #2191 

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
