### PR TITLE
Pass tracecontext from PDF generator cookies back to app

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -11,14 +11,6 @@ const CYPRESS_WINDOW_HEIGHT = env.parsed?.CYPRESS_WINDOW_HEIGHT || 1080;
 module.exports = defineConfig({
   e2e: {
     setupNodeEvents(on, config) {
-      on('task', {
-        log(args) {
-          // eslint-disable-next-line no-console
-          console.log(...args);
-          return null;
-        },
-      });
-
       on('before:browser:launch', (browser, launchOptions) => {
         if (browser.name === 'electron') {
           launchOptions.preferences.width = CYPRESS_WINDOW_WIDTH;

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -11,6 +11,14 @@ const CYPRESS_WINDOW_HEIGHT = env.parsed?.CYPRESS_WINDOW_HEIGHT || 1080;
 module.exports = defineConfig({
   e2e: {
     setupNodeEvents(on, config) {
+      on('task', {
+        log(args) {
+          // eslint-disable-next-line no-console
+          console.log(...args);
+          return null;
+        },
+      });
+
       on('before:browser:launch', (browser, launchOptions) => {
         if (browser.name === 'electron') {
           launchOptions.preferences.width = CYPRESS_WINDOW_WIDTH;

--- a/src/features/propagateTraceWhenPdf/index.ts
+++ b/src/features/propagateTraceWhenPdf/index.ts
@@ -1,0 +1,39 @@
+import axios from 'axios';
+
+import { getSearch, SearchParams } from 'src/features/routing/AppRoutingContext';
+import { appPath } from 'src/utils/urls/appUrlHelper';
+
+function getCookies(): { [key: string]: string } {
+  const cookie = {};
+  document.cookie.split(';').forEach((el) => {
+    const split = el.split('=');
+    cookie[split[0].trim()] = split.slice(1).join('=');
+  });
+  return cookie;
+}
+
+export function propagateTraceWhenPdf() {
+  const isPdf = new URLSearchParams(getSearch('')).get(SearchParams.Pdf) === '1';
+
+  if (isPdf) {
+    const cookies = getCookies();
+    axios.interceptors.request.use((config) => {
+      if (config.url?.startsWith(appPath) !== true) {
+        return config;
+      }
+
+      // This header is caught in app-lib/backend and used to allow injection of traceparent/context
+      config.headers['X-Altinn-IsPdf'] = 'true';
+
+      const traceparent = cookies['altinn-telemetry-traceparent'];
+      const tracestate = cookies['altinn-telemetry-tracestate'];
+      if (traceparent) {
+        config.headers['traceparent'] = traceparent;
+      }
+      if (tracestate) {
+        config.headers['tracestate'] = tracestate;
+      }
+      return config;
+    });
+  }
+}

--- a/src/features/routing/AppRoutingContext.tsx
+++ b/src/features/routing/AppRoutingContext.tsx
@@ -90,7 +90,7 @@ function getPath(hashFromState: string): string {
   return hash.slice(1).split('?')[0];
 }
 
-function getSearch(hashFromState: string): string {
+export function getSearch(hashFromState: string): string {
   const hash = window.inUnitTest ? hashFromState : window.location.hash;
   const search = hash.split('?')[1] ?? '';
   return search ? `?${search}` : '';

--- a/test/e2e/integration/frontend-test/pdf.ts
+++ b/test/e2e/integration/frontend-test/pdf.ts
@@ -28,11 +28,12 @@ describe('PDF', () => {
       'altinn-telemetry-tracestate': tracestateValue,
     };
 
-    cy.intercept(`*/api/**`).as('apiRequests');
+    cy.intercept(`*/instances/**`).as('apiRequests');
     cy.goto('message', { cookies });
 
     cy.testPdf(false, () => {
       cy.get<Interception<unknown, unknown>>('@apiRequests').then(({ request }) => {
+        cy.log('Request intercepted:', request.url, JSON.stringify(request.headers, null, 2));
         expect(request.headers, 'request headers').to.include({
           'X-Altinn-IsPdf': 'true',
           traceparent: traceparentValue,

--- a/test/e2e/integration/frontend-test/pdf.ts
+++ b/test/e2e/integration/frontend-test/pdf.ts
@@ -25,10 +25,7 @@ describe('PDF', () => {
       'altinn-telemetry-traceparent': traceparentValue,
       'altinn-telemetry-tracestate': tracestateValue,
     };
-    for (const [key, value] of Object.entries(cookies)) {
-      cy.setCookie(key, value);
-    }
-    cy.goto('message');
+    cy.goto('message', { cookies });
 
     cy.intercept(`/ttd/frontend-test/**`).as('apiRequests');
 

--- a/test/e2e/integration/frontend-test/pdf.ts
+++ b/test/e2e/integration/frontend-test/pdf.ts
@@ -32,7 +32,7 @@ describe('PDF', () => {
 
     cy.intercept({ method: 'GET', url: '**/applicationmetadata' }).as('appMetadata');
 
-    cy.testPdf('message', () => {
+    cy.testPdf(false, () => {
       cy.wait('@appMetadata').then(({ request }) => {
         expect(request.headers).to.have.property('traceparent', traceparent);
         expect(request.headers).to.have.property('tracestate', tracestate);

--- a/test/e2e/integration/frontend-test/pdf.ts
+++ b/test/e2e/integration/frontend-test/pdf.ts
@@ -30,10 +30,10 @@ describe('PDF', () => {
     }
     cy.goto('message');
 
-    cy.intercept({ method: 'GET', url: '**/applicationmetadata' }).as('appMetadata');
+    cy.intercept(`/ttd/frontend-test/**`).as('apiRequests');
 
     cy.testPdf(false, () => {
-      cy.wait('@appMetadata').then(({ request }) => {
+      cy.wait('@apiRequests.all').then(({ request }) => {
         expect(request.headers, 'request headers').to.include({
           'X-Altinn-IsPdf': 'true',
           traceparent: traceparentValue,

--- a/test/e2e/integration/frontend-test/pdf.ts
+++ b/test/e2e/integration/frontend-test/pdf.ts
@@ -1,3 +1,5 @@
+import type { Interception } from 'cypress/types/net-stubbing';
+
 import { AppFrontend } from 'test/e2e/pageobjects/app-frontend';
 import { Likert } from 'test/e2e/pageobjects/likert';
 
@@ -25,12 +27,12 @@ describe('PDF', () => {
       'altinn-telemetry-traceparent': traceparentValue,
       'altinn-telemetry-tracestate': tracestateValue,
     };
+
+    cy.intercept(`*/api/**`).as('apiRequests');
     cy.goto('message', { cookies });
 
-    cy.intercept(`/ttd/frontend-test/**`).as('apiRequests');
-
     cy.testPdf(false, () => {
-      cy.wait('@apiRequests.all').then(({ request }) => {
+      cy.get<Interception<unknown, unknown>>('@apiRequests').then(({ request }) => {
         expect(request.headers, 'request headers').to.include({
           'X-Altinn-IsPdf': 'true',
           traceparent: traceparentValue,

--- a/test/e2e/integration/frontend-test/pdf.ts
+++ b/test/e2e/integration/frontend-test/pdf.ts
@@ -12,34 +12,50 @@ describe('PDF', () => {
   it('should generate PDF for message step', () => {
     cy.goto('message');
 
-    cy.testPdf('message', () => {
-      cy.findByRole('heading', { level: 1, name: /frontend-test/i }).should('be.visible');
-      cy.findByRole('table').should('contain.text', 'Mottaker:Testdepartementet');
-      cy.findByRole('heading', { level: 2, name: /appen for test av app frontend/i }).should('be.visible');
-      cy.findByRole('heading', { level: 2, name: /vedlegg/i }).should('be.visible');
+    cy.testPdf({
+      snapshotName: 'message',
+      callback: () => {
+        cy.findByRole('heading', { level: 1, name: /frontend-test/i }).should('be.visible');
+        cy.findByRole('table').should('contain.text', 'Mottaker:Testdepartementet');
+        cy.findByRole('heading', { level: 2, name: /appen for test av app frontend/i }).should('be.visible');
+        cy.findByRole('heading', { level: 2, name: /vedlegg/i }).should('be.visible');
+      },
     });
   });
 
   it('downstream requests includes trace context header', () => {
     const traceparentValue = '00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01';
     const tracestateValue = 'altinn';
-    const cookies = {
-      'altinn-telemetry-traceparent': traceparentValue,
-      'altinn-telemetry-tracestate': tracestateValue,
-    };
+    const domain = new URL(Cypress.config().baseUrl!).hostname;
+    const cookieOptions: Partial<Cypress.SetCookieOptions> = { domain, sameSite: 'lax' };
 
-    cy.intercept(`*/instances/**`).as('apiRequests');
-    cy.goto('message', { cookies });
+    cy.goto('message');
 
-    cy.testPdf(false, () => {
-      cy.get<Interception<unknown, unknown>>('@apiRequests').then(({ request }) => {
-        cy.log('Request intercepted:', request.url, JSON.stringify(request.headers, null, 2));
-        expect(request.headers, 'request headers').to.include({
-          'X-Altinn-IsPdf': 'true',
-          traceparent: traceparentValue,
-          tracestate: tracestateValue,
+    cy.testPdf({
+      beforeReload: () => {
+        cy.setCookie('altinn-telemetry-traceparent', traceparentValue, cookieOptions);
+        cy.setCookie('altinn-telemetry-tracestate', tracestateValue, cookieOptions);
+        cy.intercept(`**`).as('allRequests');
+      },
+      callback: () => {
+        cy.get('@allRequests.all').then((_intercepts) => {
+          const intercepts = (_intercepts as unknown as Interception[]).filter(
+            (intercept) =>
+              intercept.request.resourceType === 'xhr' &&
+              intercept.request.url.includes(domain) &&
+              intercept.request.headers['cookie'].includes('altinn-telemetry-traceparent='),
+          );
+          expect(intercepts.length).to.be.greaterThan(10);
+          for (const { request } of intercepts) {
+            cy.log('Request intercepted:', request.url.split(domain)[1]);
+            expect(request.headers, 'request headers').to.include({
+              'x-altinn-ispdf': 'true',
+              traceparent: traceparentValue,
+              tracestate: tracestateValue,
+            });
+          }
         });
-      });
+      },
     });
   });
 
@@ -87,9 +103,10 @@ describe('PDF', () => {
     cy.findByRole('textbox', { name: /Zip Code/i }).type('0101');
     cy.findByRole('textbox', { name: /Post Place/i }).should('have.value', 'OSLO');
 
-    cy.testPdf(
-      'changeName 1',
-      () => {
+    cy.testPdf({
+      snapshotName: 'changeName 1',
+      returnToForm: true,
+      callback: () => {
         cy.findByRole('table').should('contain.text', 'Mottaker:Testdepartementet');
         cy.getSummary('Nytt fornavn').should('contain.text', 'Ola');
         cy.getSummary('Nytt etternavn').should('contain.text', 'Nordmann');
@@ -108,8 +125,7 @@ describe('PDF', () => {
         cy.getSummary('Referanse 2').should('contain.text', 'Dole');
         cy.getSummary('Adresse').should('contain.text', 'Økern 1');
       },
-      true,
-    );
+    });
 
     cy.findByRole('radio', { name: /gårdsbruk/i }).check();
     cy.findByRole('textbox', { name: /gårdsbruk du vil ta navnet fra/i }).type('Økern gård');
@@ -130,28 +146,31 @@ describe('PDF', () => {
     cy.waitUntilSaved();
     cy.gotoNavPage('form'); // Go back to form to avoid waiting for map to load while zoom animation is happending
 
-    cy.testPdf('changeName 2', () => {
-      cy.findByRole('table').should('contain.text', 'Mottaker:Testdepartementet');
-      cy.getSummary('Nytt fornavn').should('contain.text', 'Ola');
-      cy.getSummary('Nytt etternavn').should('contain.text', 'Nordmann');
-      cy.getSummary('Nytt mellomnavn').should('contain.text', '"Big G"');
-      cy.getSummary('Til:').should('contain.text', 'Ola "Big G" Nordmann');
-      cy.getSummary('begrunnelse for endring av navn').should('contain.text', 'Gårdsbruk');
-      cy.getSummary('Gårdsbruk du vil ta navnet fra').should('contain.text', 'Økern gård');
-      cy.getSummary('Kommune gårdsbruket ligger i').should('contain.text', '4444');
-      cy.getSummary('Gårdsnummer').should('contain.text', '1234');
-      cy.getSummary('Bruksnummer').should('contain.text', '56');
-      cy.getSummary('Forklar din tilknytning til gårdsbruket').should('contain.text', 'Gris');
-      cy.getSummary('Når vil du at navnendringen').should('contain.text', '01/01/2020');
-      cy.getSummary('Mobil nummer').should('contain.text', '+47 987 65 432');
-      cy.getSummary('hvor fikk du vite om skjemaet').should('contain.text', 'Altinn');
-      cy.getSummary('Referanse').should('contain.text', 'Ola Nordmann');
-      cy.getSummary('Referanse 2').should('contain.text', 'Ole');
-      cy.getSummary('Adresse').should('contain.text', 'Økern 1');
-      cy.getSummary('Velg lokasjon').findByAltText('Marker').should('be.visible');
-      cy.getSummary('Velg lokasjon')
-        .findByText(/Valgt lokasjon: 67(\.\d{1,6})?° nord, 16(\.\d{1,6})?° øst/)
-        .should('be.visible');
+    cy.testPdf({
+      snapshotName: 'changeName 2',
+      callback: () => {
+        cy.findByRole('table').should('contain.text', 'Mottaker:Testdepartementet');
+        cy.getSummary('Nytt fornavn').should('contain.text', 'Ola');
+        cy.getSummary('Nytt etternavn').should('contain.text', 'Nordmann');
+        cy.getSummary('Nytt mellomnavn').should('contain.text', '"Big G"');
+        cy.getSummary('Til:').should('contain.text', 'Ola "Big G" Nordmann');
+        cy.getSummary('begrunnelse for endring av navn').should('contain.text', 'Gårdsbruk');
+        cy.getSummary('Gårdsbruk du vil ta navnet fra').should('contain.text', 'Økern gård');
+        cy.getSummary('Kommune gårdsbruket ligger i').should('contain.text', '4444');
+        cy.getSummary('Gårdsnummer').should('contain.text', '1234');
+        cy.getSummary('Bruksnummer').should('contain.text', '56');
+        cy.getSummary('Forklar din tilknytning til gårdsbruket').should('contain.text', 'Gris');
+        cy.getSummary('Når vil du at navnendringen').should('contain.text', '01/01/2020');
+        cy.getSummary('Mobil nummer').should('contain.text', '+47 987 65 432');
+        cy.getSummary('hvor fikk du vite om skjemaet').should('contain.text', 'Altinn');
+        cy.getSummary('Referanse').should('contain.text', 'Ola Nordmann');
+        cy.getSummary('Referanse 2').should('contain.text', 'Ole');
+        cy.getSummary('Adresse').should('contain.text', 'Økern 1');
+        cy.getSummary('Velg lokasjon').findByAltText('Marker').should('be.visible');
+        cy.getSummary('Velg lokasjon')
+          .findByText(/Valgt lokasjon: 67(\.\d{1,6})?° nord, 16(\.\d{1,6})?° øst/)
+          .should('be.visible');
+      },
     });
   });
 
@@ -182,17 +201,20 @@ describe('PDF', () => {
     cy.gotoNavPage('hide');
     cy.findByRole('textbox', { name: /oppgave giver/i }).type('Ola Nordmann');
 
-    cy.testPdf('group', () => {
-      cy.findByRole('table').should('contain.text', 'Mottaker:Testdepartementet');
+    cy.testPdf({
+      snapshotName: 'group',
+      callback: () => {
+        cy.findByRole('table').should('contain.text', 'Mottaker:Testdepartementet');
 
-      cy.getSummary('Group summary title').should('contain.text', 'Endre fra : NOK 1');
-      cy.getSummary('Group summary title').should('contain.text', 'Endre verdi 1 til : NOK 5');
+        cy.getSummary('Group summary title').should('contain.text', 'Endre fra : NOK 1');
+        cy.getSummary('Group summary title').should('contain.text', 'Endre verdi 1 til : NOK 5');
 
-      cy.getSummary('Group summary title').should('contain.text', 'Endre fra : NOK 120');
-      cy.getSummary('Group summary title').should('contain.text', 'Endre verdi 120 til : NOK 350');
+        cy.getSummary('Group summary title').should('contain.text', 'Endre fra : NOK 120');
+        cy.getSummary('Group summary title').should('contain.text', 'Endre verdi 120 til : NOK 350');
 
-      cy.getSummary('Group summary title').should('contain.text', 'Endre fra : NOK 1 233');
-      cy.getSummary('Group summary title').should('contain.text', 'Endre verdi 1233 til : NOK 3 488');
+        cy.getSummary('Group summary title').should('contain.text', 'Endre fra : NOK 1 233');
+        cy.getSummary('Group summary title').should('contain.text', 'Endre verdi 1233 til : NOK 3 488');
+      },
     });
   });
 
@@ -209,31 +231,37 @@ describe('PDF', () => {
       });
     });
 
-    cy.testPdf('likert', () => {
-      cy.findByRole('table').should('contain.text', 'Mottaker:Testdepartementet');
+    cy.testPdf({
+      snapshotName: 'likert',
+      callback: () => {
+        cy.findByRole('table').should('contain.text', 'Mottaker:Testdepartementet');
 
-      cy.getSummary('Skolearbeid').should('contain.text', 'Gjør du leksene dine? : Alltid');
-      cy.getSummary('Skolearbeid').should('contain.text', 'Fungerer kalkulatoren din? : Nesten alltid');
-      cy.getSummary('Skolearbeid').should('contain.text', 'Er pulten din ryddig? : Ofte');
+        cy.getSummary('Skolearbeid').should('contain.text', 'Gjør du leksene dine? : Alltid');
+        cy.getSummary('Skolearbeid').should('contain.text', 'Fungerer kalkulatoren din? : Nesten alltid');
+        cy.getSummary('Skolearbeid').should('contain.text', 'Er pulten din ryddig? : Ofte');
 
-      cy.getSummary('Medvirkning').should('contain.text', 'Hører skolen på elevenes forslag? : Alltid');
-      cy.getSummary('Medvirkning').should(
-        'contain.text',
-        'Er dere elever med på å lage regler for hvordan dere skal ha det i klassen/gruppa? : Nesten alltid',
-      );
-      cy.getSummary('Medvirkning').should(
-        'contain.text',
-        'De voksne på skolen synes det er viktig at vi elever er greie med hverandre. : Ofte',
-      );
+        cy.getSummary('Medvirkning').should('contain.text', 'Hører skolen på elevenes forslag? : Alltid');
+        cy.getSummary('Medvirkning').should(
+          'contain.text',
+          'Er dere elever med på å lage regler for hvordan dere skal ha det i klassen/gruppa? : Nesten alltid',
+        );
+        cy.getSummary('Medvirkning').should(
+          'contain.text',
+          'De voksne på skolen synes det er viktig at vi elever er greie med hverandre. : Ofte',
+        );
+      },
     });
   });
 
   it('should generate PDF for datalist step', () => {
     cy.gotoAndComplete('datalist');
 
-    cy.testPdf('datalist', () => {
-      cy.findByRole('table').should('contain.text', 'Mottaker:Testdepartementet');
-      cy.getSummary('Hvem gjelder saken?').should('contain.text', 'Caroline');
+    cy.testPdf({
+      snapshotName: 'datalist',
+      callback: () => {
+        cy.findByRole('table').should('contain.text', 'Mottaker:Testdepartementet');
+        cy.getSummary('Hvem gjelder saken?').should('contain.text', 'Caroline');
+      },
     });
   });
 
@@ -273,8 +301,10 @@ describe('PDF', () => {
 
     cy.goto('changename');
 
-    cy.testPdf(false, () => {
-      cy.findByRole('heading', { name: /this is a custom pdf/i }).should('be.visible');
+    cy.testPdf({
+      callback: () => {
+        cy.findByRole('heading', { name: /this is a custom pdf/i }).should('be.visible');
+      },
     });
   });
 
@@ -308,10 +338,12 @@ describe('PDF', () => {
 
     cy.goto('changename');
 
-    cy.testPdf(false, () => {
-      cy.findByRole('heading', { name: /grid gruppe/i }).should('be.visible');
-      cy.findByText('Prosentandel av gjeld i boliglån').should('be.visible');
-      cy.findByText('Utregnet totalprosent').should('be.visible');
+    cy.testPdf({
+      callback: () => {
+        cy.findByRole('heading', { name: /grid gruppe/i }).should('be.visible');
+        cy.findByText('Prosentandel av gjeld i boliglån').should('be.visible');
+        cy.findByText('Utregnet totalprosent').should('be.visible');
+      },
     });
   });
 

--- a/test/e2e/integration/frontend-test/pdf.ts
+++ b/test/e2e/integration/frontend-test/pdf.ts
@@ -19,11 +19,11 @@ describe('PDF', () => {
   });
 
   it('downstream requests includes trace context header', () => {
-    const traceparent = '00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01';
-    const tracestate = 'altinn';
+    const traceparentValue = '00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01';
+    const tracestateValue = 'altinn';
     const cookies = {
-      'altinn-telemetry-traceparent': traceparent,
-      'altinn-telemetry-tracestate': tracestate,
+      'altinn-telemetry-traceparent': traceparentValue,
+      'altinn-telemetry-tracestate': tracestateValue,
     };
     for (const [key, value] of Object.entries(cookies)) {
       cy.setCookie(key, value);
@@ -34,8 +34,11 @@ describe('PDF', () => {
 
     cy.testPdf(false, () => {
       cy.wait('@appMetadata').then(({ request }) => {
-        expect(request.headers).to.have.property('traceparent', traceparent);
-        expect(request.headers).to.have.property('tracestate', tracestate);
+        expect(request.headers, 'request headers').to.include({
+          'X-Altinn-IsPdf': 'true',
+          traceparent: traceparentValue,
+          tracestate: tracestateValue,
+        });
       });
     });
   });

--- a/test/e2e/integration/subform-test/subform.ts
+++ b/test/e2e/integration/subform-test/subform.ts
@@ -186,19 +186,22 @@ describe('Subform test', () => {
     cy.findByRole('textbox', { name: /produksjonsår/i }).type('2030');
     cy.findByRole('button', { name: /ferdig/i }).click();
 
-    cy.testPdf('subform', () => {
-      cy.getSummary('Navn').should('contain.text', 'Per');
-      cy.getSummary('Alder').should('contain.text', '28 år');
+    cy.testPdf({
+      snapshotName: 'subform',
+      callback: () => {
+        cy.getSummary('Navn').should('contain.text', 'Per');
+        cy.getSummary('Alder').should('contain.text', '28 år');
 
-      cy.getSummary('Registreringsnummer').eq(0).should('contain.text', 'ABC123');
-      cy.getSummary('Merke').eq(0).should('contain.text', 'Digdir');
-      cy.getSummary('Modell').eq(0).should('contain.text', 'Scooter2000');
-      cy.getSummary('Produksjonsår').eq(0).should('contain.text', '2024');
+        cy.getSummary('Registreringsnummer').eq(0).should('contain.text', 'ABC123');
+        cy.getSummary('Merke').eq(0).should('contain.text', 'Digdir');
+        cy.getSummary('Modell').eq(0).should('contain.text', 'Scooter2000');
+        cy.getSummary('Produksjonsår').eq(0).should('contain.text', '2024');
 
-      cy.getSummary('Registreringsnummer').eq(1).should('contain.text', 'XYZ987');
-      cy.getSummary('Merke').eq(1).should('contain.text', 'Altinn');
-      cy.getSummary('Modell').eq(1).should('contain.text', '3.0');
-      cy.getSummary('Produksjonsår').eq(1).should('contain.text', '2030');
+        cy.getSummary('Registreringsnummer').eq(1).should('contain.text', 'XYZ987');
+        cy.getSummary('Merke').eq(1).should('contain.text', 'Altinn');
+        cy.getSummary('Modell').eq(1).should('contain.text', '3.0');
+        cy.getSummary('Produksjonsår').eq(1).should('contain.text', '2030');
+      },
     });
   });
 });

--- a/test/e2e/support/custom.ts
+++ b/test/e2e/support/custom.ts
@@ -594,7 +594,7 @@ Cypress.Commands.add('directSnapshot', (snapshotName, { width, minHeight }, rese
 });
 
 const DEFAULT_COMMAND_TIMEOUT = Cypress.config().defaultCommandTimeout;
-Cypress.Commands.add('testPdf', (snapshotName, callback, returnToForm = false) => {
+Cypress.Commands.add('testPdf', ({ snapshotName = false, beforeReload, callback, returnToForm = false }) => {
   cy.log('Testing PDF');
 
   // Store initial viewport size for later
@@ -628,6 +628,7 @@ Cypress.Commands.add('testPdf', (snapshotName, callback, returnToForm = false) =
     cy.visit(visitUrl);
   });
 
+  beforeReload?.();
   cy.reload();
 
   // Wait for readyForPrint, after this everything should be rendered so using timeout: 0

--- a/test/e2e/support/custom.ts
+++ b/test/e2e/support/custom.ts
@@ -778,13 +778,3 @@ Cypress.Commands.add('allowFailureOnEnd', function () {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (this.test as any).__allowFailureOnEnd = true;
 });
-
-Cypress.Commands.overwrite('log', function (log, ...args) {
-  if (Cypress.browser.isHeadless) {
-    return cy.task('log', args, { log: false }).then(() => log(...args));
-  } else {
-    // eslint-disable-next-line no-console
-    console.log(...args);
-    return log(...args);
-  }
-});

--- a/test/e2e/support/custom.ts
+++ b/test/e2e/support/custom.ts
@@ -777,3 +777,13 @@ Cypress.Commands.add('allowFailureOnEnd', function () {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (this.test as any).__allowFailureOnEnd = true;
 });
+
+Cypress.Commands.overwrite('log', function (log, ...args) {
+  if (Cypress.browser.isHeadless) {
+    return cy.task('log', args, { log: false }).then(() => log(...args));
+  } else {
+    // eslint-disable-next-line no-console
+    console.log(...args);
+    return log(...args);
+  }
+});

--- a/test/e2e/support/global.ts
+++ b/test/e2e/support/global.ts
@@ -20,6 +20,9 @@ export type StartAppInstanceOptions = {
 
   // You can add a URL suffix if you need, for example to start a specific instance
   urlSuffix?: string;
+
+  // Cookies to set before starting the app instance
+  cookies?: { [key: string]: string | { value: string; options?: Partial<Cypress.SetCookieOptions> } };
 };
 
 declare global {
@@ -29,7 +32,7 @@ declare global {
       /**
        * Quickly go to a certain task in the app
        */
-      goto(target: FrontendTestTask): Chainable<Element>;
+      goto(target: FrontendTestTask, options?: StartAppInstanceOptions): Chainable<Element>;
 
       /**
        * In 'ttd/frontend-test' we're using a pattern of initially hidden pages to expand with new test cases.

--- a/test/e2e/support/global.ts
+++ b/test/e2e/support/global.ts
@@ -20,10 +20,14 @@ export type StartAppInstanceOptions = {
 
   // You can add a URL suffix if you need, for example to start a specific instance
   urlSuffix?: string;
-
-  // Cookies to set before starting the app instance
-  cookies?: { [key: string]: string | { value: string; options?: Partial<Cypress.SetCookieOptions> } };
 };
+
+export interface TestPdfOptions {
+  snapshotName?: string;
+  beforeReload?: () => void;
+  callback: () => void;
+  returnToForm?: boolean;
+}
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -234,7 +238,7 @@ declare global {
         options: { width: number; minHeight: number },
         reset?: boolean,
       ): Chainable<null>;
-      testPdf(snapshotName: string | false, callback: () => void, returnToForm?: boolean): Chainable<null>;
+      testPdf(options: TestPdfOptions): Chainable<null>;
       getCurrentPageId(): Chainable<string>;
 
       /**

--- a/test/e2e/support/navigation.ts
+++ b/test/e2e/support/navigation.ts
@@ -1,7 +1,7 @@
 import { AppFrontend } from 'test/e2e/pageobjects/app-frontend';
 import { getLocalPartyId } from 'test/e2e/support/auth';
 import { getTargetUrl } from 'test/e2e/support/start-app-instance';
-import type { FrontendTestTask } from 'test/e2e/support/global';
+import type { FrontendTestTask, StartAppInstanceOptions } from 'test/e2e/support/global';
 
 const appFrontend = new AppFrontend();
 
@@ -77,34 +77,54 @@ function generateEvalString(target: FrontendTestTask, extra?: Extras): string {
  * These should always complete the task fully, i.e. end the task and move to the next one after it.
  * It never generates a PDF for the previous tasks.
  */
-const gotoFunctions: { [key in FrontendTestTask]: (extra?: Extras) => void } = {
-  message: () => {
+const gotoFunctions: { [key in FrontendTestTask]: (extra?: Extras, startOptions?: StartAppInstanceOptions) => void } = {
+  message: (extra?: Extras, startOptions?: StartAppInstanceOptions) => {
     cy.intercept('**/active', []).as('noActiveInstances');
-    cy.startAppInstance(appFrontend.apps.frontendTest);
+    if (extra) {
+      throw new Error('Extra not supported for message navigator');
+    }
+    cy.startAppInstance(appFrontend.apps.frontendTest, startOptions);
     cy.findByRole('button', { name: /lukk skjema/i }).should('be.visible');
   },
-  changename: (extra?: Extras) => {
+  changename: (extra?: Extras, startOptions?: StartAppInstanceOptions) => {
     cy.startAppInstance(appFrontend.apps.frontendTest, {
+      ...startOptions,
       evaluateBefore: generateEvalString('changename', extra),
     });
   },
-  group: () => {
+  group: (extra?: Extras, startOptions?: StartAppInstanceOptions) => {
+    if (extra) {
+      throw new Error('Extra not supported for group navigator');
+    }
     cy.startAppInstance(appFrontend.apps.frontendTest, {
+      ...startOptions,
       evaluateBefore: generateEvalString('group'),
     });
   },
-  likert: () => {
+  likert: (extra?: Extras, startOptions?: StartAppInstanceOptions) => {
+    if (extra) {
+      throw new Error('Extra not supported for likert navigator');
+    }
     cy.startAppInstance(appFrontend.apps.frontendTest, {
+      ...startOptions,
       evaluateBefore: generateEvalString('likert'),
     });
   },
-  datalist: () => {
+  datalist: (extra?: Extras, startOptions?: StartAppInstanceOptions) => {
+    if (extra) {
+      throw new Error('Extra not supported for datalist navigator');
+    }
     cy.startAppInstance(appFrontend.apps.frontendTest, {
+      ...startOptions,
       evaluateBefore: generateEvalString('datalist'),
     });
   },
-  confirm: () => {
+  confirm: (extra?: Extras, startOptions?: StartAppInstanceOptions) => {
+    if (extra) {
+      throw new Error('Extra not supported for confirm navigator');
+    }
     cy.startAppInstance(appFrontend.apps.frontendTest, {
+      ...startOptions,
       evaluateBefore: generateEvalString('datalist', ({ baseUrl }) => ({
         code: `await fetch('${baseUrl}/instances/' + instanceId + '/process/next', { method: 'PUT', headers });`,
       })),
@@ -112,8 +132,8 @@ const gotoFunctions: { [key in FrontendTestTask]: (extra?: Extras) => void } = {
   },
 };
 
-Cypress.Commands.add('goto', (task) => {
-  gotoFunctions[task]();
+Cypress.Commands.add('goto', (task, options) => {
+  gotoFunctions[task](undefined, options);
 });
 
 Cypress.Commands.add('gotoHiddenPage', (target) => {

--- a/test/e2e/support/start-app-instance.ts
+++ b/test/e2e/support/start-app-instance.ts
@@ -63,7 +63,7 @@ function tt02_loginSelfIdentified(user: string, pwd: string) {
 }
 
 Cypress.Commands.add('startAppInstance', (appName, options) => {
-  const { user = 'default', evaluateBefore, urlSuffix = '', authenticationLevel } = options || {};
+  const { user = 'default', evaluateBefore, urlSuffix = '', authenticationLevel, cookies } = options || {};
   const env = dotenv.config().parsed || {};
   cy.log(`Starting app instance: ${appName}`);
   if (user) {
@@ -150,6 +150,17 @@ Cypress.Commands.add('startAppInstance', (appName, options) => {
 
   user && login(user, authenticationLevel);
   !user && cy.clearCookies();
+
+  if (cookies) {
+    for (const [cookieName, cookie] of Object.entries(cookies)) {
+      if (isString(cookie)) {
+        cy.setCookie(cookieName, cookie as string, { domain: new URL(targetUrlRaw).hostname, sameSite: 'lax' });
+      } else {
+        cy.setCookie(cookieName, cookie.value, cookie.options);
+      }
+    }
+  }
+
   cy.visit(targetUrlRaw, visitOptions);
 
   if (evaluateBefore) {
@@ -158,6 +169,8 @@ Cypress.Commands.add('startAppInstance', (appName, options) => {
 
   cy.injectAxe();
 });
+
+const isString = (value: unknown): value is string => typeof value === 'string' || value instanceof String;
 
 export function getTargetUrl(appName: string) {
   return Cypress.env('type') === 'localtest'

--- a/test/e2e/support/start-app-instance.ts
+++ b/test/e2e/support/start-app-instance.ts
@@ -63,7 +63,7 @@ function tt02_loginSelfIdentified(user: string, pwd: string) {
 }
 
 Cypress.Commands.add('startAppInstance', (appName, options) => {
-  const { user = 'default', evaluateBefore, urlSuffix = '', authenticationLevel, cookies } = options || {};
+  const { user = 'default', evaluateBefore, urlSuffix = '', authenticationLevel } = options || {};
   const env = dotenv.config().parsed || {};
   cy.log(`Starting app instance: ${appName}`);
   if (user) {
@@ -151,16 +151,6 @@ Cypress.Commands.add('startAppInstance', (appName, options) => {
   user && login(user, authenticationLevel);
   !user && cy.clearCookies();
 
-  if (cookies) {
-    for (const [cookieName, cookie] of Object.entries(cookies)) {
-      if (isString(cookie)) {
-        cy.setCookie(cookieName, cookie as string, { domain: new URL(targetUrlRaw).hostname, sameSite: 'lax' });
-      } else {
-        cy.setCookie(cookieName, cookie.value, cookie.options);
-      }
-    }
-  }
-
   cy.visit(targetUrlRaw, visitOptions);
 
   if (evaluateBefore) {
@@ -169,8 +159,6 @@ Cypress.Commands.add('startAppInstance', (appName, options) => {
 
   cy.injectAxe();
 });
-
-const isString = (value: unknown): value is string => typeof value === 'string' || value instanceof String;
 
 export function getTargetUrl(appName: string) {
   return Cypress.env('type') === 'localtest'


### PR DESCRIPTION
## Description
When rendering PDF, get W3C `traceparent` propagated by the app and pass it back to the app when making subsequent requests.

Backend PR: https://github.com/Altinn/app-lib-dotnet/pull/924

Tested locally using Application Insights both with  OTel and the classic App Insights SDK

I don't know what the best place for this code is, but at least it needs to be pretty far upstream so that the interceptor is added before any downstream requests are made.

## Related Issue(s)

- N/A

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
