### PR TITLE
Allowing `maxCount: 1` in RepeatingGroup

### DIFF
--- a/src/features/devtools/utils/layoutSchemaValidation.ts
+++ b/src/features/devtools/utils/layoutSchemaValidation.ts
@@ -91,6 +91,26 @@ export function formatLayoutSchemaValidationError(error: DefinedError): string |
       return `Ugyldig verdi for egenskapen ${propertyString}, verdien \`${error.data}\` er ikke av typen \`${
         error.params.type
       }\` ${canBeExpression ? 'eller et uttrykk' : ''}`;
+    case 'minimum':
+      if (error.params.comparison === '>=') {
+        return `Ugyldig verdi for egenskapen ${propertyString}, verdien \`${error.data}\` er mindre enn minimumsverdien ${
+          error.params.limit
+        }`;
+      }
+
+      return `Ugyldig verdi for egenskapen ${propertyString}, verdien \`${error.data}\` er mindre enn eller lik minimumsverdien ${
+        error.params.limit
+      }`;
+    case 'maximum':
+      if (error.params.comparison === '<=') {
+        return `Ugyldig verdi for egenskapen ${propertyString}, verdien \`${error.data}\` er større enn maksimumsverdien ${
+          error.params.limit
+        }`;
+      }
+
+      return `Ugyldig verdi for egenskapen ${propertyString}, verdien \`${error.data}\` er større enn eller lik maksimumsverdien ${
+        error.params.limit
+      }`;
     case 'if':
     case 'anyOf':
     case 'oneOf':

--- a/src/layout/RepeatingGroup/config.ts
+++ b/src/layout/RepeatingGroup/config.ts
@@ -256,7 +256,7 @@ export const Config = new CG.component({
       'maxCount',
       new CG.int()
         .optional()
-        .setMin(2)
+        .setMin(1)
         .setTitle('Max number of rows')
         .setDescription('Maximum number of rows that can be added.'),
     ),
@@ -265,7 +265,8 @@ export const Config = new CG.component({
     new CG.prop(
       'minCount',
       new CG.int()
-        .optional()
+        .setMin(0)
+        .optional({ default: 0 })
         .setTitle('Min number of rows')
         .setDescription(
           'Minimum number of rows that should be added. If the user has not added enough rows, ' +


### PR DESCRIPTION
## Description

Setting `maxCount` on a `RepeatingGroup` component to `1` gave you a cryptic JSON-serialized error message straight from AJV in development environments. Implementing a prettier error message for that, and allowing you to set `maxCount: 1` in a RepeatingGroup.

The reason this was required to be a minimum of 2 earlier is historical; that's the way we used to differentiate between non-repeating groups and repeating groups (when the `Group` component implemented everything). It should now be possible to have a RepeatingGroup including either 0 or 1 rows, if you so wish. 

## Related Issue(s)

- https://altinn.slack.com/archives/C02EJ9HKQA3/p1732545299300419

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
