### PR TITLE
Avoid line break for required indicator in likert

### DIFF
--- a/src/layout/LikertItem/LikertItemComponent.tsx
+++ b/src/layout/LikertItem/LikertItemComponent.tsx
@@ -63,9 +63,9 @@ const RadioGroupTableRow = forwardRef<HTMLTableRowElement, IControlledRadioGroup
         >
           <span>
             <Lang id={textResourceBindings?.title} />
+            <RequiredIndicator required={required} />
           </span>
         </Label>
-        <RequiredIndicator required={required} />
         <ComponentValidations validations={validations} />
       </Table.Cell>
       {calculatedOptions?.map((option, index) => {

--- a/test/e2e/integration/frontend-test/validation.ts
+++ b/test/e2e/integration/frontend-test/validation.ts
@@ -766,7 +766,7 @@ describe('Validation', () => {
       cy.findByRole('button', { name: /Send inn/ }).click();
 
       cy.findByRole('row', {
-        name: /Hører skolen på elevenes forslag\? \*/i,
+        name: /Hører skolen på elevenes forslag\?\*/i,
       }).within(() => {
         cy.findByRole('radio', { name: /Alltid/ }).should('not.be.focused');
       });
@@ -774,7 +774,7 @@ describe('Validation', () => {
       cy.findByRole('button', { name: /Du må fylle ut hører skolen på elevenes forslag/ }).click();
 
       cy.findByRole('row', {
-        name: /Hører skolen på elevenes forslag\? \*/i,
+        name: /Hører skolen på elevenes forslag\?\*/i,
       }).within(() => {
         cy.findByRole('radio', { name: /Alltid/ }).should('be.focused');
       });


### PR DESCRIPTION
## Description

When a question in a likert gets to a certain size, the required indicator (*) rendered on the next line. Moved it inside the label to avoid this happening.

Before:
![image](https://github.com/user-attachments/assets/fffb47ed-bc1a-440c-9d3f-13d6342d6c25)

After: 
![image](https://github.com/user-attachments/assets/ec405b69-7cfc-46d4-a339-20a7236b7a2f)


<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
