### PR TITLE
Prevent PDF generator from printing "Unknown error" page

### DIFF
--- a/src/components/ReadyForPrint.tsx
+++ b/src/components/ReadyForPrint.tsx
@@ -4,12 +4,19 @@ import { useDataLoadingStore } from 'src/core/contexts/dataLoadingContext';
 import { waitForAnimationFrames } from 'src/utils/waitForAnimationFrames';
 import type { DataLoading } from 'src/core/contexts/dataLoadingContext';
 
+type ReadyType = 'print' | 'load';
+const readyId: Record<ReadyType, string> = {
+  print: 'readyForPrint',
+  load: 'finishedLoading',
+};
+
 /**
- * This element only serves to let our PDF generator know the app is ready and have rendered its content.
+ * This element mostly serves to let our PDF generator know the app is ready and have rendered its content. (type: 'print')
+ * It is also used for tests, to be able to wait for when the app has finished loading. (type: 'load')
  * It should be included in the app DOM for every possible execution path, except those where we're showing
  * loading indicators to the user while waiting for content to get ready.
  */
-export function ReadyForPrint() {
+export function ReadyForPrint({ type }: { type: ReadyType }) {
   const [assetsLoaded, setAssetsLoaded] = React.useState(false);
   const dataLoadingIsDone = useDataLoadingStore((state) => state.isDone);
 
@@ -34,7 +41,7 @@ export function ReadyForPrint() {
   return (
     <div
       style={{ display: 'none' }}
-      id='readyForPrint'
+      id={readyId[type]}
     />
   );
 }
@@ -66,7 +73,7 @@ async function waitForDataLoading(dataLoadingIsDone: DataLoading['isDone']) {
   let done: boolean = dataLoadingIsDone();
 
   while (!done) {
-    await new Promise((r) => setTimeout(r, 1000));
+    await new Promise((resolve) => window.requestIdleCallback(resolve));
     done = dataLoadingIsDone();
   }
 }

--- a/src/components/ReadyForPrint.tsx
+++ b/src/components/ReadyForPrint.tsx
@@ -73,7 +73,7 @@ async function waitForDataLoading(dataLoadingIsDone: DataLoading['isDone']) {
   let done: boolean = dataLoadingIsDone();
 
   while (!done) {
-    await new Promise((resolve) => window.requestIdleCallback(resolve));
+    await new Promise((resolve) => window.requestIdleCallback(resolve, { timeout: 100 }));
     done = dataLoadingIsDone();
   }
 }

--- a/src/components/form/Form.tsx
+++ b/src/components/form/Form.tsx
@@ -149,7 +149,7 @@ export function FormPage({ currentPageId }: { currentPageId: string | undefined 
           />
         </Grid>
       </Grid>
-      <ReadyForPrint />
+      <ReadyForPrint type='load' />
       <HandleNavigationFocusComponent />
     </>
   );

--- a/src/features/instantiate/containers/InstantiationContainer.tsx
+++ b/src/features/instantiate/containers/InstantiationContainer.tsx
@@ -27,7 +27,7 @@ export function InstantiationContainer({ children }: IInstantiateContainerProps)
             <AltinnAppHeader profile={profile} />
             <main id='main-content'>{children}</main>
             <Footer />
-            <ReadyForPrint />
+            <ReadyForPrint type='load' />
           </div>
         </RenderStart>
       </DataLoadingProvider>

--- a/src/features/instantiate/selection/InstanceSelection.tsx
+++ b/src/features/instantiate/selection/InstanceSelection.tsx
@@ -274,7 +274,7 @@ function InstanceSelection() {
           </Button>
         </div>
       </div>
-      <ReadyForPrint />
+      <ReadyForPrint type='load' />
     </TaskStoreProvider>
   );
 }

--- a/src/features/pdf/PDFWrapper.tsx
+++ b/src/features/pdf/PDFWrapper.tsx
@@ -51,7 +51,7 @@ export function PDFWrapper({ children }: PropsWithChildren) {
 
 async function waitForPrint(timeOut = 5000): Promise<boolean> {
   const start = performance.now();
-  while (document.querySelector('#pdfView #readyForPrint') === null) {
+  while (document.querySelector('#readyForPrint') === null) {
     if (performance.now() - start > timeOut) {
       return false;
     }

--- a/src/features/pdf/PdfView2.tsx
+++ b/src/features/pdf/PdfView2.tsx
@@ -181,7 +181,7 @@ function PdfWrapping({ children }: PropsWithChildren) {
         </Heading>
       </ConditionalWrapper>
       {children}
-      <ReadyForPrint />
+      <ReadyForPrint type='print' />
     </div>
   );
 }

--- a/src/features/processEnd/confirm/containers/ConfirmPage.tsx
+++ b/src/features/processEnd/confirm/containers/ConfirmPage.tsx
@@ -74,7 +74,7 @@ export const ConfirmPage = ({ instance, instanceOwnerParty, appName, application
         pdf={filterDisplayPdfAttachments(instance?.data ?? [])}
       />
       <ProcessNavigation />
-      <ReadyForPrint />
+      <ReadyForPrint type='load' />
     </>
   );
 };

--- a/src/features/processEnd/feedback/Feedback.tsx
+++ b/src/features/processEnd/feedback/Feedback.tsx
@@ -33,7 +33,7 @@ export function Feedback() {
       <Typography variant='body1'>
         <Lang id={'feedback.body'} />
       </Typography>
-      <ReadyForPrint />
+      <ReadyForPrint type='load' />
     </div>
   );
 }

--- a/src/features/receipt/ReceiptContainer.tsx
+++ b/src/features/receipt/ReceiptContainer.tsx
@@ -186,7 +186,7 @@ export const ReceiptContainer = () => {
           title={<Lang id={'receipt.title'} />}
         />
       )}
-      <ReadyForPrint />
+      <ReadyForPrint type='load' />
     </div>
   );
 };

--- a/test/e2e/integration/frontend-test/pdf.ts
+++ b/test/e2e/integration/frontend-test/pdf.ts
@@ -323,5 +323,6 @@ describe('PDF', () => {
     // To confirm we are on the PDF page, reload (which should now succeed) and check that #readyForPrint is visible
     cy.reload();
     cy.get('#readyForPrint').should('exist');
+    cy.findByRole('heading', { name: 'Ukjent feil' }).should('not.exist');
   });
 });

--- a/test/e2e/integration/frontend-test/pdf.ts
+++ b/test/e2e/integration/frontend-test/pdf.ts
@@ -1,6 +1,8 @@
 import { AppFrontend } from 'test/e2e/pageobjects/app-frontend';
 import { Likert } from 'test/e2e/pageobjects/likert';
 
+import { getInstanceIdRegExp } from 'src/utils/instanceIdRegExp';
+
 const appFrontend = new AppFrontend();
 const likertPage = new Likert();
 
@@ -286,5 +288,40 @@ describe('PDF', () => {
       cy.findByText('Prosentandel av gjeld i boliglån').should('be.visible');
       cy.findByText('Utregnet totalprosent').should('be.visible');
     });
+  });
+
+  it('should not show "#readyForPrint" on unknown error', () => {
+    cy.goto('message');
+
+    // Wait for page to load
+    cy.get('#finishedLoading').should('exist');
+    cy.waitForNetworkIdle(500);
+
+    // This should provoke an unknown error
+    cy.intercept({ method: 'GET', url: '**/data/**includeRowId=true*', times: 1 }, (req) =>
+      req.reply({ statusCode: 404, body: 'Not Found' }),
+    );
+
+    // Visit the PDF page and reload
+    cy.location('href').then((href) => {
+      const regex = getInstanceIdRegExp();
+      const instanceId = regex.exec(href)?.[1];
+      const before = href.split(regex)[0];
+      const visitUrl = `${before}${instanceId}?pdf=1`;
+      cy.visit(visitUrl);
+    });
+    cy.reload();
+
+    // Wait for page to load
+    cy.get('#finishedLoading').should('exist');
+    cy.waitForNetworkIdle(500);
+
+    // Check that we are on the error page and that #readyForPrint is not present
+    cy.findByRole('heading', { name: 'Ukjent feil' }).should('exist');
+    cy.get('#readyForPrint').should('not.exist');
+
+    // To confirm we are on the PDF page, reload (which should now succeed) and check that #readyForPrint is visible
+    cy.reload();
+    cy.get('#readyForPrint').should('exist');
   });
 });

--- a/test/e2e/integration/frontend-test/summary.ts
+++ b/test/e2e/integration/frontend-test/summary.ts
@@ -685,7 +685,7 @@ function injectExtraPageAndSetTriggers(pageValidationConfig?: PageValidation | u
     },
   );
   cy.log(`Reloading page with trigger: ${pageValidationConfig?.page ?? 'undefined'}`);
-  cy.get('#readyForPrint').then(() => {
+  cy.get('#finishedLoading').then(() => {
     cy.reload();
   });
   cy.intercept('GET', '**/api/layoutsettings/changename', {

--- a/test/e2e/manual/page-load.ts
+++ b/test/e2e/manual/page-load.ts
@@ -43,7 +43,7 @@ describe('Page load times', () => {
           for (let i = 0; i < n_loads; i++) {
             cy.waitUntilSaved();
             cy.reload(false);
-            cy.get('#readyForPrint').should('exist');
+            cy.get(PDF ? '#readyForPrint' : '#finishedLoading').should('exist');
             cy.then(() => {
               Cypress.env('_pageLoadTimes')[task].push(performance.now() - Cypress.env('_pageLoadStart'));
             });

--- a/test/e2e/support/custom.ts
+++ b/test/e2e/support/custom.ts
@@ -210,7 +210,7 @@ const knownWcagViolations: KnownViolation[] = [
 ];
 
 Cypress.Commands.add('clearSelectionAndWait', (viewport) => {
-  cy.get('#readyForPrint').should('exist');
+  cy.get('#finishedLoading').should('exist');
   cy.findByRole('progressbar').should('not.exist');
 
   // Find focused element and blur it, to ensure that we don't get any focus outlines or styles in the snapshot.
@@ -386,13 +386,13 @@ Cypress.Commands.add('testWcag', () => {
 Cypress.Commands.add('reloadAndWait', () => {
   cy.waitUntilSaved();
   cy.reload();
-  cy.get('#readyForPrint').should('exist');
+  cy.get('#finishedLoading').should('exist');
   cy.findByRole('progressbar').should('not.exist');
   cy.injectAxe();
 });
 
 Cypress.Commands.add('waitForLoad', () => {
-  cy.get('#readyForPrint').should('exist');
+  cy.get('#finishedLoading').should('exist');
   cy.findByRole('progressbar').should('not.exist');
   // An initialOption can cause a save to occur immediately after loading is finished, wait for this to finish as well
   cy.waitUntilSaved();
@@ -506,7 +506,7 @@ Cypress.Commands.add('changeLayout', (mutator, wholeLayoutMutator) => {
   cy.get('[data-testid="loader"]').should('exist');
   cy.get('[data-testid="loader"]').should('not.exist');
 
-  cy.get('#readyForPrint').should('exist');
+  cy.get('#finishedLoading').should('exist');
   cy.findByRole('progressbar').should('not.exist');
   cy.waitUntilNodesReady();
 });
@@ -632,7 +632,7 @@ Cypress.Commands.add('testPdf', (snapshotName, callback, returnToForm = false) =
   cy.reload();
 
   // Wait for readyForPrint, after this everything should be rendered so using timeout: 0
-  cy.get('#pdfView > #readyForPrint')
+  cy.get('#readyForPrint')
     .should('exist')
     .then(() => {
       // Enable print media emulation
@@ -680,8 +680,8 @@ Cypress.Commands.add('testPdf', (snapshotName, callback, returnToForm = false) =
     cy.location('href').then((href) => {
       cy.visit(href.replace('?pdf=1', ''));
     });
-    cy.get('#pdfView > #readyForPrint').should('not.exist');
-    cy.get('#readyForPrint').should('exist');
+    cy.get('#readyForPrint').should('not.exist');
+    cy.get('#finishedLoading').should('exist');
   }
 });
 


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

Since we use `#readyForPrint` in our cypress tests to check if the page has finished loading, I added a new id for this use case in the `ReadyForPrint` component. Now only the PDF page will show `#readyForPrint` and the others show `#finishedLoading` instead.

## Related Issue(s)

- closes #970

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
