### PR TITLE
Fixing plugin code broken by minification

### DIFF
--- a/src/features/alertOnChange/AlertOnChangePlugin.tsx
+++ b/src/features/alertOnChange/AlertOnChangePlugin.tsx
@@ -36,7 +36,7 @@ export class AlertOnChangePlugin<E extends ExternalConfig> extends NodeDefPlugin
   }
 
   getKey(): string {
-    return [this.constructor.name, this.settings.propName].join('/');
+    return ['AlertOnChangePlugin', this.settings.propName].join('/');
   }
 
   makeImport() {

--- a/src/features/attachments/AttachmentsPlugin.tsx
+++ b/src/features/attachments/AttachmentsPlugin.tsx
@@ -29,6 +29,10 @@ export class AttachmentsPlugin extends NodeDefPlugin<Config> {
     });
   }
 
+  getKey(): string {
+    return 'AttachmentsPlugin';
+  }
+
   stateFactory(_props: DefPluginStateFactoryProps<Config>): Config['extraState'] {
     return {
       attachments: {},

--- a/src/features/options/OptionsPlugin.tsx
+++ b/src/features/options/OptionsPlugin.tsx
@@ -37,6 +37,10 @@ export class OptionsPlugin<E extends ExternalConfig> extends NodeDefPlugin<ToInt
     });
   }
 
+  getKey(): string {
+    return 'OptionsPlugin';
+  }
+
   stateFactory(_props: DefPluginStateFactoryProps<ToInternal<E>>): DefPluginExtraState<ToInternal<E>> {
     return {
       options: undefined,

--- a/src/features/validation/ValidationPlugin.tsx
+++ b/src/features/validation/ValidationPlugin.tsx
@@ -34,6 +34,10 @@ export class ValidationPlugin extends NodeDefPlugin<Config> {
     });
   }
 
+  getKey(): string {
+    return 'ValidationPlugin';
+  }
+
   addToComponent(component: ComponentConfig) {
     this.component = component;
     if (!component.isFormLike()) {

--- a/src/layout/Cards/CardsPlugin.tsx
+++ b/src/layout/Cards/CardsPlugin.tsx
@@ -57,6 +57,10 @@ export class CardsPlugin<Type extends CompTypes>
     }
   }
 
+  getKey(): string {
+    return 'CardsPlugin';
+  }
+
   makeGenericArgs(): string {
     return `'${this.component!.type}'`;
   }

--- a/src/layout/Grid/GridRowsPlugin.tsx
+++ b/src/layout/Grid/GridRowsPlugin.tsx
@@ -83,7 +83,7 @@ export class GridRowsPlugin<E extends ExternalConfig>
   }
 
   getKey(): string {
-    return [this.constructor.name, this.settings.externalProp].join('/');
+    return ['GridRowsPlugin', this.settings.externalProp].join('/');
   }
 
   makeConstructorArgs(asGenericArgs = false): string {

--- a/src/layout/Likert/Generator/LikertRowsPlugin.tsx
+++ b/src/layout/Likert/Generator/LikertRowsPlugin.tsx
@@ -36,6 +36,10 @@ export class LikertRowsPlugin extends NodeDefPlugin<Config> implements NodeDefCh
     });
   }
 
+  getKey(): string {
+    return 'LikertRowsPlugin';
+  }
+
   addToComponent(_component: ComponentConfig): void {}
 
   extraNodeGeneratorChildren(): string {

--- a/src/layout/Tabs/TabsPlugin.tsx
+++ b/src/layout/Tabs/TabsPlugin.tsx
@@ -61,6 +61,10 @@ export class TabsPlugin<Type extends CompTypes>
     return `'${this.component!.type}'`;
   }
 
+  getKey(): string {
+    return 'TabsPlugin';
+  }
+
   claimChildren({ item, claimChild, getProto }: DefPluginChildClaimerProps<Config<Type>>): void {
     for (const [tabIdx, tab] of (item.tabs || []).entries()) {
       for (const [childIdx, child] of tab.children.entries()) {

--- a/src/utils/layout/plugins/NodeDefPlugin.tsx
+++ b/src/utils/layout/plugins/NodeDefPlugin.tsx
@@ -104,10 +104,7 @@ export abstract class NodeDefPlugin<Config extends DefPluginConfig> {
    * Makes a key that keeps this plugin unique. This is used to make sure that if we're adding the same plugin
    * multiple times to the same component, only uniquely configured plugins are added.
    */
-  getKey(): string {
-    // By default, no duplicate plugins of the same type are allowed.
-    return this.constructor.name;
-  }
+  abstract getKey(): string;
 
   /**
    * Makes constructor arguments (must be a string, most often JSON). This is used to add custom constructor arguments

--- a/src/utils/layout/plugins/NonRepeatingChildrenPlugin.tsx
+++ b/src/utils/layout/plugins/NonRepeatingChildrenPlugin.tsx
@@ -79,7 +79,7 @@ export class NonRepeatingChildrenPlugin<E extends ExternalConfig>
   }
 
   getKey(): string {
-    return [this.constructor.name, this.settings.externalProp].join('/');
+    return ['NonRepeatingChildrenPlugin', this.settings.externalProp].join('/');
   }
 
   makeConstructorArgs(asGenericArgs = false): string {

--- a/src/utils/layout/plugins/RepeatingChildrenPlugin.tsx
+++ b/src/utils/layout/plugins/RepeatingChildrenPlugin.tsx
@@ -98,7 +98,7 @@ export class RepeatingChildrenPlugin<E extends ExternalConfig>
   }
 
   getKey(): string {
-    return [this.constructor.name, this.settings.externalProp].join('/');
+    return ['RepeatingChildrenPlugin', this.settings.externalProp].join('/');
   }
 
   makeConstructorArgs(asGenericArgs = false): string {


### PR DESCRIPTION
## Description

When we generated plugin lists in generated def files, this runs without code minification. However, after code minification these keys would change into minified class names like `c` (instead of `RepeatingChildrenPlugin`). Reverting to something that's not as 'smart' fixes the problem.

This causes lots of tests to break in #2690, where I used the plugin-keys more run-time.

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [x] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
