### PR TITLE
Performance fixes that improved ra0692-01

### DIFF
--- a/src/features/alertOnChange/DeleteWarningPopover.tsx
+++ b/src/features/alertOnChange/DeleteWarningPopover.tsx
@@ -35,7 +35,7 @@ export function DeleteWarningPopover({
       onOpenChange={() => setOpen(!open)}
     >
       <Popover.Trigger asChild>{children}</Popover.Trigger>
-      <Popover.Content className={classes.popover}>
+      <Popover.Content>
         <div>{messageText}</div>
         <div className={classes.popoverButtonContainer}>
           <Button

--- a/src/features/datamodel/DataModelsProvider.tsx
+++ b/src/features/datamodel/DataModelsProvider.tsx
@@ -129,7 +129,7 @@ function initialCreateStore() {
   }));
 }
 
-const { Provider, useSelector, useLaxSelector, useSelectorAsRef } = createZustandContext({
+const { Provider, useSelector, useLaxSelector, useSelectorAsRef, useStaticSelector } = createZustandContext({
   name: 'DataModels',
   required: true,
   initialCreateStore,
@@ -355,7 +355,9 @@ export const DataModels = {
   useDataModelSchema: (dataType: string) => useSelector((state) => state.schemas[dataType]),
 
   useLookupBinding: () => {
-    const { schemaLookup, allDataTypes } = useSelector((state) => state);
+    // Using a static selector to avoid re-rendering. While the state can update later, we don't need
+    // to re-run data model validations, etc.
+    const { schemaLookup, allDataTypes } = useStaticSelector((state) => state);
     return useMemo(() => {
       if (allDataTypes?.every((dt) => schemaLookup[dt])) {
         return (reference: IDataModelReference) => schemaLookup[reference.dataType].getSchemaForPath(reference.field);

--- a/src/utils/layout/generator/GeneratorStages.tsx
+++ b/src/utils/layout/generator/GeneratorStages.tsx
@@ -402,7 +402,7 @@ function useInitialRunNum() {
 function useShouldRenderOrRun(stage: Stage, isNew: boolean, restartReason: 'hook' | 'component') {
   const initialRun = useInitialRunNum();
 
-  const [shouldRenderOrRun, shouldRestart] = NodesStore.useMemoSelector((state) => {
+  const [shouldRenderOrRun, shouldRestart] = NodesStore.useShallowSelector((state) => {
     if (isNew && state.stages.currentStage === StageFinished) {
       return [false, true];
     }
@@ -415,7 +415,6 @@ function useShouldRenderOrRun(stage: Stage, isNew: boolean, restartReason: 'hook
 
   // When new hooks and components are registered and the stages have finished (typically when a new
   // row in a repeating group is added, and thus new nodes are being generated), restart the stages.
-  const restart = NodesStore.useStaticSelector((state) => state.stages.restart);
   const store = NodesStore.useStore();
   useEffect(() => {
     const state = store.getState();
@@ -426,9 +425,9 @@ function useShouldRenderOrRun(stage: Stage, isNew: boolean, restartReason: 'hook
     const isOnLastStage = state.stages.currentStage === List[List.length - 1];
 
     if (shouldRestart && isOnLastStage) {
-      restart(restartReason);
+      state.stages.restart(restartReason);
     }
-  }, [restart, restartReason, shouldRestart, store]);
+  }, [restartReason, shouldRestart, store]);
 
   return shouldRenderOrRun;
 }

--- a/src/utils/layout/generator/GeneratorStages.tsx
+++ b/src/utils/layout/generator/GeneratorStages.tsx
@@ -416,12 +416,20 @@ function useShouldRenderOrRun(stage: Stage, isNew: boolean, restartReason: 'hook
 
   // When new hooks and components are registered and the stages have finished (typically when a new
   // row in a repeating group is added, and thus new nodes are being generated), restart the stages.
-  const restart = NodesStore.useSelector((state) => state.stages.restart);
+  const restart = NodesStore.useStaticSelector((state) => state.stages.restart);
+  const store = NodesStore.useStore();
   useEffect(() => {
-    if (shouldRestart) {
+    const state = store.getState();
+
+    // It seems that calling restart() here, even when it just falls back to setting an empty object, will
+    // cause a deep comparison and trash performance when you have many components in a form. Checking
+    // the stage beforehand will prevent this.
+    const isOnLastStage = state.stages.currentStage === List[List.length - 1];
+
+    if (shouldRestart && isOnLastStage) {
       restart(restartReason);
     }
-  }, [restart, restartReason, shouldRestart]);
+  }, [restart, restartReason, shouldRestart, store]);
 
   return shouldRenderOrRun;
 }


### PR DESCRIPTION
## Description

A few minor fixes to make the upcoming `ssb/ra0692-01` more tolerable. This form has very many components, possibly with dynamic behaviour, and simply setting data in the `NodesContext` is noticably slow (presumably because all selectors have to re-run).

1. Removed an undefined class in `src/features/alertOnChange/DeleteWarningPopover.tsx`
2. Making `useLookupBinding()` static. This didn't really need to re-render when DataModelsProvider changes(?). I didn't really look into the root cause for this, but I observed that `<DataModelValidation />` re-rendered for all nodes when clicking a checkbox (which in turn added a row to a repeating group).
3. When multiple new components were discovered in the node generator, these would all call the `restart()` function. This only caused `{}` to be set in the NodesContext. This seems harmless, but it turns out setting an empty object still means all selects have to re-run, so this contributed to a very noticable slowdown when adding a row to a repeating group (which adds multiple new components).

Sadly, this form is far from optimal after these fixes, but they're low-hanging fruit.

## Related Issue(s)

- https://altinn.slack.com/archives/C02EJ9HKQA3/p1731942708031739?thread_ts=1727953847.323699&cid=C02EJ9HKQA3

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
