### PR TITLE
Add "no-visual-testing" to example date string

### DIFF
--- a/src/layout/Datepicker/DatePickerInput.tsx
+++ b/src/layout/Datepicker/DatePickerInput.tsx
@@ -71,10 +71,7 @@ export const DatePickerInput = forwardRef(
           color='first'
           size='small'
         >
-          <CalendarIcon
-            //style={{ width: 'px', height: '24px' }}
-            title={langAsString('date_picker.aria_label_icon')}
-          />
+          <CalendarIcon title={langAsString('date_picker.aria_label_icon')} />
         </Button>
       </div>
     );

--- a/src/layout/Datepicker/DatepickerComponent.tsx
+++ b/src/layout/Datepicker/DatepickerComponent.tsx
@@ -127,7 +127,7 @@ export function DatepickerComponent({ node }: IDatepickerProps) {
             />,
           )}
         </Grid>
-        <span className={styles.formatText}>
+        <span className={`${styles.formatText} no-visual-testing`}>
           {langAsString('date_picker.format_text', [formatDate(new Date(), dateFormat, { locale: currentLocale })])}
         </span>
       </div>


### PR DESCRIPTION
## Description

 Excludes format helper string in datepicker component from percy validation

## Related Issue(s)

- closes #2566 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
