### PR TITLE
Switch from using `jsPropertySyntax` to `jsonPointer` in AJV

### DIFF
--- a/src/features/datamodel/notations.test.ts
+++ b/src/features/datamodel/notations.test.ts
@@ -1,0 +1,18 @@
+import { pointerToDotNotation } from 'src/features/datamodel/notations';
+
+type TestCase = { input: string; output: string };
+
+describe('notations', () => {
+  describe('pointerToDotNotation', () => {
+    const testCases: TestCase[] = [
+      { input: '/path/to/property', output: 'path.to.property' },
+      { input: '/path/list/7/property', output: 'path.list[7].property' },
+      { input: '/path/list/7/group/nested-list/3/property', output: 'path.list[7].group.nested-list[3].property' },
+      { input: '/path/to-dashed/property', output: 'path.to-dashed.property' },
+    ];
+
+    test.each(testCases)('pointerToDotNotation($input) returns $output', ({ input, output }) => {
+      expect(pointerToDotNotation(input)).toBe(output);
+    });
+  });
+});

--- a/src/features/datamodel/notations.test.ts
+++ b/src/features/datamodel/notations.test.ts
@@ -9,6 +9,13 @@ describe('notations', () => {
       { input: '/path/list/7/property', output: 'path.list[7].property' },
       { input: '/path/list/7/group/nested-list/3/property', output: 'path.list[7].group.nested-list[3].property' },
       { input: '/path/to-dashed/property', output: 'path.to-dashed.property' },
+
+      // https://github.com/Altinn/app-frontend-react/issues/1918
+      { input: '/Oppgave/rapporteringsenhet/e-post', output: 'Oppgave.rapporteringsenhet.e-post' },
+      {
+        input: '/Oppgave/rapporteringsenhet/kontaktperson/epost_1',
+        output: 'Oppgave.rapporteringsenhet.kontaktperson.epost_1',
+      },
     ];
 
     test.each(testCases)('pointerToDotNotation($input) returns $output', ({ input, output }) => {

--- a/src/features/devtools/utils/layoutSchemaValidation.ts
+++ b/src/features/devtools/utils/layoutSchemaValidation.ts
@@ -1,7 +1,9 @@
 /* eslint-disable no-case-declarations */
 import Ajv from 'ajv';
-import type { DefinedError, ErrorObject } from 'ajv';
+import type { DefinedError } from 'ajv';
 import type { JSONSchema7 } from 'json-schema';
+
+import { pointerToDotNotation } from 'src/features/datamodel/notations';
 
 export const LAYOUT_SCHEMA_NAME = 'layout.schema.v1.json';
 export const EMPTY_SCHEMA_NAME = '__empty__';
@@ -60,26 +62,6 @@ function removeExpressionRefsRecursive(schema: object) {
 }
 
 /**
- * Get the property path for the error. Empty means it is in the root of the component.
- */
-function getProperty(error: ErrorObject): string | undefined {
-  const instancePaths = error.instancePath.split('/').slice(1);
-
-  if (instancePaths.length === 0) {
-    return undefined;
-  }
-
-  return instancePaths
-    .map((path, i) => {
-      if (!isNaN(parseInt(path))) {
-        return `[${path}]`;
-      }
-      return `${i != 0 ? '.' : ''}${path}`;
-    })
-    .join('');
-}
-
-/**
  * Format an AJV validation error into a human readable string.
  * @param error the AJV validation error object
  * @returns a human readable string describing the error
@@ -91,7 +73,7 @@ export function formatLayoutSchemaValidationError(error: DefinedError): string |
 
   const canBeExpression = error.parentSchema?.comment === 'expression';
 
-  const property = getProperty(error);
+  const property = pointerToDotNotation(error.instancePath);
   const propertyString = property?.length ? `\`${property}\`` : '';
   const propertyReference = property?.length ? ` i \`${property}\`` : '';
 

--- a/src/features/validation/schemaValidation/SchemaValidation.tsx
+++ b/src/features/validation/schemaValidation/SchemaValidation.tsx
@@ -4,6 +4,7 @@ import { FrontendValidationSource } from '..';
 import type { FieldValidations } from '..';
 
 import { DataModels } from 'src/features/datamodel/DataModelsProvider';
+import { pointerToDotNotation } from 'src/features/datamodel/notations';
 import { useDataModelType } from 'src/features/datamodel/useBindingSchema';
 import { FD } from 'src/features/formData/FormDataWrite';
 import {
@@ -13,12 +14,7 @@ import {
   getErrorTextKey,
 } from 'src/features/validation/schemaValidation/schemaValidationUtils';
 import { Validation } from 'src/features/validation/validationContext';
-import {
-  getRootElementPath,
-  getSchemaPart,
-  getSchemaPartOldGenerator,
-  processInstancePath,
-} from 'src/utils/schemaUtils';
+import { getRootElementPath, getSchemaPart, getSchemaPartOldGenerator } from 'src/utils/schemaUtils';
 import type { TextReference } from 'src/features/language/useLanguage';
 
 export function SchemaValidation({ dataType }: { dataType: string }) {
@@ -99,7 +95,7 @@ export function SchemaValidation({ dataType }: { dataType: string }) {
           /**
            * Extract data model field from the error's instancePath
            */
-          const field = processInstancePath(error.instancePath);
+          const field = pointerToDotNotation(error.instancePath);
 
           if (!validations[field]) {
             validations[field] = [];

--- a/src/features/validation/schemaValidation/schemaValidationUtils.ts
+++ b/src/features/validation/schemaValidation/schemaValidationUtils.ts
@@ -15,17 +15,6 @@ export function createValidator(schema: JSONSchema7): Ajv {
   const ajvOptions: Options = {
     allErrors: true,
     coerceTypes: true,
-
-    /**
-     * This option is deprecated in AJV, but continues to work for now. We have unit tests that will fail if the
-     * functionality is removed from AJV. The jsPropertySyntax (ex. 'Path.To.Array[0].Item') was replaced with JSON
-     * pointers in v7 (ex. '/Path/To/Array/0/Item'). If the option to keep the old syntax is removed at some point,
-     * we'll have to implement a translator ourselves, as we'll need this format to equal our data model bindings.
-     *
-     * @see https://github.com/ajv-validator/ajv/issues/1577#issuecomment-832216719
-     */
-    jsPropertySyntax: true,
-
     strict: false,
     strictTypes: false,
     strictTuples: false,

--- a/src/utils/layout/all.test.tsx
+++ b/src/utils/layout/all.test.tsx
@@ -21,7 +21,6 @@ const ENV: 'prod' | 'all' = env.parsed?.ALTINN_ALL_APPS_ENV === 'prod' ? 'prod' 
 const MODE: 'critical' | 'all' = env.parsed?.ALTINN_ALL_APPS_MODE === 'critical' ? 'critical' : 'all';
 
 const ignoreLogAndErrors = [
-  'DEPRECATED: option jsPropertySyntax',
   'Warning: findDOMNode is deprecated and will be removed in the next major release',
   'The above error occurred in the',
   'Layout quirk(s) applied',

--- a/src/utils/schemaUtils.ts
+++ b/src/utils/schemaUtils.ts
@@ -61,12 +61,3 @@ export function getSchemaPartOldGenerator(schemaPath: string, mainSchema: object
   // all other in sub schema
   return getSchemaPart(schemaPath, getSchemaPart(`${rootElementPath}/#`, mainSchema));
 }
-
-export function processInstancePath(path: string): string {
-  let result = path.startsWith('.') ? path.slice(1) : path;
-  result = result
-    .replace(/"]\["|']\['/g, '.')
-    .replace(/\["|\['/g, '')
-    .replace(/"]|']/g, '');
-  return result;
-}


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

This removes the annoying console warnings that `jsPropertySyntax` is deprecated in AJV, and also fixes a bug in the `processInstancePath` function by deleting it entirely 😄 

## Related Issue(s)

- closes #166
- closes #1918

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
