### PR TITLE
fix: mapcomponent URL change to use new cache server dependency bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "webpack-dev-server": "5.0.4"
   },
   "dependencies": {
-    "@altinn/altinn-design-system": "0.30.0",
+    "@altinn/altinn-design-system": "0.30.1",
     "@babel/polyfill": "7.12.1",
     "@date-io/moment": "1.3.13",
     "@digdir/design-system-react": "0.54.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19,9 +19,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@altinn/altinn-design-system@npm:0.30.0":
-  version: 0.30.0
-  resolution: "@altinn/altinn-design-system@npm:0.30.0"
+"@altinn/altinn-design-system@npm:0.30.1":
+  version: 0.30.1
+  resolution: "@altinn/altinn-design-system@npm:0.30.1"
   dependencies:
     "@altinn/figma-design-tokens": "npm:^6.0.1"
     "@digdir/design-system-react": "npm:0.16.0"
@@ -32,7 +32,7 @@ __metadata:
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 10c0/46009d9c3f1df6988dd21488e61c0b753938415fc532eb5ddadead05cda718b9de1fac237c1f243af97bd8b4991ef167010c84d2352ae13fb7474006c9b70d4d
+  checksum: 10c0/29c008fb6bd9e87adf62d3a8f816bed1a1e71873a8f015fcf0cc1fe1ea6c9170b512a2b87c07f7d84628c8dee22e07b39b8c23b40a49f57f2d2d40ed7dfcd709
   languageName: node
   linkType: hard
 
@@ -4770,7 +4770,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "app-frontend-react@workspace:."
   dependencies:
-    "@altinn/altinn-design-system": "npm:0.30.0"
+    "@altinn/altinn-design-system": "npm:0.30.1"
     "@babel/core": "npm:7.25.2"
     "@babel/plugin-transform-runtime": "npm:^7.21.0"
     "@babel/polyfill": "npm:7.12.1"


### PR DESCRIPTION
## Updated altinn-design-studio to pull changes to map cache server URL
This is a fix due to the Map-component using old cache servers that are scheduled for retirement and are slow and unusable


## Verification/QA

- Manual functionality testing
  - [X] I have tested these changes manually
  - [X] No testing done/necessary
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [X] No testing done/necessary (no DOM/visual changes)
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [X] No functionality has been changed/added, so no documentation is needed
- Support in Altinn Studio
  - [X] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [X] I don't have permissions to do that, please help me out
- Labels
  - [X] I have added the correct label
