### PR TITLE
remove header summary2

### DIFF
--- a/src/layout/Header/index.tsx
+++ b/src/layout/Header/index.tsx
@@ -4,7 +4,6 @@ import type { JSX } from 'react';
 import { HeaderDef } from 'src/layout/Header/config.def.generated';
 import { HeaderComponent } from 'src/layout/Header/HeaderComponent';
 import type { PropsFromGenericComponent } from 'src/layout';
-import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types';
 
 export type IHeaderProps = PropsFromGenericComponent<'Header'>;
 
@@ -14,14 +13,4 @@ export class Header extends HeaderDef {
       return <HeaderComponent {...props} />;
     },
   );
-
-  // TODO: Temporary solution to show the summary for Headers
-  renderSummary2(props: Summary2Props<'Header'>): JSX.Element | null {
-    return (
-      <HeaderComponent
-        node={props.target}
-        containerDivRef={React.createRef()}
-      />
-    );
-  }
 }


### PR DESCRIPTION
## Description

Remove summary2 for the header component because rendering it by default often causes the summary to look disorganized. The old summary concept did also not render a summary for header components.

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
