### PR TITLE
Fixing the flaky percy snapshots (disabled nav-buttons)

### DIFF
--- a/test/e2e/integration/frontend-test/group.ts
+++ b/test/e2e/integration/frontend-test/group.ts
@@ -230,7 +230,6 @@ describe('Group', () => {
   });
 
   it('Prefilling repeating group using calculation from server', () => {
-    cy.intercept('PATCH', '**/data/**').as('saveFormData');
     init();
     const expectRows = (...rows) => {
       if (!rows.length) {
@@ -274,9 +273,6 @@ describe('Group', () => {
 
     checkPrefills({ middels: true, svaer: true });
     expectRows(['NOK 1', 'NOK 5'], ['NOK 120', 'NOK 350'], ['NOK 80 323', 'NOK 123 455']);
-
-    cy.wait('@saveFormData');
-    cy.get(appFrontend.navButtons).contains('button', 'Neste').should('not.be.disabled');
     cy.snapshot('group:prefill');
 
     checkPrefills({ middels: false, svaer: false });
@@ -465,8 +461,6 @@ describe('Group', () => {
   });
 
   it('should be able to edit components directly in the table', () => {
-    cy.intercept('PATCH', '**/data/**').as('saveFormData');
-
     cy.goto('group');
     cy.navPage('prefill').should('be.visible');
     cy.changeLayout((c) => {
@@ -485,9 +479,6 @@ describe('Group', () => {
     cy.get(appFrontend.group.showGroupToContinue).findByRole('checkbox', { name: 'Ja' }).check();
     cy.get(appFrontend.group.showGroupToContinue).findByRole('checkbox', { name: 'Ja' }).blur();
     cy.get(appFrontend.group.mainGroupTableBody).find('tr').should('have.length', 3);
-
-    cy.wait('@saveFormData');
-    cy.get(appFrontend.navButtons).contains('button', 'Neste').should('not.be.disabled');
     cy.snapshot('group:edit-in-table');
 
     for (const row of [0, 1, 2]) {

--- a/test/e2e/integration/frontend-test/group.ts
+++ b/test/e2e/integration/frontend-test/group.ts
@@ -276,7 +276,7 @@ describe('Group', () => {
     expectRows(['NOK 1', 'NOK 5'], ['NOK 120', 'NOK 350'], ['NOK 80 323', 'NOK 123 455']);
 
     cy.wait('@saveFormData');
-    cy.get(appFrontend.navButtons).contains('button', 'next').should('not.be.disabled');
+    cy.get(appFrontend.navButtons).contains('button', 'Neste').should('not.be.disabled');
     cy.snapshot('group:prefill');
 
     checkPrefills({ middels: false, svaer: false });
@@ -487,7 +487,7 @@ describe('Group', () => {
     cy.get(appFrontend.group.mainGroupTableBody).find('tr').should('have.length', 3);
 
     cy.wait('@saveFormData');
-    cy.get(appFrontend.navButtons).contains('button', 'next').should('not.be.disabled');
+    cy.get(appFrontend.navButtons).contains('button', 'Neste').should('not.be.disabled');
     cy.snapshot('group:edit-in-table');
 
     for (const row of [0, 1, 2]) {

--- a/test/e2e/integration/frontend-test/group.ts
+++ b/test/e2e/integration/frontend-test/group.ts
@@ -230,6 +230,7 @@ describe('Group', () => {
   });
 
   it('Prefilling repeating group using calculation from server', () => {
+    cy.intercept('PATCH', '**/data/**').as('saveFormData');
     init();
     const expectRows = (...rows) => {
       if (!rows.length) {
@@ -273,6 +274,9 @@ describe('Group', () => {
 
     checkPrefills({ middels: true, svaer: true });
     expectRows(['NOK 1', 'NOK 5'], ['NOK 120', 'NOK 350'], ['NOK 80 323', 'NOK 123 455']);
+
+    cy.wait('@saveFormData');
+    cy.get(appFrontend.navButtons).contains('button', 'next').should('not.be.disabled');
     cy.snapshot('group:prefill');
 
     checkPrefills({ middels: false, svaer: false });
@@ -461,6 +465,8 @@ describe('Group', () => {
   });
 
   it('should be able to edit components directly in the table', () => {
+    cy.intercept('PATCH', '**/data/**').as('saveFormData');
+
     cy.goto('group');
     cy.navPage('prefill').should('be.visible');
     cy.changeLayout((c) => {
@@ -477,7 +483,11 @@ describe('Group', () => {
     cy.get(appFrontend.group.prefill.enorm).check();
     cy.gotoNavPage('repeating');
     cy.get(appFrontend.group.showGroupToContinue).findByRole('checkbox', { name: 'Ja' }).check();
+    cy.get(appFrontend.group.showGroupToContinue).findByRole('checkbox', { name: 'Ja' }).blur();
     cy.get(appFrontend.group.mainGroupTableBody).find('tr').should('have.length', 3);
+
+    cy.wait('@saveFormData');
+    cy.get(appFrontend.navButtons).contains('button', 'next').should('not.be.disabled');
     cy.snapshot('group:edit-in-table');
 
     for (const row of [0, 1, 2]) {

--- a/test/e2e/support/custom.ts
+++ b/test/e2e/support/custom.ts
@@ -284,8 +284,8 @@ Cypress.Commands.add('getCurrentPageId', () => cy.location('hash').then((hash) =
 
 Cypress.Commands.add('snapshot', (name: string) => {
   cy.clearSelectionAndWait();
-  cy.waitUntilSaved();
   cy.waitUntilNodesReady();
+  cy.waitUntilSaved();
 
   // Running wcag tests before taking snapshot, because the resizing of the viewport can cause some elements to
   // re-render and go slightly out of sync with the proper state of the application. One example is the Dropdown
@@ -307,6 +307,12 @@ Cypress.Commands.add('snapshot', (name: string) => {
       for (const [viewport, { width, height }] of Object.entries(viewportSizes)) {
         cy.viewport(width, height);
         cy.clearSelectionAndWait(viewport as keyof typeof viewportSizes);
+
+        // Saving happens after a debounce timeout, and even though we checked for unsaved changes above, there might
+        // be new ones that appeared after viewport resizing. Let's check again right before we snapshot.
+        cy.waitUntilNodesReady();
+        cy.waitUntilSaved();
+
         cy.percySnapshot(`${name} (${viewport})`, { percyCSS, widths: [width] });
       }
 

--- a/test/e2e/support/custom.ts
+++ b/test/e2e/support/custom.ts
@@ -43,6 +43,9 @@ Cypress.Commands.add('waitUntilSaved', () => {
   // If the data-unsaved-changes attribute does not exist, the page is not in a data/form state, and we should not
   // wait for it to be saved.
   cy.get('body').should('not.have.attr', 'data-unsaved-changes', 'true');
+
+  // There should be no 'NavigationButtons' components that are disabled (another indicator that form data is saving)
+  cy.get('[data-testid=NavigationButtons] button[disabled]').should('not.exist');
 });
 
 Cypress.Commands.add('waitUntilNodesReady', () => {


### PR DESCRIPTION
## Description

For a while now, a few percy snapshots have been showing up as 'usual suspects' where the navigation buttons disabled state will toggle all the time. This seems to happen because of 'bad timing' as the snapshot code tries to wait until form data is saved, but it fails to catch the navigation buttons being disabled. I suspect this happens because the saving starts _after_ the snapshot code has 'waited until data is saved', but I'm not entirely sure. For that reason I'm applying multiple band-aids here, in hopes that at least one will prevent this issue.

## Related Issue(s)

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [x] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
