### PR TITLE
Fixing frequent re-renders with latest `app-lib-dotnet`

### DIFF
--- a/src/features/datamodel/DataModelsProvider.tsx
+++ b/src/features/datamodel/DataModelsProvider.tsx
@@ -23,7 +23,7 @@ import {
 } from 'src/features/datamodel/utils';
 import { useLayouts } from 'src/features/form/layout/LayoutsContext';
 import { useFormDataQuery } from 'src/features/formData/useFormDataQuery';
-import { useLaxInstanceAllDataElements, useLaxInstanceDataElements } from 'src/features/instance/InstanceContext';
+import { useLaxInstanceAllDataElementsNow, useLaxInstanceDataElements } from 'src/features/instance/InstanceContext';
 import { MissingRolesError } from 'src/features/instantiate/containers/MissingRolesError';
 import { useIsPdf } from 'src/hooks/useIsPdf';
 import { isAxiosError } from 'src/utils/isAxiosError';
@@ -136,7 +136,7 @@ function DataModelsLoader() {
   const layouts = useLayouts();
   const defaultDataType = useCurrentDataModelName();
   const isStateless = useApplicationMetadata().isStatelessApp;
-  const dataElements = useLaxInstanceAllDataElements();
+  const dataElements = useLaxInstanceAllDataElementsNow();
 
   // Subform
   const overriddenDataElement = useTaskStore((state) => state.overriddenDataModelUuid);

--- a/src/features/datamodel/useBindingSchema.tsx
+++ b/src/features/datamodel/useBindingSchema.tsx
@@ -10,7 +10,7 @@ import {
 } from 'src/features/applicationMetadata/appMetadataUtils';
 import { DataModels } from 'src/features/datamodel/DataModelsProvider';
 import { useLayoutSets } from 'src/features/form/layoutSets/LayoutSetsProvider';
-import { useLaxInstanceAllDataElements, useLaxInstanceId } from 'src/features/instance/InstanceContext';
+import { useLaxInstanceData, useLaxInstanceId } from 'src/features/instance/InstanceContext';
 import { useProcessTaskId } from 'src/features/instance/useProcessTaskId';
 import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
 import { useAllowAnonymous } from 'src/features/stateless/getAllowAnonymous';
@@ -29,17 +29,21 @@ export type AsSchema<T> = {
 };
 
 export function useCurrentDataModelGuid() {
-  const dataElements = useLaxInstanceAllDataElements();
   const application = useApplicationMetadata();
   const layoutSets = useLayoutSets();
   const taskId = useProcessTaskId();
 
   const overriddenDataModelGuid = useTaskStore((s) => s.overriddenDataModelUuid);
-  if (overriddenDataModelGuid) {
-    return overriddenDataModelGuid;
-  }
 
-  return getCurrentTaskDataElementId({ application, dataElements, taskId, layoutSets });
+  // Instance data elements will update often (after each save), so we have to use a selector to make
+  // sure components don't re-render too often.
+  return useLaxInstanceData((data) => {
+    if (overriddenDataModelGuid) {
+      return overriddenDataModelGuid;
+    }
+
+    return getCurrentTaskDataElementId({ application, dataElements: data.data, taskId, layoutSets });
+  });
 }
 
 type DataModelDeps = {

--- a/src/features/validation/index.ts
+++ b/src/features/validation/index.ts
@@ -1,11 +1,11 @@
 import type { ApplicationMetadata } from 'src/features/applicationMetadata/types';
 import type { AttachmentsSelector } from 'src/features/attachments/AttachmentsStorePlugin';
 import type { Expression, ExprValToActual } from 'src/features/expressions/types';
+import type { DataElementSelector } from 'src/features/instance/InstanceContext';
 import type { TextReference, ValidLangParam } from 'src/features/language/useLanguage';
 import type { DataElementHasErrorsSelector } from 'src/features/validation/validationContext';
 import type { FormDataSelector } from 'src/layout';
 import type { ILayoutSets } from 'src/layout/common.generated';
-import type { IData } from 'src/types/shared';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 import type { NodeDataSelector } from 'src/utils/layout/NodesContext';
 
@@ -225,7 +225,7 @@ export type ValidationDataSources = {
   attachmentsSelector: AttachmentsSelector;
   nodeDataSelector: NodeDataSelector;
   applicationMetadata: ApplicationMetadata;
-  dataElements: IData[];
+  dataElementsSelector: DataElementSelector;
   layoutSets: ILayoutSets;
   dataElementHasErrorsSelector: DataElementHasErrorsSelector;
 };

--- a/src/features/validation/nodeValidation/useNodeValidation.ts
+++ b/src/features/validation/nodeValidation/useNodeValidation.ts
@@ -5,7 +5,7 @@ import { useAttachmentsSelector } from 'src/features/attachments/hooks';
 import { DataModels } from 'src/features/datamodel/DataModelsProvider';
 import { useLayoutSets } from 'src/features/form/layoutSets/LayoutSetsProvider';
 import { FD } from 'src/features/formData/FormDataWrite';
-import { useLaxInstanceAllDataElements } from 'src/features/instance/InstanceContext';
+import { useLaxDataElementsSelector } from 'src/features/instance/InstanceContext';
 import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
 import { Validation } from 'src/features/validation/validationContext';
 import { implementsValidateComponent, implementsValidateEmptyField } from 'src/layout';
@@ -85,7 +85,7 @@ function useValidationDataSources(): ValidationDataSources {
   const currentLanguage = useCurrentLanguage();
   const nodeSelector = NodesInternal.useNodeDataSelector();
   const applicationMetadata = useApplicationMetadata();
-  const dataElements = useLaxInstanceAllDataElements();
+  const dataElementsSelector = useLaxDataElementsSelector();
   const layoutSets = useLayoutSets();
   const dataElementHasErrorsSelector = Validation.useDataElementHasErrorsSelector();
 
@@ -97,7 +97,7 @@ function useValidationDataSources(): ValidationDataSources {
       currentLanguage,
       nodeDataSelector: nodeSelector,
       applicationMetadata,
-      dataElements,
+      dataElementsSelector,
       layoutSets,
       dataElementHasErrorsSelector,
     }),
@@ -108,7 +108,7 @@ function useValidationDataSources(): ValidationDataSources {
       currentLanguage,
       nodeSelector,
       applicationMetadata,
-      dataElements,
+      dataElementsSelector,
       layoutSets,
       dataElementHasErrorsSelector,
     ],

--- a/src/layout/AttachmentList/AttachmentListComponent.tsx
+++ b/src/layout/AttachmentList/AttachmentListComponent.tsx
@@ -1,8 +1,8 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 
 import { AltinnAttachment } from 'src/components/atoms/AltinnAttachment';
 import { useApplicationMetadata } from 'src/features/applicationMetadata/ApplicationMetadataProvider';
-import { useLaxInstanceAllDataElements } from 'src/features/instance/InstanceContext';
+import { useLaxInstanceData } from 'src/features/instance/InstanceContext';
 import { useLaxProcessData } from 'src/features/instance/ProcessContext';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
 import { DataTypeReference, filterDisplayPdfAttachments, getDisplayAttachments } from 'src/utils/attachmentsUtils';
@@ -15,12 +15,12 @@ export type IAttachmentListProps = PropsFromGenericComponent<'AttachmentList'>;
 const emptyDataTypeArray: IDataType[] = [];
 
 export function AttachmentListComponent({ node }: IAttachmentListProps) {
-  const instanceData = useLaxInstanceAllDataElements();
   const currentTaskId = useLaxProcessData()?.currentTask?.elementId;
   const dataTypes = useApplicationMetadata().dataTypes ?? emptyDataTypeArray;
   const { dataTypeIds, textResourceBindings } = useNodeItem(node);
 
-  const attachments = useMemo(() => {
+  const attachments = useLaxInstanceData((data) => {
+    const instanceData = data.data ?? [];
     const allowedTypes = new Set(dataTypeIds ?? []);
     const includePdf =
       allowedTypes.has(DataTypeReference.RefDataAsPdf) || allowedTypes.has(DataTypeReference.IncludeAll);
@@ -54,7 +54,7 @@ export function AttachmentListComponent({ node }: IAttachmentListProps) {
 
     const otherAttachments = getDisplayAttachments(attachments);
     return [...pdfAttachments, ...otherAttachments];
-  }, [currentTaskId, dataTypes, instanceData, dataTypeIds]);
+  });
 
   return (
     <ComponentStructureWrapper node={node}>

--- a/src/layout/Subform/index.tsx
+++ b/src/layout/Subform/index.tsx
@@ -86,7 +86,7 @@ export class Subform extends SubformDef implements ValidateComponent<'Subform'>,
     node: LayoutNode<'Subform'>,
     {
       applicationMetadata,
-      dataElements,
+      dataElementsSelector,
       nodeDataSelector,
       layoutSets,
       dataElementHasErrorsSelector,
@@ -107,8 +107,8 @@ export class Subform extends SubformDef implements ValidateComponent<'Subform'>,
 
     const validations: ComponentValidation[] = [];
 
-    const elements = dataElements.filter((x) => x.dataType === targetType);
-    const numDataElements = elements?.length ?? 0;
+    const elements = dataElementsSelector((d) => d.filter((x) => x.dataType === targetType), [targetType]);
+    const numDataElements = Array.isArray(elements) ? elements.length : 0;
     const { minCount, maxCount } = dataTypeDefinition;
 
     if (minCount > 0 && numDataElements < minCount) {
@@ -129,7 +129,9 @@ export class Subform extends SubformDef implements ValidateComponent<'Subform'>,
       });
     }
 
-    const subformIdsWithError = elements?.map((dE) => dE.id).filter((id) => dataElementHasErrorsSelector(id));
+    const subformIdsWithError = Array.isArray(elements)
+      ? elements?.map((dE) => dE.id).filter((id) => dataElementHasErrorsSelector(id))
+      : [];
     if (subformIdsWithError?.length) {
       const validation: SubformValidation = {
         subformDataElementIds: subformIdsWithError,


### PR DESCRIPTION
## Description

In the latest `app-lib-dotnet`, the backend sends us updated instance data after saving form data. Great stuff, which will fix some issues we've had, but this made some of our greedy selectors re-render components too often, which also at some point caused duplicate components to show up in a repeating group (because the node hierarchy got forcefully re-rendered). This fixes the root cause, but later I'll also open a PR with a fix that makes sure that exact thing cannot happen again even despite re-rendering.

## Related Issue(s)

- #2662

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [x] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
