### PR TITLE
Fix tab navigation for dropdown

### DIFF
--- a/src/features/options/useGetOptions.ts
+++ b/src/features/options/useGetOptions.ts
@@ -61,10 +61,6 @@ export interface SetOptionsResult {
   rawData: string;
 
   setData: (values: string[]) => void;
-
-  // Workaround for dropdown (Combobox single) not clearing text input when value changes
-  // Can be used in the key-prop, will change every time the value changes
-  key: number;
 }
 
 interface EffectProps {
@@ -107,7 +103,6 @@ function useSetOptions(props: SetOptionsProps, alwaysOptions: IOptionInternal[])
     [alwaysOptions, currentValues],
   );
 
-  const [key, setKey] = useState(0);
   const setData = useCallback(
     (values: string[]) => {
       if (valueType === 'single') {
@@ -115,13 +110,11 @@ function useSetOptions(props: SetOptionsProps, alwaysOptions: IOptionInternal[])
       } else if (valueType === 'multi') {
         setValue('simpleBinding', values.join(','));
       }
-      setKey((k) => k + 1); // Workaround for Combobox
     },
     [setValue, valueType],
   );
 
   return {
-    key,
     rawData: value,
     selectedValues,
     unsafeSelectedValues: currentValues,

--- a/src/layout/Dropdown/DropdownComponent.tsx
+++ b/src/layout/Dropdown/DropdownComponent.tsx
@@ -24,7 +24,7 @@ export function DropdownComponent({ node, overrideDisplay }: IDropdownProps) {
   const { id, readOnly, textResourceBindings, alertOnChange } = item;
   const { langAsString, lang } = useLanguage(node);
 
-  const { options, isFetching, selectedValues, setData, key } = useGetOptions(node, 'single');
+  const { options, isFetching, selectedValues, setData } = useGetOptions(node, 'single');
   const debounce = FD.useDebounceImmediately();
 
   const changeMessageGenerator = useCallback(
@@ -74,7 +74,6 @@ export function DropdownComponent({ node, overrideDisplay }: IDropdownProps) {
           id={id}
           size='sm'
           hideLabel={true}
-          key={key} // Workaround for clearing text input
           value={selectedValues}
           readOnly={readOnly}
           onValueChange={handleChange}

--- a/test/e2e/integration/component-library/dropdown.ts
+++ b/test/e2e/integration/component-library/dropdown.ts
@@ -15,4 +15,12 @@ describe('Dropdown component', () => {
       .find('span.fds-paragraph')
       .should('have.text', testText);
   });
+
+  it('Retains focus after selecting a value in the dropdown', () => {
+    cy.startAppInstance(appFrontend.apps.componentLibrary, { authenticationLevel: '2' });
+    cy.gotoNavPage('Dropdown');
+    cy.dsSelect('#DropdownPage-RadioButtons', 'Moped', false);
+    cy.get('#DropdownPage-RadioButtons').should('have.value', 'Moped');
+    cy.get('#DropdownPage-RadioButtons').should('have.focus');
+  });
 });

--- a/test/e2e/support/custom.ts
+++ b/test/e2e/support/custom.ts
@@ -61,8 +61,8 @@ Cypress.Commands.add('dsReady', (selector) => {
   cy.waitUntilNodesReady();
 });
 
-Cypress.Commands.add('dsSelect', (selector, value) => {
-  cy.log(`Selecting ${value} in ${selector}`);
+Cypress.Commands.add('dsSelect', (selector, value, debounce = true) => {
+  cy.log(`Selecting ${value} in ${selector}, with debounce: ${debounce}`);
   cy.dsReady(selector);
   cy.get(selector).click();
 
@@ -71,7 +71,9 @@ Cypress.Commands.add('dsSelect', (selector, value) => {
   // https://github.com/testing-library/cypress-testing-library/issues/205#issuecomment-974688283
   cy.get('[class*="fds-combobox__option"]').findByText(value).click();
 
-  cy.get('body').click();
+  if (debounce) {
+    cy.get('body').click();
+  }
 });
 
 Cypress.Commands.add('clickAndGone', { prevSubject: true }, (subject: JQueryWithSelector | undefined) => {

--- a/test/e2e/support/global.ts
+++ b/test/e2e/support/global.ts
@@ -180,7 +180,7 @@ declare global {
       /**
        * Select from a dropdown in the design system
        */
-      dsSelect(selector: string, value: string): Chainable<null>;
+      dsSelect(selector: string, value: string, debounce?: boolean): Chainable<null>;
 
       /**
        * Shortcut for clicking an element and waiting for it to disappear


### PR DESCRIPTION
## Description

This PR removes the use of a dynamic key prop that was introduced to solve clearing the dropdown when using dynamic options and the source value for the options has changed. This does no longer seem to fix the previous issue.

Removing this workaround no longer causes the dropdown to completely re-render and lose focus after its value has updated.

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes #2486 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [x] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
