### PR TITLE
Logging errors when we see duplicate component IDs

### DIFF
--- a/src/features/form/layout/LayoutsContext.tsx
+++ b/src/features/form/layout/LayoutsContext.tsx
@@ -89,6 +89,8 @@ function processLayouts(input: ILayoutCollection): LayoutContextValue {
     expandedWidthLayouts[key] = file.data.expandedWidth;
   }
 
+  warnAboutDuplicateComponentIds(layouts);
+
   const config: ExprObjConfig<{ hidden: ExprVal.Boolean; whatever: string }> = {
     hidden: {
       returnType: 'test',
@@ -110,4 +112,24 @@ function processLayouts(input: ILayoutCollection): LayoutContextValue {
     hiddenLayoutsExpressions,
     expandedWidthLayouts,
   };
+}
+
+function warnAboutDuplicateComponentIds(layouts: ILayouts) {
+  const seenIds = new Map<string, { pageKey: string; idx: number }>();
+
+  for (const pageKey of Object.keys(layouts)) {
+    const page = layouts[pageKey] || [];
+    for (const [idx, comp] of page.entries()) {
+      const prev = seenIds.get(comp.id);
+      if (prev) {
+        window.logError(
+          `Found duplicate component id '${comp.id}' from page '${pageKey}' at index ${idx} ` +
+            `(first found on page '${prev.pageKey})' at index ${prev.idx}). Such duplicate components will ` +
+            `be automatically removed from your layout in the next release.`,
+        );
+        continue;
+      }
+      seenIds.set(comp.id, { pageKey, idx });
+    }
+  }
 }


### PR DESCRIPTION
## Description

In the upcoming #2244 duplicate component IDs in the same layout-set would be a hard error, and will be removed from the layout when first seen. To make sure app developers get time to fix their apps and get to know which components fail this check, I'm adding this code to log an error to DevTools.

## Related Issue(s)


## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
