### PR TITLE
Split by '.' only once when parsing 'dataSource' for a text resource variable

### DIFF
--- a/src/features/language/useLanguage.ts
+++ b/src/features/language/useLanguage.ts
@@ -327,6 +327,21 @@ function getTextResourceByKey(
   return getTextResourceByKey(value, textResources, dataSources);
 }
 
+function splitNTimes(text: string, sep: string, n: number) {
+  if (n === 0) {
+    return [text];
+  } else if (n < 0) {
+    throw new Error(`Invalid N:${n}`);
+  }
+  const parts = text.split(sep);
+  const out: string[] = [];
+  for (let i = 0; i < n; i++) {
+    out.push(parts.shift() ?? '');
+  }
+  out.push(parts.join(sep));
+  return out;
+}
+
 function replaceVariables(text: string, variables: IVariable[], dataSources: TextResourceVariablesDataSources) {
   const {
     node,
@@ -345,7 +360,7 @@ function replaceVariables(text: string, variables: IVariable[], dataSources: Tex
     let value = variables[idx].key;
 
     if (variable.dataSource.startsWith('dataModel')) {
-      const dataModelName = variable.dataSource.split('.')[1];
+      const dataModelName = splitNTimes(variable.dataSource, '.', 1)[1];
       const cleanPath = getKeyWithoutIndexIndicators(value);
 
       const dataTypeToRead =


### PR DESCRIPTION
## Description
Make sure we only split `dataSource` by `.` once, so that if there are datatypes with the `.` character we still use the full datatype string when resolving datamodel references for variable substitution in text resources.

This was discovered by brreg dev, ref Slack thread: https://altinn.slack.com/archives/C02EJ9HKQA3/p1733736458716249

## Related Issue(s)

- N/A

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
