### PR TITLE
Add test for component in table with innerGrid

### DIFF
--- a/test/e2e/integration/frontend-test/group-pets.ts
+++ b/test/e2e/integration/frontend-test/group-pets.ts
@@ -161,4 +161,44 @@ describe('Group (Pets)', () => {
     cy.get(appFrontend.nextButton).click();
     cy.get(appFrontend.errorReport).should('not.exist');
   });
+
+  it('innerGrid should be ignored when editing in table', () => {
+    cy.interceptLayout('group', (comp) => {
+      if (comp.id === 'pets' && comp.type === 'RepeatingGroup') {
+        comp.tableColumns = {
+          ...comp.tableColumns,
+          'pet-name': {
+            editInTable: true,
+            showInExpandedEdit: true,
+          },
+        };
+      }
+      if (comp.id === 'pet-species' && comp.type === 'Dropdown') {
+        comp.grid = {
+          ...comp.grid,
+          innerGrid: {
+            xs: 1,
+          },
+        };
+      }
+      if (comp.id === 'pet-name' && comp.type === 'Input') {
+        comp.grid = {
+          ...comp.grid,
+          innerGrid: {
+            xs: 1,
+          },
+        };
+      }
+    });
+
+    cy.goto('group');
+    cy.gotoNavPage('Kjæledyr');
+
+    cy.get(appFrontend.pets.decisionPanel.autoPetsButton).click();
+
+    cy.findAllByRole('combobox', { name: /art/i }).first().invoke('outerWidth').should('be.gt', 150);
+    cy.findAllByRole('textbox', { name: /navn/i }).first().invoke('outerWidth').should('be.gt', 200);
+
+    cy.snapshot('pets:edit-in-table');
+  });
 });


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

Added test case and snapshot for editing component in table with innerGrid, which should be overridden.

## Related Issue(s)

-  https://github.com/Altinn/app-frontend-react/pull/2289

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [x] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
