### PR TITLE
Cheaper version of zustand's useShallow

### DIFF
--- a/src/hooks/useShallowObjectMemo.ts
+++ b/src/hooks/useShallowObjectMemo.ts
@@ -11,12 +11,73 @@ export function useShallowObjectMemo<T extends Object>(next: T): T {
 
 type Object = { [key: string]: unknown };
 
+/**
+ * Assumes that both prev and next are objects with the exact same keys
+ */
 function objectShallowEqual<T extends Object>(next: T, prev?: T): prev is T {
   if (!prev) {
     return false;
   }
   for (const key in next) {
     if (next[key] !== prev[key]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Custom implementation of zustand's useShallow. This is slightly stricter about what types are allowed (only objects or arrays),
+ * but avoids constructing Map's to compare entries so this should be cheaper.
+ * See: https://github.com/pmndrs/zustand/blob/f540ca8294bbca568a97020e0f0acc7042820218/src/vanilla/shallow.ts
+ */
+export function useShallow<S, T extends ObjectOrArray>(selector: (state: S) => T): (state: S) => T {
+  const prev = useRef<T>();
+  return (state) => {
+    const next = selector(state);
+    return objectOrArrayShallowEqual(next, prev.current) ? prev.current : (prev.current = next);
+  };
+}
+
+export type ObjectOrArray = { [key: string]: unknown } | unknown[];
+
+function objectOrArrayShallowEqual<T extends ObjectOrArray>(next: T, prev?: T): prev is T {
+  if (!prev) {
+    return false;
+  }
+  if (next === prev) {
+    return true;
+  }
+
+  const aIsArray = Array.isArray(next);
+  const bIsArray = Array.isArray(prev);
+
+  // Array case
+  if (aIsArray && bIsArray) {
+    if (next.length !== prev.length) {
+      return false;
+    }
+    for (let i = 0; i < next.length; i++) {
+      if (next[i] !== prev[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  // Only one is an array
+  if (aIsArray || bIsArray) {
+    return false;
+  }
+
+  // Object case
+  for (const key in next) {
+    if (!(key in prev) || next[key] !== prev[key]) {
+      return false;
+    }
+  }
+  for (const key in prev) {
+    if (!(key in next)) {
       return false;
     }
   }


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

useShallow was more expensive than expected, this is due to it constructing a `Map` and iterating its entries to compare two objects. I made a more strict version that can compare objects or arrays but not `Map`s. This avoids allocating any `Map`s or arrays and appears to take roughly 1/6th of the time and use 1/20th of the memory.

This problem was discovered when adding / removing rows in `RA-0692`. useShallow took over 1 second for adding and almost 2 seconds for removig a row, now it takes less than 250ms. Still a bit expensive, but should make a very noticable impact. The next step could be analysing what has to run useShallow so many times, and trying to cut that down.

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
