### PR TITLE
Minor test formatting fixes

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -27,9 +27,8 @@ describe('App', () => {
   });
 
   test('should render unknown error when hasApplicationMetadataError', async () => {
-    (fetchApplicationMetadata as jest.Mock<typeof fetchApplicationMetadata>).mockImplementation(() =>
-      Promise.reject(new Error('500 Server Error')),
-    );
+    jest.mocked(fetchApplicationMetadata).mockImplementation(() => Promise.reject(new Error('500 Server Error')));
+
     await renderWithInstanceAndLayout({
       renderer: () => <App />,
     });

--- a/src/components/organisms/AltinnAppHeader.test.tsx
+++ b/src/components/organisms/AltinnAppHeader.test.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 
-import { expect } from '@jest/globals';
+import { expect, jest } from '@jest/globals';
 import { act, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
-import type { jest } from '@jest/globals';
 
 import { getIncomingApplicationMetadataMock } from 'src/__mocks__/getApplicationMetadataMock';
 import { getLogoMock } from 'src/__mocks__/getLogoMock';
@@ -38,9 +37,7 @@ describe('organisms/AltinnAppHeader', () => {
     logo?: ApplicationMetadata['logoOptions'];
   }
   const render = async ({ party, user = partyPerson, logo }: IRenderComponentProps) => {
-    (fetchApplicationMetadata as jest.Mock<typeof fetchApplicationMetadata>).mockImplementation(() =>
-      Promise.resolve(getIncomingApplicationMetadataMock({ logo })),
-    );
+    jest.mocked(fetchApplicationMetadata).mockImplementation(async () => getIncomingApplicationMetadataMock({ logo }));
 
     return await renderWithInstanceAndLayout({
       renderer: () => (

--- a/src/components/presentation/OrganisationLogo/OrganisationLogo.test.tsx
+++ b/src/components/presentation/OrganisationLogo/OrganisationLogo.test.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 
-import { expect } from '@jest/globals';
+import { expect, jest } from '@jest/globals';
 import { screen } from '@testing-library/react';
-import type { jest } from '@jest/globals';
 
 import { getIncomingApplicationMetadataMock } from 'src/__mocks__/getApplicationMetadataMock';
 import { OrganisationLogo } from 'src/components/presentation/OrganisationLogo/OrganisationLogo';
@@ -11,9 +10,7 @@ import { renderWithInstanceAndLayout } from 'src/test/renderWithProviders';
 import type { IncomingApplicationMetadata } from 'src/features/applicationMetadata/types';
 
 const render = async (logo: IncomingApplicationMetadata['logo']) => {
-  (fetchApplicationMetadata as jest.Mock<typeof fetchApplicationMetadata>).mockImplementation(() =>
-    Promise.resolve(getIncomingApplicationMetadataMock({ logo })),
-  );
+  jest.mocked(fetchApplicationMetadata).mockImplementation(async () => getIncomingApplicationMetadataMock({ logo }));
 
   return await renderWithInstanceAndLayout({
     renderer: () => <OrganisationLogo />,

--- a/src/components/presentation/Presentation.test.tsx
+++ b/src/components/presentation/Presentation.test.tsx
@@ -14,15 +14,15 @@ import { HttpStatusCodes } from 'src/utils/network/networking';
 import { returnUrlToMessagebox } from 'src/utils/urls/urlHelper';
 import type { IPresentationProvidedProps } from 'src/components/presentation/Presentation';
 
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+const assignMock = jest.fn();
+
 describe('Presentation', () => {
   const user = userEvent.setup();
-  jest.mock('axios');
-  const mockedAxios = axios as jest.Mocked<typeof axios>;
-  let assignMock = jest.fn();
   let realLocation: Location = window.location;
 
   beforeEach(() => {
-    assignMock = jest.fn();
     realLocation = window.location;
   });
 

--- a/src/core/texts/appTexts.test.tsx
+++ b/src/core/texts/appTexts.test.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 
-import { expect } from '@jest/globals';
+import { expect, jest } from '@jest/globals';
 import { screen } from '@testing-library/react';
-import type { jest } from '@jest/globals';
 
 import { getIncomingApplicationMetadataMock } from 'src/__mocks__/getApplicationMetadataMock';
 import { useAppName, useAppOwner } from 'src/core/texts/appTexts';
@@ -32,9 +31,8 @@ interface RenderProps {
 
 async function render({ nbTitle, textResources = [], orgs = {} }: RenderProps) {
   const overrides = nbTitle ? { title: { nb: nbTitle } } : {};
-  (fetchApplicationMetadata as jest.Mock<typeof fetchApplicationMetadata>).mockImplementation(() =>
-    Promise.resolve(getIncomingApplicationMetadataMock(overrides)),
-  );
+  jest.mocked(fetchApplicationMetadata).mockImplementation(async () => getIncomingApplicationMetadataMock(overrides));
+
   return await renderWithoutInstanceAndLayout({
     renderer: () => <AppTextsRenderer />,
     queries: {

--- a/src/features/expressions/shared-context.test.tsx
+++ b/src/features/expressions/shared-context.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
+import { jest } from '@jest/globals';
 import { screen } from '@testing-library/react';
-import type { jest } from '@jest/globals';
 
 import { getApplicationMetadataMock } from 'src/__mocks__/getApplicationMetadataMock';
 import { getInstanceDataMock } from 'src/__mocks__/getInstanceDataMock';
@@ -97,6 +97,8 @@ describe('Expressions shared context tests', () => {
                 : undefined;
 
         const applicationMetadata = getApplicationMetadataMock(instance ? {} : { onEntry: { show: 'stateless' } });
+        jest.mocked(fetchApplicationMetadata).mockImplementation(async () => applicationMetadata);
+
         if (instanceDataElements) {
           for (const element of instanceDataElements) {
             if (!applicationMetadata.dataTypes!.find((dt) => dt.id === element.dataType)) {
@@ -109,10 +111,6 @@ describe('Expressions shared context tests', () => {
             }
           }
         }
-
-        (fetchApplicationMetadata as jest.Mock<typeof fetchApplicationMetadata>).mockImplementation(() =>
-          Promise.resolve(applicationMetadata),
-        );
 
         await renderWithInstanceAndLayout({
           renderer: () => <TestContexts />,

--- a/src/features/expressions/shared-functions.test.tsx
+++ b/src/features/expressions/shared-functions.test.tsx
@@ -225,16 +225,10 @@ describe('Expressions shared function tests', () => {
       // Clear localstorage, because LanguageProvider uses it to cache selected languages
       localStorage.clear();
 
-      (fetchApplicationMetadata as jest.Mock<typeof fetchApplicationMetadata>).mockResolvedValue(applicationMetadata);
+      jest.mocked(fetchApplicationMetadata).mockResolvedValue(applicationMetadata);
       jest.mocked(useExternalApis).mockReturnValue(externalApis as ExternalApisResult);
-
-      if (roles) {
-        jest.mocked(useCurrentPartyRoles).mockReturnValue(roles as RoleResult);
-      }
-
-      (fetchProcessState as jest.Mock<typeof fetchProcessState>).mockImplementation(() =>
-        Promise.resolve(process ?? getProcessDataMock()),
-      );
+      jest.mocked(fetchProcessState).mockImplementation(async () => process ?? getProcessDataMock());
+      jest.mocked(useCurrentPartyRoles).mockReturnValue(roles as RoleResult);
 
       const nodeId = nodeIdFromContext(context);
       await renderWithNode({

--- a/src/features/formData/FormData.test.tsx
+++ b/src/features/formData/FormData.test.tsx
@@ -93,14 +93,12 @@ const mockSchema: JSONSchema7 = {
 type MinimalRenderProps = Partial<Omit<Parameters<typeof renderWithInstanceAndLayout>[0], 'renderer'>>;
 type RenderProps = MinimalRenderProps & { renderer: React.ReactElement };
 async function statelessRender(props: RenderProps) {
-  (fetchApplicationMetadata as jest.Mock<typeof fetchApplicationMetadata>).mockImplementationOnce(() =>
-    Promise.resolve(
-      getIncomingApplicationMetadataMock({
-        onEntry: {
-          show: 'stateless',
-        },
-      }),
-    ),
+  jest.mocked(fetchApplicationMetadata).mockImplementationOnce(async () =>
+    getIncomingApplicationMetadataMock({
+      onEntry: {
+        show: 'stateless',
+      },
+    }),
   );
   const initialRenderRef = { current: true };
   const { mocks: formDataMethods, proxies: formDataProxies } = makeFormDataMethodProxies(initialRenderRef);
@@ -160,9 +158,9 @@ async function statelessRender(props: RenderProps) {
 }
 
 async function statefulRender(props: RenderProps) {
-  (fetchApplicationMetadata as jest.Mock<typeof fetchApplicationMetadata>).mockImplementationOnce(() =>
-    Promise.resolve(getIncomingApplicationMetadataMock()),
-  );
+  jest
+    .mocked(fetchApplicationMetadata)
+    .mockImplementationOnce(() => Promise.resolve(getIncomingApplicationMetadataMock()));
   return await renderWithInstanceAndLayout({
     ...props,
     alwaysRouteToChildren: true,

--- a/src/features/formData/FormDataReaders.test.tsx
+++ b/src/features/formData/FormDataReaders.test.tsx
@@ -42,13 +42,11 @@ function TestComponent({ ids }: TestProps) {
 }
 
 async function render(props: TestProps) {
-  (fetchApplicationMetadata as jest.Mock<typeof fetchApplicationMetadata>).mockImplementationOnce(() =>
-    Promise.resolve(
-      getIncomingApplicationMetadataMock((a) => {
-        a.dataTypes = a.dataTypes.filter((dt) => !dt.appLogic?.classRef);
-        a.dataTypes.push(...generateDataTypes());
-      }),
-    ),
+  jest.mocked(fetchApplicationMetadata).mockImplementationOnce(async () =>
+    getIncomingApplicationMetadataMock((a) => {
+      a.dataTypes = a.dataTypes.filter((dt) => !dt.appLogic?.classRef);
+      a.dataTypes.push(...generateDataTypes());
+    }),
   );
   const dataModelNames = Object.keys(props.dataModels);
   const idToNameMap: { [id: string]: string } = {};

--- a/src/features/processEnd/confirm/containers/ConfirmPage.test.tsx
+++ b/src/features/processEnd/confirm/containers/ConfirmPage.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
+import { jest } from '@jest/globals';
 import { screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
-import type { jest } from '@jest/globals';
 
 import { getApplicationMetadataMock } from 'src/__mocks__/getApplicationMetadataMock';
 import { getInstanceDataMock } from 'src/__mocks__/getInstanceDataMock';
@@ -69,14 +69,12 @@ describe('ConfirmPage', () => {
   });
 
   it('should show loading when clicking submit', async () => {
-    (fetchProcessState as jest.Mock<typeof fetchProcessState>).mockImplementation(() =>
-      Promise.resolve(
-        getProcessDataMock((p) => {
-          p.currentTask!.actions = {
-            confirm: true,
-          };
-        }),
-      ),
+    jest.mocked(fetchProcessState).mockImplementation(async () =>
+      getProcessDataMock((p) => {
+        p.currentTask!.actions = {
+          confirm: true,
+        };
+      }),
     );
 
     const { mutations } = await renderWithInstanceAndLayout({

--- a/src/features/receipt/ReceiptContainer.test.tsx
+++ b/src/features/receipt/ReceiptContainer.test.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 
-import { expect } from '@jest/globals';
+import { expect, jest } from '@jest/globals';
 import { screen } from '@testing-library/react';
-import type { jest } from '@jest/globals';
 
 import { getIncomingApplicationMetadataMock } from 'src/__mocks__/getApplicationMetadataMock';
 import { getInstanceDataMock } from 'src/__mocks__/getInstanceDataMock';
@@ -78,20 +77,16 @@ const buildInstance = (hasPdf = true) =>
   });
 
 const render = async ({ autoDeleteOnProcessEnd = false, hasPdf = true }: IRender = {}) => {
-  (fetchApplicationMetadata as jest.Mock<typeof fetchApplicationMetadata>).mockImplementationOnce(() =>
-    Promise.resolve(
-      getIncomingApplicationMetadataMock((a) => {
-        a.autoDeleteOnProcessEnd = autoDeleteOnProcessEnd;
-      }),
-    ),
+  jest.mocked(fetchApplicationMetadata).mockImplementationOnce(async () =>
+    getIncomingApplicationMetadataMock((a) => {
+      a.autoDeleteOnProcessEnd = autoDeleteOnProcessEnd;
+    }),
   );
-  (fetchProcessState as jest.Mock<typeof fetchProcessState>).mockImplementation(() =>
-    Promise.resolve(
-      getProcessDataMock((p) => {
-        p.currentTask = undefined;
-        p.ended = '2022-02-05T09:19:32.8858042Z';
-      }),
-    ),
+  jest.mocked(fetchProcessState).mockImplementation(async () =>
+    getProcessDataMock((p) => {
+      p.currentTask = undefined;
+      p.ended = '2022-02-05T09:19:32.8858042Z';
+    }),
   );
 
   return await renderWithoutInstanceAndLayout({

--- a/src/features/stateless/getAllowAnonymous.test.tsx
+++ b/src/features/stateless/getAllowAnonymous.test.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 
-import { expect } from '@jest/globals';
+import { expect, jest } from '@jest/globals';
 import { screen } from '@testing-library/react';
-import type { jest } from '@jest/globals';
 
 import { getIncomingApplicationMetadataMock } from 'src/__mocks__/getApplicationMetadataMock';
 import { getLayoutSetsMock } from 'src/__mocks__/getLayoutSetsMock';
@@ -16,18 +15,16 @@ const TestComponent = () => {
 };
 
 const render = async (stateless: boolean, allowAnonymous: boolean) => {
-  (fetchApplicationMetadata as jest.Mock<typeof fetchApplicationMetadata>).mockImplementationOnce(() =>
-    Promise.resolve({
-      ...getIncomingApplicationMetadataMock(),
-      ...(stateless
-        ? {
-            onEntry: {
-              show: allowAnonymous ? 'stateless-anon' : 'stateless',
-            },
-          }
-        : {}),
-    }),
-  );
+  jest.mocked(fetchApplicationMetadata).mockImplementationOnce(async () => ({
+    ...getIncomingApplicationMetadataMock(),
+    ...(stateless
+      ? {
+          onEntry: {
+            show: allowAnonymous ? 'stateless-anon' : 'stateless',
+          },
+        }
+      : {}),
+  }));
 
   return await renderWithoutInstanceAndLayout({
     renderer: () => <TestComponent />,

--- a/src/layout/AttachmentList/AttachmentListComponent.test.tsx
+++ b/src/layout/AttachmentList/AttachmentListComponent.test.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 
-import { expect } from '@jest/globals';
+import { expect, jest } from '@jest/globals';
 import { screen } from '@testing-library/react';
-import type { jest } from '@jest/globals';
 
 import { getIncomingApplicationMetadataMock } from 'src/__mocks__/getApplicationMetadataMock';
 import { getInstanceDataMock } from 'src/__mocks__/getInstanceDataMock';
@@ -45,20 +44,19 @@ describe('AttachmentListComponent', () => {
 });
 
 const render = async (ids?: string[]) => {
-  (fetchApplicationMetadata as jest.Mock<typeof fetchApplicationMetadata>).mockImplementationOnce(() =>
-    Promise.resolve(
-      getIncomingApplicationMetadataMock((a) => {
-        a.dataTypes.push(
-          generateDataType({ id: 'not-ref-data-as-pdf', dataType: 'text/plain', taskId: 'Task_1' }),
-          generateDataType({
-            id: 'different-process-task',
-            dataType: 'text/plain',
-            taskId: 'Task_2',
-          }),
-        );
-      }),
-    ),
+  jest.mocked(fetchApplicationMetadata).mockImplementationOnce(async () =>
+    getIncomingApplicationMetadataMock((a) => {
+      a.dataTypes.push(
+        generateDataType({ id: 'not-ref-data-as-pdf', dataType: 'text/plain', taskId: 'Task_1' }),
+        generateDataType({
+          id: 'different-process-task',
+          dataType: 'text/plain',
+          taskId: 'Task_2',
+        }),
+      );
+    }),
   );
+
   return await renderGenericComponentTest({
     type: 'AttachmentList',
     renderer: (props) => <AttachmentListComponent {...props} />,

--- a/src/layout/CustomButton/CustomButtonComponent.test.tsx
+++ b/src/layout/CustomButton/CustomButtonComponent.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
+import { jest } from '@jest/globals';
 import { screen } from '@testing-library/react';
-import type { jest } from '@jest/globals';
 
 import { CustomButtonComponent } from 'src/layout/CustomButton/CustomButtonComponent';
 import { fetchProcessState } from 'src/queries/queries';
@@ -125,44 +125,42 @@ type RenderProps = {
 };
 
 async function render({ actions, actionAuthorization }: RenderProps = { actionAuthorization: [] }) {
-  (fetchProcessState as jest.Mock<typeof fetchProcessState>).mockImplementation(() =>
-    Promise.resolve({
-      started: '2024-01-03T06:52:49.716640678Z',
+  jest.mocked(fetchProcessState).mockImplementation(async () => ({
+    started: '2024-01-03T06:52:49.716640678Z',
+    ended: null,
+    endEvent: null,
+    startEvent: '2024-01-03T06:52:49.716640678Z',
+    currentTask: {
+      userActions: [
+        {
+          id: 'read',
+          authorized: true,
+          type: 'ProcessAction',
+        },
+        {
+          id: 'write',
+          authorized: true,
+          type: 'ProcessAction',
+        },
+        {
+          id: 'complete',
+          authorized: false,
+          type: 'ProcessAction',
+        },
+        ...(actionAuthorization ?? []),
+      ],
+      read: true,
+      write: true,
+      flow: 2,
+      started: '2024-01-03T06:37:22.7573522Z',
+      elementId: 'Task_1',
+      name: 'Utfylling',
+      altinnTaskType: 'data',
       ended: null,
-      endEvent: null,
-      startEvent: '2024-01-03T06:52:49.716640678Z',
-      currentTask: {
-        userActions: [
-          {
-            id: 'read',
-            authorized: true,
-            type: 'ProcessAction',
-          },
-          {
-            id: 'write',
-            authorized: true,
-            type: 'ProcessAction',
-          },
-          {
-            id: 'complete',
-            authorized: false,
-            type: 'ProcessAction',
-          },
-          ...(actionAuthorization ?? []),
-        ],
-        read: true,
-        write: true,
-        flow: 2,
-        started: '2024-01-03T06:37:22.7573522Z',
-        elementId: 'Task_1',
-        name: 'Utfylling',
-        altinnTaskType: 'data',
-        ended: null,
-        validated: null,
-        flowType: 'CompleteCurrentMoveToNext',
-      },
-    }),
-  );
+      validated: null,
+      flowType: 'CompleteCurrentMoveToNext',
+    },
+  }));
 
   await renderGenericComponentTest({
     type: 'CustomButton',

--- a/src/layout/FileUpload/FileUploadComponent.test.tsx
+++ b/src/layout/FileUpload/FileUploadComponent.test.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
 
-import { expect } from '@jest/globals';
+import { expect, jest } from '@jest/globals';
 import { screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { v4 as uuidv4 } from 'uuid';
-import type { jest } from '@jest/globals';
 import type { AxiosResponse } from 'axios';
 
 import { getIncomingApplicationMetadataMock } from 'src/__mocks__/getApplicationMetadataMock';
@@ -342,17 +341,15 @@ async function renderAbstract<T extends Types>({
   component,
   attachments: attachmentsGenerator = (dataType) => getDataElements({ dataType }),
 }: Props<T>) {
-  (fetchApplicationMetadata as jest.Mock<typeof fetchApplicationMetadata>).mockImplementationOnce(() =>
-    Promise.resolve(
-      getIncomingApplicationMetadataMock((a) => {
-        a.dataTypes.push({
-          id,
-          allowedContentTypes: ['image/png'],
-          maxCount: 4,
-          minCount: 1,
-        });
-      }),
-    ),
+  jest.mocked(fetchApplicationMetadata).mockImplementationOnce(async () =>
+    getIncomingApplicationMetadataMock((a) => {
+      a.dataTypes.push({
+        id,
+        allowedContentTypes: ['image/png'],
+        maxCount: 4,
+        minCount: 1,
+      });
+    }),
   );
   const id = uuidv4();
   const attachments = attachmentsGenerator(id);

--- a/src/layout/FileUpload/Summary/AttachmentWithTagSummaryComponent.test.tsx
+++ b/src/layout/FileUpload/Summary/AttachmentWithTagSummaryComponent.test.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 
-import { expect } from '@jest/globals';
+import { expect, jest } from '@jest/globals';
 import { screen } from '@testing-library/react';
-import type { jest } from '@jest/globals';
 
 import { getIncomingApplicationMetadataMock } from 'src/__mocks__/getApplicationMetadataMock';
 import { getInstanceDataMock } from 'src/__mocks__/getInstanceDataMock';
@@ -105,17 +104,15 @@ const render = async ({ component, addAttachment = true }: RenderProps) => {
     created: '2021-09-08T12:00:00',
   };
 
-  (fetchApplicationMetadata as jest.Mock<typeof fetchApplicationMetadata>).mockImplementationOnce(() =>
-    Promise.resolve(
-      getIncomingApplicationMetadataMock((appMetadata) => {
-        appMetadata.dataTypes.push({
-          id: 'myComponent',
-          allowedContentTypes: ['application/pdf'],
-          maxCount: 4,
-          minCount: 1,
-        });
-      }),
-    ),
+  jest.mocked(fetchApplicationMetadata).mockImplementationOnce(async () =>
+    getIncomingApplicationMetadataMock((appMetadata) => {
+      appMetadata.dataTypes.push({
+        id: 'myComponent',
+        allowedContentTypes: ['application/pdf'],
+        maxCount: 4,
+        minCount: 1,
+      });
+    }),
   );
 
   return await renderWithNode<true, LayoutNode<'FileUploadWithTag'>>({

--- a/src/layout/InstantiationButton/InstantiationButton.test.tsx
+++ b/src/layout/InstantiationButton/InstantiationButton.test.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
-import { expect } from '@jest/globals';
+import { expect, jest } from '@jest/globals';
 import { screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
-import type { jest } from '@jest/globals';
 
 import { getIncomingApplicationMetadataMock } from 'src/__mocks__/getApplicationMetadataMock';
 import { getInstanceDataMock } from 'src/__mocks__/getInstanceDataMock';
@@ -13,14 +12,12 @@ import { fetchApplicationMetadata } from 'src/queries/queries';
 import { renderGenericComponentTest } from 'src/test/renderWithProviders';
 
 const render = async () => {
-  (fetchApplicationMetadata as jest.Mock<typeof fetchApplicationMetadata>).mockImplementationOnce(() =>
-    Promise.resolve(
-      getIncomingApplicationMetadataMock({
-        onEntry: {
-          show: 'stateless',
-        },
-      }),
-    ),
+  jest.mocked(fetchApplicationMetadata).mockImplementationOnce(async () =>
+    getIncomingApplicationMetadataMock({
+      onEntry: {
+        show: 'stateless',
+      },
+    }),
   );
   return await renderGenericComponentTest({
     type: 'InstantiationButton',

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -95,8 +95,8 @@ jest.mock('src/queries/queries', () => ({
   ...jest.requireActual<AppQueries>('src/queries/queries'),
   fetchApplicationMetadata: jest
     .fn<typeof fetchApplicationMetadata>()
-    .mockImplementation(() => Promise.resolve(getIncomingApplicationMetadataMock())),
-  fetchProcessState: jest.fn<typeof fetchProcessState>(() => Promise.resolve(getProcessDataMock())),
+    .mockImplementation(async () => getIncomingApplicationMetadataMock()),
+  fetchProcessState: jest.fn<typeof fetchProcessState>(async () => getProcessDataMock()),
 }));
 
 jest.mock('react-helmet-async', () => ({

--- a/src/utils/layout/all.test.tsx
+++ b/src/utils/layout/all.test.tsx
@@ -129,9 +129,7 @@ describe('All known layout sets should evaluate as a hierarchy', () => {
     window.org = org;
     window.app = app;
 
-    (fetchApplicationMetadata as jest.Mock<typeof fetchApplicationMetadata>).mockImplementation(() =>
-      Promise.resolve(set.app.getAppMetadata()),
-    );
+    jest.mocked(fetchApplicationMetadata).mockImplementation(async () => set.app.getAppMetadata());
 
     await renderWithInstanceAndLayout({
       renderer: () =>


### PR DESCRIPTION
## Description
Bare litt forbedret formatering for enklere lesing 💁‍♀️ 

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [x] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
