### PR TITLE
Fix future issues with processing layout-sets

### DIFF
--- a/src/core/contexts/queryContext.tsx
+++ b/src/core/contexts/queryContext.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import type { PropsWithChildren } from 'react';
 
 import type { UseQueryResult } from '@tanstack/react-query';
@@ -57,6 +57,8 @@ export function createQueryContext<QD, Req extends boolean, CD = QD>(props: Quer
     const { data, isLoading, error, ...rest } = query();
     const enabled = 'enabled' in rest && !required ? rest.enabled : true;
 
+    const value = useMemo(() => (typeof data !== 'undefined' ? process(data) : undefined), [data]);
+
     if (enabled && isLoading) {
       return <Loader reason={`query-${name}`} />;
     }
@@ -65,7 +67,7 @@ export function createQueryContext<QD, Req extends boolean, CD = QD>(props: Quer
       return <DisplayError error={error as Error} />;
     }
 
-    return <Provider value={enabled ? process(data as QD) : defaultValue}>{children}</Provider>;
+    return <Provider value={enabled ? (value ?? defaultValue) : defaultValue}>{children}</Provider>;
   };
 
   return {

--- a/src/utils/layout/LayoutPage.ts
+++ b/src/utils/layout/LayoutPage.ts
@@ -14,8 +14,7 @@ export class LayoutPage implements LayoutObject {
 
   private allChildren: LayoutNode[] = [];
   private allChildIds = new Set<string>();
-
-  private _directChildren: LayoutNode[] = [];
+  private directChildren: LayoutNode[] = [];
 
   /**
    * Adds a child to the collection. For internal use only.
@@ -29,7 +28,7 @@ export class LayoutPage implements LayoutObject {
       // Direct children of a layout page are always static.
       // Only children of components like repeating groups are dynamic
       if (child.parent === this) {
-        this._directChildren.push(child);
+        this.directChildren.push(child);
       }
     }
   }
@@ -38,7 +37,11 @@ export class LayoutPage implements LayoutObject {
     if (this.allChildIds.has(child.id)) {
       this.layoutSet.unregisterNode(child);
       this.allChildIds.delete(child.id);
-      this.allChildren.splice(this.allChildren.indexOf(child), 1);
+
+      const aI = this.allChildren.indexOf(child);
+      aI > -1 && this.allChildren.splice(aI, 1);
+      const dI = this.directChildren.indexOf(child);
+      dI > -1 && this.directChildren.splice(dI, 1);
     }
   }
 
@@ -61,12 +64,8 @@ export class LayoutPage implements LayoutObject {
     return undefined;
   }
 
-  protected directChildren(_task: TraversalTask): LayoutNode[] {
-    return this._directChildren;
-  }
-
   public firstChild(task: TraversalTask): LayoutNode | undefined {
-    for (const node of this.directChildren(task)) {
+    for (const node of this.directChildren) {
       if (task.passes(node)) {
         return node;
       }
@@ -87,11 +86,11 @@ export class LayoutPage implements LayoutObject {
 
   public children(task: TraversalTask): LayoutNode[] {
     if (task.allPasses()) {
-      return this.directChildren(task);
+      return this.directChildren;
     }
 
     const children: LayoutNode[] = [];
-    for (const node of this.directChildren(task)) {
+    for (const node of this.directChildren) {
       if (task.passes(node)) {
         children.push(node);
       }


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

These are some fixes that for things that are not actually problems right now, but could become problems in the near future.

In `feat/navigation` I added some ui settings to the `layout-sets` file that needed some post-processing. It turned out that adding a `process`-function that changed the results somewhat (creates a new object) would cause problems when the query cache became stale after 10 minutes. It would trigger it to re-render with the same data, but because of the processing it would return a new object which caused the nodes to be re-created. (this is a known weakness and gets logged to the browser console). To deal with this I added a `useMemo` so that the same data should not create a new object if it runs multiple times.

A consequence of this issue was that nodes got added multiple times because "direct" children did not get deleted from the layoutPage object when removing nodes. (this was done intentionally since "direct" children are never expected to change within the same layout-set) But nevertheless I made sure these are removed as well. Additionally, the way children where removed from the `allChildren` list was a bit bad, since if the `indexOf` does not find the node it returns `-1` which in the `splice`function means remove the last element, but in that case we should not remove anything.

## Related Issue(s)

- https://github.com/Altinn/app-frontend-react/pull/2831

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
