### PR TITLE
Making node-lookups faster

### DIFF
--- a/src/utils/layout/NodesContext.tsx
+++ b/src/utils/layout/NodesContext.tsx
@@ -805,7 +805,7 @@ export function useNode<T extends string | undefined | LayoutNode>(id: T): RetVa
       return id;
     }
 
-    return state.nodes.findById(new TraversalTask(state, state.nodes, undefined, undefined), id);
+    return state.nodes.findById(id);
   });
   return node as RetValFromNode<T>;
 }

--- a/src/utils/layout/useNodeTraversal.ts
+++ b/src/utils/layout/useNodeTraversal.ts
@@ -5,7 +5,7 @@ import { BaseLayoutNode } from 'src/utils/layout/LayoutNode';
 import { LayoutPage } from 'src/utils/layout/LayoutPage';
 import { LayoutPages } from 'src/utils/layout/LayoutPages';
 import { NodesInternal, useNodesLax } from 'src/utils/layout/NodesContext';
-import type { CompTypes, ParentNode } from 'src/layout/layout';
+import type { ParentNode } from 'src/layout/layout';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 import type { NodesContext, PageData, PagesData } from 'src/utils/layout/NodesContext';
 import type { NodeData } from 'src/utils/layout/types';
@@ -95,21 +95,6 @@ export class NodeTraversal<T extends Node = LayoutPages> {
     return new NodeTraversal(this.state, this.rootNode, node) as any;
   }
 
-  targetIsRoot(): this is NodeTraversalFromRoot {
-    return this.target === this.rootNode;
-  }
-
-  targetIsPage(): this is NodeTraversalFromPage {
-    return this.target instanceof LayoutPage;
-  }
-
-  targetIsNode<T extends CompTypes | undefined>(
-    ofType?: T,
-  ): this is NodeTraversalFromNode<T extends CompTypes ? LayoutNode<T> : LayoutNode> {
-    const target = this.target;
-    return target instanceof BaseLayoutNode && (!ofType || target.isType(ofType));
-  }
-
   /**
    * Looks for a matching component upwards in the hierarchy, returning the first one (or undefined if
    * none can be found).
@@ -146,15 +131,6 @@ export class NodeTraversal<T extends Node = LayoutPages> {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return target.parents(new TraversalTask(this.state, this.rootNode, matching, undefined)) as any;
-  }
-
-  /**
-   * Looks for a matching component inside the (direct) children of this node (only makes sense for
-   * a group/container node or a page). This will only return the first match.
-   */
-  firstChild(matching?: TraversalMatcher, restriction?: TraversalRestriction): ChildFrom<T> | undefined {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return this.target.firstChild(new TraversalTask(this.state, this.rootNode, matching, restriction)) as any;
   }
 
   /**

--- a/src/utils/layout/useNodeTraversal.ts
+++ b/src/utils/layout/useNodeTraversal.ts
@@ -203,10 +203,7 @@ export class NodeTraversal<T extends Node = LayoutPages> {
       throw new Error('Cannot call findById() on a LayoutNode object');
     }
 
-    return (this.target as LayoutPage | LayoutPages).findById(
-      new TraversalTask(this.state, this.rootNode, undefined, undefined),
-      id,
-    );
+    return this.rootNode.findById(id);
   }
 }
 


### PR DESCRIPTION
## Description

This should make node-lookups faster. Previously, every page would be iterated to look for a node object, but as node-ids can no longer be duplicated/re-used across pages, we can just create a Map to look them up directly. This also has the advantage of running `getBaseComponentId()` 0 or 1 times, instead of once-per-page for pages that don't have the node in them. 

I also removed some unused code in node traversal.

## Related Issue(s)

- #2699
- #2688

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [x] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
