### PR TITLE
Fix bugs in List component

### DIFF
--- a/src/layout/List/ListComponent.test.tsx
+++ b/src/layout/List/ListComponent.test.tsx
@@ -205,6 +205,9 @@ describe('ListComponent', () => {
     const user = userEvent.setup({ delay: null });
     const { formDataMethods } = await render({ component: { tableHeadersMobile: ['Name', 'FlagLink'] } });
 
+    // Make sure test is not broken by changing mobile-view implementation
+    expect(useDeviceWidths.useIsMobile).toHaveBeenCalled();
+
     // There should be one radio for each country, but none of them should be checked
     await waitFor(() => expect(screen.getAllByRole('radio')).toHaveLength(6));
     expect(screen.queryByRole('radio', { checked: true })).not.toBeInTheDocument();

--- a/src/layout/List/ListComponent.test.tsx
+++ b/src/layout/List/ListComponent.test.tsx
@@ -6,6 +6,7 @@ import { userEvent } from '@testing-library/user-event';
 
 import { defaultDataTypeMock } from 'src/__mocks__/getLayoutSetsMock';
 import { useDataModelBindings } from 'src/features/formData/useDataModelBindings';
+import * as useDeviceWidths from 'src/hooks/useDeviceWidths';
 import { ListComponent } from 'src/layout/List/ListComponent';
 import { renderGenericComponentTest } from 'src/test/renderWithProviders';
 import { useNodeItem } from 'src/utils/layout/useNodeItem';
@@ -125,6 +126,11 @@ const render = async ({ component, ...rest }: Partial<RenderGenericComponentTest
   });
 
 describe('ListComponent', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useRealTimers();
+  });
+
   it('should render rows that is sent in but not rows that is not sent in', async () => {
     await render();
 
@@ -190,7 +196,30 @@ describe('ListComponent', () => {
       { op: 'add', path: '/CountryPopulation', value: 6 },
       { op: 'add', path: '/CountryHighestMountain', value: 170 },
     ]);
+  });
 
-    jest.useRealTimers();
+  it('should save all field values in when in mobile', async () => {
+    jest.useFakeTimers();
+    jest.spyOn(useDeviceWidths, 'useIsMobile').mockReturnValue(true);
+
+    const user = userEvent.setup({ delay: null });
+    const { formDataMethods } = await render({ component: { tableHeadersMobile: ['Name', 'FlagLink'] } });
+
+    // There should be one radio for each country, but none of them should be checked
+    await waitFor(() => expect(screen.getAllByRole('radio')).toHaveLength(6));
+    expect(screen.queryByRole('radio', { checked: true })).not.toBeInTheDocument();
+
+    // Select the second row
+    const swedishRow = screen.getByRole('radio', { name: /sweden/i });
+    await user.click(swedishRow);
+
+    expect(formDataMethods.setMultiLeafValues).toHaveBeenCalledWith({
+      debounceTimeout: undefined,
+      changes: [
+        { reference: { field: 'CountryName', dataType: defaultDataTypeMock }, newValue: 'Sweden' },
+        { reference: { field: 'CountryPopulation', dataType: defaultDataTypeMock }, newValue: 10 },
+        { reference: { field: 'CountryHighestMountain', dataType: defaultDataTypeMock }, newValue: 1738 },
+      ],
+    });
   });
 });

--- a/src/layout/List/ListComponent.tsx
+++ b/src/layout/List/ListComponent.tsx
@@ -57,15 +57,12 @@ export const ListComponent = ({ node }: IListProps) => {
   const bindings = item.dataModelBindings ?? ({} as IDataModelBindingsForList);
   const { formData, setValues } = useDataModelBindings(bindings);
 
-  const filteredHeaders = Object.fromEntries(Object.entries(tableHeaders).filter(([key]) => shouldIncludeColumn(key)));
-  const filteredRows: Row[] =
-    data?.listItems?.map((row) => {
-      const result = Object.fromEntries(Object.entries(row).filter(([key]) => shouldIncludeColumn(key)));
-      return result;
-    }) ?? [];
+  const tableHeadersToShowInMobile = Object.keys(tableHeaders).filter(
+    (key) => !tableHeadersMobile || tableHeadersMobile.includes(key),
+  );
 
   const selectedRow =
-    filteredRows.find((row) => Object.keys(formData).every((key) => row[key] === formData[key])) ?? '';
+    data?.listItems.find((row) => Object.keys(formData).every((key) => row[key] === formData[key])) ?? '';
 
   function handleRowSelect({ selectedValue }: { selectedValue: Row }) {
     const next: Row = {};
@@ -73,10 +70,6 @@ export const ListComponent = ({ node }: IListProps) => {
       next[binding] = selectedValue[binding];
     }
     setValues(next);
-  }
-
-  function shouldIncludeColumn(key: string): boolean {
-    return !isMobile || !tableHeadersMobile || tableHeadersMobile.includes(key);
   }
 
   function isRowSelected(row: Row): boolean {
@@ -105,17 +98,17 @@ export const ListComponent = ({ node }: IListProps) => {
           className={classes.mobileRadioGroup}
           value={JSON.stringify(selectedRow)}
         >
-          {filteredRows.map((row) => (
+          {data?.listItems.map((row) => (
             <Radio
               key={JSON.stringify(row)}
               value={JSON.stringify(row)}
               className={cn(classes.mobileRadio, { [classes.selectedRow]: isRowSelected(row) })}
               onClick={() => handleRowSelect({ selectedValue: row })}
             >
-              {Object.entries(row).map(([key, value]) => (
+              {tableHeadersToShowInMobile.map((key) => (
                 <div key={key}>
                   <strong>{tableHeaders[key]}</strong>
-                  <span>{typeof value === 'string' ? lang(value) : value}</span>
+                  <span>{typeof row[key] === 'string' ? lang(row[key]) : row[key]}</span>
                 </div>
               ))}
             </Radio>
@@ -154,7 +147,7 @@ export const ListComponent = ({ node }: IListProps) => {
         <Table.Head>
           <Table.Row>
             <Table.HeaderCell />
-            {Object.entries(filteredHeaders).map(([key, value]) => (
+            {Object.entries(tableHeaders).map(([key, value]) => (
               <Table.HeaderCell
                 key={key}
                 sortable={sortableColumns?.includes(key)}
@@ -174,7 +167,7 @@ export const ListComponent = ({ node }: IListProps) => {
           </Table.Row>
         </Table.Head>
         <Table.Body>
-          {filteredRows.map((row) => (
+          {data?.listItems.map((row) => (
             <Table.Row
               key={JSON.stringify(row)}
               onClick={() => {
@@ -196,14 +189,14 @@ export const ListComponent = ({ node }: IListProps) => {
                   name={node.id}
                 />
               </Table.Cell>
-              {Object.entries(row).map(([key, value]) => (
+              {Object.keys(tableHeaders).map((key) => (
                 <Table.Cell
                   key={key}
                   className={cn({
                     [classes.selectedRowCell]: isRowSelected(row),
                   })}
                 >
-                  {typeof value === 'string' ? lang(value) : value}
+                  {typeof row[key] === 'string' ? lang(row[key]) : row[key]}
                 </Table.Cell>
               ))}
             </Table.Row>

--- a/src/layout/List/index.tsx
+++ b/src/layout/List/index.tsx
@@ -111,23 +111,16 @@ export class List extends ListDef {
   }
 
   validateDataModelBindings(ctx: LayoutValidationCtx<'List'>): string[] {
-    const possibleBindings = Object.keys(ctx.item.tableHeaders ?? {});
-
     const errors: string[] = [];
+
     for (const binding of Object.keys(ctx.item.dataModelBindings ?? {})) {
-      if (possibleBindings.includes(binding)) {
-        const [newErrors] = this.validateDataModelBindingsAny(
-          ctx,
-          binding,
-          ['string', 'number', 'integer', 'boolean'],
-          false,
-        );
-        errors.push(...(newErrors || []));
-      } else {
-        errors.push(
-          `Bindingen ${binding} er ikke gyldig for denne komponenten. Gyldige bindinger er definert i 'tableHeaders'`,
-        );
-      }
+      const [newErrors] = this.validateDataModelBindingsAny(
+        ctx,
+        binding,
+        ['string', 'number', 'integer', 'boolean'],
+        false,
+      );
+      errors.push(...(newErrors || []));
     }
 
     return errors;


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

- Removes dataModelBinding validation that asserts that you can only use bindings from table headers. This check was broken when initially added, but fixed in #2108. It turns out that several apps in prod used dataModelBindings for mapping columns that were not shown in tableHeaders, so fixing this dataModelBinding validation was a breaking change.
- Removing `filteredRows` from `ListComponent`. This would filter out values that should not be shown in mobile view if `tableHeadersMobile` was set. The only problem is that the filteredRows object was also used for setting formData, so if you scaled down your browser window, some fields may no longer get saved when you click the row. Added unit tests for this.
- Table was using the raw data-list row when mapping cells in the table body. This does not preserve the column ordering specified in table-headers, and if not all columns in the data-list were used in table headers it would add more columns to the table body than the header has (see image below). Now using tableHeaders as the source of truth for what goes where.

![image](https://github.com/user-attachments/assets/a9a46003-3dc4-494e-9c95-1c048461dccb)


## Related Issue(s)

- https://digdir.slack.com/archives/C0760NPT2BE/p1729059789947969

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
