### PR TITLE
Added openByDefault property to Accordion

### DIFF
--- a/src/layout/Accordion/Accordion.tsx
+++ b/src/layout/Accordion/Accordion.tsx
@@ -12,7 +12,7 @@ import type { PropsFromGenericComponent } from 'src/layout';
 type IAccordionProps = PropsFromGenericComponent<'Accordion'>;
 
 export const Accordion = ({ node }: IAccordionProps) => {
-  const { textResourceBindings, renderAsAccordionItem, headingLevel } = node.item;
+  const { textResourceBindings, renderAsAccordionItem, headingLevel, openByDefault } = node.item;
   const { langAsString } = useLanguage();
 
   const title = langAsString(textResourceBindings?.title ?? '');
@@ -23,6 +23,7 @@ export const Accordion = ({ node }: IAccordionProps) => {
         title={title}
         className={classes.container}
         headingLevel={headingLevel}
+        open={openByDefault}
       >
         <Grid
           item={true}
@@ -50,6 +51,7 @@ export const Accordion = ({ node }: IAccordionProps) => {
       <AccordionItem
         title={title}
         headingLevel={headingLevel}
+        open={openByDefault}
       >
         <Grid
           item={true}

--- a/src/layout/Accordion/AccordionItem.tsx
+++ b/src/layout/Accordion/AccordionItem.tsx
@@ -4,6 +4,7 @@ import { Accordion as DesignSystemAccordion } from '@digdir/designsystemet-react
 import cn from 'classnames';
 
 import classes from 'src/layout/Accordion/Accordion.module.css';
+import type { ExprVal, ExprValToActualOrExpr } from 'src/features/expressions/types';
 import type { HeadingLevel } from 'src/layout/common.generated';
 
 interface AccordionBaseComponentProps {
@@ -11,6 +12,7 @@ interface AccordionBaseComponentProps {
   children: React.ReactNode;
   className?: string;
   headingLevel?: HeadingLevel;
+  open?: ExprValToActualOrExpr<ExprVal.Boolean>;
 }
 
 export const AccordionItem = ({
@@ -18,9 +20,26 @@ export const AccordionItem = ({
   children,
   className,
   headingLevel = 2,
-}: AccordionBaseComponentProps): React.JSX.Element => (
-  <DesignSystemAccordion.Item className={cn(className, classes.accordion)}>
-    <DesignSystemAccordion.Header level={headingLevel}>{title}</DesignSystemAccordion.Header>
-    <DesignSystemAccordion.Content>{children}</DesignSystemAccordion.Content>
-  </DesignSystemAccordion.Item>
-);
+  open,
+}: AccordionBaseComponentProps): React.JSX.Element => {
+  const [isOpen, setOpen] = React.useState(open);
+
+  const handleHeaderClick = () => {
+    setOpen(!isOpen);
+  };
+
+  return (
+    <DesignSystemAccordion.Item
+      open={isOpen as boolean}
+      className={cn(className, classes.accordion)}
+    >
+      <DesignSystemAccordion.Header
+        onHeaderClick={handleHeaderClick}
+        level={headingLevel}
+      >
+        {title}
+      </DesignSystemAccordion.Header>
+      <DesignSystemAccordion.Content>{children}</DesignSystemAccordion.Content>
+    </DesignSystemAccordion.Item>
+  );
+};

--- a/src/layout/Accordion/config.ts
+++ b/src/layout/Accordion/config.ts
@@ -1,4 +1,5 @@
 import { CG, Variant } from 'src/codegen/CG';
+import { ExprVal } from 'src/features/expressions/types';
 import { CompCategory } from 'src/layout/common';
 
 export const Config = new CG.component({
@@ -27,6 +28,15 @@ export const Config = new CG.component({
         .setTitle('Children')
         .setDescription('List of child component IDs to show inside the Accordion (limited to a few component types)'),
     ).onlyIn(Variant.External),
+  )
+  .addProperty(
+    new CG.prop(
+      'openByDefault',
+      new CG.expr(ExprVal.Boolean)
+        .optional({ default: false })
+        .setTitle('Open by default')
+        .setDescription('Boolean value indicating if the accordion should be open by default'),
+    ),
   )
   .addProperty(new CG.prop('childComponents', new CG.arr(CG.layoutNode)).onlyIn(Variant.Internal))
   .addProperty(new CG.prop('renderAsAccordionItem', new CG.bool().optional()).onlyIn(Variant.Internal))


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->
Added openByDefault property to Accordion, that accepts boolean true/false and expressions

## Note
I noticed that Ole Martin had commented on issue 2238 that it should not be possible to have more that one children open at once in a AccordionGroup. This option is currently not implemented.

## Related Issue(s)
- closes #2238 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
