### PR TITLE
Fix labels rendered as span not getting their styling set

### DIFF
--- a/src/components/label/LabelContent.tsx
+++ b/src/components/label/LabelContent.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { HelpText } from '@digdir/designsystemet-react';
+import cn from 'classnames';
 
 import { Description } from 'src/components/form/Description';
 import { OptionalIndicator } from 'src/components/form/OptionalIndicator';
@@ -19,9 +20,18 @@ export type LabelContentProps = Readonly<{
   readOnly?: boolean;
   help?: string;
   labelSettings?: ILabelSettings;
-}>;
+}> & { className?: string };
 
-export function LabelContent({ id, label, description, required, readOnly, help, labelSettings }: LabelContentProps) {
+export function LabelContent({
+  id,
+  label,
+  description,
+  required,
+  readOnly,
+  help,
+  labelSettings,
+  className,
+}: LabelContentProps) {
   const { overrideDisplay } = useFormComponentCtxStrict();
   const { langAsString } = useLanguage();
 
@@ -32,7 +42,7 @@ export function LabelContent({ id, label, description, required, readOnly, help,
   return (
     <span
       id={id}
-      className={classes.labelWrapper}
+      className={cn(classes.labelWrapper, className)}
     >
       <span className={classes.labelContainer}>
         <span className={classes.labelContent}>


### PR DESCRIPTION
## Description

Fixes label rendered as span not getting its styling from the designsystem by allowing the designsystem to set classnames on the span.

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
