### PR TITLE
Purge azure front door cache on deploy

### DIFF
--- a/.github/scripts/purge-frontdoor-cache.sh
+++ b/.github/scripts/purge-frontdoor-cache.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 fdSubscription=$FD_SUBSCRIPTION
 fdResourceGroup=$FD_RESOURCEGROUP
 fdProfileName=$FD_PROFILE

--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -199,5 +199,14 @@ else
     fi
     azcopy sync "$TARGET" "$AZURE_TARGET_URI/toolkits${AZURE_STORAGE_ACCOUNT_TOKEN}" "${AZCOPY_TOOLKITS_OPTS[@]}" "${AZCOPY_ADDITIONAL_OPTS[@]}"
     echo "-------------------------------------"
+    if [[ "$SYNC_AZURE_CDN" != "no" ]]; then
+      AFD_PATH_PREFIX="/toolkits/altinn-app-frontend"
+      AFD_PATHS=( --path "$AFD_PATH_PREFIX/index.json" )
+      if [[ "$PRE_RELEASE" == "no" ]]; then
+        AFD_PATHS+=( --path "$AFD_PATH_PREFIX/$APP_MAJOR/*" --path "$AFD_PATH_PREFIX/$APP_MAJOR_MINOR/*" )
+      fi
+      bash ./purge-frontdoor-cache.sh "${AFD_PATHS[@]}"
+      echo "-------------------------------------"
+    fi
   fi
 fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,9 @@ on:
 
 jobs:
   build:
+    name: Build and deploy
     runs-on: ubuntu-latest
-    name: Build
+    environment: prod
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -34,9 +35,21 @@ jobs:
           token: ${{secrets.ALTINN_CDN_TOKEN}}
           path: cdn
 
+      - name: Azure login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID_FC }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID_FC }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID_FC }}
+
       - name: Run release script
         working-directory: app-frontend
-        if: "!github.event.release.prerelease"
+        if: '!github.event.release.prerelease'
+        env:
+          FD_DOMAIN: ${{ vars.AZURE_DOMAIN_FC }}
+          FD_ENDPOINT: ${{ vars.AZURE_ENDPOINT_FC }}
+          FD_PROFILE: ${{ vars.AZURE_PROFILE_FC }}
+          FD_RESOURCEGROUP: ${{ vars.AZURE_RESOURCE_GROUP_FC }}
         run: |
           bash .github/scripts/release.sh \
            --frontend . \
@@ -48,16 +61,21 @@ jobs:
 
       - name: Run release script (pre-release)
         working-directory: app-frontend
-        if: "github.event.release.prerelease"
+        if: 'github.event.release.prerelease'
+        env:
+          FD_DOMAIN: ${{ vars.AZURE_DOMAIN_FC }}
+          FD_ENDPOINT: ${{ vars.AZURE_ENDPOINT_FC }}
+          FD_PROFILE: ${{ vars.AZURE_PROFILE_FC }}
+          FD_RESOURCEGROUP: ${{ vars.AZURE_RESOURCE_GROUP_FC }}
         run: |
-         bash .github/scripts/release.sh \
-           --frontend . \
-           --cdn ../cdn \
-           --commit \
-           --pre-release \
-           --azure-sync-cdn \
-           --azure-sa-name "${{ secrets.PRODUCTION_STORAGEACCOUNT_NAME }}" \
-           --azure-sa-token "${{ secrets.PRODUCTION_ALTINN_CDN_SAS_TOKEN }}"
+          bash .github/scripts/release.sh \
+            --frontend . \
+            --cdn ../cdn \
+            --commit \
+            --pre-release \
+            --azure-sync-cdn \
+            --azure-sa-name "${{ secrets.PRODUCTION_STORAGEACCOUNT_NAME }}" \
+            --azure-sa-token "${{ secrets.PRODUCTION_ALTINN_CDN_SAS_TOKEN }}"
 
       - name: Push to CDN
         working-directory: cdn


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

Purge Azure Front Door cache on release.
- Purging `index.json` should make pre-releases show up in localtest immediately
- For actual releases also purging `/major/` and `/major.minor/` so that e.g. `/4/` or `/4.8/` points to the new version immediately