### PR TITLE
removes fetchProcessState from AppQueriesProvider and mocks with jest

### DIFF
--- a/src/features/expressions/shared-functions.test.tsx
+++ b/src/features/expressions/shared-functions.test.tsx
@@ -12,7 +12,7 @@ import { getSharedTests } from 'src/features/expressions/shared';
 import { ExprVal } from 'src/features/expressions/types';
 import { ExprValidation } from 'src/features/expressions/validation';
 import { useExternalApis } from 'src/features/externalApi/useExternalApi';
-import { fetchApplicationMetadata } from 'src/queries/queries';
+import { fetchApplicationMetadata, fetchProcessState } from 'src/queries/queries';
 import { renderWithNode } from 'src/test/renderWithProviders';
 import { useEvalExpression } from 'src/utils/layout/generator/useEvalExpression';
 import type { SharedTestFunctionContext } from 'src/features/expressions/shared';
@@ -214,6 +214,10 @@ describe('Expressions shared function tests', () => {
       (fetchApplicationMetadata as jest.Mock<typeof fetchApplicationMetadata>).mockResolvedValue(applicationMetadata);
       (useExternalApis as jest.Mock<typeof useExternalApis>).mockReturnValue(externalApis as ExternalApisResult);
 
+      (fetchProcessState as jest.Mock<typeof fetchProcessState>).mockImplementation(() =>
+        Promise.resolve(process ?? getProcessDataMock()),
+      );
+
       const nodeId = nodeIdFromContext(context);
       await renderWithNode({
         nodeId,
@@ -231,7 +235,6 @@ describe('Expressions shared function tests', () => {
           fetchLayouts: async () => layouts ?? getDefaultLayouts(),
           fetchFormData,
           fetchInstanceData,
-          ...(process ? { fetchProcessState: async () => process } : {}),
           ...(frontendSettings ? { fetchApplicationSettings: async () => frontendSettings } : {}),
           fetchUserProfile: async () => profile,
           fetchTextResources: async () => ({

--- a/src/features/instance/ProcessContext.tsx
+++ b/src/features/instance/ProcessContext.tsx
@@ -5,7 +5,6 @@ import { skipToken, useQuery, useQueryClient } from '@tanstack/react-query';
 import { createStore } from 'zustand';
 import type { QueryClient } from '@tanstack/react-query';
 
-import { useAppQueries } from 'src/core/contexts/AppQueriesProvider';
 import { ContextNotProvided } from 'src/core/contexts/context';
 import { createZustandContext } from 'src/core/contexts/zustandContext';
 import { DisplayError } from 'src/core/errorHandling/DisplayError';
@@ -14,6 +13,7 @@ import { useApplicationMetadata } from 'src/features/applicationMetadata/Applica
 import { useLayoutSets } from 'src/features/form/layoutSets/LayoutSetsProvider';
 import { useNavigationParam } from 'src/features/routing/AppRoutingContext';
 import { TaskKeys, useNavigatePage } from 'src/hooks/useNavigatePage';
+import { fetchProcessState } from 'src/queries/queries';
 import { ProcessTaskType } from 'src/types';
 import { behavesLikeDataTask } from 'src/utils/formLayout';
 import type { QueryDefinition } from 'src/core/queries/usePrefetchQuery';
@@ -52,8 +52,7 @@ const { Provider, useSelector, useLaxSelector, useHasProvider } = createZustandC
 export const useHasProcessProvider = () => useHasProvider();
 
 // Also used for prefetching @see appPrefetcher.ts
-export function useProcessQueryDef(instanceId?: string): QueryDefinition<IProcess> {
-  const { fetchProcessState } = useAppQueries();
+export function getProcessQueryDef(instanceId?: string): QueryDefinition<IProcess> {
   return {
     queryKey: ['fetchProcessState', instanceId],
     queryFn: instanceId ? () => fetchProcessState(instanceId) : skipToken,
@@ -62,7 +61,7 @@ export function useProcessQueryDef(instanceId?: string): QueryDefinition<IProces
 }
 
 function useProcessQuery(instanceId: string) {
-  const utils = useQuery<IProcess, HttpClientError>(useProcessQueryDef(instanceId));
+  const utils = useQuery<IProcess, HttpClientError>(getProcessQueryDef(instanceId));
 
   useEffect(() => {
     utils.error && window.logError('Fetching process state failed:\n', utils.error);

--- a/src/features/processEnd/confirm/containers/ConfirmPage.test.tsx
+++ b/src/features/processEnd/confirm/containers/ConfirmPage.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { jest } from '@jest/globals';
 import { screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 
@@ -8,6 +9,7 @@ import { getInstanceDataMock } from 'src/__mocks__/getInstanceDataMock';
 import { getPartyMock, getPartyWithSubunitMock } from 'src/__mocks__/getPartyMock';
 import { getProcessDataMock } from 'src/__mocks__/getProcessDataMock';
 import { ConfirmPage, type IConfirmPageProps } from 'src/features/processEnd/confirm/containers/ConfirmPage';
+import { fetchProcessState } from 'src/queries/queries';
 import { renderWithInstanceAndLayout } from 'src/test/renderWithProviders';
 
 jest.mock('react-helmet-async');
@@ -69,16 +71,18 @@ describe('ConfirmPage', () => {
   });
 
   it('should show loading when clicking submit', async () => {
+    (fetchProcessState as jest.Mock<typeof fetchProcessState>).mockImplementation(() =>
+      Promise.resolve(
+        getProcessDataMock((p) => {
+          p.currentTask!.actions = {
+            confirm: true,
+          };
+        }),
+      ),
+    );
+
     const { mutations } = await renderWithInstanceAndLayout({
       renderer: () => <ConfirmPage {...props} />,
-      queries: {
-        fetchProcessState: async () =>
-          getProcessDataMock((p) => {
-            p.currentTask!.actions = {
-              confirm: true,
-            };
-          }),
-      },
     });
 
     const submitBtnText = /send inn/i;

--- a/src/features/receipt/ReceiptContainer.test.tsx
+++ b/src/features/receipt/ReceiptContainer.test.tsx
@@ -10,7 +10,7 @@ import { InstanceProvider } from 'src/features/instance/InstanceContext';
 import { staticUseLanguageForTests } from 'src/features/language/useLanguage';
 import { getSummaryDataObject, ReceiptContainer } from 'src/features/receipt/ReceiptContainer';
 import { TaskKeys } from 'src/hooks/useNavigatePage';
-import { fetchApplicationMetadata } from 'src/queries/queries';
+import { fetchApplicationMetadata, fetchProcessState } from 'src/queries/queries';
 import { InstanceRouter, renderWithoutInstanceAndLayout } from 'src/test/renderWithProviders';
 import { PartyType } from 'src/types/shared';
 import type { SummaryDataObject } from 'src/components/table/AltinnSummaryTable';
@@ -86,6 +86,15 @@ const render = async ({ autoDeleteOnProcessEnd = false, hasPdf = true }: IRender
       }),
     ),
   );
+  (fetchProcessState as jest.Mock<typeof fetchProcessState>).mockImplementation(() =>
+    Promise.resolve(
+      getProcessDataMock((p) => {
+        p.currentTask = undefined;
+        p.ended = '2022-02-05T09:19:32.8858042Z';
+      }),
+    ),
+  );
+
   return await renderWithoutInstanceAndLayout({
     renderer: () => (
       <InstanceProvider>
@@ -118,11 +127,6 @@ const render = async ({ autoDeleteOnProcessEnd = false, hasPdf = true }: IRender
         },
       }),
       fetchInstanceData: async () => buildInstance(hasPdf),
-      fetchProcessState: async () =>
-        getProcessDataMock((p) => {
-          p.currentTask = undefined;
-          p.ended = '2022-02-05T09:19:32.8858042Z';
-        }),
       fetchFormData: async () => ({}),
     },
   });

--- a/src/layout/CustomButton/CustomButtonComponent.test.tsx
+++ b/src/layout/CustomButton/CustomButtonComponent.test.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 
 import { screen } from '@testing-library/react';
+import type { jest } from '@jest/globals';
 
 import { CustomButtonComponent } from 'src/layout/CustomButton/CustomButtonComponent';
+import { fetchProcessState } from 'src/queries/queries';
 import { renderGenericComponentTest } from 'src/test/renderWithProviders';
 import type { CustomAction } from 'src/layout/CustomButton/config.generated';
 import type { IUserAction } from 'src/types/shared';
@@ -123,6 +125,45 @@ type RenderProps = {
 };
 
 async function render({ actions, actionAuthorization }: RenderProps = { actionAuthorization: [] }) {
+  (fetchProcessState as jest.Mock<typeof fetchProcessState>).mockImplementation(() =>
+    Promise.resolve({
+      started: '2024-01-03T06:52:49.716640678Z',
+      ended: null,
+      endEvent: null,
+      startEvent: '2024-01-03T06:52:49.716640678Z',
+      currentTask: {
+        userActions: [
+          {
+            id: 'read',
+            authorized: true,
+            type: 'ProcessAction',
+          },
+          {
+            id: 'write',
+            authorized: true,
+            type: 'ProcessAction',
+          },
+          {
+            id: 'complete',
+            authorized: false,
+            type: 'ProcessAction',
+          },
+          ...(actionAuthorization ?? []),
+        ],
+        read: true,
+        write: true,
+        flow: 2,
+        started: '2024-01-03T06:37:22.7573522Z',
+        elementId: 'Task_1',
+        name: 'Utfylling',
+        altinnTaskType: 'data',
+        ended: null,
+        validated: null,
+        flowType: 'CompleteCurrentMoveToNext',
+      },
+    }),
+  );
+
   await renderGenericComponentTest({
     type: 'CustomButton',
     renderer: (props) => <CustomButtonComponent {...props} />,
@@ -131,44 +172,6 @@ async function render({ actions, actionAuthorization }: RenderProps = { actionAu
         title: 'Custom button',
       },
       actions,
-    },
-    queries: {
-      fetchProcessState: async () => ({
-        started: '2024-01-03T06:52:49.716640678Z',
-        ended: null,
-        endEvent: null,
-        startEvent: '2024-01-03T06:52:49.716640678Z',
-        currentTask: {
-          userActions: [
-            {
-              id: 'read',
-              authorized: true,
-              type: 'ProcessAction',
-            },
-            {
-              id: 'write',
-              authorized: true,
-              type: 'ProcessAction',
-            },
-            {
-              id: 'complete',
-              authorized: false,
-              type: 'ProcessAction',
-            },
-            ...(actionAuthorization ?? []),
-          ],
-          read: true,
-          write: true,
-          flow: 2,
-          started: '2024-01-03T06:37:22.7573522Z',
-          elementId: 'Task_1',
-          name: 'Utfylling',
-          altinnTaskType: 'data',
-          ended: null,
-          validated: null,
-          flowType: 'CompleteCurrentMoveToNext',
-        },
-      }),
     },
   });
 }

--- a/src/queries/appPrefetcher.ts
+++ b/src/queries/appPrefetcher.ts
@@ -5,7 +5,7 @@ import { getApplicationMetadataQueryDef } from 'src/features/applicationMetadata
 import { useApplicationSettingsQueryDef } from 'src/features/applicationSettings/ApplicationSettingsProvider';
 import { useLayoutSetsQueryDef } from 'src/features/form/layoutSets/LayoutSetsProvider';
 import { useInstanceDataQueryDef } from 'src/features/instance/InstanceContext';
-import { useProcessQueryDef } from 'src/features/instance/ProcessContext';
+import { getProcessQueryDef } from 'src/features/instance/ProcessContext';
 import { useOrgsQueryDef } from 'src/features/orgs/OrgsProvider';
 import { useCurrentPartyQueryDef, usePartiesQueryDef } from 'src/features/party/PartiesProvider';
 import { useProfileQueryDef } from 'src/features/profile/ProfileProvider';
@@ -29,7 +29,7 @@ export function AppPrefetcher() {
   usePrefetchQuery(useCurrentPartyQueryDef(true), Boolean(partyId));
 
   usePrefetchQuery(useInstanceDataQueryDef(false, partyId, instanceGuid));
-  usePrefetchQuery(useProcessQueryDef(instanceId));
+  usePrefetchQuery(getProcessQueryDef(instanceId));
 
   return null;
 }

--- a/src/queries/types.ts
+++ b/src/queries/types.ts
@@ -1,6 +1,6 @@
 import type * as queries from 'src/queries/queries';
 
-type IgnoredQueries = 'fetchApplicationMetadata' | 'fetchExternalApi';
+type IgnoredQueries = 'fetchApplicationMetadata' | 'fetchExternalApi' | 'fetchProcessState';
 
 export type AppQueriesContext = Omit<typeof queries, IgnoredQueries>;
 

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -10,7 +10,8 @@ import { jestPreviewConfigure } from 'jest-preview';
 import { TextDecoder, TextEncoder } from 'util';
 
 import { getIncomingApplicationMetadataMock } from 'src/__mocks__/getApplicationMetadataMock';
-import type { fetchApplicationMetadata } from 'src/queries/queries';
+import { getProcessDataMock } from 'src/__mocks__/getProcessDataMock';
+import type { fetchApplicationMetadata, fetchProcessState } from 'src/queries/queries';
 import type { AppQueries } from 'src/queries/types';
 
 // Importing CSS for jest-preview to look nicer
@@ -92,4 +93,5 @@ jest.mock('src/queries/queries', () => ({
   fetchApplicationMetadata: jest
     .fn<typeof fetchApplicationMetadata>()
     .mockImplementation(() => Promise.resolve(getIncomingApplicationMetadataMock())),
+  fetchProcessState: jest.fn<typeof fetchProcessState>(() => Promise.resolve(getProcessDataMock())),
 }));

--- a/src/test/allApps.ts
+++ b/src/test/allApps.ts
@@ -6,7 +6,6 @@ import { v4 as uuidv4 } from 'uuid';
 import type { JSONSchema7 } from 'json-schema';
 
 import { getInstanceDataMock } from 'src/__mocks__/getInstanceDataMock';
-import { getProcessDataMock } from 'src/__mocks__/getProcessDataMock';
 import { MINIMUM_APPLICATION_VERSION } from 'src/features/applicationMetadata/minVersion';
 import { cleanLayout } from 'src/features/form/layout/cleanLayout';
 import { layoutSetIsDefault } from 'src/features/form/layoutSets/TypeGuards';
@@ -16,7 +15,7 @@ import type { IFormDynamics } from 'src/features/form/dynamics';
 import type { ITextResourceResult } from 'src/features/language/textResources';
 import type { ILayoutFile, ILayoutSet, ILayoutSets, ILayoutSettings } from 'src/layout/common.generated';
 import type { ILayoutCollection } from 'src/layout/layout';
-import type { IInstance, IProcess } from 'src/types/shared';
+import type { IInstance } from 'src/types/shared';
 
 export class ExternalApp {
   private compat = false;
@@ -317,10 +316,6 @@ export class ExternalAppLayoutSet {
       assert(i.data[0].dataType === 'test-data-model');
       i.data[0].dataType = this.config.dataType;
     });
-  }
-
-  simulateProcess(): IProcess {
-    return getProcessDataMock();
   }
 
   simulateValidUrlHash(): string {

--- a/src/test/renderWithProviders.tsx
+++ b/src/test/renderWithProviders.tsx
@@ -20,7 +20,6 @@ import { orderDetailsResponsePayload } from 'src/__mocks__/getOrderDetailsPayloa
 import { getOrgsMock } from 'src/__mocks__/getOrgsMock';
 import { getPartyMock } from 'src/__mocks__/getPartyMock';
 import { paymentResponsePayload } from 'src/__mocks__/getPaymentPayloadMock';
-import { getProcessDataMock } from 'src/__mocks__/getProcessDataMock';
 import { getProfileMock } from 'src/__mocks__/getProfileMock';
 import { getTextResourcesMock } from 'src/__mocks__/getTextResourcesMock';
 import { AppQueriesProvider } from 'src/core/contexts/AppQueriesProvider';
@@ -160,7 +159,6 @@ const defaultQueryMocks: AppQueries = {
   fetchPostPlace: async () => ({ valid: true, result: 'OSLO' }),
   fetchLayoutSettings: async () => ({ pages: { order: [] } }),
   fetchLayouts: () => Promise.reject(new Error('fetchLayouts not mocked')),
-  fetchProcessState: async () => getProcessDataMock(),
   fetchInstanceData: async () => getInstanceDataMock(),
   fetchBackendValidations: async () => [],
   fetchBackendValidationsForDataElement: async () => [],

--- a/src/utils/layout/all.test.tsx
+++ b/src/utils/layout/all.test.tsx
@@ -132,6 +132,7 @@ describe('All known layout sets should evaluate as a hierarchy', () => {
     (fetchApplicationMetadata as jest.Mock<typeof fetchApplicationMetadata>).mockImplementation(() =>
       Promise.resolve(set.app.getAppMetadata()),
     );
+
     await renderWithInstanceAndLayout({
       renderer: () =>
         env.parsed?.ALTINN_ALL_APPS_RENDER_COMPONENTS === 'true' ? <RenderAllComponents /> : <TestApp />,
@@ -142,7 +143,6 @@ describe('All known layout sets should evaluate as a hierarchy', () => {
         fetchFormData: async () => set.getModel().simulateDataModel(),
         fetchDataModelSchema: async () => set.getModel().getSchema(),
         fetchInstanceData: async () => set.simulateInstance(),
-        fetchProcessState: async () => set.simulateProcess(),
         fetchLayoutSchema: async () => layoutSchema as unknown as JSONSchema7,
         fetchRuleHandler: async () => set.getRuleHandler(),
         fetchDynamics: async () => set.getRuleConfiguration(),


### PR DESCRIPTION
## Description

Removes `fetchProcessState` from `AppQueriesProvider` to support efforts towards removing `AppQueriesProvider` altogether (because all queries are static and therefore do not need to be in a context + contexts = tight coupling). Also supports further work with parallel signing. 

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
