### PR TITLE
Fix payment information component not fetching latest data on first render

### DIFF
--- a/src/layout/PaymentDetails/PaymentDetailsComponent.tsx
+++ b/src/layout/PaymentDetails/PaymentDetailsComponent.tsx
@@ -20,6 +20,11 @@ export function PaymentDetailsComponent({ node }: IPaymentDetailsProps) {
   const mappedValues = FD.useMapping(mapping);
   const prevMappedValues = useRef<Record<string, unknown>>(mappedValues);
 
+  // refetch data on mount by invalidating cache as the first fetch is done by the formPrefetcher
+  useEffect(() => {
+    refetchOrderDetails();
+  });
+
   useEffect(() => {
     if (!hasUnsavedChanges && mapping && !deepEqual(prevMappedValues.current, mappedValues)) {
       refetchOrderDetails();

--- a/src/layout/PaymentDetails/PaymentDetailsComponent.tsx
+++ b/src/layout/PaymentDetails/PaymentDetailsComponent.tsx
@@ -22,7 +22,6 @@ export function PaymentDetailsComponent({ node }: IPaymentDetailsProps) {
 
   // refetch data on mount by invalidating cache as the first fetch is done by the formPrefetcher
   useEffect(() => {
-    console.log('refetchOrderDetails');
     refetchOrderDetails();
   }, [refetchOrderDetails]);
 

--- a/src/layout/PaymentDetails/PaymentDetailsComponent.tsx
+++ b/src/layout/PaymentDetails/PaymentDetailsComponent.tsx
@@ -22,8 +22,9 @@ export function PaymentDetailsComponent({ node }: IPaymentDetailsProps) {
 
   // refetch data on mount by invalidating cache as the first fetch is done by the formPrefetcher
   useEffect(() => {
+    console.log('refetchOrderDetails');
     refetchOrderDetails();
-  });
+  }, [refetchOrderDetails]);
 
   useEffect(() => {
     if (!hasUnsavedChanges && mapping && !deepEqual(prevMappedValues.current, mappedValues)) {


### PR DESCRIPTION
## Description

Because the order details are prefetched when the form loads we have to refetch the data when mounting the component in order to not use the stale cached data the was prefetched.

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes #2277 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
