### PR TITLE
Queue for removing nodes

### DIFF
--- a/src/utils/layout/NodesContext.tsx
+++ b/src/utils/layout/NodesContext.tsx
@@ -109,6 +109,12 @@ export interface AddNodeRequest<T extends CompTypes = CompTypes> {
   rowIndex: number | undefined;
 }
 
+export interface RemoveNodeRequest<T extends CompTypes = CompTypes> {
+  node: LayoutNode<T>;
+  claim: ChildClaim;
+  rowIndex: number | undefined;
+}
+
 export interface SetNodePropRequest<T extends CompTypes, K extends keyof NodeData<T>> {
   node: LayoutNode<T>;
   prop: K;
@@ -148,7 +154,7 @@ export type NodesContext = {
 
   setNodes: (nodes: LayoutPages) => void;
   addNodes: (requests: AddNodeRequest[]) => void;
-  removeNode: (node: LayoutNode, claim: ChildClaim, rowIndex: number | undefined) => void;
+  removeNodes: (request: RemoveNodeRequest[]) => void;
   setNodeProps: (requests: SetNodePropRequest<CompTypes, keyof NodeData>[]) => void;
   addError: (error: string, node: LayoutPage | LayoutNode) => void;
   markHiddenViaRule: (hiddenFields: { [nodeId: string]: true }) => void;
@@ -245,33 +251,37 @@ export function createNodesDataStore({ registry, validationsProcessedLast }: Cre
           addRemoveCounter: state.addRemoveCounter + 1,
         };
       }),
-    removeNode: (node, claim, rowIndex) =>
+    removeNodes: (requests) =>
       set((state) => {
         const nodeData = { ...state.nodeData };
         const childrenMap = { ...state.childrenMap };
-        if (!nodeData[node.id]) {
-          return {};
+
+        for (const { node, claim, rowIndex } of requests) {
+          if (!nodeData[node.id]) {
+            continue;
+          }
+
+          if (node.parent instanceof BaseLayoutNode && nodeData[node.parent.id]) {
+            const additionalParentState = node.parent.def.removeChild(
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              nodeData[node.parent.id] as any,
+              node,
+              claim,
+              rowIndex,
+            );
+            nodeData[node.parent.id] = {
+              ...nodeData[node.parent.id],
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              ...(additionalParentState as any),
+            };
+            childrenMap[node.parent.id] = [...(childrenMap[node.parent.id] || [])];
+            childrenMap[node.parent.id] = childrenMap[node.parent.id]!.filter((id) => id !== node.id);
+          }
+
+          delete nodeData[node.id];
+          node.page._removeChild(node);
         }
 
-        if (node.parent instanceof BaseLayoutNode && nodeData[node.parent.id]) {
-          const additionalParentState = node.parent.def.removeChild(
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            nodeData[node.parent.id] as any,
-            node,
-            claim,
-            rowIndex,
-          );
-          nodeData[node.parent.id] = {
-            ...nodeData[node.parent.id],
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            ...(additionalParentState as any),
-          };
-          childrenMap[node.parent.id] = [...(childrenMap[node.parent.id] || [])];
-          childrenMap[node.parent.id] = childrenMap[node.parent.id]!.filter((id) => id !== node.id);
-        }
-
-        delete nodeData[node.id];
-        node.page._removeChild(node);
         return {
           nodeData,
           childrenMap,
@@ -1198,7 +1208,7 @@ export const NodesInternal = {
   useAddPage: () => Store.useStaticSelector((s) => s.addPage),
   useSetPageProps: () => Store.useStaticSelector((s) => s.setPageProps),
   useAddNodes: () => Store.useStaticSelector((s) => s.addNodes),
-  useRemoveNode: () => Store.useStaticSelector((s) => s.removeNode),
+  useRemoveNodes: () => Store.useStaticSelector((s) => s.removeNodes),
   useAddError: () => Store.useStaticSelector((s) => s.addError),
   useMarkHiddenViaRule: () => Store.useStaticSelector((s) => s.markHiddenViaRule),
   useSetWaitForCommits: () => Store.useStaticSelector((s) => s.setWaitForCommits),

--- a/src/utils/layout/generator/CommitQueue.tsx
+++ b/src/utils/layout/generator/CommitQueue.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect } from 'react';
 
+import { useAsRef } from 'src/hooks/useAsRef';
 import { generatorLog } from 'src/utils/layout/generator/debug';
 import { GeneratorInternal } from 'src/utils/layout/generator/GeneratorContext';
 import { NODES_TICK_TIMEOUT, StageFinished } from 'src/utils/layout/generator/GeneratorStages';
@@ -7,6 +8,7 @@ import {
   type AddNodeRequest,
   NodesInternal,
   NodesStore,
+  type RemoveNodeRequest,
   type SetNodePropRequest,
   type SetPagePropRequest,
 } from 'src/utils/layout/NodesContext';
@@ -17,6 +19,7 @@ import type { SetRowExtrasRequest, SetRowUuidRequest } from 'src/utils/layout/pl
  */
 export interface RegistryCommitQueues {
   addNodes: AddNodeRequest[];
+  removeNodes: RemoveNodeRequest[];
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   setNodeProps: SetNodePropRequest<any, any>[];
   setRowExtras: SetRowExtrasRequest[];
@@ -42,6 +45,7 @@ export function useGetAwaitingCommits() {
 
 export function useCommit() {
   const addNodes = NodesInternal.useAddNodes();
+  const removeNodes = NodesInternal.useRemoveNodes();
   const setNodeProps = NodesInternal.useSetNodeProps();
   const setPageProps = NodesInternal.useSetPageProps();
   const setRowExtras = NodesInternal.useSetRowExtras();
@@ -54,6 +58,14 @@ export function useCommit() {
       generatorLog('logCommits', 'Committing', toCommit.addNodes.length, 'addNodes requests');
       addNodes(toCommit.addNodes);
       toCommit.addNodes.length = 0; // This truncates the array, but keeps the reference
+      updateCommitsPendingInBody(toCommit);
+      return true;
+    }
+
+    if (toCommit.removeNodes.length) {
+      generatorLog('logCommits', 'Committing', toCommit.removeNodes.length, 'removeNodes requests');
+      removeNodes(toCommit.removeNodes);
+      toCommit.removeNodes.length = 0;
       updateCommitsPendingInBody(toCommit);
       return true;
     }
@@ -97,7 +109,7 @@ export function useCommit() {
 
     updateCommitsPendingInBody(toCommit);
     return changes;
-  }, [addNodes, setNodeProps, setRowExtras, setRowUuids, setPageProps, registry]);
+  }, [addNodes, removeNodes, setNodeProps, setRowExtras, setRowUuids, setPageProps, registry]);
 }
 
 export function SetWaitForCommits() {
@@ -134,6 +146,7 @@ export function SetWaitForCommits() {
  */
 export const NodesStateQueue = {
   useAddNode: (req: AddNodeRequest, condition = true) => useAddToQueue('addNodes', false, req, condition),
+  useRemoveNode: (req: RemoveNodeRequest) => useAddToQueueOnUnmount('removeNodes', true, req),
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   useSetNodeProp: (req: SetNodePropRequest<any, any>, condition = true) =>
     useAddToQueue('setNodeProps', true, req, condition),
@@ -164,6 +177,33 @@ function useAddToQueue<T extends keyof RegistryCommitQueues>(
       commit();
     }
   }
+}
+
+function useAddToQueueOnUnmount<T extends keyof RegistryCommitQueues>(
+  queue: T,
+  commitAfter: boolean,
+  request: RegistryCommitQueues[T][number],
+) {
+  const registry = GeneratorInternal.useRegistry();
+  const toCommit = registry.current.toCommit;
+  const ref = useAsRef(request);
+  const commit = useCommitWhenFinished();
+
+  useEffect(() => {
+    const reg = registry.current;
+    const request = ref.current;
+
+    return () => {
+      reg.toCommitCount += 1;
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      toCommit[queue].push(request as any);
+      updateCommitsPendingInBody(toCommit);
+      if (commitAfter) {
+        commit();
+      }
+    };
+  }, [commit, commitAfter, queue, ref, registry, toCommit]);
 }
 
 /**

--- a/src/utils/layout/generator/GeneratorStages.tsx
+++ b/src/utils/layout/generator/GeneratorStages.tsx
@@ -232,6 +232,7 @@ export function useRegistry() {
     toCommitCount: 0,
     toCommit: {
       addNodes: [],
+      removeNodes: [],
       setNodeProps: [],
       setRowExtras: [],
       setRowUuid: [],

--- a/src/utils/layout/generator/NodeGenerator.tsx
+++ b/src/utils/layout/generator/NodeGenerator.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import type { PropsWithChildren } from 'react';
 
 import { evalExpr } from 'src/features/expressions';
@@ -119,7 +119,6 @@ function AddRemoveNode<T extends CompTypes>({ node, intermediateItem, claim }: A
   const rowIndex = GeneratorInternal.useRowIndex();
   const pageKey = GeneratorInternal.usePage()?.pageKey ?? '';
   const stateFactoryProps = { item: intermediateItem, parent, rowIndex, pageKey } satisfies StateFactoryProps<T>;
-  const removeNode = NodesInternal.useRemoveNode();
   const isAdded = NodesInternal.useIsAdded(node);
 
   NodesStateQueue.useAddNode(
@@ -133,14 +132,7 @@ function AddRemoveNode<T extends CompTypes>({ node, intermediateItem, claim }: A
     !isAdded,
   );
 
-  const nodeRef = useAsRef(node);
-  const rowIndexRef = useAsRef(rowIndex);
-  useEffect(
-    () => () => {
-      removeNode(nodeRef.current, claim, rowIndexRef.current);
-    },
-    [removeNode, nodeRef, claim, rowIndexRef],
-  );
+  NodesStateQueue.useRemoveNode({ node, claim, rowIndex });
 
   return null;
 }


### PR DESCRIPTION
## Description

Reported by SSB. When submitting a form with a large amount of rows in a repeating group, the submit button could end up stalling the main thread and prompting the user with a 'page is stuck, do you want to leave it?' warning. It turns out this happened because of sequential state updates removing nodes from the hierarchy when unmounting the data task.

This should optimize the situation by collecting all the removal requests and iterating them all more closely in the zustand action function.

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
