### PR TITLE
Fix DevTools in subform

### DIFF
--- a/src/components/presentation/Presentation.tsx
+++ b/src/components/presentation/Presentation.tsx
@@ -108,3 +108,12 @@ const { Provider: PresentationProvider, useHasProvider } = createContext<undefin
 });
 
 export const useHasPresentation = () => useHasProvider();
+
+/**
+ * The loader component will check if a presentation component already exists,
+ * and if so, will not create one. In cases where we don't want to show any presentation
+ * for loaders, this can be used to prevent the loader from creating a presentation.
+ */
+export function DummyPresentation({ children }: PropsWithChildren) {
+  return <PresentationProvider value={undefined}>{children}</PresentationProvider>;
+}

--- a/src/components/wrappers/ProcessWrapper.tsx
+++ b/src/components/wrappers/ProcessWrapper.tsx
@@ -142,11 +142,7 @@ export const ProcessWrapper = () => {
         <Routes>
           <Route
             path=':pageKey/:componentId/*'
-            element={
-              <PresentationComponent type={ProcessTaskType.Data}>
-                <ComponentRouting />
-              </PresentationComponent>
-            }
+            element={<ComponentRouting />}
           />
           <Route
             path='*'

--- a/src/core/loading/Loader.tsx
+++ b/src/core/loading/Loader.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { AltinnContentIconFormData } from 'src/components/atoms/AltinnContentIconFormData';
 import { AltinnContentLoader } from 'src/components/molecules/AltinnContentLoader';
 import { PresentationComponent, useHasPresentation } from 'src/components/presentation/Presentation';
-import { useTaskStore } from 'src/core/contexts/taskStoreContext';
 import { LoadingProvider } from 'src/core/loading/LoadingContext';
 import { Lang } from 'src/features/language/Lang';
 import { ProcessTaskType } from 'src/types';
@@ -14,17 +13,8 @@ interface LoaderProps {
 }
 
 export const Loader = (props: LoaderProps) => {
-  const overriddenDataModelUuid = useTaskStore((state) => state.overriddenDataModelUuid);
-  const overriddenTaskId = useTaskStore((state) => state.overriddenTaskId);
   const hasPresentation = useHasPresentation();
 
-  if (overriddenDataModelUuid) {
-    return null;
-  }
-
-  if (overriddenTaskId) {
-    return null;
-  }
   if (!hasPresentation) {
     return (
       <LoadingProvider reason={props.reason}>

--- a/src/features/devtools/DevTools.module.css
+++ b/src/features/devtools/DevTools.module.css
@@ -1,10 +1,25 @@
 @media print {
-  .appContainer {
-    display: contents;
+  .page-padding {
+    display: none;
   }
   .panel {
     display: none;
   }
+}
+
+.panel-error > * {
+  margin-top: 0;
+}
+.panel-error {
+  overflow: hidden;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  height: 100%;
+  text-align: center;
+  color: var(--fds-colors-red-600);
+  border: 3px solid var(--fds-colors-red-600);
 }
 
 .panel {

--- a/src/features/devtools/DevTools.tsx
+++ b/src/features/devtools/DevTools.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect } from 'react';
-import type { PropsWithChildren } from 'react';
 
 import { OpenDevToolsButton } from 'src/features/devtools/components/OpenDevToolsButton/OpenDevToolsButton';
 import { useDevToolsStore } from 'src/features/devtools/data/DevToolsStore';
@@ -7,7 +6,7 @@ import { DevToolsPanel } from 'src/features/devtools/DevToolsPanel';
 import { useLayoutValidation } from 'src/features/devtools/layoutValidation/useLayoutValidation';
 import { useIsDev } from 'src/hooks/useIsDev';
 
-export const DevTools = ({ children }: PropsWithChildren) => {
+export const DevTools = () => {
   const isDev = useIsDev();
   const panelOpen = useDevToolsStore((state) => state.isOpen);
   const { open: openPanel, close: closePanel } = useDevToolsStore((state) => state.actions);
@@ -51,9 +50,7 @@ export const DevTools = ({ children }: PropsWithChildren) => {
       <DevToolsPanel
         isOpen={panelOpen}
         close={() => setPanelOpen(false)}
-      >
-        {children}
-      </DevToolsPanel>
+      />
     </>
   );
 };

--- a/src/features/devtools/DevToolsPanel.tsx
+++ b/src/features/devtools/DevToolsPanel.tsx
@@ -12,12 +12,12 @@ function clampHeight(height: number): number {
   return Math.min(Math.max(height, 10), window.innerHeight);
 }
 
-interface IDevToolsPanelProps extends PropsWithChildren {
+interface IDevToolsPanelProps {
   isOpen: boolean;
   close: () => void;
 }
 
-export const DevToolsPanel = ({ isOpen, close, children }: IDevToolsPanelProps) => {
+export const DevToolsPanel = ({ isOpen, close }: IDevToolsPanelProps) => {
   const [height, setHeight] = useState(250);
 
   const resizeHandler = (mouseDownEvent: React.MouseEvent) => {
@@ -56,16 +56,13 @@ export const DevToolsPanel = ({ isOpen, close, children }: IDevToolsPanelProps) 
     document.body.addEventListener('touchend', onTouchEnd, { once: true });
   };
 
-  return (
-    <>
-      <div
-        id='appContainer'
-        className={classes.appContainer}
-        style={{ paddingBottom: isOpen ? height : 0 }}
-      >
-        {children}
-      </div>
-      {isOpen && (
+  if (isOpen) {
+    return (
+      <>
+        <div
+          className={classes.pagePadding}
+          style={{ paddingBottom: height }}
+        />
         <div
           className={classes.panel}
           style={{ height }}
@@ -91,10 +88,44 @@ export const DevToolsPanel = ({ isOpen, close, children }: IDevToolsPanelProps) 
                 />
               </Button>
             </div>
-            <DevToolsControls />
+            <DevToolsErrorBoundary>
+              <DevToolsControls />
+            </DevToolsErrorBoundary>
           </div>
         </div>
-      )}
-    </>
-  );
+      </>
+    );
+  }
+
+  return null;
 };
+
+interface IErrorBoundary {
+  lastError?: Error;
+}
+class DevToolsErrorBoundary extends React.Component<PropsWithChildren, IErrorBoundary> {
+  constructor(props: PropsWithChildren) {
+    super(props);
+    this.state = { lastError: undefined };
+  }
+
+  static getDerivedStateFromError(lastError: Error): IErrorBoundary {
+    return { lastError };
+  }
+
+  render(): React.ReactNode {
+    const { lastError } = this.state;
+    const { children } = this.props;
+
+    if (lastError) {
+      return (
+        <div className={classes.panelError}>
+          <h2>An uncaught error occured</h2>
+          <p>Check the browser&apos;s console for details</p>
+        </div>
+      );
+    }
+
+    return children;
+  }
+}

--- a/src/features/devtools/DevToolsPanel.tsx
+++ b/src/features/devtools/DevToolsPanel.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 import React, { useState } from 'react';
-import type { PropsWithChildren } from 'react';
+import type { ErrorInfo, PropsWithChildren } from 'react';
 
 import { Close } from '@navikt/ds-icons';
 
@@ -111,6 +111,15 @@ class DevToolsErrorBoundary extends React.Component<PropsWithChildren, IErrorBou
 
   static getDerivedStateFromError(lastError: Error): IErrorBoundary {
     return { lastError };
+  }
+
+  componentDidCatch(_: Error, info: ErrorInfo) {
+    /**
+     * In development, react already logs the component trace, so no need to do it manually as well.
+     */
+    if (process.env.NODE_ENV !== 'development') {
+      console.error(`The above error occurred in the component:`, info.componentStack);
+    }
   }
 
   render(): React.ReactNode {

--- a/src/features/devtools/components/DevNavigationButtons/DevNavigationButtons.tsx
+++ b/src/features/devtools/components/DevNavigationButtons/DevNavigationButtons.tsx
@@ -96,7 +96,7 @@ const InnerDevNavigationButtons = () => {
       <div className={cn(classes.dropdown, { [classes.responsiveDropdown]: !compactView })}>
         <Combobox
           size='sm'
-          value={[pageKey!]}
+          value={pageKey ? [pageKey] : []}
           onValueChange={handleChange}
           className={comboboxClasses.container}
         >

--- a/src/features/pdf/PdfView2.tsx
+++ b/src/features/pdf/PdfView2.tsx
@@ -6,6 +6,7 @@ import { Grid } from '@material-ui/core';
 
 import { ConditionalWrapper } from 'src/components/ConditionalWrapper';
 import { OrganisationLogo } from 'src/components/presentation/OrganisationLogo/OrganisationLogo';
+import { DummyPresentation } from 'src/components/presentation/Presentation';
 import { ReadyForPrint } from 'src/components/ReadyForPrint';
 import { DataLoadingState, useDataLoadingStore } from 'src/core/contexts/dataLoadingContext';
 import { useAppName, useAppOwner } from 'src/core/texts/appTexts';
@@ -53,31 +54,33 @@ export const PDFView2 = () => {
   }
 
   return (
-    <DataLoaderStoreInit>
-      <PdfWrapping>
-        <div className={classes.instanceInfo}>
-          <InstanceInformation
-            elements={{
-              dateSent: true,
-              sender: true,
-              receiver: true,
-              referenceNumber: true,
-            }}
-          />
-        </div>
-        {order
-          ?.filter((pageKey) => !isHiddenPage(pageKey))
-          .filter((pageKey) => !pdfSettings?.excludedPages.includes(pageKey))
-          .map((pageKey) => (
-            <PdfForPage
-              key={pageKey}
-              pageKey={pageKey}
-              pdfSettings={pdfSettings}
+    <DummyPresentation>
+      <DataLoaderStoreInit>
+        <PdfWrapping>
+          <div className={classes.instanceInfo}>
+            <InstanceInformation
+              elements={{
+                dateSent: true,
+                sender: true,
+                receiver: true,
+                referenceNumber: true,
+              }}
             />
-          ))}
-        <SubformSummaryComponent2 />
-      </PdfWrapping>
-    </DataLoaderStoreInit>
+          </div>
+          {order
+            ?.filter((pageKey) => !isHiddenPage(pageKey))
+            .filter((pageKey) => !pdfSettings?.excludedPages.includes(pageKey))
+            .map((pageKey) => (
+              <PdfForPage
+                key={pageKey}
+                pageKey={pageKey}
+                pdfSettings={pdfSettings}
+              />
+            ))}
+          <SubformSummaryComponent2 />
+        </PdfWrapping>
+      </DataLoaderStoreInit>
+    </DummyPresentation>
   );
 };
 

--- a/src/layout/Subform/SubformWrapper.tsx
+++ b/src/layout/Subform/SubformWrapper.tsx
@@ -1,12 +1,14 @@
 import React, { useEffect } from 'react';
 
 import { Form } from 'src/components/form/Form';
+import { PresentationComponent } from 'src/components/presentation/Presentation';
 import { useTaskStore } from 'src/core/contexts/taskStoreContext';
 import { Loader } from 'src/core/loading/Loader';
 import { FormProvider } from 'src/features/form/FormContext';
 import { useDataTypeFromLayoutSet } from 'src/features/form/layout/LayoutsContext';
 import { useNavigationParam } from 'src/features/routing/AppRoutingContext';
 import { useNavigatePage } from 'src/hooks/useNavigatePage';
+import { ProcessTaskType } from 'src/types';
 import { useNodeItem } from 'src/utils/layout/useNodeItem';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
@@ -19,7 +21,9 @@ export function SubformWrapper({ node }: { node: LayoutNode<'Subform'> }) {
 
   return (
     <FormProvider>
-      <Form />
+      <PresentationComponent type={ProcessTaskType.Data}>
+        <Form />
+      </PresentationComponent>
     </FormProvider>
   );
 }


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

Fixes dev-tools crashing in subform. Also makes the subform-loading look a bit better by not showing an empty form container.

Added an error boundary inside of the dev tools panel as well, so errors like this are less annoying in the future

Cleaned up dev tools component by removing `{children}` since we no longer wrap the application in it.

## Related Issue(s)

- closes #2818 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
