### PR TITLE
fix: use allowedPartyTypes to filter valid parties

### DIFF
--- a/src/components/altinnParty.test.tsx
+++ b/src/components/altinnParty.test.tsx
@@ -7,6 +7,7 @@ import { userEvent } from '@testing-library/user-event';
 import { getPartyMock } from 'src/__mocks__/getPartyMock';
 import { AltinnParty } from 'src/components/altinnParty';
 import { renderWithInstanceAndLayout } from 'src/test/renderWithProviders';
+import { PartyType } from 'src/types/shared';
 import type { IAltinnPartyProps } from 'src/components/altinnParty';
 
 const user = userEvent.setup();
@@ -88,7 +89,7 @@ describe('altinnParty', () => {
         party: {
           ...getPartyMock(),
           orgNumber: '1000000',
-          partyTypeName: 2,
+          partyTypeName: PartyType.Organisation,
         },
       });
       expect(screen.getByTestId('org-icon')).toBeVisible();

--- a/src/features/party/partyProviderUtils.test.ts
+++ b/src/features/party/partyProviderUtils.test.ts
@@ -42,7 +42,7 @@ describe('flattenParties', () => {
         name: 'Party2',
         onlyHierarchyElementWithNoAccess: false,
         partyId: 3,
-        partyTypeName: 1,
+        partyTypeName: PartyType.Person,
         ssn: null,
       },
       {
@@ -52,7 +52,7 @@ describe('flattenParties', () => {
             name: 'ChildParty1',
             onlyHierarchyElementWithNoAccess: false,
             partyId: 2,
-            partyTypeName: 4,
+            partyTypeName: PartyType.SubUnit,
             ssn: null,
           },
         ],
@@ -60,7 +60,7 @@ describe('flattenParties', () => {
         name: 'Party1',
         onlyHierarchyElementWithNoAccess: false,
         partyId: 1,
-        partyTypeName: 2,
+        partyTypeName: PartyType.Organisation,
         ssn: null,
       },
       {
@@ -68,7 +68,7 @@ describe('flattenParties', () => {
         name: 'ChildParty1',
         onlyHierarchyElementWithNoAccess: false,
         partyId: 2,
-        partyTypeName: 4,
+        partyTypeName: PartyType.SubUnit,
         ssn: null,
       },
     ];

--- a/src/features/party/partyProviderUtils.ts
+++ b/src/features/party/partyProviderUtils.ts
@@ -1,4 +1,4 @@
-import { type IParty, PartyType } from 'src/types/shared';
+import { type IParty } from 'src/types/shared';
 import type { ApplicationMetadata } from 'src/features/applicationMetadata/types';
 
 export const flattenParties = (parties: IParty[]): IParty[] => {
@@ -22,19 +22,12 @@ export const reduceToValidParties = (parties: IParty[], appMetadata: Application
   const allParties = flattenParties(parties);
   const { partyTypesAllowed } = appMetadata;
 
-  const partyTypeFilters = {
-    [PartyType.Organisation]: partyTypesAllowed.organisation,
-    [PartyType.SubUnit]: partyTypesAllowed.subUnit,
-    [PartyType.Person]: partyTypesAllowed.person,
-    [PartyType.BankruptcyEstate]: partyTypesAllowed.bankruptcyEstate,
-  };
-
   // Fun fact: If all party types are false then all are true
-  if (Object.values(partyTypeFilters).every((value) => !value)) {
+  if (Object.values(partyTypesAllowed).every((value) => !value)) {
     return allParties.filter((party) => !party.isDeleted && !party.onlyHierarchyElementWithNoAccess);
   }
 
   return allParties.filter(
-    (party) => !party.isDeleted && !party.onlyHierarchyElementWithNoAccess && partyTypeFilters[party.partyTypeName],
+    (party) => !party.isDeleted && !party.onlyHierarchyElementWithNoAccess && partyTypesAllowed[party.partyTypeName],
   );
 };

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -151,11 +151,11 @@ export interface IParty {
  * @see https://github.com/Altinn/altinn-platform/blob/main/Altinn.Platform.Models/src/Register/Enums/PartyType.cs
  */
 export enum PartyType {
-  Person = 1,
-  Organisation = 2,
-  SelfIdentified = 3,
-  SubUnit = 4,
-  BankruptcyEstate = 5,
+  Person = 'person',
+  Organisation = 'organisation',
+  SelfIdentified = 'selfIdentified',
+  SubUnit = 'subUnit',
+  BankruptcyEstate = 'bankruptcyEstate',
 }
 
 export interface IPerson {

--- a/test/e2e/integration/frontend-test/party-selection.ts
+++ b/test/e2e/integration/frontend-test/party-selection.ts
@@ -78,7 +78,7 @@ const ExamplePerson2: IParty = {
 const InvalidParty: IParty = {
   partyId: 50085642,
   partyUuid: 'bb1aeb78-237e-47fb-b600-727803500985',
-  partyTypeName: 1,
+  partyTypeName: PartyType.Person,
   orgNumber: '',
   ssn: '23033600534',
   unitType: null,


### PR DESCRIPTION
## Description

Our form at Digital gravferdsmelding has suddenly startet displaying this error message locally, and it seems like this started in version 4.4.0.

![image](https://github.com/user-attachments/assets/984991ab-eeb7-4733-acc1-62d7724561ca)

I think the issue was introduced in this [PR](https://github.com/Altinn/app-frontend-react/pull/2126/files/9242729e088a86bf477dd28050870b716c9c6f09#diff-9c7e421849a215d3749ef23201a265f6f0202ad2ed7a562c332715aa615f648e) but I am not quite sure if this is a bug in the app frontend or if our app is providing incorrect data.

The issue occurs because when the frontend is reducing valid parties it filters each party on a condition `partyTypeFilters[party.partyTypeName]` from line 38 in `partyProviderUtils`. The issue with this is that `partyTypeFilters` is an object that is contructed in this util function like this: 
```tsx
const partyTypeFilters = {
  [PartyType.Organisation]: partyTypesAllowed.organisation,
  [PartyType.SubUnit]: partyTypesAllowed.subUnit,
  [PartyType.Person]: partyTypesAllowed.person,
  [PartyType.BankruptcyEstate]: partyTypesAllowed.bankruptcyEstate,
};
```

Where `PartyType` looks like this: 
```tsx 
export enum PartyType {
  Person = 1,
  Organisation = 2,
  SelfIdentified = 3,
  SubUnit = 4,
  BankruptcyEstate = 5,
}
```

This, in my case, evaluates to a filter like this: 
```tsx
const partyTypeFilters = {
  2: false,
  4: false,
  1: true,
  5: false,
};
```
However, `party.partyTypeName` is not an int representing one of these values, but rather a string `"person"`, which means that line 38 will always evaluate to `false` for every party, even though that party should be valid. 

So I am wondering if the `partyTypeName` should actually be the string `"person"`, and there is a bug in the code, or are we doing something incorrectly in our form that makes the `/parties`-endpoint return incorrect data?

EDIT: I see that the cypress tests are all failing, and that the types for `IParty` suggest that `partyTypeName` should in fact be `PartyTypes` (enum integer value). Can someone confirm if this is correct? :sweat_smile: 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
