### PR TITLE
Preventing removal of stale values with `renderAsSummary`

### DIFF
--- a/src/features/options/StoreOptionsInNode.tsx
+++ b/src/features/options/StoreOptionsInNode.tsx
@@ -54,7 +54,8 @@ function StoreOptionsInNodeWorker({ valueType }: GeneratorOptionProps) {
   // we don't store option values here so it makes no sense to do this,
   // consider solving this more elegantly in the future.
   // AFAIK, stale values are not removed from attachment tags, maybe they should?
-  const shouldRemoveStaleValues = !node.isType('FileUploadWithTag');
+  const shouldRemoveStaleValues =
+    !node.isType('FileUploadWithTag') && !('renderAsSummary' in item && item.renderAsSummary);
 
   return (
     <>


### PR DESCRIPTION
## Description

In these cases, stale values should not be removed. I've actually added tests here, but I haven't deployed them yet. I'm testing this by adding a component to the `shifting-options` page in `ttd/frontend-test` which would fail an existing test if stale options were removed. I'm not deploying that until this PR is merged, as all other PRs would fail without this fix.

## Related Issue(s)

- https://altinn.slack.com/archives/C02EJ9HKQA3/p1729583206442549?thread_ts=1729512493.045959&cid=C02EJ9HKQA3

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated (in a sense, yes)
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
