### PR TITLE
Add workflow for quickly rolling back to an earlier release

### DIFF
--- a/.github/scripts/revert.sh
+++ b/.github/scripts/revert.sh
@@ -57,6 +57,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+ROOT=$(pwd)
 TARGET=toolkits/altinn-app-frontend
 AZURE_TARGET_URI="https://${AZURE_STORAGE_ACCOUNT_NAME}.blob.core.windows.net/app-frontend"
 
@@ -165,7 +166,7 @@ else
     if [[ "$SYNC_AZURE_CDN" != "no" ]]; then
       AFD_PATH_PREFIX="/toolkits/altinn-app-frontend"
       AFD_PATHS=( --path "$AFD_PATH_PREFIX/$APP_MAJOR/*" --path "$AFD_PATH_PREFIX/$APP_MAJOR_MINOR/*" )
-      bash "$PATH_TO_FRONTEND/.github/scripts/purge-frontdoor-cache.sh" "${AFD_PATHS[@]}"
+      bash "$ROOT/.github/scripts/purge-frontdoor-cache.sh" "${AFD_PATHS[@]}"
       echo "-------------------------------------"
     fi
   fi

--- a/.github/workflows/revert.yml
+++ b/.github/workflows/revert.yml
@@ -40,7 +40,7 @@ jobs:
            --tag "${{ inputs.tag }}" \
            --actor "${{ github.actor }}" \
            --actor_id "${{ github.actor_id }}" \
-           --cdn ../cdn \
+           --cdn ./cdn \
            --commit \
            --azure-sync-cdn \
            --azure-sa-name "${{ secrets.PRODUCTION_STORAGEACCOUNT_NAME }}" \


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

With big changes coming up in the next release, I thought it would be a good idea to have the ability to quickly roll back to an earlier release in case we introduce bugs that affect a lot of apps/users, without having to create a new release.

This workflow works by manually dispatching from the `Actions`-page where you specify the tag of the version you want to roll back to. The workflow will checkout the `altinn-cdn`-repo where we store our builds, and copy the selected version over into the `major` (e.g. `/4/`) and `major.minor` (e.g. `/4.8/`) folders, sync this to azure, and purge the cache.

This can be used if shit really hits the fan as it should be much faster than fixing the bug and building a new version. When the bug(s) are eventually fixed, releasing a new version should still overwrite this temporary roll back.
