### PR TITLE
Fixing failing `component` lookups when deeply linked

### DIFF
--- a/src/components/PDFGeneratorPreview/PDFGeneratorPreview.tsx
+++ b/src/components/PDFGeneratorPreview/PDFGeneratorPreview.tsx
@@ -10,8 +10,8 @@ import { useTaskTypeFromBackend } from 'src/features/instance/ProcessContext';
 import { Lang } from 'src/features/language/Lang';
 import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
 import { useLanguage } from 'src/features/language/useLanguage';
-import { useIsLocalOrStaging } from 'src/hooks/useIsDev';
 import { ProcessTaskType } from 'src/types';
+import { isLocalOrStaging } from 'src/utils/isDev';
 import { getPdfPreviewUrl } from 'src/utils/urls/appUrlHelper';
 
 export function PDFGeneratorPreview({
@@ -30,9 +30,8 @@ export function PDFGeneratorPreview({
   const taskType = useTaskTypeFromBackend();
   const instanceId = useLaxInstance((state) => state.instanceId);
   const language = useCurrentLanguage();
-  const isLocalOrStaging = useIsLocalOrStaging();
 
-  const disabled = taskType !== ProcessTaskType.Data || !instanceId || !isLocalOrStaging;
+  const disabled = taskType !== ProcessTaskType.Data || !instanceId || !isLocalOrStaging();
 
   const { langAsString } = useLanguage();
 

--- a/src/features/devtools/DevTools.tsx
+++ b/src/features/devtools/DevTools.tsx
@@ -4,10 +4,9 @@ import { OpenDevToolsButton } from 'src/features/devtools/components/OpenDevTool
 import { useDevToolsStore } from 'src/features/devtools/data/DevToolsStore';
 import { DevToolsPanel } from 'src/features/devtools/DevToolsPanel';
 import { useLayoutValidation } from 'src/features/devtools/layoutValidation/useLayoutValidation';
-import { useIsDev } from 'src/hooks/useIsDev';
+import { isDev } from 'src/utils/isDev';
 
 export const DevTools = () => {
-  const isDev = useIsDev();
   const panelOpen = useDevToolsStore((state) => state.isOpen);
   const { open: openPanel, close: closePanel } = useDevToolsStore((state) => state.actions);
 
@@ -41,7 +40,7 @@ export const DevTools = () => {
 
   return (
     <>
-      {isDev && (
+      {isDev() && (
         <OpenDevToolsButton
           isHidden={panelOpen}
           onClick={() => setPanelOpen(true)}

--- a/src/features/devtools/components/PDFPreviewButton/PDFPreviewButton.tsx
+++ b/src/features/devtools/components/PDFPreviewButton/PDFPreviewButton.tsx
@@ -8,15 +8,12 @@ import { PDFGeneratorPreview } from 'src/components/PDFGeneratorPreview/PDFGener
 import classes from 'src/features/devtools/components/PDFPreviewButton/PDFPreview.module.css';
 import { useDevToolsStore } from 'src/features/devtools/data/DevToolsStore';
 import { useTaskTypeFromBackend } from 'src/features/instance/ProcessContext';
-import { useIsStudioPreview } from 'src/hooks/useIsDev';
 import { ProcessTaskType } from 'src/types';
+import { isStudioPreview } from 'src/utils/isDev';
 
 export const PDFPreviewButton = () => {
   const taskType = useTaskTypeFromBackend();
   const setPdfPreview = useDevToolsStore((state) => state.actions.setPdfPreview);
-
-  // PDF generator is not available in altinn studio preview
-  const isStudioPreview = useIsStudioPreview();
 
   return (
     <Fieldset
@@ -43,7 +40,8 @@ export const PDFPreviewButton = () => {
         />
         Forhåndsvis PDF
       </Button>
-      {!isStudioPreview && (
+      {/* PDF generator is not available in altinn studio preview */}
+      {!isStudioPreview() && (
         <PDFGeneratorPreview
           showErrorDetails={true}
           buttonTitle='Generer PDF'

--- a/src/features/instantiate/containers/InvalidSubformLayoutError.tsx
+++ b/src/features/instantiate/containers/InvalidSubformLayoutError.tsx
@@ -5,11 +5,10 @@ import { useDevToolsStore } from 'src/features/devtools/data/DevToolsStore';
 import { DevToolsTab } from 'src/features/devtools/data/types';
 import { InstantiationErrorPage } from 'src/features/instantiate/containers/InstantiationErrorPage';
 import { Lang } from 'src/features/language/Lang';
-import { useIsDev } from 'src/hooks/useIsDev';
+import { isDev } from 'src/utils/isDev';
 import type { InvalidSubformLayoutException } from 'src/features/formData/InvalidSubformLayoutException';
 
 export function InvalidSubformLayoutError({ error }: { error: InvalidSubformLayoutException }) {
-  const isDev = useIsDev();
   const open = useDevToolsStore((s) => s.actions.open);
   const setActiveTab = useDevToolsStore((s) => s.actions.setActiveTab);
 
@@ -47,7 +46,7 @@ export function InvalidSubformLayoutError({ error }: { error: InvalidSubformLayo
               />,
             ]}
           />
-          {isDev && (
+          {isDev() && (
             <>
               <br />
               <br />

--- a/src/features/instantiate/containers/UnknownError.tsx
+++ b/src/features/instantiate/containers/UnknownError.tsx
@@ -5,10 +5,9 @@ import { useDevToolsStore } from 'src/features/devtools/data/DevToolsStore';
 import { DevToolsTab } from 'src/features/devtools/data/types';
 import { InstantiationErrorPage } from 'src/features/instantiate/containers/InstantiationErrorPage';
 import { Lang } from 'src/features/language/Lang';
-import { useIsDev } from 'src/hooks/useIsDev';
+import { isDev } from 'src/utils/isDev';
 
 export function UnknownError() {
-  const isDev = useIsDev();
   const open = useDevToolsStore((s) => s.actions.open);
   const setActiveTab = useDevToolsStore((s) => s.actions.setActiveTab);
 
@@ -35,7 +34,7 @@ export function UnknownError() {
               />,
             ]}
           />
-          {isDev && (
+          {isDev() && (
             <>
               <br />
               <br />

--- a/src/hooks/delayedSelectors.test.tsx
+++ b/src/hooks/delayedSelectors.test.tsx
@@ -5,47 +5,65 @@ import { userEvent } from '@testing-library/user-event';
 import { createStore } from 'zustand';
 
 import { createZustandContext } from 'src/core/contexts/zustandContext';
+import { useMultipleDelayedSelectors } from 'src/hooks/delayedSelectors';
 
 interface State {
   state: number;
+  someString: string;
   increment: () => void;
   decrement: () => void;
+  setString: (someString: string) => void;
 }
 
 function initialCreateStore() {
   return createStore<State>((set) => ({
     state: 0,
+    someString: 'test',
     increment: () => set((state) => ({ state: state.state + 1 })),
     decrement: () => set((state) => ({ state: state.state - 1 })),
+    setString: (someString: string) => set({ someString }),
   }));
 }
 
-const { Provider, useDelayedSelector, useSelector } = createZustandContext({
-  name: 'Test',
+const Ctx1 = createZustandContext({
+  name: 'Ctx1',
+  required: true,
+  initialCreateStore,
+});
+
+const Ctx2 = createZustandContext({
+  name: 'Ctx1',
   required: true,
   initialCreateStore,
 });
 
 const useSelectorWithStringCache = () =>
-  useDelayedSelector({
+  Ctx1.useDelayedSelector({
     mode: 'simple',
     selector: (cacheKey: string) => (state) =>
       `cacheKey = ${cacheKey}, state = ${state.state}, random number = ${Math.random()}`,
   });
 
 const useSelectorWithFunctionCache = () =>
-  useDelayedSelector({
+  Ctx1.useDelayedSelector({
     mode: 'innerSelector',
     makeArgs: (state) => [state],
   });
 
-function TestComponent() {
+interface Props {
+  onGetValue: (source: string, value: unknown) => void;
+}
+
+function TestComponent({ onGetValue }: Props) {
   return (
-    <Provider>
-      <TestStringCache />
-      <TestFunctionCache />
-      <IncrementButton />
-    </Provider>
+    <Ctx1.Provider>
+      <Ctx2.Provider>
+        <TestStringCache />
+        <TestFunctionCache />
+        <TestMultiDelayedSelector onGetValue={onGetValue} />
+        <IncrementButton />
+      </Ctx2.Provider>
+    </Ctx1.Provider>
   );
 }
 
@@ -146,7 +164,7 @@ function SelectValueWithFunctionCache({
 }
 
 function IncrementButton() {
-  const increment = useSelector((state) => state.increment);
+  const increment = Ctx1.useSelector((state) => state.increment);
   return (
     <button
       data-testid='increment'
@@ -176,9 +194,94 @@ function functionResult(renderCount = 1, previous?: string) {
   return new RegExp(`Counter = ${expectedState}, random = \\d+\\.\\d+, render = ${renderCount}`);
 }
 
+function TestMultiDelayedSelector({ onGetValue }: Props) {
+  const renderCount = useRef(0);
+  renderCount.current += 1;
+
+  const otherCount = useRef(0);
+  const [depState1, setDepState1] = useState(0);
+  const [depState2, setDepState2] = useState(0);
+  const props1 = Ctx1.useDelayedSelectorProps(
+    {
+      mode: 'simple',
+      selector: (divideBy: number) => (state) => `ctx1 = ${state.state / divideBy}`,
+    },
+    [depState1],
+  );
+  const props2 = Ctx2.useDelayedSelectorProps(
+    {
+      mode: 'innerSelector',
+      makeArgs: (state) => [state.state, depState2] as const,
+    },
+    [depState2],
+  );
+
+  const setString = Ctx2.useStaticSelector((state) => state.setString);
+  const incrementCtx1 = Ctx1.useStaticSelector((state) => state.increment);
+  const incrementCtx2 = Ctx2.useStaticSelector((state) => state.increment);
+
+  const [ds1, ds2] = useMultipleDelayedSelectors(props1, props2);
+
+  return (
+    <>
+      <div data-testid='multiple-selectors-render-count'>{renderCount.current}</div>
+
+      {/* Setters */}
+      <button onClick={() => setDepState1((was) => was + 1)}>Increment depState1</button>
+      <button onClick={() => setDepState2((was) => was + 1)}>Increment depState2</button>
+      <button onClick={incrementCtx1}>Increment ctx1</button>
+      <button onClick={incrementCtx2}>Increment ctx2</button>
+      <button
+        onClick={() => {
+          incrementCtx1();
+          incrementCtx2();
+        }}
+      >
+        Increment both
+      </button>
+      <button onClick={() => (otherCount.current += 1)}>Increment otherCount</button>
+      <button onClick={() => setString('new string')}>Set fixed string in ctx2</button>
+
+      {/* Getters */}
+      <button onClick={() => onGetValue('ds1', ds1(2))}>Get ds1 divided by 2</button>
+      <button
+        onClick={() =>
+          onGetValue(
+            'ds2',
+            ds2((state) => [state, otherCount.current], []), // Intentionally not putting otherCount in the deps
+          )
+        }
+      >
+        Get ds2 without otherCount in deps
+      </button>
+      <button
+        onClick={() =>
+          onGetValue(
+            'ds2',
+            ds2((state) => [state, otherCount.current], [otherCount.current]),
+          )
+        }
+      >
+        Get ds2 with otherCount in deps
+      </button>
+      <button
+        onClick={() =>
+          onGetValue(
+            'ds2',
+            ds2((state, dep) => state + dep, []),
+          )
+        }
+      >
+        Get ds2 + depState2
+      </button>
+    </>
+  );
+}
+
 describe('useDelayedSelector', () => {
   it('should cache according to cache key', async () => {
-    render(<TestComponent />);
+    const fn = jest.fn();
+    render(<TestComponent onGetValue={fn} />);
 
     expect(screen.getByTestId('test1-1').textContent).toMatch(stringResult('test1'));
     let firstStringValue = screen.getByTestId('test1-1').textContent!;
@@ -221,5 +324,83 @@ describe('useDelayedSelector', () => {
     firstFunctionValue = screen.getByTestId('test3-1').textContent!;
 
     expect(screen.getByTestId('test3-2').textContent).toMatch(functionResult(3, firstFunctionValue));
+  });
+
+  it('multiple selectors behave as expected', async () => {
+    const fn = jest.fn();
+    render(<TestComponent onGetValue={fn} />);
+
+    expect(screen.getByTestId('multiple-selectors-render-count').textContent).toBe('1');
+
+    // Incrementing does not change the render count, as no state has been fetched yet
+    await userEvent.click(screen.getByText('Increment ctx1'));
+    expect(screen.getByTestId('multiple-selectors-render-count').textContent).toBe('1');
+
+    // Fetching ds1 will also not trigger a re-render, as this is the first time it's being fetched
+    await userEvent.click(screen.getByText('Get ds1 divided by 2'));
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenLastCalledWith('ds1', 'ctx1 = 0.5');
+    expect(screen.getByTestId('multiple-selectors-render-count').textContent).toBe('1');
+    fn.mockClear();
+
+    // Incrementing now will immediately re-render, as ds1 has been fetched before
+    await userEvent.click(screen.getByText('Increment ctx1'));
+    expect(screen.getByTestId('multiple-selectors-render-count').textContent).toBe('2');
+
+    // Incrementing once again will not re-render, as ds1 hasn't been fetched yet after the last increment
+    await userEvent.click(screen.getByText('Increment ctx1'));
+    expect(screen.getByTestId('multiple-selectors-render-count').textContent).toBe('2');
+
+    // Getting ctx2 will not trigger a re-render, as it's the first time it's
+    // being fetched, and ctx2 has not been changed
+    await userEvent.click(screen.getByText('Get ds2 without otherCount in deps'));
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenLastCalledWith('ds2', [0, 0]);
+    expect(screen.getByTestId('multiple-selectors-render-count').textContent).toBe('2');
+    fn.mockClear();
+
+    // Incrementing ctx1 again will not trigger a re-render, as ds1 has still not been fetched, only ds2
+    await userEvent.click(screen.getByText('Increment ctx1'));
+    expect(screen.getByTestId('multiple-selectors-render-count').textContent).toBe('2');
+
+    // If we increment otherCount now, it should not trigger a re-render, and getting ds2 again should return
+    // the same value as before (even though otherCount has changed). This happens because otherCount is not in the
+    // dependencies of the selector.
+    await userEvent.click(screen.getByText('Increment otherCount'));
+    await userEvent.click(screen.getByText('Get ds2 without otherCount in deps'));
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenLastCalledWith('ds2', [0, 0]);
+    fn.mockClear();
+
+    // But if we get ds2 with otherCount in the deps, the count should be correct
+    await userEvent.click(screen.getByText('Get ds2 with otherCount in deps'));
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenLastCalledWith('ds2', [0, 1]);
+    fn.mockClear();
+
+    // If we increment both now, it should trigger a re-render.
+    await userEvent.click(screen.getByText('Increment both'));
+    expect(screen.getByTestId('multiple-selectors-render-count').textContent).toBe('3');
+
+    // Incrementing both once more should not trigger a re-render, as nothing has been selected this time
+    await userEvent.click(screen.getByText('Increment both'));
+    expect(screen.getByTestId('multiple-selectors-render-count').textContent).toBe('3');
+
+    // Make sure we select from ctx2, but not the string
+    await userEvent.click(screen.getByText('Get ds2 + depState2'));
+    await userEvent.click(screen.getByText('Get ds2 with otherCount in deps'));
+    expect(screen.getByTestId('multiple-selectors-render-count').textContent).toBe('3');
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(fn).toHaveBeenNthCalledWith(1, 'ds2', 2);
+    expect(fn).toHaveBeenNthCalledWith(2, 'ds2', [2, 1]);
+    fn.mockClear();
+
+    // Setting a fixed string in ctx2 should not trigger a re-render. This string does not affect the selected state.
+    await userEvent.click(screen.getByText('Set fixed string in ctx2'));
+    expect(screen.getByTestId('multiple-selectors-render-count').textContent).toBe('3');
+    await userEvent.click(screen.getByText('Get ds2 with otherCount in deps'));
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenLastCalledWith('ds2', [2, 1]);
+    fn.mockClear();
   });
 });

--- a/src/hooks/delayedSelectors.test.tsx
+++ b/src/hooks/delayedSelectors.test.tsx
@@ -239,6 +239,16 @@ function TestMultiDelayedSelector({ onGetValue }: Props) {
       >
         Increment both
       </button>
+      <button
+        onClick={() => {
+          incrementCtx1();
+          incrementCtx2();
+          incrementCtx1();
+          incrementCtx2();
+        }}
+      >
+        Increment both twice
+      </button>
       <button onClick={() => (otherCount.current += 1)}>Increment otherCount</button>
       <button onClick={() => setString('new string')}>Set fixed string in ctx2</button>
 
@@ -383,7 +393,7 @@ describe('useDelayedSelector', () => {
     expect(screen.getByTestId('multiple-selectors-render-count').textContent).toBe('3');
 
     // Incrementing both once more should not trigger a re-render, as nothing has been selected this time
-    await userEvent.click(screen.getByText('Increment both'));
+    await userEvent.click(screen.getByText('Increment both twice'));
     expect(screen.getByTestId('multiple-selectors-render-count').textContent).toBe('3');
 
     // Make sure we select from ctx2, but not the string
@@ -391,8 +401,8 @@ describe('useDelayedSelector', () => {
     await userEvent.click(screen.getByText('Get ds2 with otherCount in deps'));
     expect(screen.getByTestId('multiple-selectors-render-count').textContent).toBe('3');
     expect(fn).toHaveBeenCalledTimes(2);
-    expect(fn).toHaveBeenNthCalledWith(1, 'ds2', 2);
-    expect(fn).toHaveBeenNthCalledWith(2, 'ds2', [2, 1]);
+    expect(fn).toHaveBeenNthCalledWith(1, 'ds2', 3);
+    expect(fn).toHaveBeenNthCalledWith(2, 'ds2', [3, 1]);
     fn.mockClear();
 
     // Setting a fixed string in ctx2 should not trigger a re-render. This string does not affect the selected state.
@@ -400,7 +410,17 @@ describe('useDelayedSelector', () => {
     expect(screen.getByTestId('multiple-selectors-render-count').textContent).toBe('3');
     await userEvent.click(screen.getByText('Get ds2 with otherCount in deps'));
     expect(fn).toHaveBeenCalledTimes(1);
-    expect(fn).toHaveBeenLastCalledWith('ds2', [2, 1]);
+    expect(fn).toHaveBeenLastCalledWith('ds2', [3, 1]);
     fn.mockClear();
+
+    // Getting from ctx1 to prepare for the next increment
+    await userEvent.click(screen.getByText('Get ds1 divided by 2'));
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenLastCalledWith('ds1', 'ctx1 = 3.5');
+    fn.mockClear();
+
+    // Incrementing both twice now should only trigger one re-render.
+    await userEvent.click(screen.getByText('Increment both twice'));
+    expect(screen.getByTestId('multiple-selectors-render-count').textContent).toBe('4');
   });
 });

--- a/src/hooks/delayedSelectors.ts
+++ b/src/hooks/delayedSelectors.ts
@@ -5,6 +5,7 @@ import type { StoreApi } from 'zustand';
 
 import { ContextNotProvided } from 'src/core/contexts/context';
 import { ShallowArrayMap } from 'src/core/structures/ShallowArrayMap';
+import { isDev } from 'src/utils/isDev';
 
 type Selector<T, U> = (state: T) => U;
 type SelectorMap<C extends DSConfig> = ShallowArrayMap<{
@@ -175,12 +176,16 @@ abstract class BaseDelayedSelector<C extends DSConfig> {
 
     const cacheKey = this.makeCacheKey(args);
     const prev = this.selectorsCalled?.get(cacheKey);
+    let returnPrev = false;
     if (prev) {
       // Performance-wise we could also just have called the selector here, it doesn't really matter. What is
       // important however, is that we let developers know as early as possible if they forgot to include a dependency
       // or otherwise used the hook incorrectly, so we'll make sure to return the value to them here even if it
       // could be stale (but only when improperly used).
-      return prev.value;
+      returnPrev = true;
+      if (!isDev()) {
+        return prev.value;
+      }
     }
 
     // We don't need to initialize the arraymap before checking for the previous value,
@@ -199,6 +204,19 @@ abstract class BaseDelayedSelector<C extends DSConfig> {
       const fullSelector: Selector<TypeFromConf<C>, unknown> = (state) => selector(...args)(state);
       const value = fullSelector(state);
       this.selectorsCalled.set(cacheKey, { fullSelector, value });
+
+      if (returnPrev && prev) {
+        if (!this.equalityFn(value, prev.value)) {
+          console.warn(
+            'Delayed selector: When selecting, the prev and next value are not equal. You probably forgot ' +
+              'to pass one or more dependencies. The prev value will be returned, even if the next ' +
+              'value is the latest state.',
+            { prev: prev.value, next: value },
+          );
+        }
+        return prev.value;
+      }
+
       return value;
     }
 
@@ -215,6 +233,19 @@ abstract class BaseDelayedSelector<C extends DSConfig> {
 
       const value = fullSelector(state);
       this.selectorsCalled.set(cacheKey, { fullSelector, value });
+
+      if (returnPrev && prev) {
+        if (!this.equalityFn(value, prev.value)) {
+          console.warn(
+            'Delayed selector: When selecting, the prev and next value are not equal. You probably forgot ' +
+              'to pass one or more dependencies. The prev value will be returned, even if the next ' +
+              'value is the latest state.',
+            { prev: prev.value, next: value },
+          );
+        }
+        return prev.value;
+      }
+
       return value;
     }
 

--- a/src/hooks/delayedSelectors.ts
+++ b/src/hooks/delayedSelectors.ts
@@ -28,7 +28,10 @@ type ModeFromConf<C extends DSConfig> = C extends DSConfig<any, infer M> ? M : n
  * will not be able to be used as a cache key.
  */
 export function useDelayedSelector<C extends DSConfig>(props: DSProps<C>): DSReturn<C> {
-  const state = useRef(new SingleDelayedSelectorController(props));
+  const state = useRef<SingleDelayedSelectorController<C>>();
+  if (!state.current) {
+    state.current = new SingleDelayedSelectorController(props);
+  }
 
   // Check if any deps have changed
   state.current.checkDeps(props);
@@ -37,7 +40,10 @@ export function useDelayedSelector<C extends DSConfig>(props: DSProps<C>): DSRet
 }
 
 export function useMultipleDelayedSelectors<P extends MultiDSProps>(...props: P): { [I in keyof P]: DSReturn<P[I]> } {
-  const state = useRef(new MultiDelayedSelectorController(props));
+  const state = useRef<MultiDelayedSelectorController<P>>();
+  if (!state.current) {
+    state.current = new MultiDelayedSelectorController(props);
+  }
 
   // Check if any deps have changed
   state.current.checkDeps(props);

--- a/src/hooks/useIsDev.test.ts
+++ b/src/hooks/useIsDev.test.ts
@@ -1,7 +1,7 @@
 import { jest } from '@jest/globals';
 
 import { orgs } from 'src/__mocks__/orgs';
-import { useIsDev } from 'src/hooks/useIsDev';
+import { isDev } from 'src/utils/isDev';
 
 const location = window.location;
 
@@ -17,38 +17,38 @@ describe('useIsDev', () => {
   it('should return true if hostname is local.altinn.cloud', () => {
     mockHostName('local.altinn.cloud');
     expect(window.location.hostname).toBe('local.altinn.cloud');
-    expect(useIsDev()).toBe(true);
+    expect(isDev()).toBe(true);
   });
 
   it('should return true if hostname is dev.altinn.studio', () => {
     mockHostName('dev.altinn.studio');
     expect(window.location.hostname).toBe('dev.altinn.studio');
-    expect(useIsDev()).toBe(true);
+    expect(isDev()).toBe(true);
   });
 
   it('should return true if hostname is altinn.studio', () => {
     mockHostName('altinn.studio');
     expect(window.location.hostname).toBe('altinn.studio');
-    expect(useIsDev()).toBe(true);
+    expect(isDev()).toBe(true);
   });
 
   it('should return true if hostname is studio.localhost', () => {
     mockHostName('studio.localhost');
     expect(window.location.hostname).toBe('studio.localhost');
-    expect(useIsDev()).toBe(true);
+    expect(isDev()).toBe(true);
   });
 
   it('should return false if hostname is altinn3local.no', () => {
     mockHostName('altinn3local.no');
     expect(window.location.hostname).toBe('altinn3local.no');
-    expect(useIsDev()).toBe(false);
+    expect(isDev()).toBe(false);
   });
 
   orgs.forEach((org) => {
     it(`should return true if hostname is ${org}.apps.tt02.altinn.no`, () => {
       mockHostName(`${org}.apps.tt02.altinn.no`);
       expect(window.location.hostname).toBe(`${org}.apps.tt02.altinn.no`);
-      expect(useIsDev()).toBe(true);
+      expect(isDev()).toBe(true);
     });
   });
 
@@ -56,7 +56,7 @@ describe('useIsDev', () => {
     it(`should return false if hostname is ${org}.apps.altinn.no`, () => {
       mockHostName(`${org}.apps.altinn.no`);
       expect(window.location.hostname).toBe(`${org}.apps.altinn.no`);
-      expect(useIsDev()).toBe(false);
+      expect(isDev()).toBe(false);
     });
   });
 });

--- a/src/layout/GenericComponent.tsx
+++ b/src/layout/GenericComponent.tsx
@@ -5,11 +5,11 @@ import classNames from 'classnames';
 
 import { NavigationResult, useFinishNodeNavigation } from 'src/features/form/layout/NavigateToNode';
 import { Lang } from 'src/features/language/Lang';
-import { useIsDev } from 'src/hooks/useIsDev';
 import { FormComponentContextProvider } from 'src/layout/FormComponentContext';
 import classes from 'src/layout/GenericComponent.module.css';
 import { SummaryComponent } from 'src/layout/Summary/SummaryComponent';
 import { gridBreakpoints, pageBreakStyles } from 'src/utils/formComponentUtils';
+import { isDev } from 'src/utils/isDev';
 import { ComponentErrorBoundary } from 'src/utils/layout/ComponentErrorBoundary';
 import { Hidden, NodesInternal, useNode } from 'src/utils/layout/NodesContext';
 import { useNodeItem } from 'src/utils/layout/useNodeItem';
@@ -257,8 +257,7 @@ const gridToClasses = (labelGrid: IGridStyling | undefined, classes: { [key: str
 
 const ErrorList = ({ node, errors }: { node: LayoutNode; errors: string[] }) => {
   const id = node.id;
-  const isDev = useIsDev();
-  if (!isDev) {
+  if (!isDev()) {
     return null;
   }
 

--- a/src/utils/isDev.test.ts
+++ b/src/utils/isDev.test.ts
@@ -9,7 +9,7 @@ function mockHostName(hostname: string) {
   jest.spyOn(window, 'location', 'get').mockReturnValue({ ...location, hostname });
 }
 
-describe('useIsDev', () => {
+describe('isDev', () => {
   beforeEach(() => {
     jest.spyOn(window, 'location', 'get').mockRestore();
   });

--- a/src/utils/isDev.ts
+++ b/src/utils/isDev.ts
@@ -1,12 +1,18 @@
 const devHostNames = [/^local\.altinn\.cloud$/, /^\S+\.apps\.tt02\.altinn\.no$/];
 const studioHostNames = [/^dev\.altinn\.studio$/, /^altinn\.studio$/, /^studio\.localhost$/];
 
+let isDevCache: boolean | null = null;
+
 /**
  * Indicates whether the application is running in a development environment.
  * This can be either through LocalTest, altinn studio preview or TT02.
  */
 export function isDev(): boolean {
-  return isLocalOrStaging() || isStudioPreview();
+  if (isDevCache !== null) {
+    return isDevCache;
+  }
+  isDevCache = isLocalOrStaging() || isStudioPreview();
+  return isDevCache;
 }
 
 /**

--- a/src/utils/isDev.ts
+++ b/src/utils/isDev.ts
@@ -5,22 +5,20 @@ const studioHostNames = [/^dev\.altinn\.studio$/, /^altinn\.studio$/, /^studio\.
  * Indicates whether the application is running in a development environment.
  * This can be either through LocalTest, altinn studio preview or TT02.
  */
-export function useIsDev(): boolean {
-  const isLocalOrStaging = useIsLocalOrStaging();
-  const isStudioPreview = useIsStudioPreview();
-  return isLocalOrStaging || isStudioPreview;
+export function isDev(): boolean {
+  return isLocalOrStaging() || isStudioPreview();
 }
 
 /**
  * Indicates whether the application is running through LocalTest or in TT02 (staging).
  */
-export function useIsLocalOrStaging(): boolean {
+export function isLocalOrStaging(): boolean {
   return devHostNames.some((host) => host.test(window.location.hostname));
 }
 
 /**
  * Indicates whether the application is running in Altinn Studio Preview.
  */
-export function useIsStudioPreview(): boolean {
+export function isStudioPreview(): boolean {
   return studioHostNames.some((host) => host.test(window.location.hostname));
 }

--- a/src/utils/isDev.ts
+++ b/src/utils/isDev.ts
@@ -8,7 +8,7 @@ let isDevCache: boolean | null = null;
  * This can be either through LocalTest, altinn studio preview or TT02.
  */
 export function isDev(): boolean {
-  if (isDevCache !== null) {
+  if (isDevCache !== null && !window.inUnitTest) {
     return isDevCache;
   }
   isDevCache = isLocalOrStaging() || isStudioPreview();

--- a/src/utils/layout/generator/validation/GenerationValidationContext.tsx
+++ b/src/utils/layout/generator/validation/GenerationValidationContext.tsx
@@ -12,7 +12,7 @@ import {
   EMPTY_SCHEMA_NAME,
   LAYOUT_SCHEMA_NAME,
 } from 'src/features/devtools/utils/layoutSchemaValidation';
-import { useIsDev } from 'src/hooks/useIsDev';
+import { isDev } from 'src/utils/isDev';
 import { NodesInternal } from 'src/utils/layout/NodesContext';
 
 interface Context {
@@ -69,10 +69,9 @@ function FetchLayoutSchema({
 
 function useIsLayoutValidationEnabled() {
   const hasBeenEnabledBefore = useRef(false);
-  const isDev = useIsDev();
   const panelOpen = useDevToolsStore((s) => s.isOpen);
   const hasErrors = NodesInternal.useHasErrors();
-  const enabled = isDev || hasErrors || panelOpen || hasBeenEnabledBefore.current;
+  const enabled = isDev() || hasErrors || panelOpen || hasBeenEnabledBefore.current;
   hasBeenEnabledBefore.current = enabled;
 
   if (window.forceNodePropertiesValidation === 'on') {

--- a/test/e2e/integration/frontend-test/all-process-steps.ts
+++ b/test/e2e/integration/frontend-test/all-process-steps.ts
@@ -408,6 +408,7 @@ const knownDataModels: { [key: string]: unknown } = {
     },
     ShiftingOptions: null,
     FilteredOptions: null,
+    LinkedHidden: null,
   },
   'nested-group': {
     skjemanummer: 1603,

--- a/test/e2e/integration/frontend-test/dynamics.ts
+++ b/test/e2e/integration/frontend-test/dynamics.ts
@@ -171,4 +171,33 @@ describe('Dynamics', () => {
     cy.get(appFrontend.changeOfName.reference).should('be.visible');
     cy.get(appFrontend.changeOfName.reference2).should('be.visible');
   });
+
+  it('Deeply linked hidden with component lookups', () => {
+    cy.gotoHiddenPage('linked-hidden');
+
+    function fillOut(componentId: string, correctValue = 'Ja', incorrectValue = 'Nei') {
+      if (incorrectValue) {
+        cy.get('[data-componentid="TrapAlert"]').should('not.exist');
+        cy.get('[data-componentid="NoShowAlert"]').should('not.exist');
+        cy.get(`[data-componentid="${componentId}"]`).findByRole('radio', { name: incorrectValue }).click();
+        componentId === 'LinkedHidden6' && cy.get('[data-componentid="TrapAlert"]').should('be.visible');
+        cy.get('[data-componentid="NoShowAlert"]').should('be.visible');
+      }
+      cy.get(`[data-componentid="${componentId}"]`).findByRole('radio', { name: correctValue }).click();
+      cy.get('[data-componentid="NoShowAlert"]').should('not.exist');
+      cy.get('[data-componentid="TrapAlert"]').should('not.exist');
+    }
+
+    fillOut('LinkedHidden1');
+    fillOut('LinkedHidden2');
+    fillOut('LinkedHidden3');
+    fillOut('LinkedHidden4');
+    fillOut('LinkedHidden5');
+    fillOut('LinkedHidden6', 'Nei', 'Ja');
+    fillOut('LinkedHidden7', 'Neida, jeg gikk ikke på den, jeg lover', '');
+    fillOut('LinkedHidden8', 'Ja!');
+    fillOut('LinkedHidden9', 'Jeg lover', 'Nei, nå er jeg sur');
+
+    cy.get('[data-componentid="TheTextField"]').find('input').type('Jeg bestod testen, hurra!');
+  });
 });


### PR DESCRIPTION
## Description

Multiple apps had problems with `["component", ...]` expressions after the performance-related fixed in the release on the 27th of november. This problem was caused by the new multiple-delayed-selectors functionality, specifically the code that tried to reduce the amount of re-renders triggered when state changes. Unit-testing uncovers that React _marks the component for re-rendering_, so we don't have to worry about multiple re-renders being triggered after all. Removing that code fixes the problem.

Also:
- Adding a unit-test to test simple functionality for multiple delayed selectors
- Adding a cypress test more closely resembling the actual use-case that triggered this problem. 10 components are chained visible via `["component", ...]` expressions, and without this fix the third one failed to show up (now all of them do).
- Changing useIsDev() from a hook-like signature to just a plain function (with a cache when not unit-testing it). This way I could call it from inside the delayed selectors.
- Developer exprience: Logging to the console when a delayed selector is called multiple times, but returns a different result. This is usually what happens if you forget to pass your dependencies to the deps-array (second argument).

## Related Issue(s)

- https://altinn.slack.com/archives/C02EJ9HKQA3/p1733256844754139

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
