### PR TITLE
Performance: Make node data commit queue cheaper

### DIFF
--- a/src/core/contexts/zustandContext.tsx
+++ b/src/core/contexts/zustandContext.tsx
@@ -36,6 +36,11 @@ export function createZustandContext<Store extends StoreApi<Type>, Type = Extrac
    */
   const useSelector: SelectorFunc<Type> = (selector) => useStore(useCtx(), selector);
 
+  /**
+   * A light weight hook that can be used to select static values from the store like update functions which are never changed.
+   */
+  const useStaticSelector: SelectorFunc<Type> = (selector) => selector(useCtx().getState());
+
   const useSelectorAsRef: SelectorRefFunc<Type> = (selector) => {
     const store = useCtx();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -173,5 +178,6 @@ export function createZustandContext<Store extends StoreApi<Type>, Type = Extrac
     useHasProvider,
     useStore: useCtx,
     useLaxStore: useLaxCtx,
+    useStaticSelector,
   };
 }

--- a/src/utils/layout/NodesContext.tsx
+++ b/src/utils/layout/NodesContext.tsx
@@ -1193,15 +1193,15 @@ export const NodesInternal = {
   useHasErrors: () => Store.useSelector((s) => s.hasErrors),
 
   useStore: () => Store.useStore(),
-  useSetNodeProps: () => Store.useSelector((s) => s.setNodeProps),
-  useSetNodes: () => Store.useSelector((s) => s.setNodes),
-  useAddPage: () => Store.useSelector((s) => s.addPage),
-  useSetPageProps: () => Store.useSelector((s) => s.setPageProps),
-  useAddNodes: () => Store.useSelector((s) => s.addNodes),
-  useRemoveNode: () => Store.useSelector((s) => s.removeNode),
-  useAddError: () => Store.useSelector((s) => s.addError),
-  useMarkHiddenViaRule: () => Store.useSelector((s) => s.markHiddenViaRule),
-  useSetWaitForCommits: () => Store.useSelector((s) => s.setWaitForCommits),
+  useSetNodeProps: () => Store.useStaticSelector((s) => s.setNodeProps),
+  useSetNodes: () => Store.useStaticSelector((s) => s.setNodes),
+  useAddPage: () => Store.useStaticSelector((s) => s.addPage),
+  useSetPageProps: () => Store.useStaticSelector((s) => s.setPageProps),
+  useAddNodes: () => Store.useStaticSelector((s) => s.addNodes),
+  useRemoveNode: () => Store.useStaticSelector((s) => s.removeNode),
+  useAddError: () => Store.useStaticSelector((s) => s.addError),
+  useMarkHiddenViaRule: () => Store.useStaticSelector((s) => s.markHiddenViaRule),
+  useSetWaitForCommits: () => Store.useStaticSelector((s) => s.setWaitForCommits),
 
   ...(Object.values(StorePlugins)
     .map((plugin) => plugin.extraHooks(Store))

--- a/src/utils/layout/generator/CommitQueue.tsx
+++ b/src/utils/layout/generator/CommitQueue.tsx
@@ -26,17 +26,18 @@ export interface RegistryCommitQueues {
 }
 
 export function useGetAwaitingCommits() {
-  const toCommit = GeneratorInternal.useCommitQueue();
+  const registry = GeneratorInternal.useRegistry();
 
-  return useCallback(
-    () =>
+  return useCallback(() => {
+    const toCommit = registry.current.toCommit;
+    return (
       toCommit.addNodes.length +
       toCommit.setNodeProps.length +
       toCommit.setRowExtras.length +
       toCommit.setRowUuid.length +
-      toCommit.setPageProps.length,
-    [toCommit],
-  );
+      toCommit.setPageProps.length
+    );
+  }, [registry]);
 }
 
 export function useCommit() {
@@ -45,9 +46,10 @@ export function useCommit() {
   const setPageProps = NodesInternal.useSetPageProps();
   const setRowExtras = NodesInternal.useSetRowExtras();
   const setRowUuids = NodesInternal.useSetRowUuids();
-  const toCommit = GeneratorInternal.useCommitQueue();
+  const registry = GeneratorInternal.useRegistry();
 
   return useCallback(() => {
+    const toCommit = registry.current.toCommit;
     if (toCommit.addNodes.length) {
       generatorLog('logCommits', 'Committing', toCommit.addNodes.length, 'addNodes requests');
       addNodes(toCommit.addNodes);
@@ -95,14 +97,15 @@ export function useCommit() {
 
     updateCommitsPendingInBody(toCommit);
     return changes;
-  }, [addNodes, setNodeProps, setRowExtras, setRowUuids, toCommit, setPageProps]);
+  }, [addNodes, setNodeProps, setRowExtras, setRowUuids, setPageProps, registry]);
 }
 
 export function SetWaitForCommits() {
   const setWaitForCommits = NodesInternal.useSetWaitForCommits();
-  const toCommit = GeneratorInternal.useCommitQueue();
+  const registry = GeneratorInternal.useRegistry();
 
   const waitForCommits = useCallback(async () => {
+    const toCommit = registry.current.toCommit;
     let didWait = false;
     while (Object.values(toCommit).some((arr) => arr.length > 0)) {
       await new Promise((resolve) => setTimeout(resolve, 4));
@@ -113,7 +116,7 @@ export function SetWaitForCommits() {
     if (didWait) {
       await new Promise((resolve) => setTimeout(resolve, 10));
     }
-  }, [toCommit]);
+  }, [registry]);
 
   useEffect(() => {
     setWaitForCommits(waitForCommits);
@@ -148,7 +151,7 @@ function useAddToQueue<T extends keyof RegistryCommitQueues>(
   condition: boolean,
 ) {
   const registry = GeneratorInternal.useRegistry();
-  const toCommit = GeneratorInternal.useCommitQueue();
+  const toCommit = registry.current.toCommit;
   const commit = useCommitWhenFinished();
 
   if (condition) {

--- a/src/utils/layout/generator/GeneratorContext.tsx
+++ b/src/utils/layout/generator/GeneratorContext.tsx
@@ -169,7 +169,6 @@ export function GeneratorGlobalProvider({ children, ...rest }: PropsWithChildren
 export const GeneratorInternal = {
   useIsInsideGenerator: () => useCtx().depth > 0,
   useRegistry: () => useCtx().registry,
-  useCommitQueue: () => useCtx().registry.current.toCommit,
   useDirectMutators: () => useCtx().directMutators ?? emptyArray,
   useRecursiveMutators: () => useCtx().recursiveMutators ?? emptyArray,
   useDepth: () => useCtx().depth,

--- a/src/utils/layout/plugins/RepeatingChildrenStorePlugin.tsx
+++ b/src/utils/layout/plugins/RepeatingChildrenStorePlugin.tsx
@@ -150,9 +150,9 @@ export class RepeatingChildrenStorePlugin extends NodeDataPlugin<RepeatingChildr
 
   extraHooks(store: NodesStoreFull): RepeatingChildrenStorePluginConfig['extraHooks'] {
     return {
-      useSetRowExtras: () => store.useSelector((state) => state.setRowExtras),
-      useSetRowUuids: () => store.useSelector((state) => state.setRowUuids),
-      useRemoveRow: () => store.useSelector((state) => state.removeRow),
+      useSetRowExtras: () => store.useStaticSelector((state) => state.setRowExtras),
+      useSetRowUuids: () => store.useStaticSelector((state) => state.setRowUuids),
+      useRemoveRow: () => store.useStaticSelector((state) => state.removeRow),
     };
   }
 }


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

Subscribing to a store seems to be a bit expensive, and in some cases it can be avoided. Static functions inside of the store used for updating data will never change, and so does not need to be subscribed to for changes. This makes the node data commit queue significantly cheaper.

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
