### PR TITLE
Rewriting `AppRoutingContext` to avoid late URL state problems

### DIFF
--- a/src/components/form/Form.tsx
+++ b/src/components/form/Form.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
-import { useLocation } from 'react-router-dom';
 
 import Grid from '@material-ui/core/Grid';
 import deepEqual from 'fast-deep-equal';
@@ -21,6 +20,7 @@ import {
   SearchParams,
   useNavigate,
   useNavigationParam,
+  useNavigationPath,
   useQueryKey,
   useQueryKeysAsString,
   useQueryKeysAsStringAsRef,
@@ -160,7 +160,7 @@ export function FormFirstPage() {
   const navigate = useNavigate();
   const startUrl = useStartUrl();
 
-  const currentLocation = `${useLocation().pathname}${useQueryKeysAsString()}`;
+  const currentLocation = `${useNavigationPath()}${useQueryKeysAsString()}`;
 
   useEffect(() => {
     if (currentLocation !== startUrl) {
@@ -182,7 +182,6 @@ function useRedirectToStoredPage() {
   const instanceGuid = useNavigationParam('instanceGuid');
   const { isValidPageId, navigateToPage } = useNavigatePage();
   const applicationMetadataId = useApplicationMetadata()?.id;
-  const location = useLocation().pathname;
 
   const instanceId = `${partyId}/${instanceGuid}`;
   const currentViewCacheKey = instanceId || applicationMetadataId;
@@ -195,7 +194,7 @@ function useRedirectToStoredPage() {
         navigateToPage(lastVisitedPage, { replace: true });
       }
     }
-  }, [pageKey, currentViewCacheKey, isValidPageId, location, navigateToPage]);
+  }, [pageKey, currentViewCacheKey, isValidPageId, navigateToPage]);
 }
 
 /**

--- a/src/components/form/Form.tsx
+++ b/src/components/form/Form.tsx
@@ -18,6 +18,7 @@ import { useUiConfigContext } from 'src/features/form/layout/UiConfigContext';
 import { usePageSettings } from 'src/features/form/layoutSettings/LayoutSettingsContext';
 import { useLanguage } from 'src/features/language/useLanguage';
 import {
+  SearchParams,
   useNavigate,
   useNavigationParam,
   useQueryKey,
@@ -26,7 +27,7 @@ import {
 } from 'src/features/routing/AppRoutingContext';
 import { useOnFormSubmitValidation } from 'src/features/validation/callbacks/onFormSubmitValidation';
 import { useTaskErrors } from 'src/features/validation/selectors/taskErrors';
-import { SearchParams, useCurrentView, useNavigatePage, useStartUrl } from 'src/hooks/useNavigatePage';
+import { useCurrentView, useNavigatePage, useStartUrl } from 'src/hooks/useNavigatePage';
 import { GenericComponentById } from 'src/layout/GenericComponent';
 import { extractBottomButtons } from 'src/utils/formLayout';
 import { getPageTitle } from 'src/utils/getPageTitle';

--- a/src/components/form/LinkToPotentialNode.tsx
+++ b/src/components/form/LinkToPotentialNode.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import type { LinkProps } from 'react-router-dom';
 
-import { SearchParams } from 'src/hooks/useNavigatePage';
+import { SearchParams } from 'src/features/routing/AppRoutingContext';
 import { Hidden, useNode } from 'src/utils/layout/NodesContext';
 
 type Props = LinkProps & { children?: React.ReactNode };

--- a/src/components/wrappers/ProcessWrapper.tsx
+++ b/src/components/wrappers/ProcessWrapper.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { Helmet } from 'react-helmet-async';
-import { Route, Routes, useLocation } from 'react-router-dom';
+import { Route, Routes } from 'react-router-dom';
 
 import { Button } from '@digdir/designsystemet-react';
 import Grid from '@material-ui/core/Grid';
@@ -21,7 +21,12 @@ import { PDFWrapper } from 'src/features/pdf/PDFWrapper';
 import { Confirm } from 'src/features/processEnd/confirm/containers/Confirm';
 import { Feedback } from 'src/features/processEnd/feedback/Feedback';
 import { ReceiptContainer } from 'src/features/receipt/ReceiptContainer';
-import { useNavigate, useNavigationParam, useQueryKeysAsString } from 'src/features/routing/AppRoutingContext';
+import {
+  useNavigate,
+  useNavigationParam,
+  useNavigationPath,
+  useQueryKeysAsString,
+} from 'src/features/routing/AppRoutingContext';
 import { TaskKeys, useIsCurrentTask, useNavigatePage, useStartUrl } from 'src/hooks/useNavigatePage';
 import { implementsSubRouting } from 'src/layout';
 import { RedirectBackToMainForm } from 'src/layout/Subform/SubformWrapper';
@@ -86,7 +91,7 @@ export function NavigateToStartUrl() {
   const currentTaskId = useLaxProcessData()?.currentTask?.elementId;
   const startUrl = useStartUrl(currentTaskId);
 
-  const currentLocation = `${useLocation().pathname}${useQueryKeysAsString()}`;
+  const currentLocation = `${useNavigationPath()}${useQueryKeysAsString()}`;
 
   useEffect(() => {
     if (currentLocation !== startUrl) {

--- a/src/features/expressions/expression-functions.ts
+++ b/src/features/expressions/expression-functions.ts
@@ -4,7 +4,7 @@ import type { Mutable } from 'utility-types';
 import { ExprRuntimeError, NodeNotFound, NodeNotFoundWithoutContext } from 'src/features/expressions/errors';
 import { ExprVal } from 'src/features/expressions/types';
 import { addError } from 'src/features/expressions/validation';
-import { SearchParams } from 'src/hooks/useNavigatePage';
+import { SearchParams } from 'src/features/routing/AppRoutingContext';
 import { implementsDisplayData } from 'src/layout';
 import { buildAuthContext } from 'src/utils/authContext';
 import { isDate } from 'src/utils/dateHelpers';

--- a/src/features/instance/ProcessNavigationContext.tsx
+++ b/src/features/instance/ProcessNavigationContext.tsx
@@ -12,7 +12,7 @@ import { useLaxInstanceId, useStrictInstanceRefetch } from 'src/features/instanc
 import { useReFetchProcessData } from 'src/features/instance/ProcessContext';
 import { Lang } from 'src/features/language/Lang';
 import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
-import { useNavigationParam } from 'src/features/routing/AppRoutingContext';
+import { useIsSubformPage } from 'src/features/routing/AppRoutingContext';
 import { useUpdateInitialValidations } from 'src/features/validation/backendValidation/backendValidationQuery';
 import { appSupportsIncrementalValidationFeatures } from 'src/features/validation/backendValidation/backendValidationUtils';
 import { useOnFormSubmitValidation } from 'src/features/validation/callbacks/onFormSubmitValidation';
@@ -174,7 +174,7 @@ export function ProcessNavigationProvider({ children }: React.PropsWithChildren)
 
 export const useProcessNavigation = () => {
   // const { isSubformPage } = useNavigationParams();
-  const isSubformPage = useNavigationParam('isSubformPage');
+  const isSubformPage = useIsSubformPage();
   if (isSubformPage) {
     throw new Error('Cannot use process navigation in a subform');
   }

--- a/src/features/routing/AppRoutingContext.tsx
+++ b/src/features/routing/AppRoutingContext.tsx
@@ -90,7 +90,8 @@ function getPath(hashFromState: string): string {
 
 function getSearch(hashFromState: string): string {
   const hash = window.inUnitTest ? hashFromState : window.location.hash;
-  return hash.split('?')[1] ?? '';
+  const search = hash.split('?')[1] ?? '';
+  return search ? `?${search}` : '';
 }
 
 /**

--- a/src/features/routing/AppRoutingContext.tsx
+++ b/src/features/routing/AppRoutingContext.tsx
@@ -95,6 +95,7 @@ export const useNavigationParam = <T extends keyof PathParams>(key: T) =>
     return paramFrom(matches, key) as PathParams[T];
   });
 
+export const useNavigationPath = () => useSelector(() => getPath());
 export const useNavigationParams = () => useSelector(() => matchParams(getPath()));
 export const useNavigationEffect = () => useSelector((ctx) => ctx.effectCallback);
 export const useSetNavigationEffect = () => useSelector((ctx) => ctx.setEffectCallback);

--- a/src/features/routing/AppRoutingContext.tsx
+++ b/src/features/routing/AppRoutingContext.tsx
@@ -5,7 +5,6 @@ import type { MutableRefObject, PropsWithChildren } from 'react';
 import { createStore } from 'zustand';
 
 import { createZustandContext } from 'src/core/contexts/zustandContext';
-import type { SearchParams } from 'src/hooks/useNavigatePage';
 
 export type NavigationEffectCb = () => void;
 
@@ -17,6 +16,13 @@ interface PathParams {
   componentId?: string;
   dataElementId?: string;
   mainPageKey?: string;
+}
+
+export enum SearchParams {
+  FocusComponentId = 'focusComponentId',
+  ExitSubform = 'exitSubform',
+  Validate = 'validate',
+  Pdf = 'pdf',
 }
 
 interface Context {

--- a/src/hooks/useIsPdf.ts
+++ b/src/hooks/useIsPdf.ts
@@ -1,8 +1,9 @@
 import { useQueryKey } from 'src/features/routing/AppRoutingContext';
+import { SearchParams } from 'src/hooks/useNavigatePage';
 
 /**
  * Hook checking whether we are in PDF generation mode
  */
 export function useIsPdf() {
-  return useQueryKey('pdf') === '1';
+  return useQueryKey(SearchParams.Pdf) === '1';
 }

--- a/src/hooks/useIsPdf.ts
+++ b/src/hooks/useIsPdf.ts
@@ -1,5 +1,4 @@
-import { useQueryKey } from 'src/features/routing/AppRoutingContext';
-import { SearchParams } from 'src/hooks/useNavigatePage';
+import { SearchParams, useQueryKey } from 'src/features/routing/AppRoutingContext';
 
 /**
  * Hook checking whether we are in PDF generation mode

--- a/src/hooks/useNavigatePage.ts
+++ b/src/hooks/useNavigatePage.ts
@@ -40,6 +40,7 @@ export enum SearchParams {
   FocusComponentId = 'focusComponentId',
   ExitSubform = 'exitSubform',
   Validate = 'validate',
+  Pdf = 'pdf',
 }
 
 const emptyArray: never[] = [];
@@ -125,10 +126,10 @@ export const useStartUrl = (forcedTaskId?: string) => {
   const queryKeys = useQueryKeysAsString();
   const order = usePageOrder();
   // This needs up to date params, so using the native hook that re-renders often
-  // However, this hook is only used in cases where we immediatly navigate to a different path
+  // However, this hook is only used in cases where we immediately navigate to a different path
   // so it does not make a difference here.
-  const { partyId, instanceGuid, taskId, isSubformPage, mainPageKey, componentId, dataElementId } =
-    useNavigationParams();
+  const { partyId, instanceGuid, taskId, mainPageKey, componentId, dataElementId } = useNavigationParams();
+  const isSubformPage = !!mainPageKey;
   const taskType = useGetTaskTypeById()(taskId);
   const isStateless = useApplicationMetadata().isStatelessApp;
 
@@ -353,7 +354,7 @@ export function useNavigatePage() {
   }, [getPreviousPage, navigateToPage]);
 
   const exitSubform = async () => {
-    if (!navParams.current.isSubformPage || !navParams.current.mainPageKey) {
+    if (!navParams.current.mainPageKey) {
       window.logWarn('Tried to close subform page while not in a subform.');
       return;
     }

--- a/src/hooks/useNavigatePage.ts
+++ b/src/hooks/useNavigatePage.ts
@@ -8,6 +8,7 @@ import { useLaxLayoutSettings, usePageSettings } from 'src/features/form/layoutS
 import { FD } from 'src/features/formData/FormDataWrite';
 import { useGetTaskTypeById, useLaxProcessData } from 'src/features/instance/ProcessContext';
 import {
+  SearchParams,
   useAllNavigationParamsAsRef,
   useNavigate as useCtxNavigate,
   useNavigationParam,
@@ -34,13 +35,6 @@ export interface NavigateToPageOptions {
 export enum TaskKeys {
   ProcessEnd = 'ProcessEnd',
   CustomReceipt = 'CustomReceipt',
-}
-
-export enum SearchParams {
-  FocusComponentId = 'focusComponentId',
-  ExitSubform = 'exitSubform',
-  Validate = 'validate',
-  Pdf = 'pdf',
 }
 
 const emptyArray: never[] = [];

--- a/src/layout/CustomButton/CustomButtonComponent.tsx
+++ b/src/layout/CustomButton/CustomButtonComponent.tsx
@@ -9,7 +9,7 @@ import { useResetScrollPosition } from 'src/core/ui/useResetScrollPosition';
 import { FD } from 'src/features/formData/FormDataWrite';
 import { useLaxProcessData } from 'src/features/instance/ProcessContext';
 import { Lang } from 'src/features/language/Lang';
-import { useNavigationParam } from 'src/features/routing/AppRoutingContext';
+import { useIsSubformPage, useNavigationParam } from 'src/features/routing/AppRoutingContext';
 import { useOnPageNavigationValidation } from 'src/features/validation/callbacks/onPageNavigationValidation';
 import { useNavigatePage } from 'src/hooks/useNavigatePage';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
@@ -67,7 +67,7 @@ const isServerAction = (action: CBTypes.CustomAction): action is CBTypes.ServerA
 function useHandleClientActions(): UseHandleClientActions {
   const { navigateToPage, navigateToNextPage, navigateToPreviousPage, exitSubform } = useNavigatePage();
   const mainPageKey = useNavigationParam('mainPageKey');
-  const isSubformPage = useNavigationParam('isSubformPage');
+  const isSubformPage = useIsSubformPage();
 
   const frontendActions: ClientActionHandlers = useMemo(
     () => ({

--- a/src/layout/FileUpload/FileUploadComponent.tsx
+++ b/src/layout/FileUpload/FileUploadComponent.tsx
@@ -8,7 +8,7 @@ import { useAttachmentsFor, useAttachmentsUploader } from 'src/features/attachme
 import { Lang } from 'src/features/language/Lang';
 import { useLanguage } from 'src/features/language/useLanguage';
 import { useGetOptions } from 'src/features/options/useGetOptions';
-import { useNavigationParam } from 'src/features/routing/AppRoutingContext';
+import { useIsSubformPage } from 'src/features/routing/AppRoutingContext';
 import { ComponentValidations } from 'src/features/validation/ComponentValidations';
 import { useUnifiedValidationsForNode } from 'src/features/validation/selectors/unifiedValidationsForNode';
 import { hasValidationErrors } from 'src/features/validation/utils';
@@ -38,7 +38,7 @@ export function FileUploadComponent({ node }: IFileUploadWithTagProps): React.JS
     textResourceBindings,
     dataModelBindings,
   } = item;
-  const isSubformPage = useNavigationParam('isSubformPage');
+  const isSubformPage = useIsSubformPage();
   if (isSubformPage) {
     throw new Error('Cannot use a FileUpload components within a subform');
   }

--- a/src/layout/Subform/SubformComponent.tsx
+++ b/src/layout/Subform/SubformComponent.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 
 import { Button, Spinner, Table } from '@digdir/designsystemet-react';
 import { Grid } from '@material-ui/core';
@@ -13,7 +12,7 @@ import { useFormDataQuery } from 'src/features/formData/useFormDataQuery';
 import { useStrictDataElements, useStrictInstanceId } from 'src/features/instance/InstanceContext';
 import { Lang } from 'src/features/language/Lang';
 import { useLanguage } from 'src/features/language/useLanguage';
-import { useIsSubformPage } from 'src/features/routing/AppRoutingContext';
+import { useIsSubformPage, useNavigate } from 'src/features/routing/AppRoutingContext';
 import { useAddEntryMutation, useDeleteEntryMutation } from 'src/features/subformData/useSubformMutations';
 import { isSubformValidation } from 'src/features/validation';
 import { useComponentValidationsForNode } from 'src/features/validation/selectors/componentValidationsForNode';

--- a/src/layout/Subform/SubformComponent.tsx
+++ b/src/layout/Subform/SubformComponent.tsx
@@ -13,7 +13,7 @@ import { useFormDataQuery } from 'src/features/formData/useFormDataQuery';
 import { useStrictDataElements, useStrictInstanceId } from 'src/features/instance/InstanceContext';
 import { Lang } from 'src/features/language/Lang';
 import { useLanguage } from 'src/features/language/useLanguage';
-import { useNavigationParam } from 'src/features/routing/AppRoutingContext';
+import { useIsSubformPage } from 'src/features/routing/AppRoutingContext';
 import { useAddEntryMutation, useDeleteEntryMutation } from 'src/features/subformData/useSubformMutations';
 import { isSubformValidation } from 'src/features/validation';
 import { useComponentValidationsForNode } from 'src/features/validation/selectors/componentValidationsForNode';
@@ -35,7 +35,7 @@ export function SubformComponent({ node }: PropsFromGenericComponent<'Subform'>)
     showDeleteButton = true,
   } = useNodeItem(node);
 
-  const isSubformPage = useNavigationParam('isSubformPage');
+  const isSubformPage = useIsSubformPage();
   if (isSubformPage) {
     window.logErrorOnce('Cannot use a SubformComponent component within a subform');
     throw new Error('Cannot use a SubformComponent component within a subform');

--- a/src/layout/Subform/SubformComponent.tsx
+++ b/src/layout/Subform/SubformComponent.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import { Button, Spinner, Table } from '@digdir/designsystemet-react';
 import { Grid } from '@material-ui/core';
@@ -12,7 +13,7 @@ import { useFormDataQuery } from 'src/features/formData/useFormDataQuery';
 import { useStrictDataElements, useStrictInstanceId } from 'src/features/instance/InstanceContext';
 import { Lang } from 'src/features/language/Lang';
 import { useLanguage } from 'src/features/language/useLanguage';
-import { useIsSubformPage, useNavigate } from 'src/features/routing/AppRoutingContext';
+import { useIsSubformPage } from 'src/features/routing/AppRoutingContext';
 import { useAddEntryMutation, useDeleteEntryMutation } from 'src/features/subformData/useSubformMutations';
 import { isSubformValidation } from 'src/features/validation';
 import { useComponentValidationsForNode } from 'src/features/validation/selectors/componentValidationsForNode';

--- a/src/layout/Subform/Summary/SubformSummaryTable.tsx
+++ b/src/layout/Subform/Summary/SubformSummaryTable.tsx
@@ -13,7 +13,7 @@ import { useStrictDataElements, useStrictInstanceId } from 'src/features/instanc
 import { Lang } from 'src/features/language/Lang';
 import { useLanguage } from 'src/features/language/useLanguage';
 import { usePdfModeActive } from 'src/features/pdf/PDFWrapper';
-import { useNavigationParam } from 'src/features/routing/AppRoutingContext';
+import { useIsSubformPage } from 'src/features/routing/AppRoutingContext';
 import { isSubformValidation } from 'src/features/validation';
 import { useComponentValidationsForNode } from 'src/features/validation/selectors/componentValidationsForNode';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
@@ -102,7 +102,7 @@ function SubformTableRow({
 export function SubformSummaryTable({ targetNode }: ISubformSummaryComponent): React.JSX.Element | null {
   const { id, layoutSet, textResourceBindings, tableColumns = [] } = useNodeItem(targetNode);
 
-  const isSubformPage = useNavigationParam('isSubformPage');
+  const isSubformPage = useIsSubformPage();
   if (isSubformPage) {
     window.logErrorOnce('Cannot use a SubformComponent component within a subform');
     throw new Error('Cannot use a SubformComponent component within a subform');

--- a/src/layout/Subform/Summary/SubformSummaryTable.tsx
+++ b/src/layout/Subform/Summary/SubformSummaryTable.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
 
 import { Paragraph, Spinner, Table } from '@digdir/designsystemet-react';
 import { Grid } from '@material-ui/core';
@@ -13,7 +12,7 @@ import { useStrictDataElements, useStrictInstanceId } from 'src/features/instanc
 import { Lang } from 'src/features/language/Lang';
 import { useLanguage } from 'src/features/language/useLanguage';
 import { usePdfModeActive } from 'src/features/pdf/PDFWrapper';
-import { useIsSubformPage } from 'src/features/routing/AppRoutingContext';
+import { useIsSubformPage, useNavigate } from 'src/features/routing/AppRoutingContext';
 import { isSubformValidation } from 'src/features/validation';
 import { useComponentValidationsForNode } from 'src/features/validation/selectors/componentValidationsForNode';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';

--- a/src/layout/Subform/Summary/SubformSummaryTable.tsx
+++ b/src/layout/Subform/Summary/SubformSummaryTable.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import { Paragraph, Spinner, Table } from '@digdir/designsystemet-react';
 import { Grid } from '@material-ui/core';
@@ -12,7 +13,7 @@ import { useStrictDataElements, useStrictInstanceId } from 'src/features/instanc
 import { Lang } from 'src/features/language/Lang';
 import { useLanguage } from 'src/features/language/useLanguage';
 import { usePdfModeActive } from 'src/features/pdf/PDFWrapper';
-import { useIsSubformPage, useNavigate } from 'src/features/routing/AppRoutingContext';
+import { useIsSubformPage } from 'src/features/routing/AppRoutingContext';
 import { isSubformValidation } from 'src/features/validation';
 import { useComponentValidationsForNode } from 'src/features/validation/selectors/componentValidationsForNode';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';


### PR DESCRIPTION
## Description

When loading app-frontend, the would be a moment where `AppRoutingContext` would be out-of-sync with the real URL, causing the wrong thing to be rendered. For example, for a brief moment the 'you're on the wrong task' screen would be visible while progressing to the next task, only to be corrected a short moment later.

This was all caused by our `AppRoutingContext`. While it did solve re-rendering issues when irrelevant parts of the URL changed (such as the equivalent of `useNavigationParam('instanceGuid')` would re-render your component when the page key in the URL changed), the current (pre this PR) `AppRoutingContext` also has to wait until a `useEffect()` is triggered to update the store, which at _that_ point can run selectors again and cause re-renders that corrects the UI.

This fix always reads the URL from `window.location`, but also has the `useEffect()` to update the state in order to force existing components to re-render when the relevant parts of the URL changes. The URL we store in zustand is _never read_.

EDIT: One problem uncovered in the tests was that DataModelsProvider now had outdated state, causing validation to happen on a non-writable data type in the `custom-confirm.ts` test. I fixes this as well, such that DataModelsProvider hangs on a `<Loader />` while updating the state.

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
