### PR TITLE
Fixing problems with removal of stale options

### DIFF
--- a/src/features/expressions/expression-functions.ts
+++ b/src/features/expressions/expression-functions.ts
@@ -1,7 +1,6 @@
 import dot from 'dot-object';
 import type { Mutable } from 'utility-types';
 
-import { ContextNotProvided } from 'src/core/contexts/context';
 import { ExprRuntimeError, NodeNotFound, NodeNotFoundWithoutContext } from 'src/features/expressions/errors';
 import { ExprVal } from 'src/features/expressions/types';
 import { addError } from 'src/features/expressions/validation';
@@ -233,17 +232,7 @@ export const ExprFunctions = {
       }
 
       const node = ensureNode(this.node);
-      const closest = this.dataSources.nodeTraversal(
-        (t) =>
-          t.with(node).closest((c) => c.type === 'node' && (c.layout.id === id || c.layout.baseComponentId === id)),
-        [node, id],
-      );
-
-      if (closest === ContextNotProvided) {
-        // Expressions will run before the layout is fully loaded, so we might not have all the components available
-        // yet. If that's the case, silently ignore this expression.
-        return null;
-      }
+      const closest = this.dataSources.nodeTraversal((t) => t.with(node).closestId(id), [node, id]);
 
       const dataModelBindings = closest
         ? this.dataSources.nodeDataSelector((picker) => picker(closest)?.layout.dataModelBindings, [closest])
@@ -328,16 +317,7 @@ export const ExprFunctions = {
       }
 
       const node = ensureNode(this.node);
-      const targetNode = this.dataSources.nodeTraversal(
-        (t) => t.with(node).closest((c) => c.type === 'node' && (c.item?.id === id || c.item?.baseComponentId === id)),
-        [node, id],
-      );
-
-      if (targetNode === ContextNotProvided) {
-        // Expressions will run before the layout is fully loaded, so we might not have all the components available
-        // yet. If that's the case, silently ignore this expression.
-        return null;
-      }
+      const targetNode = this.dataSources.nodeTraversal((t) => t.with(node).closestId(id), [node, id]);
 
       if (!targetNode) {
         throw new ExprRuntimeError(this.expr, this.path, `Unable to find component with identifier ${id}`);
@@ -416,17 +396,7 @@ export const ExprFunctions = {
       }
 
       const node = ensureNode(this.node);
-      const closest = this.dataSources.nodeTraversal(
-        (t) =>
-          t.with(node).closest((c) => c.type === 'node' && (c.layout.id === id || c.layout.baseComponentId === id)),
-        [node, id],
-      );
-
-      if (closest === ContextNotProvided) {
-        // Expressions will run before the layout is fully loaded, so we might not have all the components available
-        // yet. If that's the case, silently ignore this expression.
-        return null;
-      }
+      const closest = this.dataSources.nodeTraversal((t) => t.with(node).closestId(id), [node, id]);
 
       if (!closest) {
         throw new ExprRuntimeError(this.expr, this.path, `Unable to find component with identifier ${id}`);

--- a/src/features/options/useGetOptions.ts
+++ b/src/features/options/useGetOptions.ts
@@ -7,6 +7,7 @@ import { castOptionsToStrings } from 'src/features/options/castOptionsToStrings'
 import { useGetOptionsQuery } from 'src/features/options/useGetOptionsQuery';
 import { useNodeOptions } from 'src/features/options/useNodeOptions';
 import { useSourceOptions } from 'src/hooks/useSourceOptions';
+import { useGetAwaitingCommits } from 'src/utils/layout/generator/GeneratorStages';
 import { Hidden, NodesInternal } from 'src/utils/layout/NodesContext';
 import { useNodeItem } from 'src/utils/layout/useNodeItem';
 import { filterDuplicateOptions, verifyOptions } from 'src/utils/options';
@@ -190,9 +191,18 @@ function usePreselectedOptionIndex(props: EffectProps) {
  * is gone, we should not save stale/invalid data, so we clear it.
  */
 function useRemoveStaleValues(props: EffectProps) {
+  const [_, setForceRerender] = useState(0);
+  const getAwaiting = useGetAwaitingCommits();
   useEffect(() => {
     const { options, unsafeSelectedValues, setValue, isNodeHidden, isNodesReady } = props;
     if (!options || !isNodesReady || isNodeHidden) {
+      return;
+    }
+    const awaitingCommits = getAwaiting();
+    if (awaitingCommits > 0) {
+      // We should not remove values if there are pending commits. We'll force a re-render to delay this check until
+      // the pending commits are done. This is needed because getAwaiting() is not reactive.
+      setForceRerender((r) => r + 1);
       return;
     }
 
@@ -200,7 +210,7 @@ function useRemoveStaleValues(props: EffectProps) {
     if (itemsToRemove.length > 0) {
       setValue(unsafeSelectedValues.filter((v) => !itemsToRemove.includes(v)));
     }
-  }, [props]);
+  }, [props, getAwaiting]);
 }
 
 export function useFetchOptions({ node, valueType, item }: FetchOptionsProps): GetOptionsResult {

--- a/src/features/validation/callbacks/onFormSubmitValidation.ts
+++ b/src/features/validation/callbacks/onFormSubmitValidation.ts
@@ -65,7 +65,7 @@ export function useOnFormSubmitValidation() {
     );
 
     if (nodesWithAnyError !== ContextNotProvided && nodesWithAnyError.length > 0) {
-      setNodeVisibility(nodesWithAnyError, ValidationMask.All);
+      setNodeVisibility(nodesWithAnyError, ValidationMask.AllIncludingBackend);
       return true;
     }
 

--- a/src/layout/RepeatingGroup/RepeatingGroup.module.css
+++ b/src/layout/RepeatingGroup/RepeatingGroup.module.css
@@ -227,7 +227,7 @@ table > tbody > tr.editingRow:hover {
   box-sizing: border-box;
 }
 
-.tableNotEmptyCaption {
+.fullWidthCaption {
   padding-left: var(--modal-padding-x);
   padding-right: var(--modal-padding-x);
 }

--- a/src/layout/RepeatingGroup/Table/RepeatingGroupTable.tsx
+++ b/src/layout/RepeatingGroup/Table/RepeatingGroupTable.tsx
@@ -95,7 +95,7 @@ export function RepeatingGroupTable(): React.JSX.Element | null {
         {textResourceBindings?.title && (
           <Caption
             id={`group-${id}-caption`}
-            className={cn({ [classes.tableNotEmptyCaption]: !isEmpty })}
+            className={cn({ [classes.fullWidthCaption]: !isEmpty && !isNested })}
             title={<Lang id={textResourceBindings.title} />}
             description={textResourceBindings.description && <Lang id={textResourceBindings.description} />}
             labelSettings={labelSettings}

--- a/src/utils/layout/generator/LayoutSetGenerator.tsx
+++ b/src/utils/layout/generator/LayoutSetGenerator.tsx
@@ -85,32 +85,17 @@ export function LayoutSetGenerator() {
 }
 
 function SaveFinishedNodesToStore({ pages }: { pages: LayoutPages }) {
-  const layouts = useLayouts();
   const existingNodes = useNodesWhenNotReady();
   const setNodes = NodesInternal.useSetNodes();
-  const isFinished = GeneratorStages.useIsFinished();
-  const layoutKeys = useMemo(() => Object.keys(layouts), [layouts]);
+  const isFinishedAddingNodes = GeneratorStages.AddNodes.useIsDone();
+  const numPages = Object.keys(useLayouts()).length;
+  const shouldSet = existingNodes !== pages && pages && (isFinishedAddingNodes || numPages === 0);
 
   useEffect(() => {
-    if (existingNodes === pages) {
-      return;
-    }
-
-    // With this being a useEffect, it will always run after all the children here have rendered - unless, importantly,
-    // the children themselves rely on useEffect() to run in order to reach a stable state.
-    const numPages = layoutKeys.length;
-    if (!pages) {
-      return;
-    }
-    if (numPages === 0) {
-      setNodes(pages);
-      return;
-    }
-
-    if (isFinished) {
+    if (shouldSet) {
       setNodes(pages);
     }
-  }, [layoutKeys, pages, isFinished, setNodes, existingNodes]);
+  }, [pages, setNodes, shouldSet]);
 
   return null;
 }

--- a/src/utils/layout/types.ts
+++ b/src/utils/layout/types.ts
@@ -1,5 +1,5 @@
 import type { CompDef } from 'src/layout';
-import type { CompIntermediate, CompInternal, CompTypes, TypeFromNode } from 'src/layout/layout';
+import type { CompIntermediate, CompIntermediateExact, CompInternal, CompTypes, TypeFromNode } from 'src/layout/layout';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 import type { LayoutPage } from 'src/utils/layout/LayoutPage';
 import type { HiddenState } from 'src/utils/layout/NodesContext';
@@ -16,7 +16,7 @@ export interface BaseRow {
 }
 
 export interface StateFactoryProps<Type extends CompTypes> {
-  item: CompIntermediate<Type>;
+  item: CompIntermediateExact<Type>;
   parent: LayoutNode | LayoutPage;
   row?: BaseRow;
 }

--- a/src/utils/layout/useExpressionDataSources.ts
+++ b/src/utils/layout/useExpressionDataSources.ts
@@ -13,7 +13,7 @@ import { useNodeOptionsSelector } from 'src/features/options/useNodeOptions';
 import { Hidden, NodesInternal } from 'src/utils/layout/NodesContext';
 import { useDataModelBindingTranspose } from 'src/utils/layout/useDataModelBindingTranspose';
 import { useNodeFormDataSelector } from 'src/utils/layout/useNodeItem';
-import { useNodeTraversalSelectorLax } from 'src/utils/layout/useNodeTraversal';
+import { useNodeTraversalSelector } from 'src/utils/layout/useNodeTraversal';
 import type { AttachmentsSelector } from 'src/features/attachments/AttachmentsStorePlugin';
 import type { ExternalApisResult } from 'src/features/externalApi/useExternalApi';
 import type { IUseLanguage } from 'src/features/language/useLanguage';
@@ -24,7 +24,7 @@ import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 import type { NodeDataSelector } from 'src/utils/layout/NodesContext';
 import type { DataModelTransposeSelector } from 'src/utils/layout/useDataModelBindingTranspose';
 import type { NodeFormDataSelector } from 'src/utils/layout/useNodeItem';
-import type { NodeTraversalSelectorLax } from 'src/utils/layout/useNodeTraversal';
+import type { NodeTraversalSelector } from 'src/utils/layout/useNodeTraversal';
 
 export interface ExpressionDataSources {
   process?: IProcess;
@@ -39,7 +39,7 @@ export interface ExpressionDataSources {
   isHiddenSelector: ReturnType<typeof Hidden.useIsHiddenSelector>;
   nodeFormDataSelector: NodeFormDataSelector;
   nodeDataSelector: NodeDataSelector;
-  nodeTraversal: NodeTraversalSelectorLax;
+  nodeTraversal: NodeTraversalSelector;
   transposeSelector: DataModelTransposeSelector;
   externalApis: ExternalApisResult;
 }
@@ -57,7 +57,7 @@ export function useExpressionDataSources(): ExpressionDataSources {
   const isHiddenSelector = Hidden.useIsHiddenSelector();
   const nodeFormDataSelector = useNodeFormDataSelector();
   const nodeDataSelector = NodesInternal.useNodeDataSelector();
-  const nodeTraversal = useNodeTraversalSelectorLax();
+  const nodeTraversal = useNodeTraversalSelector();
   const transposeSelector = useDataModelBindingTranspose();
 
   const externalApiIds = useApplicationMetadata().externalApiIds ?? [];

--- a/src/utils/layout/useNodeTraversal.ts
+++ b/src/utils/layout/useNodeTraversal.ts
@@ -119,6 +119,20 @@ export class NodeTraversal<T extends Node = LayoutPages> {
   }
 
   /**
+   * Looks for a component with a specific ID upwards in the hierarchy, using the same rules as closest().
+   */
+  closestId(id: string): LayoutNode | undefined {
+    return this.target.closest(
+      new TraversalTask(
+        this.state,
+        this.rootNode,
+        (c) => c.type === 'node' && (c.layout.id === id || c.layout.baseComponentId === id),
+        undefined,
+      ),
+    );
+  }
+
+  /**
    * Like children(), but will only match upwards along the tree towards the top page (LayoutPage)
    */
   parents(matching?: TraversalMatcher): ParentsFrom<T> {
@@ -389,4 +403,4 @@ export function useNodeTraversalSelectorSilent() {
   return useNodeTraversalSelectorProto(Strictness.returnUndefined);
 }
 
-export type NodeTraversalSelectorLax = ReturnType<typeof useNodeTraversalSelectorLax>;
+export type NodeTraversalSelector = ReturnType<typeof useNodeTraversalSelector>;


### PR DESCRIPTION
## Description

Found and fixed a few bugs:
1. Components that were set to be hidden using expressions like `["equals", ["component", ...], "something"]` would not get hidden until after all the nodes had been loaded, because the traversal selector could not traverse the hierarchy until it was ready. In practice, all the node traversal in expressions look up another component ID, so I made a simpler function for that (which always works as long as the nodes have been added first), and then set nodes earlier in the hierarchy generation process.
2. 'Remove stale values' in option components correctly wait until nodes are ready, but they were eager to start working even when there are awaiting commits to the node state. Fixing this makes the removal slower, but safer.
3. The caption title in a nested repeating group got too much padding, and appeared to the right of the nested table itself.
4. When fixing the first problem I noticed that the `displayValue` expression function mistakenly looked for another node `item` property when traversing, so it was depending on all expressions to have run before it could work. This crashed hard when using `displayValue` in a `hidden` property, as those expressions run before others do.

## Related Issue(s)

- issue reported to me directly on Slack (sorry, no link, contact me to get a copy)
- may be identical to #2429
- may be related to #2432

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
    - I'm working on these, but there are more subtle bugs to be found and fixed before those tests are ready 
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->