### PR TITLE
Added download option for Link component

### DIFF
--- a/src/layout/Link/LinkComponent.test.tsx
+++ b/src/layout/Link/LinkComponent.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import { jest } from '@jest/globals';
 import { screen } from '@testing-library/react';
 
 import { LinkComponent } from 'src/layout/Link/LinkComponent';
@@ -40,6 +39,7 @@ describe('LinkComponent', () => {
       'href',
       'https://www.digdir.no/service',
     );
+    expect(screen.getByRole('link', { name: 'Link to service' })).not.toHaveAttribute('download');
   });
 
   it('should have correct link attributes when openInNewTab = false', async () => {
@@ -51,31 +51,36 @@ describe('LinkComponent', () => {
       'href',
       'https://www.digdir.no/service',
     );
+    expect(screen.getByRole('link', { name: 'Link to service' })).not.toHaveAttribute('download');
   });
 
-  it('button should call window.open() with correct arguments when openInNewTab = true', async () => {
-    global.open = jest.fn() as Window['open'];
-    await render({
-      title: 'Button to service',
+  it('should have correct link attributes when download is set', async () => {
+    await renderWithDownload({
+      title: 'Link to service',
       target: 'https://www.digdir.no/service',
-      style: 'primary',
-      openInNewTab: true,
+      style: 'link',
+      download: 'file.txt',
     });
 
-    screen.getByRole('button', { name: 'Button to service' }).click();
-    expect(global.open).toHaveBeenCalledWith('https://www.digdir.no/service', '_blank');
+    expect(screen.getByRole('link', { name: 'Link to service' })).not.toHaveAttribute('target');
+    expect(screen.getByRole('link', { name: 'Link to service' })).not.toHaveAttribute('rel');
+    expect(screen.getByRole('link', { name: 'Link to service' })).toHaveAttribute(
+      'href',
+      'https://www.digdir.no/service',
+    );
+    expect(screen.getByRole('link', { name: 'Link to service' })).toHaveAttribute('download', 'file.txt');
   });
 
-  it('button should call window.open() with correct arguments when openInNewTab = false', async () => {
-    global.open = jest.fn() as Window['open'];
-    await render({
+  it('button should have correct link attributes when download is set', async () => {
+    await renderWithDownload({
       title: 'Button to service',
       target: 'https://www.digdir.no/service',
-      style: 'primary',
+      style: 'secondary',
+      download: 'file.txt',
     });
 
-    screen.getByRole('button', { name: 'Button to service' }).click();
-    expect(global.open).toHaveBeenCalledWith('https://www.digdir.no/service', '_self');
+    // should verify onclick target, but don't know how...
+    expect(screen.getByRole('button', { name: 'Button to service' })).toBeInTheDocument();
   });
 });
 
@@ -88,6 +93,23 @@ const render = async ({ title, target, openInNewTab = false, style = 'primary' }
       textResourceBindings: {
         title,
         target,
+      },
+      openInNewTab,
+      style: style as LinkStyle,
+    },
+  });
+};
+
+const renderWithDownload = async ({ title, target, openInNewTab = false, style = 'primary', download = '' }) => {
+  await renderGenericComponentTest({
+    type: 'Link',
+    renderer: (props) => <LinkComponent {...props} />,
+    component: {
+      id: 'some-id',
+      textResourceBindings: {
+        title,
+        target,
+        download,
       },
       openInNewTab,
       style: style as LinkStyle,

--- a/src/layout/Link/LinkComponent.tsx
+++ b/src/layout/Link/LinkComponent.tsx
@@ -26,11 +26,13 @@ export function LinkComponent({ node }: ILinkComponent) {
   const { langAsString } = useLanguage();
   const parentIsPage = node.parent instanceof LayoutPage;
   const style = { marginTop: parentIsPage ? 'var(--button-margin-top)' : undefined };
+  const downloadName = textResourceBindings?.download;
 
   const Link = () => (
     <div style={style}>
       <a
         id={`link-${id}`}
+        download={downloadName !== undefined ? (downloadName === '' ? true : langAsString(downloadName)) : undefined}
         href={langAsString(textResourceBindings?.target)}
         target={openInNewTab ? '_blank' : undefined}
         rel={openInNewTab ? 'noreferrer' : undefined}
@@ -47,11 +49,25 @@ export function LinkComponent({ node }: ILinkComponent) {
       color={buttonStyles[linkStyle].color}
       variant={buttonStyles[linkStyle].variant}
       size='small'
-      onClick={() => window.open(langAsString(textResourceBindings?.target), openInNewTab ? '_blank' : '_self')}
+      onClick={LinkButtonOnClick()}
     >
       <Lang id={textResourceBindings?.title} />
     </Button>
   );
+
+  function LinkButtonOnClick() {
+    return () => {
+      const anchor = document.createElement('a');
+      anchor.href = langAsString(textResourceBindings?.target);
+      anchor.target = openInNewTab ? '_blank' : '_self';
+      if (textResourceBindings?.download !== undefined) {
+        anchor.download = textResourceBindings?.download === '' ? '' : langAsString(textResourceBindings?.download);
+      }
+      document.body.appendChild(anchor);
+      anchor.click();
+      document.body.removeChild(anchor);
+    };
+  }
 
   return (
     <ComponentStructureWrapper node={node}>

--- a/src/layout/Link/config.ts
+++ b/src/layout/Link/config.ts
@@ -30,6 +30,14 @@ export const Config = new CG.component({
       description: 'The title/text of the link',
     }),
   )
+  .addTextResource(
+    new CG.trb({
+      name: 'download',
+      title: 'Download',
+      description:
+        'Download target instead of navigating to it. Non-blank value is passed to the download attribute and becomes the filename of the downloaded file. Blank value means default filename is used.',
+    }),
+  )
   .addProperty(
     new CG.prop(
       'style',


### PR DESCRIPTION
## Description

Added a download option to the Link component. This is useful in scenarios where users should be able to download a resource instead of navigating to it.

Example: PDF document fetched from service owner as a base64 encoded string. Using Link component with download option, this can be presented to user as a link or button which downloads the file when clicked. 


## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [x] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` label to this PR for proper release notes grouping
  - [x] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
