### PR TITLE
Fixing hard fail on missing `componentRef` in Summary

### DIFF
--- a/src/__mocks__/getDataListMock.ts
+++ b/src/__mocks__/getDataListMock.ts
@@ -1,0 +1,17 @@
+import type { IDataList } from 'src/features/dataLists';
+
+export function getDataListMock(): IDataList {
+  return {
+    listItems: [
+      { id: 1, name: 'John Doe', age: 30 },
+      { id: 2, name: 'Jane Doe', age: 25 },
+    ],
+    _metaData: {
+      page: 1,
+      pageCount: 1,
+      pageSize: 2,
+      totaltItemsCount: 2,
+      links: [],
+    },
+  };
+}

--- a/src/__mocks__/getInstanceDataMock.ts
+++ b/src/__mocks__/getInstanceDataMock.ts
@@ -49,7 +49,7 @@ export function getInstanceDataMock(mutate?: (data: IInstance) => void): IInstan
         lastChangedBy: '12345',
       },
     ],
-    id: '91cefc5e-c47b-40ff-a8a4-05971205f783',
+    id: '12345/91cefc5e-c47b-40ff-a8a4-05971205f783',
     instanceState: undefined,
     lastChanged: new Date('2020-01-01').toISOString(),
     org: 'mockOrg',

--- a/src/features/validation/callbacks/onFormSubmitValidation.ts
+++ b/src/features/validation/callbacks/onFormSubmitValidation.ts
@@ -65,7 +65,7 @@ export function useOnFormSubmitValidation() {
     );
 
     if (nodesWithAnyError !== ContextNotProvided && nodesWithAnyError.length > 0) {
-      setNodeVisibility(nodesWithAnyError, ValidationMask.All);
+      setNodeVisibility(nodesWithAnyError, ValidationMask.AllIncludingBackend);
       return true;
     }
 

--- a/src/layout/Group/SummaryGroupComponent.tsx
+++ b/src/layout/Group/SummaryGroupComponent.tsx
@@ -59,6 +59,7 @@ export function SummaryGroupComponent({
             isSummary={true}
             renderLayoutNode={(node) => (
               <SummaryComponentFromNode
+                key={node.id}
                 targetNode={node}
                 summaryNode={summaryNode}
                 overrides={overrides}

--- a/src/layout/Summary/ValidateSummary.tsx
+++ b/src/layout/Summary/ValidateSummary.tsx
@@ -1,0 +1,26 @@
+import { useEffect } from 'react';
+
+import { NodesInternal } from 'src/utils/layout/NodesContext';
+import type { NodeValidationProps } from 'src/layout/layout';
+
+export function ValidateSummary({ node, externalItem }: NodeValidationProps<'Summary'>) {
+  const addError = NodesInternal.useAddError();
+  const targetType = NodesInternal.useTypeFromId(externalItem.componentRef);
+
+  useEffect(() => {
+    if (!targetType) {
+      const error = `Målet for oppsummeringen (${externalItem.componentRef}) ble ikke funnet`;
+      addError(error, node);
+      window.logErrorOnce(`Validation error for '${node.id}': ${error}`);
+    }
+    // TODO: This would be nice to have, but it would possibly fail in prod for 'ssb/ra0709-01'. Investigate the
+    // effects of point a Summary to another Summary first.
+    // if (targetType === 'Summary' || targetType === 'Summary2') {
+    //   const error = `Oppsummeringen refererer til en annen oppsummering (${externalItem.componentRef})`;
+    //   addError(error, node);
+    //   window.logErrorOnce(`Validation error for '${node.id}': ${error}`);
+    // }
+  }, [addError, externalItem.componentRef, node, targetType]);
+
+  return null;
+}

--- a/src/layout/Summary/index.tsx
+++ b/src/layout/Summary/index.tsx
@@ -3,7 +3,9 @@ import type { JSX } from 'react';
 
 import { SummaryDef } from 'src/layout/Summary/config.def.generated';
 import { SummaryComponent } from 'src/layout/Summary/SummaryComponent';
+import { ValidateSummary } from 'src/layout/Summary/ValidateSummary';
 import type { PropsFromGenericComponent } from 'src/layout';
+import type { NodeValidationProps } from 'src/layout/layout';
 
 export class Summary extends SummaryDef {
   render = forwardRef<HTMLElement, PropsFromGenericComponent<'Summary'>>(
@@ -25,5 +27,9 @@ export class Summary extends SummaryDef {
 
   shouldRenderInAutomaticPDF() {
     return false;
+  }
+
+  renderLayoutValidators(props: NodeValidationProps<'Summary'>): React.JSX.Element | null {
+    return <ValidateSummary {...props} />;
   }
 }

--- a/src/test/allApps.ts
+++ b/src/test/allApps.ts
@@ -430,7 +430,7 @@ export function ensureAppsDirIsSet(runVoidTest = true) {
  */
 function parseJsonTolerantly<T = unknown>(content: string): T {
   // Remove multiline comments
-  content = content.replace(/\/\*([\s\S]*?)\*\//g, '$1');
+  content = content.replace(/\/\*([\s\S]*?)\*\//g, '');
 
   // Remove single-line comments, but not in strings
   content = content.replace(/^(.*?)\/\/(.*)$/gm, (_, m1, m2) => {

--- a/src/test/allApps.ts
+++ b/src/test/allApps.ts
@@ -45,6 +45,14 @@ export class ExternalApp {
     }
   }
 
+  private fileSize(path: string) {
+    try {
+      return fs.statSync(this.rootDir + path).size;
+    } catch (_err) {
+      return 0;
+    }
+  }
+
   private dirExists(path: string) {
     try {
       return fs.statSync(this.rootDir + path).isDirectory();
@@ -157,7 +165,7 @@ export class ExternalApp {
 
   getRuleConfiguration(layoutSetId: string): { data: IFormDynamics } | null {
     const path = `/App/ui/${layoutSetId}/RuleConfiguration.json`;
-    if (!this.fileExists(path)) {
+    if (!this.fileExists(path) || this.fileSize(path) === 0) {
       return null;
     }
 

--- a/src/test/renderWithProviders.tsx
+++ b/src/test/renderWithProviders.tsx
@@ -11,6 +11,7 @@ import type { RenderOptions, waitForOptions } from '@testing-library/react';
 import type { AxiosResponse } from 'axios';
 import type { JSONSchema7 } from 'json-schema';
 
+import { getDataListMock } from 'src/__mocks__/getDataListMock';
 import { getInstanceDataMock } from 'src/__mocks__/getInstanceDataMock';
 import { getLayoutSetsMock } from 'src/__mocks__/getLayoutSetsMock';
 import { getLogoMock } from 'src/__mocks__/getLogoMock';
@@ -45,7 +46,6 @@ import { PageNavigationRouter } from 'src/test/routerUtils';
 import { AltinnAppTheme } from 'src/theme/altinnAppTheme';
 import { useNodes } from 'src/utils/layout/NodesContext';
 import { useNodeTraversalSelectorSilent } from 'src/utils/layout/useNodeTraversal';
-import type { IDataList } from 'src/features/dataLists';
 import type { IFooterLayout } from 'src/features/footer/types';
 import type { FormDataWriteProxies, Proxy } from 'src/features/formData/FormDataWriteProxies';
 import type { FormDataMethods } from 'src/features/formData/FormDataWriteStateMachine';
@@ -138,9 +138,8 @@ const defaultQueryMocks: AppQueries = {
   fetchRefreshJwtToken: async () => ({}),
   fetchCustomValidationConfig: async () => null,
   fetchFormData: async () => ({}),
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  fetchOptions: async () => ({ data: [], headers: {} }) as unknown as AxiosResponse<IRawOption[], any>,
-  fetchDataList: async () => ({}) as unknown as IDataList,
+  fetchOptions: async () => ({ data: [], headers: {} }) as unknown as AxiosResponse<IRawOption[], unknown>,
+  fetchDataList: async () => getDataListMock(),
   fetchPdfFormat: async () => ({ excludedPages: [], excludedComponents: [] }),
   fetchDynamics: async () => null,
   fetchRuleHandler: async () => null,

--- a/src/utils/layout/NodesContext.tsx
+++ b/src/utils/layout/NodesContext.tsx
@@ -955,6 +955,7 @@ export const NodesInternal = {
       mode: 'innerSelector',
       makeArgs: (state) => [((node) => selectNodeData(node, state)) satisfies NodePicker],
     }),
+  useTypeFromId: (id: string) => Store.useSelector((s) => s.nodeData[id]?.layout.type),
   useIsAdded: (node: LayoutNode | LayoutPage) =>
     Store.useSelector((s) => {
       if (node instanceof LayoutPage) {

--- a/src/utils/layout/all.test.tsx
+++ b/src/utils/layout/all.test.tsx
@@ -30,6 +30,7 @@ const ignoreLogAndErrors = [
         'er ikke tillatt i `textResourceBindings`',
         'Egenskapen `pageRef` er ikke tillatt',
         'samsvarer ikke med mønsteret `^[0-9a-zA-Z][',
+        /Målet for oppsummeringen \([^)]*\) ble ikke funnet/,
       ]
     : []),
 
@@ -43,7 +44,10 @@ function TestApp() {
   const filteredErrors: Record<string, string[]> = {};
 
   for (const key in errors) {
-    const filtered = errors[key].filter((err) => !ignoreLogAndErrors.some((ignore) => err.includes(ignore)));
+    const filtered = errors[key].filter(
+      (err) =>
+        !ignoreLogAndErrors.some((ignore) => (ignore instanceof RegExp ? ignore.test(err) : err.includes(ignore))),
+    );
     if (filtered.length) {
       filteredErrors[key] = filtered;
     }
@@ -207,7 +211,9 @@ function filterAndCleanMockCalls(mock: jest.Mock): string[] {
           continue;
         }
         if (typeof arg === 'string') {
-          shouldIgnore = ignoreLogAndErrors.some((remove) => arg.includes(remove));
+          shouldIgnore = ignoreLogAndErrors.some((remove) =>
+            remove instanceof RegExp ? remove.test(arg) : arg.includes(remove),
+          );
           if (shouldIgnore) {
             continue;
           }


### PR DESCRIPTION
## Description

When a `Summary` component pointed to another component that was missing from the layout, that would fail hard, reach the error boundary and make the entire app break in some cases. This should make the error more graceful (and not show up in prod).

## Related Issue(s)

- https://altinn.slack.com/archives/C02EJ9HKQA3/p1726216138773189
- https://altinn.slack.com/archives/C02EJ9HKQA3/p1726214776378099

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
