### PR TITLE
Fix flaky Map and PDF snapshots

### DIFF
--- a/test/e2e/integration/frontend-test/components.ts
+++ b/test/e2e/integration/frontend-test/components.ts
@@ -745,12 +745,22 @@ describe('UI Components', () => {
   });
 
   it('Map component with simpleBinding', () => {
-    cy.intercept('GET', 'https://cache.kartverket.no/**/*.png', { fixture: 'map-tile.png' });
-    cy.intercept('GET', 'https://tile.openstreetmap.org/**/*.png', { fixture: 'map-tile.png' });
-    cy.interceptLayout('changename', (comp) => {
-      if (comp.id === 'map' && comp.type === 'Map') {
-        delete comp.dataModelBindings.geometries;
-      }
+    cy.fixture('map-tile.png', 'base64').then((data) => {
+      cy.interceptLayout('changename', (component) => {
+        if (component.type === 'Map' && component.id === 'map') {
+          component.layers = [
+            {
+              url: `data:image/png;base64,${data}`,
+              attribution: '&copy; <a href="about:blank">Team Apps</a>',
+            },
+          ];
+          delete component.dataModelBindings.geometries;
+        }
+
+        if (component.type === 'Input' && component.id === 'map-location') {
+          component.hidden = false;
+        }
+      });
     });
 
     cy.goto('changename');
@@ -777,6 +787,11 @@ describe('UI Components', () => {
       .findByText(/59(\.\d{1,6})?, 10(\.\d{1,6})?/)
       .should('be.visible');
 
+    // Set exact location so snapshot is consistent
+    cy.findByRole('textbox', { name: /eksakt lokasjon/i }).clear();
+    cy.findByRole('textbox', { name: /eksakt lokasjon/i }).type('59.930803,10.801246');
+    cy.waitUntilSaved();
+
     // Force the map component to remount to skip the zoom animation
     cy.gotoNavPage('form');
     cy.gotoNavPage('map');
@@ -788,12 +803,18 @@ describe('UI Components', () => {
   });
 
   it('Map component with geometries should center the map around the geometries', () => {
-    cy.intercept('GET', 'https://cache.kartverket.no/**/*.png', { fixture: 'map-tile.png' });
-    cy.intercept('GET', 'https://tile.openstreetmap.org/**/*.png', { fixture: 'map-tile.png' });
-    cy.interceptLayout('changename', (comp) => {
-      if (comp.id === 'map' && comp.type === 'Map') {
-        delete comp.dataModelBindings.simpleBinding;
-      }
+    cy.fixture('map-tile.png', 'base64').then((data) => {
+      cy.interceptLayout('changename', (component) => {
+        if (component.type === 'Map' && component.id === 'map') {
+          component.layers = [
+            {
+              url: `data:image/png;base64,${data}`,
+              attribution: '&copy; <a href="about:blank">Team Apps</a>',
+            },
+          ];
+          delete component.dataModelBindings.simpleBinding;
+        }
+      });
     });
 
     cy.goto('changename');

--- a/test/e2e/integration/frontend-test/components.ts
+++ b/test/e2e/integration/frontend-test/components.ts
@@ -781,6 +781,9 @@ describe('UI Components', () => {
     cy.gotoNavPage('form');
     cy.gotoNavPage('map');
 
+    // Make sure tiles are not faded before taking the snapshot
+    cy.get('.leaflet-layer img').each((layer) => cy.wrap(layer).should('have.css', 'opacity', '1'));
+
     cy.snapshot('components:map-simpleBinding');
   });
 

--- a/test/e2e/support/global.ts
+++ b/test/e2e/support/global.ts
@@ -120,6 +120,7 @@ declare global {
         taskName: FrontendTestTask | string,
         mutator?: (component: CompExternal) => void,
         wholeLayoutMutator?: (layoutSet: ILayoutCollection) => void,
+        options?: { times?: number },
       ): Chainable<null>;
 
       /**


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

The snapshots for Map and PDF have been a little inconsistent. This is due to a couple of reasons:
1. Percy loaded the real map tiles, because it does not care if I intercept the url in cypress.
2. The location when clicking the map in cypress was not 100% consistent and could be slightly off
3. PDF snapshots used cypress's `blackout` option when taking a screenshot, this does not make fonts monospace, so it would lead to slightly different sized blacked out areas.

To fix these, I did the following:
1. Intercept the component config to rewrite the url of the map layers, so percy should now use the mock tiles as well
2. Before taking a snapshot, overwrite the location to an exact lat/long string
3. Inject the same css we use for percy before taking a screenshot instead of using the `blackout` feature.

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
