### PR TITLE
Adding back `eslint` automatic formatting in generated files

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,4 +1,4 @@
-import { fixupConfigRules, fixupPluginRules, includeIgnoreFile } from '@eslint/compat';
+import { fixupConfigRules, fixupPluginRules } from '@eslint/compat';
 import { FlatCompat } from '@eslint/eslintrc';
 import js from '@eslint/js';
 import pluginCypress from 'eslint-plugin-cypress/flat';
@@ -21,12 +21,10 @@ const compat = new FlatCompat({
   recommendedConfig: js.configs.recommended,
   allConfig: js.configs.all,
 });
-const gitignorePath = path.resolve(__dirname, '.gitignore');
 
 export default tseslint.config(
   js.configs.recommended,
   ...tseslint.configs.recommended,
-  includeIgnoreFile(gitignorePath),
   ...fixupConfigRules(
     compat.extends(
       'eslint:recommended',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -178,4 +178,11 @@ export default tseslint.config(
       'no-console': 'off',
     },
   },
+  {
+    files: ['src/**/*.generated.{ts,tsx}'],
+    rules: {
+      'no-explicit-any': 'off',
+      '@typescript-eslint/no-explicit-any': 'off',
+    },
+  },
 );

--- a/src/codegen/run.ts
+++ b/src/codegen/run.ts
@@ -69,12 +69,11 @@ async function getComponentList() {
       const config = require(`src/layout/${key}/config`).Config;
       config.setType(componentList[key], key);
       configMap[key] = config;
-      const out = config.generateConfigFile();
-      return `/* eslint-disable @typescript-eslint/no-explicit-any */\n${out}`;
+      return config.generateConfigFile();
     });
     const defClass = await CodeGeneratorContext.generateTypeScript(tsPathDef, () => {
       const def = configMap[key].generateDefClass();
-      return [`/* eslint-disable @typescript-eslint/no-explicit-any */`, `import React from 'react';`, def].join('\n');
+      return `import React from 'react';\n\n${def}`;
     });
 
     promises.push(saveTsFile(tsPathConfig, config));

--- a/src/codegen/run.ts
+++ b/src/codegen/run.ts
@@ -64,19 +64,20 @@ async function getComponentList() {
     const tsPathConfig = `src/layout/${key}/config.generated.ts`;
     const tsPathDef = `src/layout/${key}/config.def.generated.tsx`;
 
-    const content = await CodeGeneratorContext.generateTypeScript(tsPathConfig, () => {
+    const config = await CodeGeneratorContext.generateTypeScript(tsPathConfig, () => {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const config = require(`src/layout/${key}/config`).Config;
       config.setType(componentList[key], key);
       configMap[key] = config;
-      return config.generateConfigFile();
+      const out = config.generateConfigFile();
+      return `/* eslint-disable @typescript-eslint/no-explicit-any */\n${out}`;
     });
     const defClass = await CodeGeneratorContext.generateTypeScript(tsPathDef, () => {
       const def = configMap[key].generateDefClass();
-      return `import React from 'react';\n\n${def}`;
+      return [`/* eslint-disable @typescript-eslint/no-explicit-any */`, `import React from 'react';`, def].join('\n');
     });
 
-    promises.push(saveTsFile(tsPathConfig, content));
+    promises.push(saveTsFile(tsPathConfig, config));
     promises.push(saveTsFile(tsPathDef, defClass));
   }
 


### PR DESCRIPTION
## Description

Generated TS files use eslint to run prettier and to look good, so that the code generator does not have to deal with indentations and whatnot. This fell out recently when the generated files were ignored (in order to not have to deal with `any`s in those files). This adds back support for running eslint, but just ignores anys.

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
