### PR TITLE
Fix/null error in useLanguage

### DIFF
--- a/src/features/datamodel/DataModelsProvider.tsx
+++ b/src/features/datamodel/DataModelsProvider.tsx
@@ -306,15 +306,16 @@ function LoadExpressionValidationConfig({ dataType }: LoaderProps) {
   return null;
 }
 
+const emptyArray = [];
 export const DataModels = {
   useFullStateRef: () => useSelectorAsRef((state) => state),
 
   useLaxDefaultDataType: () => useLaxMemoSelector((state) => state.defaultDataType),
 
-  useReadableDataTypes: () => useMemoSelector((state) => state.allDataTypes ?? []),
-  useLaxReadableDataTypes: () => useLaxMemoSelector((state) => state.allDataTypes!),
+  useReadableDataTypes: () => useMemoSelector((state) => state.allDataTypes ?? emptyArray),
+  useLaxReadableDataTypes: () => useLaxMemoSelector((state) => state.allDataTypes ?? emptyArray),
 
-  useWritableDataTypes: () => useMemoSelector((state) => state.writableDataTypes!),
+  useWritableDataTypes: () => useMemoSelector((state) => state.writableDataTypes ?? emptyArray),
 
   useDataModelSchema: (dataType: string) => useSelector((state) => state.schemas[dataType]),
 

--- a/src/features/datamodel/DataModelsProvider.tsx
+++ b/src/features/datamodel/DataModelsProvider.tsx
@@ -312,9 +312,9 @@ export const DataModels = {
 
   useLaxDefaultDataType: () => useLaxMemoSelector((state) => state.defaultDataType),
 
+  // The following hooks use emptyArray if the value is null, so cannot be used to determine whether or not the datamodels are finished loading
   useReadableDataTypes: () => useMemoSelector((state) => state.allDataTypes ?? emptyArray),
   useLaxReadableDataTypes: () => useLaxMemoSelector((state) => state.allDataTypes ?? emptyArray),
-
   useWritableDataTypes: () => useMemoSelector((state) => state.writableDataTypes ?? emptyArray),
 
   useDataModelSchema: (dataType: string) => useSelector((state) => state.schemas[dataType]),


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

It was somehow possible for language to be used with DatamodelsProvider provided (not `ContextNotProvided`) but still before they had finished loading (value was `null`). So adding a null coalecence to return empty array in those cases for the public hooks. But this means they cannot be used to determine loading, but the LoadingBlocker uses the state directly so it should still work as before.

## Related Issue(s)

- https://altinn.slack.com/archives/C02EJ9HKQA3/p1729515603349109?thread_ts=1729512254.943649&cid=C02EJ9HKQA3

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
