### PR TITLE
Actions (publish) based on PR comments

### DIFF
--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -102,7 +102,7 @@ if ! [[ "$CURRENT_VERSION" =~ ^v ]]; then
   exit 1
 fi
 
-VERSION_REGEX="^[\d\.]+(-[a-z0-9.]+)?$"
+VERSION_REGEX="^[\d\.]+(-[a-z0-9.\-]+)?$"
 if ! echo "$APP_FULL" | grep --quiet --perl-regexp "$VERSION_REGEX"; then
   echo "Error: Broken/unexpected version number: $APP_FULL"
   exit 1

--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -30,6 +30,7 @@ jobs:
           branch=$(gh pr view ${{ github.event.issue.number }} --repo ${{ github.repository }} --json headRefName | jq -r '.headRefName' | sed 's/.*\///')
           version=$(git describe --abbrev=0 --tags 2>/dev/null).$branch.$sha
           git tag -a $version -m "PR release $version"
+          echo "FRONTEND_PACKAGE_VERSION=$version" >> $GITHUB_ENV
 
       - name: Checkout Altinn-CDN repository
         uses: actions/checkout@v4
@@ -74,7 +75,7 @@ jobs:
         name: Comment on PR
         with:
           script: |
-            const version = process.env.MINVERVERSIONOVERRIDE;
+            const version = process.env.FRONTEND_PACKAGE_VERSION;
 
             github.rest.issues.createComment({
               issue_number: context.issue.number,
@@ -82,6 +83,6 @@ jobs:
               repo: context.repo.repo,
               body: `## Published PR packages:\n` +
                 `\n` +
-                `* [Altinn.App.Api ${version}](https://www.nuget.org/packages/Altinn.App.Api.Experimental/${version})\n` +
-                `* [Altinn.App.Core ${version}](https://www.nuget.org/packages/Altinn.App.Core.Experimental/${version})\n`
+                `* \`<link rel="stylesheet" type="text/css" href="https://altinncdn.no/toolkits/altinn-app-frontend/${version}/altinn-app-frontend.css">\`\n` +
+                `* \`<script src="https://altinncdn.no/toolkits/altinn-app-frontend/${version}/altinn-app-frontend.js"></script>\`\n`
             })

--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -11,6 +11,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ format('refs/pull/{0}/head', github.event.issue.number) }}
+          path: app-frontend
           fetch-depth: 0
 
       - name: install node
@@ -23,6 +24,7 @@ jobs:
         run: yarn --immutable
 
       - name: Build PR release version
+        working-directory: app-frontend
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -1,0 +1,87 @@
+name: PR actions
+on:
+  issue_comment:
+    types: [created, edited]
+jobs:
+  publish:
+    name: Publish PR packages
+    runs-on: ubuntu-latest
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '/publish')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ format('refs/pull/{0}/head', github.event.issue.number) }}
+          fetch-depth: 0
+
+      - name: install node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: install dependencies
+        working-directory: app-frontend
+        run: yarn --immutable
+
+      - name: Build PR release version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          sha=$(gh pr view ${{ github.event.issue.number }} --repo ${{ github.repository }} --json headRefOid | jq -r '.headRefOid' | cut -c1-8)
+          branch=$(gh pr view ${{ github.event.issue.number }} --repo ${{ github.repository }} --json headRefName | jq -r '.headRefName' | sed 's/.*\///')
+          version=$(git describe --abbrev=0 --tags 2>/dev/null).$branch.$sha
+          git tag -a $version -m "PR release $version"
+
+      - name: Checkout Altinn-CDN repository
+        uses: actions/checkout@v4
+        if: '!env.ACT'
+        with:
+          repository: 'Altinn/altinn-cdn'
+          token: ${{secrets.ALTINN_CDN_TOKEN}}
+          path: cdn
+
+      - name: Azure login
+        uses: azure/login@v2
+        if: '!env.ACT'
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID_FC }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID_FC }}
+          subscription-id: ${{ secrets.AZURE_CDN_SUBSCRIPTION_ID_FC }}
+
+      - name: Run release script (pre-release)
+        working-directory: app-frontend
+        if: '!env.ACT'
+        env:
+          FD_DOMAIN: ${{ vars.AZURE_DOMAIN_FC }}
+          FD_ENDPOINT: ${{ vars.AZURE_ENDPOINT_FC }}
+          FD_PROFILE: ${{ vars.AZURE_PROFILE_FC }}
+          FD_RESOURCEGROUP: ${{ vars.AZURE_RESOURCE_GROUP_FC }}
+        run: |
+          bash .github/scripts/release.sh \
+            --frontend . \
+            --cdn ../cdn \
+            --commit \
+            --pre-release \
+            --azure-sync-cdn \
+            --azure-sa-name "${{ secrets.PRODUCTION_STORAGEACCOUNT_NAME }}" \
+            --azure-sa-token "${{ secrets.PRODUCTION_ALTINN_CDN_SAS_TOKEN }}"
+
+      - name: Push to CDN
+        working-directory: cdn
+        if: '!env.ACT'
+        run: git push
+
+      - uses: actions/github-script@v7
+        name: Comment on PR
+        with:
+          script: |
+            const version = process.env.MINVERVERSIONOVERRIDE;
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `## Published PR packages:\n` +
+                `\n` +
+                `* [Altinn.App.Api ${version}](https://www.nuget.org/packages/Altinn.App.Api.Experimental/${version})\n` +
+                `* [Altinn.App.Core ${version}](https://www.nuget.org/packages/Altinn.App.Core.Experimental/${version})\n`
+            })


### PR DESCRIPTION
## Description

Workflows for doing stuff in response to PR comments.
Works similarly in app-lib, with the exeception of using MinVer there. Here I opted for using a local tag prior to running the release script, so the hope is that the only required change there is to update the version regex. With this change I expect PR releases to be published to the CDN repo (and Azure Storage), though it has to be tested from main since that's where the workflow has to be for `issue_comment` triggers

## Related Issue(s)

- https://github.com/Altinn/app-frontend-react/issues/2822

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [x] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
