### PR TITLE
Queue for removing rows

### DIFF
--- a/src/layout/Likert/Generator/LikertGeneratorChildren.tsx
+++ b/src/layout/Likert/Generator/LikertGeneratorChildren.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useMemo } from 'react';
 
 import { FD } from 'src/features/formData/FormDataWrite';
 import { getLikertStartStopIndex } from 'src/utils/formLayout';
@@ -69,7 +69,6 @@ interface GenerateRowProps {
 const GenerateRow = React.memo(function GenerateRow({ rowIndex, questionsBinding, plugin }: GenerateRowProps) {
   const parentItem = GeneratorInternal.useIntermediateItem() as CompIntermediate<'Likert'>;
   const node = GeneratorInternal.useParent() as LayoutNode<'Likert'>;
-  const removeRow = NodesInternal.useRemoveRow();
   const depth = GeneratorInternal.useDepth();
 
   const childId = `${parentItem.id}-item`;
@@ -127,12 +126,7 @@ const GenerateRow = React.memo(function GenerateRow({ rowIndex, questionsBinding
     [rowIndex, depth, questionsBinding],
   );
 
-  useEffect(
-    () => () => {
-      removeRow(node, plugin);
-    },
-    [node, plugin, removeRow],
-  );
+  NodesStateQueue.useRemoveRow({ node, plugin });
 
   return (
     <GeneratorRowProvider

--- a/src/utils/layout/NodesContext.tsx
+++ b/src/utils/layout/NodesContext.tsx
@@ -234,12 +234,6 @@ export function createNodesDataStore({ registry, validationsProcessedLast }: Cre
             continue;
           }
 
-          if (layouts !== state.layouts) {
-            // The layouts have changed since the request was added, so there's no need to remove the node (it was
-            // automatically removed when resetting the NodesContext state upon the layout change)
-            continue;
-          }
-
           delete nodeData[node.id];
           node.page._removeChild(node);
           count += 1;

--- a/src/utils/layout/generator/GeneratorStages.tsx
+++ b/src/utils/layout/generator/GeneratorStages.tsx
@@ -235,6 +235,7 @@ export function useRegistry() {
     toCommit: {
       addNodes: [],
       removeNodes: [],
+      removeRows: [],
       setNodeProps: [],
       setRowExtras: [],
       setPageProps: [],

--- a/src/utils/layout/generator/NodeRepeatingChildren.tsx
+++ b/src/utils/layout/generator/NodeRepeatingChildren.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useEffect, useMemo } from 'react';
+import React, { Fragment, useMemo } from 'react';
 
 import dot from 'dot-object';
 import deepEqual from 'fast-deep-equal';
@@ -95,7 +95,6 @@ const GenerateRow = React.memo(function GenerateRow({
   plugin,
 }: GenerateRowProps) {
   const node = GeneratorInternal.useParent() as LayoutNode;
-  const removeRow = NodesInternal.useRemoveRow();
   const depth = GeneratorInternal.useDepth();
   const directMutators = useMemo(() => [mutateMultiPageIndex(multiPageMapping)], [multiPageMapping]);
 
@@ -108,12 +107,7 @@ const GenerateRow = React.memo(function GenerateRow({
     [rowIndex, depth, groupBinding],
   );
 
-  useEffect(
-    () => () => {
-      removeRow(node, plugin);
-    },
-    [node, plugin, removeRow],
-  );
+  NodesStateQueue.useRemoveRow({ node, plugin });
 
   return (
     <GeneratorRowProvider

--- a/src/utils/layout/plugins/RepeatingChildrenStorePlugin.tsx
+++ b/src/utils/layout/plugins/RepeatingChildrenStorePlugin.tsx
@@ -89,7 +89,13 @@ export class RepeatingChildrenStorePlugin extends NodeDataPlugin<RepeatingChildr
           const nodeData = { ...state.nodeData };
 
           let count = 0;
-          for (const { node, plugin } of requests) {
+          for (const { node, plugin, layouts } of requests) {
+            if (layouts !== state.layouts) {
+              // The layouts have changed since the request was added, so there's no need to remove the row (it was
+              // automatically removed when resetting the NodesContext state upon the layout change)
+              continue;
+            }
+
             const thisNode = nodeData[node.id];
             if (!thisNode) {
               continue;


### PR DESCRIPTION
## Description

In `ssb/ra0255-02`, when generating a PDF at the end of the data task, app-frontend spent a long time cleaning up rows when exiting the data task. This could lock up frontend for a while, and even trigger a 'this page is unresponsive' message for the user. Using a queue to remove rows fixes this problem.

## Related Issue(s)

- #2704
- https://altinn.studio/repos/ssb/ra0255-02/issues/12

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
