### PR TITLE
stricter label check

### DIFF
--- a/.github/workflows/check-label-added.yml
+++ b/.github/workflows/check-label-added.yml
@@ -1,7 +1,7 @@
-name: "Label Check"
+name: 'Label Check'
 on:
   pull_request:
-    types: [opened, edited, labeled, unlabeled, synchronize]
+    types: [opened, labeled, unlabeled]
 
 jobs:
   check-label:
@@ -12,10 +12,8 @@ jobs:
         with:
           script: |
             const labels = context.payload.pull_request.labels;
-            const hasIgnoreLabel = labels.some(label => label.name === 'ignore-for-release');
-            if (!hasIgnoreLabel) {
-              const hasMatchingLabel = labels.some(label => /^kind\/.*/.test(label.name));
-              if (!hasMatchingLabel) {
-                core.setFailed('The PR must have at least one label matching the pattern "kind/*", unless it has the "ignore-for-release" label.');
-              }
+            const required_labels = ['kind/breaking-change', 'kind/product-feature', 'kind/bug', 'kind/other', 'kind/dependencies', 'ignore-for-release'];
+            const hasMatchingLabel = labels.some((label) => required_labels.includes(label.name));
+            if (!hasMatchingLabel) {
+              core.setFailed('The PR must have one of the following labels:\n- ' + required_labels.join('\n- '));
             }


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

I noticed an uncategorized change that was caused by the label `kind/feature-request`, which is not used for release notes grouping but was allowed by the label-check. I changed it to only allow the specific labels we use in `release.yml`. Additionally I removed some triggers that are probably not necessary.

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
