### PR TITLE
Quickfix: Broken FileUploadWithTag and simpleBinding

### DIFF
--- a/src/features/options/StoreOptionsInNode.tsx
+++ b/src/features/options/StoreOptionsInNode.tsx
@@ -50,12 +50,20 @@ function StoreOptionsInNodeWorker({ valueType }: GeneratorOptionProps) {
     return false;
   }
 
+  // Quickfix to fix simpleBinding being cleared as stale in FileUploadWithTag,
+  // we don't store option values here so it makes no sense to do this,
+  // consider solving this more elegantly in the future.
+  // AFAIK, stale values are not removed from attachment tags, maybe they should?
+  const shouldRemoveStaleValues = !node.isType('FileUploadWithTag');
+
   return (
     <>
-      <EffectRemoveStaleValues
-        valueType={valueType}
-        options={options}
-      />
+      {shouldRemoveStaleValues && (
+        <EffectRemoveStaleValues
+          valueType={valueType}
+          options={options}
+        />
+      )}
       {preselectedOption !== undefined && (
         <EffectPreselectedOptionIndex
           preselectedOption={preselectedOption}


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

The logic for removing stale option values was mistakenly also applied to removing the simpleBinding (which cointains the attachment id) of FileUploadWithTag. This components has options after all, but the value is stored on the attachment data element instead of in the data model at the location of simpleBinding as the rest of them do. This caused it to remove the form data value immediately, and if it is inside of a repeating group, the attachment disappears, because it no longer knows which attachment to map.

This was not covered in any cypress test cases, since in `changeName` layout the fileuploadwithtag does not use datamodelbindings, and in `repeating` the filuploadwithtag used `list` instead of `simpleBinding` and so did not experience this issue.

We should definitely add tests for this, but I want to get this quick fix out to prod quickly.

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
