### PR TITLE
Fix duplicate required validation for options-based components

### DIFF
--- a/src/features/validation/nodeValidation/emptyFieldValidation.ts
+++ b/src/features/validation/nodeValidation/emptyFieldValidation.ts
@@ -1,0 +1,103 @@
+import {
+  type ComponentValidation,
+  FrontendValidationSource,
+  type ValidationDataSources,
+  ValidationMask,
+} from 'src/features/validation';
+import { getFieldNameKey } from 'src/utils/formComponentUtils';
+import type { IDataModelReference } from 'src/layout/common.generated';
+import type { CompTypes, CompWithBinding } from 'src/layout/layout';
+import type { LayoutNode } from 'src/utils/layout/LayoutNode';
+
+/**
+ * Default implementation of runEmptyFieldValidation
+ * Checks all of the component's dataModelBindings and returns one error for each one missing data
+ */
+export function runEmptyFieldValidationAllBindings<Type extends CompTypes>(
+  node: LayoutNode<Type>,
+  { formDataSelector, invalidDataSelector, nodeDataSelector }: ValidationDataSources,
+): ComponentValidation[] {
+  const required = nodeDataSelector(
+    (picker) => {
+      const item = picker(node)?.item;
+      return item && 'required' in item ? item.required : false;
+    },
+    [node],
+  );
+  const dataModelBindings = nodeDataSelector((picker) => picker(node)?.layout.dataModelBindings, [node]);
+  if (!required || !dataModelBindings) {
+    return [];
+  }
+
+  const validations: ComponentValidation[] = [];
+
+  for (const [bindingKey, reference] of Object.entries(dataModelBindings as Record<string, IDataModelReference>)) {
+    const data = formDataSelector(reference) ?? invalidDataSelector(reference);
+    const asString =
+      typeof data === 'string' || typeof data === 'number' || typeof data === 'boolean' ? String(data) : '';
+    const trb = nodeDataSelector((picker) => picker(node)?.item?.textResourceBindings, [node]);
+
+    if (asString.length === 0) {
+      const key =
+        trb && 'requiredValidation' in trb && trb.requiredValidation
+          ? trb.requiredValidation
+          : 'form_filler.error_required';
+      const fieldReference = { key: getFieldNameKey(trb, bindingKey), makeLowerCase: true };
+
+      validations.push({
+        source: FrontendValidationSource.EmptyField,
+        bindingKey,
+        message: { key, params: [fieldReference] },
+        severity: 'error',
+        category: ValidationMask.Required,
+      });
+    }
+  }
+  return validations;
+}
+
+/**
+ * Special implementation of runEmptyFieldValidation
+ * Only checks simpleBinding, this is useful for components that may save additional data which is not directly controlled by the user,
+ * like options-based components that can store the label and metadata about the options along side the actual value
+ */
+export function runEmptyFieldValidationOnlySimpleBinding<Type extends CompWithBinding<'simpleBinding'>>(
+  node: LayoutNode<Type>,
+  { formDataSelector, invalidDataSelector, nodeDataSelector }: ValidationDataSources,
+): ComponentValidation[] {
+  const required = nodeDataSelector(
+    (picker) => {
+      const item = picker(node)?.item;
+      return item && 'required' in item ? item.required : false;
+    },
+    [node],
+  );
+  const reference = nodeDataSelector((picker) => picker(node)?.layout.dataModelBindings.simpleBinding, [node]);
+  if (!required || !reference) {
+    return [];
+  }
+
+  const validations: ComponentValidation[] = [];
+
+  const data = formDataSelector(reference) ?? invalidDataSelector(reference);
+  const asString =
+    typeof data === 'string' || typeof data === 'number' || typeof data === 'boolean' ? String(data) : '';
+  const trb = nodeDataSelector((picker) => picker(node)?.item?.textResourceBindings, [node]);
+
+  if (asString.length === 0) {
+    const key =
+      trb && 'requiredValidation' in trb && trb.requiredValidation
+        ? trb.requiredValidation
+        : 'form_filler.error_required';
+    const fieldReference = { key: getFieldNameKey(trb, 'simpleBinding'), makeLowerCase: true };
+
+    validations.push({
+      source: FrontendValidationSource.EmptyField,
+      bindingKey: 'simpleBinding',
+      message: { key, params: [fieldReference] },
+      severity: 'error',
+      category: ValidationMask.Required,
+    });
+  }
+  return validations;
+}

--- a/src/layout/Checkboxes/CheckboxesContainerComponent.test.tsx
+++ b/src/layout/Checkboxes/CheckboxesContainerComponent.test.tsx
@@ -10,6 +10,7 @@ import { CheckboxContainerComponent } from 'src/layout/Checkboxes/CheckboxesCont
 import { LayoutStyle } from 'src/layout/common.generated';
 import { renderGenericComponentTest } from 'src/test/renderWithProviders';
 import type { IRawOption } from 'src/layout/common.generated';
+import type { AppQueries } from 'src/queries/types';
 import type { RenderGenericComponentTestProps } from 'src/test/renderWithProviders';
 
 const twoOptions: IRawOption[] = [
@@ -35,9 +36,16 @@ interface Props extends Partial<RenderGenericComponentTestProps<'Checkboxes'>> {
   options?: IRawOption[];
   formData?: string;
   groupData?: object;
+  queries?: Partial<AppQueries>;
 }
 
-const render = async ({ component, options, formData, groupData = getFormDataMockForRepGroup() }: Props = {}) =>
+const render = async ({
+  component,
+  options,
+  formData,
+  groupData = getFormDataMockForRepGroup(),
+  queries,
+}: Props = {}) =>
   await renderGenericComponentTest({
     type: 'Checkboxes',
     renderer: (props) => <CheckboxContainerComponent {...props} />,
@@ -45,6 +53,9 @@ const render = async ({ component, options, formData, groupData = getFormDataMoc
       optionsId: 'countries',
       dataModelBindings: {
         simpleBinding: { dataType: defaultDataTypeMock, field: 'selectedValues' },
+      },
+      textResourceBindings: {
+        title: 'Land',
       },
       ...component,
     },
@@ -55,6 +66,7 @@ const render = async ({ component, options, formData, groupData = getFormDataMoc
             Promise.resolve({ data: options, headers: {} } as AxiosResponse<IRawOption[], any>)
           : Promise.reject(new Error('No options provided to render()')),
       fetchFormData: async () => (formData ? { selectedValues: formData, ...groupData } : { ...groupData }),
+      ...queries,
     },
   });
 
@@ -285,5 +297,26 @@ describe('CheckboxesContainerComponent', () => {
         newValue: 'Value for second',
       });
     });
+  });
+
+  it('required validation should only show for simpleBinding', async () => {
+    await render({
+      component: {
+        showValidations: ['Required'],
+        required: true,
+        dataModelBindings: {
+          simpleBinding: { dataType: defaultDataTypeMock, field: 'value' },
+          label: { dataType: defaultDataTypeMock, field: 'label' },
+          metadata: { dataType: defaultDataTypeMock, field: 'metadata' },
+        },
+      },
+      options: [],
+      queries: {
+        fetchFormData: () => Promise.resolve({ simpleBinding: '', label: '', metadata: '' }),
+      },
+    });
+
+    expect(screen.getAllByRole('listitem')).toHaveLength(1);
+    expect(screen.getByRole('listitem')).toHaveTextContent('Du må fylle ut land');
   });
 });

--- a/src/layout/Checkboxes/index.tsx
+++ b/src/layout/Checkboxes/index.tsx
@@ -2,17 +2,19 @@ import React, { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { getCommaSeparatedOptionsToText } from 'src/features/options/getCommaSeparatedOptionsToText';
+import { runEmptyFieldValidationOnlySimpleBinding } from 'src/features/validation/nodeValidation/emptyFieldValidation';
 import { CheckboxContainerComponent } from 'src/layout/Checkboxes/CheckboxesContainerComponent';
 import { CheckboxesSummary } from 'src/layout/Checkboxes/CheckboxesSummary';
 import { CheckboxesDef } from 'src/layout/Checkboxes/config.def.generated';
 import { MultipleChoiceSummary } from 'src/layout/Checkboxes/MultipleChoiceSummary';
 import type { LayoutValidationCtx } from 'src/features/devtools/layoutValidation/types';
 import type { DisplayDataProps } from 'src/features/displayData';
+import type { ComponentValidation, ValidationDataSources } from 'src/features/validation';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { CheckboxSummaryOverrideProps } from 'src/layout/Summary2/config.generated';
 import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types';
-import type { LayoutNode } from 'src/utils/layout/LayoutNode';
+import type { BaseLayoutNode, LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class Checkboxes extends CheckboxesDef {
   render = forwardRef<HTMLElement, PropsFromGenericComponent<'Checkboxes'>>(
@@ -47,6 +49,13 @@ export class Checkboxes extends CheckboxesDef {
         emptyFieldText={props.override?.emptyFieldText}
       />
     );
+  }
+
+  runEmptyFieldValidation(
+    node: BaseLayoutNode<'Checkboxes'>,
+    validationDataSources: ValidationDataSources,
+  ): ComponentValidation[] {
+    return runEmptyFieldValidationOnlySimpleBinding(node, validationDataSources);
   }
 
   validateDataModelBindings(ctx: LayoutValidationCtx<'Checkboxes'>): string[] {

--- a/src/layout/Dropdown/DropdownComponent.test.tsx
+++ b/src/layout/Dropdown/DropdownComponent.test.tsx
@@ -59,6 +59,9 @@ const render = async ({ component, options, ...rest }: Props = {}) => {
     component: {
       optionsId: 'countries',
       readOnly: false,
+      textResourceBindings: {
+        title: 'Land',
+      },
       dataModelBindings: {
         simpleBinding: { dataType: defaultDataTypeMock, field: 'myDropdown' },
       },
@@ -310,5 +313,26 @@ describe('DropdownComponent', () => {
     );
 
     jest.useRealTimers();
+  });
+
+  it('required validation should only show for simpleBinding', async () => {
+    await render({
+      component: {
+        showValidations: ['Required'],
+        required: true,
+        dataModelBindings: {
+          simpleBinding: { dataType: defaultDataTypeMock, field: 'value' },
+          label: { dataType: defaultDataTypeMock, field: 'label' },
+          metadata: { dataType: defaultDataTypeMock, field: 'metadata' },
+        },
+      },
+      options: countries,
+      queries: {
+        fetchFormData: () => Promise.resolve({ simpleBinding: '', label: '', metadata: '' }),
+      },
+    });
+
+    expect(screen.getAllByRole('listitem')).toHaveLength(1);
+    expect(screen.getByRole('listitem')).toHaveTextContent('Du må fylle ut land');
   });
 });

--- a/src/layout/Dropdown/index.tsx
+++ b/src/layout/Dropdown/index.tsx
@@ -2,16 +2,18 @@ import React, { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { getSelectedValueToText } from 'src/features/options/getSelectedValueToText';
+import { runEmptyFieldValidationOnlySimpleBinding } from 'src/features/validation/nodeValidation/emptyFieldValidation';
 import { DropdownDef } from 'src/layout/Dropdown/config.def.generated';
 import { DropdownComponent } from 'src/layout/Dropdown/DropdownComponent';
 import { DropdownSummary } from 'src/layout/Dropdown/DropdownSummary';
 import { SummaryItemSimple } from 'src/layout/Summary/SummaryItemSimple';
 import type { LayoutValidationCtx } from 'src/features/devtools/layoutValidation/types';
 import type { DisplayDataProps } from 'src/features/displayData';
+import type { ComponentValidation, ValidationDataSources } from 'src/features/validation';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types';
-import type { LayoutNode } from 'src/utils/layout/LayoutNode';
+import type { BaseLayoutNode, LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class Dropdown extends DropdownDef {
   render = forwardRef<HTMLElement, PropsFromGenericComponent<'Dropdown'>>(
@@ -46,6 +48,13 @@ export class Dropdown extends DropdownDef {
         emptyFieldText={props.override?.emptyFieldText}
       />
     );
+  }
+
+  runEmptyFieldValidation(
+    node: BaseLayoutNode<'Dropdown'>,
+    validationDataSources: ValidationDataSources,
+  ): ComponentValidation[] {
+    return runEmptyFieldValidationOnlySimpleBinding(node, validationDataSources);
   }
 
   validateDataModelBindings(ctx: LayoutValidationCtx<'Dropdown'>): string[] {

--- a/src/layout/LikertItem/index.tsx
+++ b/src/layout/LikertItem/index.tsx
@@ -2,14 +2,16 @@ import React, { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { getSelectedValueToText } from 'src/features/options/getSelectedValueToText';
+import { runEmptyFieldValidationOnlySimpleBinding } from 'src/features/validation/nodeValidation/emptyFieldValidation';
 import { LikertItemDef } from 'src/layout/LikertItem/config.def.generated';
 import { LikertItemComponent } from 'src/layout/LikertItem/LikertItemComponent';
 import { SummaryItemSimple } from 'src/layout/Summary/SummaryItemSimple';
 import type { LayoutValidationCtx } from 'src/features/devtools/layoutValidation/types';
 import type { DisplayDataProps } from 'src/features/displayData';
+import type { ComponentValidation, ValidationDataSources } from 'src/features/validation';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
-import type { LayoutNode } from 'src/utils/layout/LayoutNode';
+import type { BaseLayoutNode, LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class LikertItem extends LikertItemDef {
   render = forwardRef<HTMLTableRowElement, PropsFromGenericComponent<'LikertItem'>>(
@@ -39,6 +41,13 @@ export class LikertItem extends LikertItemDef {
   renderSummary({ targetNode }: SummaryRendererProps<'LikertItem'>): JSX.Element | null {
     const displayData = this.useDisplayData(targetNode);
     return <SummaryItemSimple formDataAsString={displayData} />;
+  }
+
+  runEmptyFieldValidation(
+    node: BaseLayoutNode<'LikertItem'>,
+    validationDataSources: ValidationDataSources,
+  ): ComponentValidation[] {
+    return runEmptyFieldValidationOnlySimpleBinding(node, validationDataSources);
   }
 
   validateDataModelBindings(ctx: LayoutValidationCtx<'LikertItem'>): string[] {

--- a/src/layout/MultipleSelect/MultipleSelectComponent.test.tsx
+++ b/src/layout/MultipleSelect/MultipleSelectComponent.test.tsx
@@ -28,7 +28,9 @@ const render = async ({ component, ...rest }: Partial<RenderGenericComponentTest
       ],
       readOnly: false,
       required: false,
-      textResourceBindings: {},
+      textResourceBindings: {
+        title: 'Velg',
+      },
       ...component,
     },
     ...rest,
@@ -61,5 +63,25 @@ describe('MultipleSelect', () => {
         newValue: 'value1,value3',
       }),
     );
+  });
+
+  it('required validation should only show for simpleBinding', async () => {
+    await render({
+      component: {
+        showValidations: ['Required'],
+        required: true,
+        dataModelBindings: {
+          simpleBinding: { dataType: defaultDataTypeMock, field: 'value' },
+          label: { dataType: defaultDataTypeMock, field: 'label' },
+          metadata: { dataType: defaultDataTypeMock, field: 'metadata' },
+        },
+      },
+      queries: {
+        fetchFormData: () => Promise.resolve({ simpleBinding: '', label: '', metadata: '' }),
+      },
+    });
+
+    expect(screen.getAllByRole('listitem')).toHaveLength(1);
+    expect(screen.getByRole('listitem')).toHaveTextContent('Du må fylle ut velg');
   });
 });

--- a/src/layout/MultipleSelect/index.tsx
+++ b/src/layout/MultipleSelect/index.tsx
@@ -2,16 +2,18 @@ import React, { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { getCommaSeparatedOptionsToText } from 'src/features/options/getCommaSeparatedOptionsToText';
+import { runEmptyFieldValidationOnlySimpleBinding } from 'src/features/validation/nodeValidation/emptyFieldValidation';
 import { MultipleChoiceSummary } from 'src/layout/Checkboxes/MultipleChoiceSummary';
 import { MultipleSelectDef } from 'src/layout/MultipleSelect/config.def.generated';
 import { MultipleSelectComponent } from 'src/layout/MultipleSelect/MultipleSelectComponent';
 import { MultipleSelectSummary } from 'src/layout/MultipleSelect/MultipleSelectSummary';
 import type { LayoutValidationCtx } from 'src/features/devtools/layoutValidation/types';
 import type { DisplayDataProps } from 'src/features/displayData';
+import type { ComponentValidation, ValidationDataSources } from 'src/features/validation';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types';
-import type { LayoutNode } from 'src/utils/layout/LayoutNode';
+import type { BaseLayoutNode, LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class MultipleSelect extends MultipleSelectDef {
   render = forwardRef<HTMLElement, PropsFromGenericComponent<'MultipleSelect'>>(
@@ -51,6 +53,13 @@ export class MultipleSelect extends MultipleSelectDef {
         emptyFieldText={props.override?.emptyFieldText}
       />
     );
+  }
+
+  runEmptyFieldValidation(
+    node: BaseLayoutNode<'MultipleSelect'>,
+    validationDataSources: ValidationDataSources,
+  ): ComponentValidation[] {
+    return runEmptyFieldValidationOnlySimpleBinding(node, validationDataSources);
   }
 
   validateDataModelBindings(ctx: LayoutValidationCtx<'MultipleSelect'>): string[] {

--- a/src/layout/RadioButtons/ControlledRadioGroup.test.tsx
+++ b/src/layout/RadioButtons/ControlledRadioGroup.test.tsx
@@ -9,6 +9,7 @@ import { defaultDataTypeMock } from 'src/__mocks__/getLayoutSetsMock';
 import { ControlledRadioGroup } from 'src/layout/RadioButtons/ControlledRadioGroup';
 import { renderGenericComponentTest } from 'src/test/renderWithProviders';
 import type { IRawOption } from 'src/layout/common.generated';
+import type { AppQueries } from 'src/queries/types';
 import type { RenderGenericComponentTestProps } from 'src/test/renderWithProviders';
 
 const threeOptions: IRawOption[] = [
@@ -31,9 +32,16 @@ interface Props extends Partial<RenderGenericComponentTestProps<'RadioButtons'>>
   formData?: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   groupData?: any;
+  queries?: Partial<AppQueries>;
 }
 
-const render = async ({ component, options, formData, groupData = getFormDataMockForRepGroup() }: Props = {}) =>
+const render = async ({
+  component,
+  options,
+  formData,
+  groupData = getFormDataMockForRepGroup(),
+  queries,
+}: Props = {}) =>
   await renderGenericComponentTest({
     type: 'RadioButtons',
     renderer: (props) => <ControlledRadioGroup {...props} />,
@@ -41,6 +49,9 @@ const render = async ({ component, options, formData, groupData = getFormDataMoc
       optionsId: 'countries',
       preselectedOptionIndex: undefined,
       dataModelBindings: { simpleBinding: { dataType: defaultDataTypeMock, field: 'myRadio' } },
+      textResourceBindings: {
+        title: 'Land',
+      },
       ...component,
     },
     queries: {
@@ -50,6 +61,7 @@ const render = async ({ component, options, formData, groupData = getFormDataMoc
             Promise.resolve({ data: options, headers: {} } as AxiosResponse<IRawOption[], any>)
           : Promise.reject(new Error('No options provided to render()')),
       fetchFormData: async () => (formData ? { myRadio: formData, ...groupData } : { ...groupData }),
+      ...queries,
     },
   });
 
@@ -237,5 +249,26 @@ describe('RadioButtonsContainerComponent', () => {
     expect(options[0].getAttribute('value')).toBe('sweden');
     expect(options[1].getAttribute('value')).toBe('norway');
     expect(options[2].getAttribute('value')).toBe('denmark');
+  });
+
+  it('required validation should only show for simpleBinding', async () => {
+    await render({
+      component: {
+        showValidations: ['Required'],
+        required: true,
+        dataModelBindings: {
+          simpleBinding: { dataType: defaultDataTypeMock, field: 'value' },
+          label: { dataType: defaultDataTypeMock, field: 'label' },
+          metadata: { dataType: defaultDataTypeMock, field: 'metadata' },
+        },
+      },
+      options: [],
+      queries: {
+        fetchFormData: () => Promise.resolve({ simpleBinding: '', label: '', metadata: '' }),
+      },
+    });
+
+    expect(screen.getAllByRole('listitem')).toHaveLength(1);
+    expect(screen.getByRole('listitem')).toHaveTextContent('Du må fylle ut land');
   });
 });

--- a/src/layout/RadioButtons/index.tsx
+++ b/src/layout/RadioButtons/index.tsx
@@ -2,16 +2,18 @@ import React, { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { getSelectedValueToText } from 'src/features/options/getSelectedValueToText';
+import { runEmptyFieldValidationOnlySimpleBinding } from 'src/features/validation/nodeValidation/emptyFieldValidation';
 import { RadioButtonsDef } from 'src/layout/RadioButtons/config.def.generated';
 import { ControlledRadioGroup } from 'src/layout/RadioButtons/ControlledRadioGroup';
 import { RadioButtonsSummary } from 'src/layout/RadioButtons/RadioButtonsSummary';
 import { SummaryItemSimple } from 'src/layout/Summary/SummaryItemSimple';
 import type { LayoutValidationCtx } from 'src/features/devtools/layoutValidation/types';
 import type { DisplayDataProps } from 'src/features/displayData';
+import type { ComponentValidation, ValidationDataSources } from 'src/features/validation';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types';
-import type { LayoutNode } from 'src/utils/layout/LayoutNode';
+import type { BaseLayoutNode, LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class RadioButtons extends RadioButtonsDef {
   render = forwardRef<HTMLElement, PropsFromGenericComponent<'RadioButtons'>>(
@@ -42,6 +44,13 @@ export class RadioButtons extends RadioButtonsDef {
         isCompact={props.isCompact}
       />
     );
+  }
+
+  runEmptyFieldValidation(
+    node: BaseLayoutNode<'RadioButtons'>,
+    validationDataSources: ValidationDataSources,
+  ): ComponentValidation[] {
+    return runEmptyFieldValidationOnlySimpleBinding(node, validationDataSources);
   }
 
   validateDataModelBindings(ctx: LayoutValidationCtx<'RadioButtons'>): string[] {

--- a/src/layout/layout.ts
+++ b/src/layout/layout.ts
@@ -2,7 +2,7 @@ import type { $Keys, PickByValue } from 'utility-types';
 
 import type { CompBehaviors, CompCapabilities } from 'src/codegen/Config';
 import type { CompCategory } from 'src/layout/common';
-import type { ILayoutFile } from 'src/layout/common.generated';
+import type { IDataModelReference, ILayoutFile } from 'src/layout/common.generated';
 import type { ComponentTypeConfigs, getComponentConfigs } from 'src/layout/components.generated';
 import type { CompClassMapCategories } from 'src/layout/index';
 import type {
@@ -158,6 +158,14 @@ export type CompWithCap<Capability extends keyof CompCapabilities> = {
 
 export type CompWithBehavior<Behavior extends keyof CompBehaviors> = {
   [Type in CompTypes]: ComponentConfigs[Type]['behaviors'][Behavior] extends true ? Type : never;
+}[CompTypes];
+
+export type CompWithBinding<BindingKey extends string> = {
+  [Type in CompTypes]: ComponentTypeConfigs[Type]['layout']['dataModelBindings'] extends {
+    [key in BindingKey]?: IDataModelReference;
+  }
+    ? Type
+    : never;
 }[CompTypes];
 
 export interface NodeValidationProps<T extends CompTypes> {


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

Makes sure to only validate `required` against `simpleBinding` where the other bindings are just for adding additional data that the user has no control over.

## Related Issue(s)

- closes #2599 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
