### PR TITLE
Fix text resource bindings for summary2

### DIFF
--- a/src/layout/Address/AddressSummary/AddressSummary.tsx
+++ b/src/layout/Address/AddressSummary/AddressSummary.tsx
@@ -29,7 +29,12 @@ export function AddressSummary({ componentNode }: AddressSummaryProps) {
     <div className={classes.addressSummaryComponent}>
       <div>
         <SingleValueSummary
-          title={<Lang id={title || 'address_component.address'} />}
+          title={
+            <Lang
+              id={title || 'address_component.address'}
+              node={componentNode}
+            />
+          }
           displayData={address}
           componentNode={componentNode}
         />
@@ -42,7 +47,12 @@ export function AddressSummary({ componentNode }: AddressSummaryProps) {
       {!simplified && (
         <div>
           <SingleValueSummary
-            title={<Lang id={careOfTitle || 'address_component.care_of'} />}
+            title={
+              <Lang
+                id={careOfTitle || 'address_component.care_of'}
+                node={componentNode}
+              />
+            }
             displayData={careOf}
             componentNode={componentNode}
             hideEditButton={true}
@@ -57,7 +67,12 @@ export function AddressSummary({ componentNode }: AddressSummaryProps) {
       <div className={classes.addressSummaryComponentZipCode}>
         <div className={classes.addressComponentZipCode}>
           <SingleValueSummary
-            title={<Lang id={zipCodeTitle || 'address_component.zip_code'} />}
+            title={
+              <Lang
+                id={zipCodeTitle || 'address_component.zip_code'}
+                node={componentNode}
+              />
+            }
             displayData={zipCode}
             componentNode={componentNode}
             hideEditButton={true}
@@ -70,7 +85,12 @@ export function AddressSummary({ componentNode }: AddressSummaryProps) {
 
         <div className={classes.addressSummaryComponentPostplace}>
           <SingleValueSummary
-            title={<Lang id={postPlaceTitle || 'address_component.post_place'} />}
+            title={
+              <Lang
+                id={postPlaceTitle || 'address_component.post_place'}
+                node={componentNode}
+              />
+            }
             displayData={postPlace}
             componentNode={componentNode}
             hideEditButton={true}
@@ -83,7 +103,12 @@ export function AddressSummary({ componentNode }: AddressSummaryProps) {
         {!simplified && (
           <div>
             <SingleValueSummary
-              title={<Lang id={houseNumberTitle || 'address_component.house_number'} />}
+              title={
+                <Lang
+                  id={houseNumberTitle || 'address_component.house_number'}
+                  node={componentNode}
+                />
+              }
               displayData={houseNumber}
               componentNode={componentNode}
               hideEditButton={true}

--- a/src/layout/Checkboxes/CheckboxesSummary.tsx
+++ b/src/layout/Checkboxes/CheckboxesSummary.tsx
@@ -26,7 +26,12 @@ export function CheckboxesSummary({
 
   return (
     <MultipleValueSummary
-      title={<Lang id={title} />}
+      title={
+        <Lang
+          id={title}
+          node={componentNode}
+        />
+      }
       componentNode={componentNode}
       isCompact={isCompact}
       showAsList={showAsList}

--- a/src/layout/Datepicker/DatepickerSummary.tsx
+++ b/src/layout/Datepicker/DatepickerSummary.tsx
@@ -21,7 +21,14 @@ export const DatepickerSummary = ({ componentNode, isCompact, emptyFieldText }: 
 
   return (
     <SingleValueSummary
-      title={title && <Lang id={title} />}
+      title={
+        title && (
+          <Lang
+            id={title}
+            node={componentNode}
+          />
+        )
+      }
       displayData={displayData}
       errors={errors}
       componentNode={componentNode}

--- a/src/layout/Dropdown/DropdownSummary.tsx
+++ b/src/layout/Dropdown/DropdownSummary.tsx
@@ -21,7 +21,14 @@ export const DropdownSummary = ({ componentNode, isCompact, emptyFieldText }: Dr
 
   return (
     <SingleValueSummary
-      title={title && <Lang id={title} />}
+      title={
+        title && (
+          <Lang
+            id={title}
+            node={componentNode}
+          />
+        )
+      }
       displayData={displayData}
       errors={errors}
       componentNode={componentNode}

--- a/src/layout/Grid/GridSummary.tsx
+++ b/src/layout/Grid/GridSummary.tsx
@@ -115,7 +115,10 @@ export const GridSummary = ({ componentNode }: GridSummaryProps) => {
             size='xs'
             level={4}
           >
-            <Lang id={title} />
+            <Lang
+              id={title}
+              node={componentNode}
+            />
           </Heading>
         </caption>
       )}

--- a/src/layout/Group/GroupSummary.tsx
+++ b/src/layout/Group/GroupSummary.tsx
@@ -80,7 +80,10 @@ export const GroupSummary = ({ componentNode, hierarchyLevel = 0, summaryOverrid
         size={isNestedGroup ? 'xsmall' : 'small'}
         level={headingLevel}
       >
-        <Lang id={summaryTitle ?? title} />
+        <Lang
+          id={summaryTitle ?? title}
+          node={componentNode}
+        />
       </Heading>
       <Grid
         container

--- a/src/layout/Header/HeaderComponent.tsx
+++ b/src/layout/Header/HeaderComponent.tsx
@@ -59,13 +59,21 @@ export const HeaderComponent = ({ node }: IHeaderProps) => {
             id={id}
             {...getHeaderProps(size)}
           >
-            <Lang id={textResourceBindings?.title} />
+            <Lang
+              id={textResourceBindings?.title}
+              node={node}
+            />
           </Heading>
         </Grid>
         {textResourceBindings?.help && (
           <Grid item={true}>
             <HelpTextContainer
-              helpText={<Lang id={textResourceBindings.help} />}
+              helpText={
+                <Lang
+                  id={textResourceBindings.help}
+                  node={node}
+                />
+              }
               title={langAsString(textResourceBindings?.title)}
             />
           </Grid>

--- a/src/layout/Input/InputSummary.tsx
+++ b/src/layout/Input/InputSummary.tsx
@@ -21,7 +21,14 @@ export const InputSummary = ({ componentNode, isCompact, emptyFieldText }: Input
 
   return (
     <SingleValueSummary
-      title={title && <Lang id={title} />}
+      title={
+        title && (
+          <Lang
+            id={title}
+            node={componentNode}
+          />
+        )
+      }
       displayData={displayData}
       errors={errors}
       componentNode={componentNode}

--- a/src/layout/Likert/Summary2/LikertSummary.tsx
+++ b/src/layout/Likert/Summary2/LikertSummary.tsx
@@ -29,7 +29,12 @@ export function LikertSummary({ componentNode, emptyFieldText, isCompact }: Like
   if (!rows.length || rows.length <= 0) {
     return (
       <SingleValueSummary
-        title={title}
+        title={
+          <Lang
+            id={title}
+            node={componentNode}
+          />
+        }
         componentNode={componentNode}
         errors={errors}
         hideEditButton={readOnly}
@@ -46,7 +51,10 @@ export function LikertSummary({ componentNode, emptyFieldText, isCompact }: Like
           size='xs'
           level={4}
         >
-          <Lang id={title} />
+          <Lang
+            id={title}
+            node={componentNode}
+          />
         </Heading>
       </div>
       {rows.map((row) => (

--- a/src/layout/List/ListSummary.tsx
+++ b/src/layout/List/ListSummary.tsx
@@ -21,7 +21,14 @@ export const ListSummary = ({ componentNode, isCompact, emptyFieldText }: ListCo
 
   return (
     <SingleValueSummary
-      title={title && <Lang id={title} />}
+      title={
+        title && (
+          <Lang
+            id={title}
+            node={componentNode}
+          />
+        )
+      }
       displayData={displayData}
       errors={errors}
       componentNode={componentNode}

--- a/src/layout/Map/Summary2/MapSummary.tsx
+++ b/src/layout/Map/Summary2/MapSummary.tsx
@@ -37,7 +37,12 @@ export function MapSummary({ componentNode, emptyFieldText, isCompact }: MapSumm
   if (markerBinding && !markerLocationIsValid) {
     return (
       <SingleValueSummary
-        title={title}
+        title={
+          <Lang
+            id={title}
+            node={componentNode}
+          />
+        }
         componentNode={componentNode}
         errors={errors}
         hideEditButton={readOnly}

--- a/src/layout/MultipleSelect/MultipleSelectSummary.tsx
+++ b/src/layout/MultipleSelect/MultipleSelectSummary.tsx
@@ -28,7 +28,12 @@ export function MultipleSelectSummary({
 
   return (
     <MultipleValueSummary
-      title={<Lang id={title} />}
+      title={
+        <Lang
+          id={title}
+          node={componentNode}
+        />
+      }
       componentNode={componentNode}
       showAsList={showAsList}
       isCompact={isCompact}

--- a/src/layout/Paragraph/ParagraphComponent.tsx
+++ b/src/layout/Paragraph/ParagraphComponent.tsx
@@ -31,16 +31,27 @@ export function ParagraphComponent({ node }: IParagraphProps) {
           <Paragraph asChild={!hasInlineContent}>
             {!hasInlineContent ? (
               <div>
-                <Lang id={textResourceBindings?.title} />
+                <Lang
+                  id={textResourceBindings?.title}
+                  node={node}
+                />
               </div>
             ) : (
-              <Lang id={textResourceBindings?.title} />
+              <Lang
+                id={textResourceBindings?.title}
+                node={node}
+              />
             )}
           </Paragraph>
         </div>
         {textResourceBindings?.help && (
           <HelpTextContainer
-            helpText={<Lang id={textResourceBindings?.help} />}
+            helpText={
+              <Lang
+                id={textResourceBindings?.help}
+                node={node}
+              />
+            }
             title={elementAsString(text)}
           />
         )}

--- a/src/layout/RadioButtons/RadioButtonsSummary.tsx
+++ b/src/layout/RadioButtons/RadioButtonsSummary.tsx
@@ -20,7 +20,14 @@ export const RadioButtonsSummary = ({ componentNode, isCompact, emptyFieldText }
   const title = useNodeItem(componentNode, (i) => i.textResourceBindings?.title);
   return (
     <SingleValueSummary
-      title={title && <Lang id={title} />}
+      title={
+        title && (
+          <Lang
+            id={title}
+            node={componentNode}
+          />
+        )
+      }
       displayData={displayData}
       errors={errors}
       componentNode={componentNode}

--- a/src/layout/RepeatingGroup/Summary2/RepeatingGroupSummary.tsx
+++ b/src/layout/RepeatingGroup/Summary2/RepeatingGroupSummary.tsx
@@ -53,7 +53,10 @@ export const RepeatingGroupSummary = ({
         size='xs'
         level={4}
       >
-        <Lang id={title} />
+        <Lang
+          id={title}
+          node={componentNode}
+        />
       </Heading>
       <div className={cn(classes.contentWrapper, { [classes.nestedContentWrapper]: isNested })}>
         {rows.map((row, index) => (

--- a/src/layout/RepeatingGroup/Summary2/RepeatingGroupSummary.tsx
+++ b/src/layout/RepeatingGroup/Summary2/RepeatingGroupSummary.tsx
@@ -57,7 +57,7 @@ export const RepeatingGroupSummary = ({
       </Heading>
       <div className={cn(classes.contentWrapper, { [classes.nestedContentWrapper]: isNested })}>
         {rows.map((row, index) => (
-          <>
+          <React.Fragment key={row?.uuid}>
             {index != 0 && <hr className={classes.rowDivider} />}
             <Grid
               key={row?.uuid}
@@ -72,7 +72,7 @@ export const RepeatingGroupSummary = ({
                 />
               ))}
             </Grid>
-          </>
+          </React.Fragment>
         ))}
       </div>
       {errors?.map(({ message }) => (

--- a/src/layout/Tabs/TabsSummary.tsx
+++ b/src/layout/Tabs/TabsSummary.tsx
@@ -42,7 +42,10 @@ export const TabsSummary = ({ componentNode }: TabsSummaryProps) => {
               size='xs'
               level={4}
             >
-              <Lang id={tab.title} />
+              <Lang
+                id={tab.title}
+                node={componentNode}
+              />
             </Heading>
             <Grid
               container

--- a/src/layout/TextArea/TextAreaSummary.tsx
+++ b/src/layout/TextArea/TextAreaSummary.tsx
@@ -21,7 +21,14 @@ export const TextAreaSummary = ({ componentNode, isCompact, emptyFieldText }: Te
 
   return (
     <SingleValueSummary
-      title={title && <Lang id={title} />}
+      title={
+        title && (
+          <Lang
+            id={title}
+            node={componentNode}
+          />
+        )
+      }
       displayData={displayData}
       errors={errors}
       componentNode={componentNode}


### PR DESCRIPTION
## Description

Assigns node context to the use of text resource bindings for summary2 components. This allows the summary2 components to use text resource bindings that use row-specific variables based on which row the component exists.

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes #2606

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
