### PR TITLE
Direct Percy snapshot method to capture PDF with emulated print media

### DIFF
--- a/test/e2e/support/global.ts
+++ b/test/e2e/support/global.ts
@@ -218,6 +218,11 @@ declare global {
       clearSelectionAndWait(viewport?: 'desktop' | 'tablet' | 'mobile'): Chainable<null>;
 
       getSummary(label: string): Chainable<Element>;
+      directSnapshot(
+        snapshotName: string,
+        options: { width: number; minHeight: number },
+        reset?: boolean,
+      ): Chainable<null>;
       testPdf(snapshotName: string | false, callback: () => void, returnToForm?: boolean): Chainable<null>;
       getCurrentPageId(): Chainable<string>;
 


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

In #2283, snapshots were added to PDF testing in order to catch visual bugs in PDF. Additionally, print media emulation was added to PDF testing so that css using `@media print` will be applied. This is sometimes used to hide elements, and so it then became possible to test that elements that should be hidden actually are hidden in PDF.

However, the combination of print media emulation and snapshots was not working in this version. This is due to how Percy takes snapshots. Percy does not take screenshots of the browser window directly, but rather, it stores a snapshot of the DOM, uploads this to its own servers, puts this DOM snapshot into its own browser, and takes screenshots at different viewport sizes there. Because of this, we loose the context of our own browser which uses print media emulation.

To fix this we need to take a screenshot directly in the browser running cypress, and somehow upload this image to Percy. This is not something that Percy supports. So instead, I take a screenshot, convert it to a base64 data url, and change the whole document to only contain an image tag with the dataurl as the `src`. Percy will happily upload this DOM-snapshot and take its own screenshot of my screenshot.

This may seem like a hacky solution, but percy actually has a CLI-tool that allows you to upload a set of existing screenshot images, and would you guess how it does this? By putting the image into an image tag and uploading the HTML: https://github.com/percy/cli/blob/master/packages/cli-upload/src/utils.js 🤦 My solution is based on the Percy CLI-tool, so I am pretty sure this is the only proper way to achieve this, and it seems to work perfectly well. Though, I wish I could simply upload an image directly...


Here is an [example](https://percy.io/700b0900/altinn-app-frontend-react/builds/36373331/changed/1988767608?browser=chrome&browser_ids=59&device_name=&group_snapshots_by=similar_diff&os=&other-browser=&subcategories=unreviewed%2Cchanges_requested%2Capproved&utm_source=github_status_public&viewLayout=overlay&viewMode=new&width=794&widths=794%2C1280) of what the PDF snapshots look like now. You can tell that print styling is applied due to it now having a white background instead of a gray background.

## Related Issue(s)

- ~~closes #{issue number}~~

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [x] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
