### PR TITLE
Document allowedKeysForUserDefinedMetadata property

### DIFF
--- a/schemas/json/application/application-metadata.schema.v1.json
+++ b/schemas/json/application/application-metadata.schema.v1.json
@@ -388,6 +388,14 @@
           "items": {
             "type": "string"
           }
+        },
+        "allowedKeysForUserDefinedMetadata":{
+          "type":"array",
+          "title": "Allowed keys for UserDefinedMetadata",
+          "description": "A list of allowed keys for UserDefinedMetadata key-value array. If not set, any key can be used.",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },


### PR DESCRIPTION
Document allowedKeysForUserDefinedMetadata property on data type, which allows configuring which UserAllowedMetadata keys are allowed to be used.
