### PR TITLE
Fixing several issues with the new Datepicker and making behavior closer to the old one

### DIFF
--- a/src/layout/Datepicker/DatePickerCalendar.tsx
+++ b/src/layout/Datepicker/DatePickerCalendar.tsx
@@ -43,7 +43,7 @@ export const DatePickerCalendar = ({
       }}
       locale={currentLocale}
       today={new Date()}
-      month={selectedDate}
+      defaultMonth={selectedDate}
       disabled={[{ before: minDate, after: maxDate }]}
       weekStartsOn={1}
       mode='single'

--- a/src/layout/Datepicker/DatePickerInput.tsx
+++ b/src/layout/Datepicker/DatePickerInput.tsx
@@ -1,4 +1,5 @@
 import React, { forwardRef, useEffect, useState } from 'react';
+import { PatternFormat } from 'react-number-format';
 import type { RefObject } from 'react';
 
 import { Button, Textfield } from '@digdir/designsystemet-react';
@@ -8,6 +9,7 @@ import { format, isValid } from 'date-fns';
 import { useLanguage } from 'src/features/language/useLanguage';
 import styles from 'src/layout/Datepicker/Calendar.module.css';
 import { getSaveFormattedDateString, strictParseFormat, strictParseISO } from 'src/utils/dateHelpers';
+import { getFormatDisplay, getFormatPattern } from 'src/utils/formatDateLocale';
 
 export interface DatePickerInputProps {
   id: string;
@@ -25,8 +27,10 @@ export const DatePickerInput = forwardRef(
     { id, value, formatString, timeStamp, onValueChange, isDialogOpen, readOnly, onClick }: DatePickerInputProps,
     ref: RefObject<HTMLButtonElement>,
   ) => {
-    const dateValue = value ? strictParseISO(value) : undefined;
-    const formattedDateValue = dateValue && isValid(dateValue) ? format(dateValue, formatString) : value;
+    const formatDisplay = getFormatDisplay(formatString);
+    const formatPattern = getFormatPattern(formatDisplay);
+    const dateValue = strictParseISO(value);
+    const formattedDateValue = dateValue ? format(dateValue, formatString) : value;
     const [inputValue, setInputValue] = useState(formattedDateValue ?? '');
 
     useEffect(() => {
@@ -53,12 +57,15 @@ export const DatePickerInput = forwardRef(
 
     return (
       <div className={styles.calendarInputWrapper}>
-        <Textfield
+        <PatternFormat
+          format={formatPattern}
+          customInput={Textfield}
+          mask='_'
           className={styles.calendarInput}
           type='text'
           id={id}
           value={inputValue}
-          placeholder={formatString}
+          placeholder={formatDisplay}
           onChange={handleChange}
           onBlur={saveValue}
           readOnly={readOnly}

--- a/src/layout/Datepicker/DatePickerInput.tsx
+++ b/src/layout/Datepicker/DatePickerInput.tsx
@@ -1,12 +1,9 @@
-import React, { forwardRef, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { PatternFormat } from 'react-number-format';
-import type { RefObject } from 'react';
 
-import { Button, Textfield } from '@digdir/designsystemet-react';
-import { CalendarIcon } from '@navikt/aksel-icons';
+import { Textfield } from '@digdir/designsystemet-react';
 import { format, isValid } from 'date-fns';
 
-import { useLanguage } from 'src/features/language/useLanguage';
 import styles from 'src/layout/Datepicker/Calendar.module.css';
 import { getSaveFormattedDateString, strictParseFormat, strictParseISO } from 'src/utils/dateHelpers';
 import { getFormatPattern } from 'src/utils/formatDateLocale';
@@ -17,78 +14,56 @@ export interface DatePickerInputProps {
   timeStamp: boolean;
   value?: string;
   onValueChange?: (value: string) => void;
-  onClick?: () => void;
-  isDialogOpen?: boolean;
   readOnly?: boolean;
 }
 
-export const DatePickerInput = forwardRef(
-  (
-    { id, value, datepickerFormat, timeStamp, onValueChange, isDialogOpen, readOnly, onClick }: DatePickerInputProps,
-    ref: RefObject<HTMLButtonElement>,
-  ) => {
-    const formatPattern = getFormatPattern(datepickerFormat);
-    const dateValue = strictParseISO(value);
-    const formattedDateValue = dateValue ? format(dateValue, datepickerFormat) : value;
-    const [inputValue, setInputValue] = useState(formattedDateValue ?? '');
+export function DatePickerInput({
+  id,
+  value,
+  datepickerFormat,
+  timeStamp,
+  onValueChange,
+  readOnly,
+}: DatePickerInputProps) {
+  const formatPattern = getFormatPattern(datepickerFormat);
+  const dateValue = strictParseISO(value);
+  const formattedDateValue = dateValue ? format(dateValue, datepickerFormat) : value;
+  const [inputValue, setInputValue] = useState(formattedDateValue ?? '');
 
-    useEffect(() => {
-      setInputValue(formattedDateValue ?? '');
-    }, [formattedDateValue]);
+  useEffect(() => {
+    setInputValue(formattedDateValue ?? '');
+  }, [formattedDateValue]);
 
-    const saveValue = (e: React.ChangeEvent<HTMLInputElement>) => {
-      const stringValue = e.target.value;
-      const date = strictParseFormat(stringValue, datepickerFormat);
-      const valueToSave = getSaveFormattedDateString(date, timeStamp) ?? stringValue;
-      onValueChange && onValueChange(valueToSave);
-    };
+  const saveValue = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const stringValue = e.target.value;
+    const date = strictParseFormat(stringValue, datepickerFormat);
+    const valueToSave = getSaveFormattedDateString(date, timeStamp) ?? stringValue;
+    onValueChange && onValueChange(valueToSave);
+  };
 
-    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-      const stringValue = e.target.value;
-      setInputValue(stringValue);
-      // If the date is valid, save immediately
-      if (stringValue.length == 0 || isValid(strictParseFormat(stringValue, datepickerFormat))) {
-        saveValue(e);
-      }
-    };
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const stringValue = e.target.value;
+    setInputValue(stringValue);
+    // If the date is valid, save immediately
+    if (stringValue.length == 0 || isValid(strictParseFormat(stringValue, datepickerFormat))) {
+      saveValue(e);
+    }
+  };
 
-    const { langAsString } = useLanguage();
-
-    return (
-      <div className={styles.calendarInputWrapper}>
-        <PatternFormat
-          format={formatPattern}
-          customInput={Textfield}
-          mask='_'
-          className={styles.calendarInput}
-          type='text'
-          id={id}
-          value={inputValue}
-          placeholder={datepickerFormat.toUpperCase()}
-          onChange={handleChange}
-          onBlur={saveValue}
-          readOnly={readOnly}
-          aria-readonly={readOnly}
-        />
-        <Button
-          id={`${id}-button`}
-          variant='tertiary'
-          icon={true}
-          aria-controls='dialog'
-          aria-haspopup='dialog'
-          onClick={onClick}
-          aria-expanded={isDialogOpen}
-          aria-label={langAsString('date_picker.aria_label_icon')}
-          ref={ref}
-          disabled={readOnly}
-          color='first'
-          size='small'
-        >
-          <CalendarIcon title={langAsString('date_picker.aria_label_icon')} />
-        </Button>
-      </div>
-    );
-  },
-);
-
-DatePickerInput.displayName = 'DatePickerInput';
+  return (
+    <PatternFormat
+      format={formatPattern}
+      customInput={Textfield}
+      mask='_'
+      className={styles.calendarInput}
+      type='text'
+      id={id}
+      value={inputValue}
+      placeholder={datepickerFormat.toUpperCase()}
+      onChange={handleChange}
+      onBlur={saveValue}
+      readOnly={readOnly}
+      aria-readonly={readOnly}
+    />
+  );
+}

--- a/src/layout/Datepicker/DatePickerInput.tsx
+++ b/src/layout/Datepicker/DatePickerInput.tsx
@@ -9,11 +9,11 @@ import { format, isValid } from 'date-fns';
 import { useLanguage } from 'src/features/language/useLanguage';
 import styles from 'src/layout/Datepicker/Calendar.module.css';
 import { getSaveFormattedDateString, strictParseFormat, strictParseISO } from 'src/utils/dateHelpers';
-import { getFormatDisplay, getFormatPattern } from 'src/utils/formatDateLocale';
+import { getFormatPattern } from 'src/utils/formatDateLocale';
 
 export interface DatePickerInputProps {
   id: string;
-  formatString: string;
+  datepickerFormat: string;
   timeStamp: boolean;
   value?: string;
   onValueChange?: (value: string) => void;
@@ -24,13 +24,12 @@ export interface DatePickerInputProps {
 
 export const DatePickerInput = forwardRef(
   (
-    { id, value, formatString, timeStamp, onValueChange, isDialogOpen, readOnly, onClick }: DatePickerInputProps,
+    { id, value, datepickerFormat, timeStamp, onValueChange, isDialogOpen, readOnly, onClick }: DatePickerInputProps,
     ref: RefObject<HTMLButtonElement>,
   ) => {
-    const formatDisplay = getFormatDisplay(formatString);
-    const formatPattern = getFormatPattern(formatDisplay);
+    const formatPattern = getFormatPattern(datepickerFormat);
     const dateValue = strictParseISO(value);
-    const formattedDateValue = dateValue ? format(dateValue, formatString) : value;
+    const formattedDateValue = dateValue ? format(dateValue, datepickerFormat) : value;
     const [inputValue, setInputValue] = useState(formattedDateValue ?? '');
 
     useEffect(() => {
@@ -39,7 +38,7 @@ export const DatePickerInput = forwardRef(
 
     const saveValue = (e: React.ChangeEvent<HTMLInputElement>) => {
       const stringValue = e.target.value;
-      const date = strictParseFormat(stringValue, formatString);
+      const date = strictParseFormat(stringValue, datepickerFormat);
       const valueToSave = getSaveFormattedDateString(date, timeStamp) ?? stringValue;
       onValueChange && onValueChange(valueToSave);
     };
@@ -48,7 +47,7 @@ export const DatePickerInput = forwardRef(
       const stringValue = e.target.value;
       setInputValue(stringValue);
       // If the date is valid, save immediately
-      if (isValid(strictParseFormat(stringValue, formatString))) {
+      if (stringValue.length == 0 || isValid(strictParseFormat(stringValue, datepickerFormat))) {
         saveValue(e);
       }
     };
@@ -65,7 +64,7 @@ export const DatePickerInput = forwardRef(
           type='text'
           id={id}
           value={inputValue}
-          placeholder={formatDisplay}
+          placeholder={datepickerFormat.toUpperCase()}
           onChange={handleChange}
           onBlur={saveValue}
           readOnly={readOnly}

--- a/src/layout/Datepicker/DatepickerComponent.test.tsx
+++ b/src/layout/Datepicker/DatepickerComponent.test.tsx
@@ -179,12 +179,12 @@ describe('DatepickerComponent', () => {
   it('should call setLeafValue if not finished filling out the date', async () => {
     const { formDataMethods } = await render();
 
-    await userEvent.type(screen.getByRole('textbox'), `12.34`);
+    await userEvent.type(screen.getByRole('textbox'), `1234`);
     await userEvent.tab();
 
     expect(formDataMethods.setLeafValue).toHaveBeenCalledWith({
       reference: { field: 'myDate', dataType: defaultDataTypeMock },
-      newValue: '12.34',
+      newValue: '12.34.____',
     });
   });
 

--- a/src/layout/Datepicker/DatepickerComponent.tsx
+++ b/src/layout/Datepicker/DatepickerComponent.tsx
@@ -13,13 +13,8 @@ import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper'
 import styles from 'src/layout/Datepicker/Calendar.module.css';
 import { DatePickerCalendar } from 'src/layout/Datepicker/DatePickerCalendar';
 import { DatePickerInput } from 'src/layout/Datepicker/DatePickerInput';
-import {
-  getDateConstraint,
-  getDateFormat,
-  getLocale,
-  getSaveFormattedDateString,
-  strictParseISO,
-} from 'src/utils/dateHelpers';
+import { getDateConstraint, getDateFormat, getSaveFormattedDateString, strictParseISO } from 'src/utils/dateHelpers';
+import { getDatepickerFormat } from 'src/utils/formatDateLocale';
 import { useNodeItem } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 
@@ -30,7 +25,6 @@ export type IDatepickerProps = PropsFromGenericComponent<'Datepicker'>;
 export function DatepickerComponent({ node }: IDatepickerProps) {
   const { langAsString } = useLanguage();
   const languageLocale = useCurrentLanguage();
-  const currentLocale = getLocale(languageLocale ?? 'nb');
   const { minDate, maxDate, format, timeStamp = true, readOnly, required, id, dataModelBindings } = useNodeItem(node);
 
   const [isDialogOpen, setIsDialogOpen] = useState(false);
@@ -38,7 +32,7 @@ export function DatepickerComponent({ node }: IDatepickerProps) {
 
   const calculatedMinDate = getDateConstraint(minDate, 'min');
   const calculatedMaxDate = getDateConstraint(maxDate, 'max');
-  const dateFormat = getDateFormat(format, languageLocale);
+  const dateFormat = getDatepickerFormat(getDateFormat(format, languageLocale));
   const isMobile = useIsMobile();
 
   const { setValue, formData } = useDataModelBindings(dataModelBindings);
@@ -111,7 +105,7 @@ export function DatepickerComponent({ node }: IDatepickerProps) {
               id={id}
               value={value}
               isDialogOpen={isMobile ? modalRef.current?.open : isDialogOpen}
-              formatString={dateFormat}
+              datepickerFormat={dateFormat}
               timeStamp={timeStamp}
               onValueChange={handleInputValueChange}
               onClick={() => (isMobile ? modalRef.current?.showModal() : setIsDialogOpen(!isDialogOpen))}
@@ -131,7 +125,7 @@ export function DatepickerComponent({ node }: IDatepickerProps) {
           )}
         </Grid>
         <span className={`${styles.formatText} no-visual-testing`}>
-          {langAsString('date_picker.format_text', [formatDate(new Date(), dateFormat, { locale: currentLocale })])}
+          {langAsString('date_picker.format_text', [formatDate(new Date(), dateFormat)])}
         </span>
       </div>
     </ComponentStructureWrapper>

--- a/src/layout/Datepicker/DatepickerComponent.tsx
+++ b/src/layout/Datepicker/DatepickerComponent.tsx
@@ -38,13 +38,13 @@ export function DatepickerComponent({ node }: IDatepickerProps) {
 
   const calculatedMinDate = getDateConstraint(minDate, 'min');
   const calculatedMaxDate = getDateConstraint(maxDate, 'max');
-  const dateFormat = getDateFormat(format || 'dd.MM.yyyy', languageLocale);
+  const dateFormat = getDateFormat(format, languageLocale);
   const isMobile = useIsMobile();
 
   const { setValue, formData } = useDataModelBindings(dataModelBindings);
   const value = formData.simpleBinding;
   const dateValue = strictParseISO(value);
-  const dayPickerDate = dateValue && isValidDate(dateValue) ? dateValue : new Date();
+  const dayPickerDate = dateValue ? dateValue : new Date();
 
   const handleDayPickerSelect = (date: Date) => {
     if (date && isValidDate(date)) {

--- a/src/layout/Datepicker/DatepickerDialog.tsx
+++ b/src/layout/Datepicker/DatepickerDialog.tsx
@@ -1,0 +1,61 @@
+import React, { useEffect, useRef } from 'react';
+import type { PropsWithChildren, ReactNode } from 'react';
+
+import { Modal, Popover } from '@digdir/designsystemet-react';
+
+import { useIsMobile } from 'src/hooks/useDeviceWidths';
+import styles from 'src/layout/Datepicker/Calendar.module.css';
+
+export function DatePickerDialog({
+  children,
+  trigger,
+  isDialogOpen,
+  setIsDialogOpen,
+}: PropsWithChildren<{ trigger: ReactNode; isDialogOpen: boolean; setIsDialogOpen: (open: boolean) => void }>) {
+  const isMobile = useIsMobile();
+  const modalRef = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    isDialogOpen && modalRef.current?.showModal();
+    !isDialogOpen && modalRef.current?.close();
+  }, [isMobile, isDialogOpen]);
+
+  if (isMobile) {
+    return (
+      <>
+        {trigger}
+        <Modal
+          role='dialog'
+          ref={modalRef}
+          onInteractOutside={() => setIsDialogOpen(false)}
+          style={{ width: 'fit-content', minWidth: 'fit-content' }}
+        >
+          <Modal.Content>{children}</Modal.Content>
+        </Modal>
+      </>
+    );
+  }
+  return (
+    <Popover
+      portal={true}
+      open={isDialogOpen}
+      onClose={() => setIsDialogOpen(false)}
+      size='lg'
+      placement='top'
+    >
+      <Popover.Trigger
+        onClick={() => setIsDialogOpen(!isDialogOpen)}
+        asChild={true}
+      >
+        {trigger}
+      </Popover.Trigger>
+      <Popover.Content
+        className={styles.calendarWrapper}
+        aria-modal
+        autoFocus={true}
+      >
+        {children}
+      </Popover.Content>
+    </Popover>
+  );
+}

--- a/src/layout/Datepicker/DropdownCaption.tsx
+++ b/src/layout/Datepicker/DropdownCaption.tsx
@@ -36,8 +36,7 @@ export const DropdownCaption = ({ calendarMonth, id }: MonthCaptionProps) => {
 
   const years = getYears(fromDate, toDate, calendarMonth.date.getFullYear()).reverse();
   const months = getMonths(fromDate, toDate, calendarMonth.date);
-  const yearDropdownLabel = langAsString('date_picker.aria_label_year_dropdown');
-  const MonthDropdownLabel = langAsString('date_picker.aria_label_month_dropdown');
+
   return (
     <>
       <div className={styles.dropdownCaption}>
@@ -59,20 +58,21 @@ export const DropdownCaption = ({ calendarMonth, id }: MonthCaptionProps) => {
             size='small'
             value={[calendarMonth.date.getMonth().toString()]}
             onValueChange={(months) => handleMonthChange(months[0])}
-            aria-label={MonthDropdownLabel}
+            aria-label={langAsString('date_picker.aria_label_month_dropdown')}
             className={comboboxClasses.container}
             portal={!isMobile}
           >
             <Combobox.Empty>
               <Lang id={'form_filler.no_options_found'} />
             </Combobox.Empty>
-            {months.map((value) => (
+            {months.map((date) => (
               <Combobox.Option
-                key={value.getMonth()}
-                value={value.getMonth().toString()}
-                displayValue={formatMonthDropdown(value.getMonth(), currentLocale)}
+                ref={scrollToIfSelected(date.getMonth() === calendarMonth.date.getMonth())}
+                key={date.getMonth()}
+                value={date.getMonth().toString()}
+                displayValue={formatMonthDropdown(date.getMonth(), currentLocale)}
               >
-                <Lang id={formatMonthDropdown(value.getMonth(), currentLocale)} />
+                <Lang id={formatMonthDropdown(date.getMonth(), currentLocale)} />
               </Combobox.Option>
             ))}
           </Combobox>
@@ -82,7 +82,7 @@ export const DropdownCaption = ({ calendarMonth, id }: MonthCaptionProps) => {
             size='small'
             value={[calendarMonth.date.getFullYear().toString()]}
             onValueChange={(years) => handleYearChange(years[0])}
-            aria-label={yearDropdownLabel}
+            aria-label={langAsString('date_picker.aria_label_year_dropdown')}
             className={comboboxClasses.container}
             portal={!isMobile}
           >
@@ -91,6 +91,7 @@ export const DropdownCaption = ({ calendarMonth, id }: MonthCaptionProps) => {
             </Combobox.Empty>
             {years.map((date) => (
               <Combobox.Option
+                ref={scrollToIfSelected(date.getFullYear() === calendarMonth.date.getFullYear())}
                 key={date.getFullYear().toString()}
                 value={date.getFullYear().toString()}
                 displayValue={date.getFullYear().toString()}
@@ -115,3 +116,21 @@ export const DropdownCaption = ({ calendarMonth, id }: MonthCaptionProps) => {
     </>
   );
 };
+
+/**
+ * This is a workaround to make sure that the selected option is visible when opening the dropdown see: https://github.com/Altinn/app-frontend-react/issues/2637
+ * The ref attribute will call this function with the option element, and this will try to scroll it into view once.
+ * When it succeeds, we set a 'data-scroll' attribute to make sure it does not keep trying so the user can scroll as they please.
+ */
+function scrollToIfSelected(selected: boolean) {
+  return selected
+    ? (el: HTMLButtonElement) => {
+        if (el && !el.getAttribute('data-scroll') && el.parentElement) {
+          el.parentElement.scrollTop = el.offsetTop;
+          if (el.offsetTop == 0 || (el.offsetTop > 0 && el.parentElement.scrollTop > 0)) {
+            el.setAttribute('data-scroll', 'true');
+          }
+        }
+      }
+    : undefined;
+}

--- a/src/layout/Datepicker/DropdownCaption.tsx
+++ b/src/layout/Datepicker/DropdownCaption.tsx
@@ -124,11 +124,20 @@ export const DropdownCaption = ({ calendarMonth, id }: MonthCaptionProps) => {
  */
 function scrollToIfSelected(selected: boolean) {
   return selected
-    ? (el: HTMLButtonElement) => {
-        if (el && !el.getAttribute('data-scroll') && el.parentElement) {
+    ? (el: HTMLButtonElement | null) => {
+        if (
+          el &&
+          el.parentElement &&
+          // The option list seems to first render with unbounded height and later rendering with scroll-bars, we need to check again when the height changes
+          el.getAttribute('data-scroll-element-height') !== `${el.parentElement.clientHeight}`
+        ) {
           el.parentElement.scrollTop = el.offsetTop;
-          if (el.offsetTop == 0 || (el.offsetTop > 0 && el.parentElement.scrollTop > 0)) {
-            el.setAttribute('data-scroll', 'true');
+          if (
+            el.offsetTop == 0 || // no scrolling necessary
+            el.parentElement.scrollHeight - el.parentElement.clientHeight == 0 || // container does not have scroll-bars
+            (el.offsetTop > 0 && el.parentElement.scrollTop > 0) // check that we have actually scrolled
+          ) {
+            el.setAttribute('data-scroll-element-height', `${el.parentElement.clientHeight}`);
           }
         }
       }

--- a/src/layout/Datepicker/index.tsx
+++ b/src/layout/Datepicker/index.tsx
@@ -9,7 +9,7 @@ import { DatepickerComponent } from 'src/layout/Datepicker/DatepickerComponent';
 import { DatepickerSummary } from 'src/layout/Datepicker/DatepickerSummary';
 import { SummaryItemSimple } from 'src/layout/Summary/SummaryItemSimple';
 import { formatISOString, getDateConstraint, getDateFormat, strictParseISO } from 'src/utils/dateHelpers';
-import { getFormatDisplay } from 'src/utils/formatDateLocale';
+import { getDatepickerFormat } from 'src/utils/formatDateLocale';
 import type { LayoutValidationCtx } from 'src/features/devtools/layoutValidation/types';
 import type { DisplayDataProps } from 'src/features/displayData';
 import type { BaseValidation, ComponentValidation, ValidationDataSources } from 'src/features/validation';
@@ -88,13 +88,13 @@ export class Datepicker extends DatepickerDef implements ValidateComponent<'Date
       nodeDataSelector((picker) => picker(node)?.item?.format, [node]),
       currentLanguage,
     );
-    const formatDisplay = getFormatDisplay(format);
+    const datePickerFormat = getDatepickerFormat(format).toUpperCase();
 
     const validations: ComponentValidation[] = [];
     const date = strictParseISO(dataAsString);
     if (!date) {
       validations.push({
-        message: { key: 'date_picker.invalid_date_message', params: [formatDisplay] },
+        message: { key: 'date_picker.invalid_date_message', params: [datePickerFormat] },
         severity: 'error',
         source: FrontendValidationSource.Component,
         category: ValidationMask.Component,

--- a/src/layout/Datepicker/index.tsx
+++ b/src/layout/Datepicker/index.tsx
@@ -1,14 +1,14 @@
 import React, { forwardRef } from 'react';
 import type { JSX } from 'react';
 
-import { isAfter, isBefore, isValid, parseISO } from 'date-fns';
+import { isAfter, isBefore, isValid } from 'date-fns';
 
 import { FrontendValidationSource, ValidationMask } from 'src/features/validation';
 import { DatepickerDef } from 'src/layout/Datepicker/config.def.generated';
 import { DatepickerComponent } from 'src/layout/Datepicker/DatepickerComponent';
 import { DatepickerSummary } from 'src/layout/Datepicker/DatepickerSummary';
 import { SummaryItemSimple } from 'src/layout/Summary/SummaryItemSimple';
-import { formatISOString, getDateConstraint, getDateFormat } from 'src/utils/dateHelpers';
+import { formatISOString, getDateConstraint, getDateFormat, strictParseISO } from 'src/utils/dateHelpers';
 import type { LayoutValidationCtx } from 'src/features/devtools/layoutValidation/types';
 import type { DisplayDataProps } from 'src/features/displayData';
 import type { BaseValidation, ComponentValidation, ValidationDataSources } from 'src/features/validation';
@@ -89,7 +89,7 @@ export class Datepicker extends DatepickerDef implements ValidateComponent<'Date
     );
 
     const validations: ComponentValidation[] = [];
-    const date = parseISO(dataAsString);
+    const date = strictParseISO(dataAsString);
     if (!isValid(date)) {
       validations.push({
         message: { key: 'date_picker.invalid_date_message', params: [format] },
@@ -99,14 +99,14 @@ export class Datepicker extends DatepickerDef implements ValidateComponent<'Date
       });
     }
 
-    if (isBefore(date, minDate)) {
+    if (date && isBefore(date, minDate)) {
       validations.push({
         message: { key: 'date_picker.min_date_exeeded' },
         severity: 'error',
         source: FrontendValidationSource.Component,
         category: ValidationMask.Component,
       });
-    } else if (isAfter(date, maxDate)) {
+    } else if (date && isAfter(date, maxDate)) {
       validations.push({
         message: { key: 'date_picker.max_date_exeeded' },
         severity: 'error',

--- a/src/layout/Datepicker/index.tsx
+++ b/src/layout/Datepicker/index.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import type { JSX } from 'react';
 
-import { isAfter, isBefore, isValid } from 'date-fns';
+import { isAfter, isBefore } from 'date-fns';
 
 import { FrontendValidationSource, ValidationMask } from 'src/features/validation';
 import { DatepickerDef } from 'src/layout/Datepicker/config.def.generated';
@@ -9,6 +9,7 @@ import { DatepickerComponent } from 'src/layout/Datepicker/DatepickerComponent';
 import { DatepickerSummary } from 'src/layout/Datepicker/DatepickerSummary';
 import { SummaryItemSimple } from 'src/layout/Summary/SummaryItemSimple';
 import { formatISOString, getDateConstraint, getDateFormat, strictParseISO } from 'src/utils/dateHelpers';
+import { getFormatDisplay } from 'src/utils/formatDateLocale';
 import type { LayoutValidationCtx } from 'src/features/devtools/layoutValidation/types';
 import type { DisplayDataProps } from 'src/features/displayData';
 import type { BaseValidation, ComponentValidation, ValidationDataSources } from 'src/features/validation';
@@ -87,12 +88,13 @@ export class Datepicker extends DatepickerDef implements ValidateComponent<'Date
       nodeDataSelector((picker) => picker(node)?.item?.format, [node]),
       currentLanguage,
     );
+    const formatDisplay = getFormatDisplay(format);
 
     const validations: ComponentValidation[] = [];
     const date = strictParseISO(dataAsString);
-    if (!isValid(date)) {
+    if (!date) {
       validations.push({
-        message: { key: 'date_picker.invalid_date_message', params: [format] },
+        message: { key: 'date_picker.invalid_date_message', params: [formatDisplay] },
         severity: 'error',
         source: FrontendValidationSource.Component,
         category: ValidationMask.Component,

--- a/src/utils/dateHelpers.test.ts
+++ b/src/utils/dateHelpers.test.ts
@@ -1,5 +1,5 @@
 import { jest } from '@jest/globals';
-import { formatISO, parseISO } from 'date-fns';
+import { formatISO, isValid, parseISO } from 'date-fns';
 
 import { DateFlags } from 'src/types';
 import {
@@ -9,7 +9,7 @@ import {
   getDateConstraint,
   getDateFormat,
   getSaveFormattedDateString,
-  parseISOString,
+  strictParseISO,
 } from 'src/utils/dateHelpers';
 
 describe('dateHelpers', () => {
@@ -85,36 +85,35 @@ describe('dateHelpers', () => {
     });
   });
 
-  describe('parseISOString', () => {
+  describe('strictParseISO', () => {
     const tests: {
-      props: Parameters<typeof parseISOString>;
-      expected: Omit<ReturnType<typeof parseISOString>, 'date'> & { date: string | null };
+      props: Parameters<typeof strictParseISO>;
+      expected: { isValid: boolean; date: string | null };
     }[] = [
-      { props: [undefined], expected: { isValid: false, date: null, input: '' } },
-      { props: ['asdf'], expected: { isValid: false, date: null, input: 'asdf' } },
-      { props: ['2023-45-01'], expected: { isValid: false, date: null, input: '2023-45-01' } },
-      { props: ['2023-05-34'], expected: { isValid: false, date: null, input: '2023-05-34' } },
+      { props: [undefined], expected: { isValid: false, date: null } },
+      { props: ['asdf'], expected: { isValid: false, date: null } },
+      { props: ['2023-45-01'], expected: { isValid: false, date: null } },
+      { props: ['2023-05-34'], expected: { isValid: false, date: null } },
       {
         props: ['2023-13-33T23:00:00.000Z'],
-        expected: { isValid: false, date: null, input: '2023-13-33T23:00:00.000Z' },
+        expected: { isValid: false, date: null },
       },
-      { props: ['2023-07-07'], expected: { isValid: true, date: '2023-07-07T00:00:00.000Z', input: undefined } },
+      { props: ['2023-07-07'], expected: { isValid: true, date: '2023-07-07T00:00:00.000Z' } },
       {
         props: ['2023-07-07T00:00:00.000Z'],
-        expected: { isValid: true, date: '2023-07-07T00:00:00.000Z', input: undefined },
+        expected: { isValid: true, date: '2023-07-07T00:00:00.000Z' },
       },
       {
         props: ['2023-12-31T23:00:00.000Z'],
-        expected: { isValid: true, date: '2023-12-31T23:00:00.000Z', input: undefined },
+        expected: { isValid: true, date: '2023-12-31T23:00:00.000Z' },
       },
     ];
     tests.forEach(({ props, expected }) => {
       it(`should return ${JSON.stringify(expected)} when called with ${JSON.stringify(props)}`, () => {
-        const { isValid, date, input } = parseISOString(...props);
-        expect(isValid).toEqual(expected.isValid);
+        const date = strictParseISO(...props);
+        expect(isValid(date)).toEqual(expected.isValid);
         const dateStr = date?.toISOString() ?? null;
         expect(dateStr).toEqual(expected.date);
-        expect(input).toEqual(expected.input);
       });
     });
   });

--- a/src/utils/dateHelpers.test.ts
+++ b/src/utils/dateHelpers.test.ts
@@ -1,11 +1,10 @@
 import { jest } from '@jest/globals';
-import { format, parseISO } from 'date-fns';
+import { formatISO, parseISO } from 'date-fns';
 
 import { DateFlags } from 'src/types';
 import {
   DatepickerMaxDateDefault,
   DatepickerMinDateDefault,
-  DatepickerSaveFormatTimestamp,
   formatISOString,
   getDateConstraint,
   getDateFormat,
@@ -81,7 +80,7 @@ describe('dateHelpers', () => {
     tests.forEach(({ props, expected }) => {
       it(`should return ${expected} when called with ${JSON.stringify(props)}`, () => {
         const result = getDateConstraint(...props);
-        expect(format(result, DatepickerSaveFormatTimestamp)).toEqual(expected);
+        expect(formatISO(result, { representation: 'complete' })).toEqual(expected);
       });
     });
   });

--- a/src/utils/dateHelpers.ts
+++ b/src/utils/dateHelpers.ts
@@ -1,4 +1,4 @@
-import { endOfDay, formatDate, formatISO, isValid, parseISO, startOfDay } from 'date-fns';
+import { endOfDay, format, formatDate, formatISO, isValid, parse, parseISO, startOfDay } from 'date-fns';
 import type { Locale } from 'date-fns/locale';
 
 import { DateFlags } from 'src/types';
@@ -7,9 +7,7 @@ import { locales } from 'src/utils/dateLocales';
 export const DatepickerMinDateDefault = '1900-01-01T00:00:00Z';
 export const DatepickerMaxDateDefault = '2100-01-01T23:59:59Z';
 export const DatepickerFormatDefault = 'dd.MM.yyyy';
-export const DatepickerSaveFormatTimestamp = "yyyy-MM-dd'T'HH:mm:ssXXXXX";
 export const PrettyDateAndTime = 'dd.MM.yyyy HH.mm.ss';
-export const DatepickerSaveFormatNoTimestamp = 'yyyy-MM-dd';
 
 export type DateResult =
   | {
@@ -107,4 +105,31 @@ export function parseISOString(isoString: string | undefined): DateResult {
       input: isoString ?? '',
     };
   }
+}
+
+/**
+ * The date-fns parseISO function is a bit too lax for us, and will parse e.g. '01' as the date '0100-01-01',
+ * this function requires at least a full date to parse successfully.
+ * This prevents the value in the Datepicker input from changing while typing.
+ */
+export function strictParseISO(isoString: string | undefined): Date | null {
+  const minimumDate = 'yyyy-MM-dd';
+  if (!isoString || isoString.length < minimumDate.length) {
+    return null;
+  }
+  return parseISO(isoString);
+}
+
+/**
+ * The format function is a bit too lax, and will parse '01/01/1' (format: 'dd/MM/yyyy', which requires full year) as '01/01/0001',
+ * this function requires that the parsed date when formatted using the same format is equal to the input.
+ * This prevents the value in the Datepicker input from changing while typing.
+ */
+export function strictParseFormat(formattedDate: string | undefined, formatString: string): Date | null {
+  if (!formattedDate) {
+    return null;
+  }
+  const date = parse(formattedDate, formatString, new Date());
+  const newFormattedDate = isValid(date) ? format(date, formatString) : undefined;
+  return newFormattedDate && newFormattedDate === formattedDate ? date : null;
 }

--- a/src/utils/dateHelpers.ts
+++ b/src/utils/dateHelpers.ts
@@ -61,8 +61,8 @@ export function getDateConstraint(dateOrFlag: string | DateFlags | undefined, co
     return shiftTime(new Date());
   }
 
-  const { date, isValid } = parseISOString(dateOrFlag);
-  if (isValid) {
+  const date = strictParseISO(dateOrFlag);
+  if (date && isValid(date)) {
     return shiftTime(date);
   }
   if (constraint === 'min') {
@@ -73,10 +73,10 @@ export function getDateConstraint(dateOrFlag: string | DateFlags | undefined, co
 }
 
 export function formatISOString(isoString: string | undefined, format: string, locale?: Locale): string | null {
-  const isoDate = parseISOString(isoString).date;
+  const date = strictParseISO(isoString);
 
-  if (isoDate) {
-    return formatDate(isoDate, format, { locale });
+  if (date && isValid(date)) {
+    return formatDate(date, format, { locale });
   } else {
     return null;
   }
@@ -90,34 +90,19 @@ export function getLocale(language: string): Locale {
   return locales[language] ?? locales.nb;
 }
 
-export function parseISOString(isoString: string | undefined): DateResult {
-  const date = parseISO(isoString ?? '');
-  if (isValid(date)) {
-    return {
-      isValid: true,
-      date,
-      input: undefined,
-    };
-  } else {
-    return {
-      isValid: false,
-      date: null,
-      input: isoString ?? '',
-    };
-  }
-}
-
 /**
  * The date-fns parseISO function is a bit too lax for us, and will parse e.g. '01' as the date '0100-01-01',
  * this function requires at least a full date to parse successfully.
  * This prevents the value in the Datepicker input from changing while typing.
+ * It returns either a valid date or null
  */
 export function strictParseISO(isoString: string | undefined): Date | null {
   const minimumDate = 'yyyy-MM-dd';
   if (!isoString || isoString.length < minimumDate.length) {
     return null;
   }
-  return parseISO(isoString);
+  const date = parseISO(isoString);
+  return isValid(date) ? date : null;
 }
 
 /**

--- a/src/utils/formatDateLocale.ts
+++ b/src/utils/formatDateLocale.ts
@@ -114,6 +114,28 @@ export function formatDateLocale(localeStr: string, date: Date, unicodeFormat?: 
   }, '');
 }
 
+export function getFormatDisplay(unicodeFormat: string): string {
+  const tokens = unicodeFormat.split(UNICODE_TOKENS) as Token[];
+  const separators: Separator[] = unicodeFormat.match(UNICODE_TOKENS) ?? [];
+
+  return tokens.reduce((acc, token: Token, index) => {
+    if (['y', 'yy', 'yyy', 'yyyy', 'u', 'uu', 'uuu', 'uuuu'].includes(token)) {
+      return `${acc}YYYY${separators?.[index] ?? ''}`;
+    }
+    if (['M', 'MM', 'MMM', 'MMMM', 'MMMMM'].includes(token)) {
+      return `${acc}MM${separators?.[index] ?? ''}`;
+    }
+    if (['d', 'dd'].includes(token)) {
+      return `${acc}DD${separators?.[index] ?? ''}`;
+    }
+    return acc;
+  }, '');
+}
+
+export function getFormatPattern(formatDisplay: string): string {
+  return formatDisplay.replaceAll(/D|M|Y/g, '#');
+}
+
 function selectPartToUse(parts: Intl.DateTimeFormatPart[], token: Token) {
   if (['G', 'GG', 'GGG', 'GGGG', 'GGGGG'].includes(token)) {
     return parts.find((part) => part.type === 'era');

--- a/src/utils/formatDateLocale.ts
+++ b/src/utils/formatDateLocale.ts
@@ -114,26 +114,29 @@ export function formatDateLocale(localeStr: string, date: Date, unicodeFormat?: 
   }, '');
 }
 
-export function getFormatDisplay(unicodeFormat: string): string {
+/**
+ * This function will massage locale date formats to require a fixed number of characters so that a pattern-format can be used on the text input
+ */
+export function getDatepickerFormat(unicodeFormat: string): string {
   const tokens = unicodeFormat.split(UNICODE_TOKENS) as Token[];
   const separators: Separator[] = unicodeFormat.match(UNICODE_TOKENS) ?? [];
 
   return tokens.reduce((acc, token: Token, index) => {
     if (['y', 'yy', 'yyy', 'yyyy', 'u', 'uu', 'uuu', 'uuuu'].includes(token)) {
-      return `${acc}YYYY${separators?.[index] ?? ''}`;
+      return `${acc}yyyy${separators?.[index] ?? ''}`;
     }
     if (['M', 'MM', 'MMM', 'MMMM', 'MMMMM'].includes(token)) {
       return `${acc}MM${separators?.[index] ?? ''}`;
     }
     if (['d', 'dd'].includes(token)) {
-      return `${acc}DD${separators?.[index] ?? ''}`;
+      return `${acc}dd${separators?.[index] ?? ''}`;
     }
     return acc;
   }, '');
 }
 
-export function getFormatPattern(formatDisplay: string): string {
-  return formatDisplay.replaceAll(/D|M|Y/g, '#');
+export function getFormatPattern(datePickerFormat: string): string {
+  return datePickerFormat.replaceAll(/d|m|y/gi, '#');
 }
 
 function selectPartToUse(parts: Intl.DateTimeFormatPart[], token: Token) {


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

### Fixes:
- DateInput is able to parse any ISO string, not just the particular format we save
- DateInput automatically fills inn separator characters
  - This is similar to how the old one worked
  - Now you can only type numbers, and no more than required
  - To achieve this, I used the `PatternFormat` which is also used for number-formatting in the `Input`-component. I modify the raw format to have fixed length for day, month, and year to make this work. This also makes the error message less confusing, see: https://altinn.slack.com/archives/C02EJ9HKQA3/p1729692095041289?thread_ts=1729512493.045959&cid=C02EJ9HKQA3
![image](https://github.com/user-attachments/assets/015b170e-b120-4c25-852c-db0aba9df698)
Now it looks like this instead with the default format for `nb`:
![image](https://github.com/user-attachments/assets/45f5126d-3812-4b45-aff1-dbd79a29c0ac)
- DayPicker: changing month using arrows or dropdowns now works
- DayPicker: clicking the small arrows (chevron) in dropdown now works as expected
- DayPicker: Dropdowns now scroll to the selected value, instead of showing the year `2124`
  - This required a workaround because the Combobox component does not have any support for this.

### Other changes
I refactored a few things, for example moving the calendar button outside of the input component and structuring the dialog a bit differently.



## Related Issue(s)

- closes https://github.com/Altinn/app-frontend-react/issues/2608
- closes https://github.com/Altinn/app-frontend-react/issues/2637

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
