### PR TITLE
Add 'base' element to 'head' to normalize relative urls/references

### DIFF
--- a/src/features/baseurlinjection.ts
+++ b/src/features/baseurlinjection.ts
@@ -4,9 +4,7 @@
 //   folder of the app.
 // The `base` element in the HTML head will make relative references resolve from `base.href`.
 // Bugreport: https://github.com/Altinn/app-frontend-react/issues/2257
-const heads = document.getElementsByTagName('head');
-if (heads && heads.length > 0) {
-  const head = heads[0];
+(() => {
   const base = document.createElement('base');
   const { protocol, hostname, port: _port } = window.location;
   const { org, app } = window;
@@ -15,5 +13,5 @@ if (heads && heads.length > 0) {
   const isDefaultPort = isDefaultHttpsPort || isDefaultHttpPort;
   const port = _port && !isDefaultPort ? `:${_port}` : '';
   base.href = `${protocol}//${hostname}${port}/${org}/${app}/`;
-  head.appendChild(base);
-}
+  document.head.appendChild(base);
+})();

--- a/src/features/baseurlinjection.ts
+++ b/src/features/baseurlinjection.ts
@@ -1,0 +1,16 @@
+
+// Apps are running in a subpath of `/{org}/{app}` both locally and in deployed environments
+// some features make use of relative paths that should resolve relative to this subpath.
+// * `image.src` on the `ImageComponent` might have `some-image.jpg` which we expect to then exist in the `wwwroot/`
+//   folder of the app.
+// The `base` element in the HTML head will make relative references resolve from `base.href`.
+// Bugreport: https://github.com/Altinn/app-frontend-react/issues/2257
+const heads = document.getElementsByTagName('head');
+if (heads && heads.length > 0)
+{
+  const head = heads[0];
+  const base = document.createElement('base');
+  base.href = window.location.protocol + '//' + window.location.hostname + (window.location.port ? ':' + window.location.port : '');
+  base.href += `${window.org}/${window.app}/`;
+  head.appendChild(base);
+}

--- a/src/features/baseurlinjection.ts
+++ b/src/features/baseurlinjection.ts
@@ -4,7 +4,7 @@
 //   folder of the app.
 // The `base` element in the HTML head will make relative references resolve from `base.href`.
 // Bugreport: https://github.com/Altinn/app-frontend-react/issues/2257
-(() => {
+{
   const base = document.createElement('base');
   const { protocol, hostname, port: _port } = window.location;
   const { org, app } = window;
@@ -14,4 +14,4 @@
   const port = _port && !isDefaultPort ? `:${_port}` : '';
   base.href = `${protocol}//${hostname}${port}/${org}/${app}/`;
   document.head.appendChild(base);
-})();
+}

--- a/src/features/baseurlinjection.ts
+++ b/src/features/baseurlinjection.ts
@@ -1,4 +1,3 @@
-
 // Apps are running in a subpath of `/{org}/{app}` both locally and in deployed environments
 // some features make use of relative paths that should resolve relative to this subpath.
 // * `image.src` on the `ImageComponent` might have `some-image.jpg` which we expect to then exist in the `wwwroot/`
@@ -9,9 +8,12 @@ const heads = document.getElementsByTagName('head');
 if (heads && heads.length > 0) {
   const head = heads[0];
   const base = document.createElement('base');
-  base.href = window.location.protocol + '//' +
-    window.location.hostname +
-    (window.location.port ? ':' + window.location.port : '');
-  base.href += `${window.org}/${window.app}/`;
+  const { protocol, hostname, port: _port } = window.location;
+  const { org, app } = window;
+  const isDefaultHttpsPort = protocol === 'https:' && _port === '443';
+  const isDefaultHttpPort = protocol === 'http:' && _port === '80';
+  const isDefaultPort = isDefaultHttpsPort || isDefaultHttpPort;
+  const port = _port && !isDefaultPort ? `:${_port}` : '';
+  base.href = `${protocol}//${hostname}${port}/${org}/${app}/`;
   head.appendChild(base);
 }

--- a/src/features/baseurlinjection.ts
+++ b/src/features/baseurlinjection.ts
@@ -9,7 +9,9 @@ const heads = document.getElementsByTagName('head');
 if (heads && heads.length > 0) {
   const head = heads[0];
   const base = document.createElement('base');
-  base.href = window.location.protocol + '//' + window.location.hostname + (window.location.port ? ':' + window.location.port : '');
+  base.href = window.location.protocol + '//' +
+    window.location.hostname +
+    (window.location.port ? ':' + window.location.port : '');
   base.href += `${window.org}/${window.app}/`;
   head.appendChild(base);
 }

--- a/src/features/baseurlinjection.ts
+++ b/src/features/baseurlinjection.ts
@@ -6,8 +6,7 @@
 // The `base` element in the HTML head will make relative references resolve from `base.href`.
 // Bugreport: https://github.com/Altinn/app-frontend-react/issues/2257
 const heads = document.getElementsByTagName('head');
-if (heads && heads.length > 0)
-{
+if (heads && heads.length > 0) {
   const head = heads[0];
   const base = document.createElement('base');
   base.href = window.location.protocol + '//' + window.location.hostname + (window.location.port ? ':' + window.location.port : '');

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,6 +7,7 @@ import { createRoot } from 'react-dom/client';
 import { createHashRouter, RouterProvider, ScrollRestoration } from 'react-router-dom';
 import { Slide, ToastContainer } from 'react-toastify';
 
+import 'src/features/baseurlinjection';
 import 'src/features/toggles';
 import 'src/features/logging';
 import 'src/features/styleInjection';


### PR DESCRIPTION
## Description

The browser I tested (Chrome) exhibited different behaviors when resolving relative URLs depending on wether or not the hash for client side routing in the URL was prefixed with a slash or not. In other words

* This worked: `https://pat.apps.tt02.altinn.no/pat/varemerke/#/instance/...`
* This did not: `https://pat.apps.tt02.altinn.no/pat/varemerke#/instance/...` - the resolved absolute URL did not include the app ID

This PR adds a `base` element to the head of the document as early as possible (one of the first imports in index).

## Related Issue(s)

- closes https://github.com/Altinn/app-frontend-react/issues/2257

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
