### PR TITLE
Add regression test for PaymentDetails component

### DIFF
--- a/src/layout/PaymentDetails/PaymentDetailsComponent.tsx
+++ b/src/layout/PaymentDetails/PaymentDetailsComponent.tsx
@@ -19,7 +19,7 @@ export function PaymentDetailsComponent({ node }: IPaymentDetailsProps) {
   const hasUnsavedChanges = FD.useHasUnsavedChanges();
 
   const mappedValues = FD.useMapping(mapping);
-  const prevMappedValues = useRef<Record<string, unknown>>(mappedValues);
+  const prevMappedValues = useRef<Record<string, unknown> | undefined>(undefined);
 
   // refetch data on mount by invalidating cache as the first fetch is done by the formPrefetcher
   useEffect(() => {

--- a/test/e2e/integration/payment-test/payment.ts
+++ b/test/e2e/integration/payment-test/payment.ts
@@ -77,4 +77,17 @@ describe('Payment', () => {
       });
     });
   });
+
+  describe('PaymentInformation component', () => {
+    it('should display the payment information', () => {
+      // hiding the payment details component on the page where the orderlines are created in order to test the
+      // payment information component fetching order details on first render
+      cy.interceptLayout('05GoodsAndServices', (component) => {
+        if (component.id === 'paymentDetails' && component.type === 'PaymentDetails') {
+          component.hidden = true;
+        }
+      });
+      cy.findByRole('row', { name: /1 - test 1 1000 NOK/ }).should('exist');
+    });
+  });
 });

--- a/test/e2e/integration/payment-test/payment.ts
+++ b/test/e2e/integration/payment-test/payment.ts
@@ -79,9 +79,10 @@ describe('Payment', () => {
   });
 
   describe('PaymentInformation component', () => {
-    it('should display the payment information', () => {
+    it('should re-fetch stale data when rendering the component for the first time after the relevant data in the datamodel has changed', () => {
       // hiding the payment details component on the page where the orderlines are created in order to test the
-      // payment information component fetching order details on first render
+      // payment information component fetching order details on first render. Another payment details component exists
+      // on the last page of the data task, where this test is being performed.
       cy.interceptLayout('05GoodsAndServices', (component) => {
         if (component.id === 'paymentDetails' && component.type === 'PaymentDetails') {
           component.hidden = true;


### PR DESCRIPTION
## Description

Adding a cypress test make sure orderlines are fetched and displayed for PaymentDetails component.

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
