### PR TITLE
Broken deep validations in nested repeating groups

### DIFF
--- a/src/features/validation/selectors/deepValidationsForNode.ts
+++ b/src/features/validation/selectors/deepValidationsForNode.ts
@@ -9,10 +9,10 @@ import type { TraversalRestriction } from 'src/utils/layout/useNodeTraversal';
  */
 export function useDeepValidationsForNode(
   node: LayoutNode | undefined,
-  onlyChildren: boolean = false,
+  includeSelf = true,
   restriction?: TraversalRestriction,
 ): NodeRefValidation[] {
   const showAll = Validation.useShowAllBackendErrors();
   const mask = showAll ? 'showAll' : 'visible';
-  return NodesInternal.useVisibleValidationsDeep(node, mask, onlyChildren ? 1 : undefined, restriction);
+  return NodesInternal.useVisibleValidationsDeep(node, mask, includeSelf, restriction);
 }

--- a/src/layout/RepeatingGroup/Table/RepeatingGroupTableRow.tsx
+++ b/src/layout/RepeatingGroup/Table/RepeatingGroupTableRow.tsx
@@ -123,7 +123,7 @@ export const RepeatingGroupTableRow = React.memo(function RepeatingGroupTableRow
   const tableEditingNodeIds = tableNodes
     .filter((n) => shouldEditInTable(editForGroup, n, columnSettings))
     .map((n) => n.id);
-  const rowValidations = useDeepValidationsForNode(node, true, index);
+  const rowValidations = useDeepValidationsForNode(node, false, index);
   const rowHasErrors = rowValidations.some(
     (validation) => validation.severity === 'error' && !tableEditingNodeIds.includes(validation.nodeId),
   );

--- a/test/e2e/integration/frontend-test/validation.ts
+++ b/test/e2e/integration/frontend-test/validation.ts
@@ -741,142 +741,140 @@ describe('Validation', () => {
     cy.findByRole('textbox', { name: /når vil du at navnendringen skal skje\?\*/i }).should('be.visible');
   });
 
-  describe('Falsy values', () => {
-    it('should validate boolean fields as set in the data model even when they are set to false', () => {
-      cy.interceptLayout('message', (component) => {
-        if (component.id === 'falsyRadioButton') {
-          component.hidden = false;
+  it('should validate boolean fields as set in the data model even when they are set to false', () => {
+    cy.interceptLayout('message', (component) => {
+      if (component.id === 'falsyRadioButton') {
+        component.hidden = false;
+      }
+    });
+    cy.goto('message');
+
+    cy.findByRole('radio', { name: 'False' }).click();
+    cy.findByRole('button', { name: 'Send inn' }).click();
+
+    // content from next page
+    cy.findByText('Nåværende navn').should('exist');
+  });
+
+  it('should validate number fields as set in the data model when a falsy value is input', () => {
+    cy.interceptLayout('message', (component) => {
+      if (component.id === 'falsyInput') {
+        component.hidden = false;
+      }
+    });
+    cy.goto('message');
+
+    cy.findByRole('textbox', { name: 'Input with falsy value*' }).type('0');
+    cy.findByRole('button', { name: 'Send inn' }).click();
+
+    // Content from next page
+    cy.findByText('Nåværende navn').should('exist');
+  });
+
+  it('Should navigate and focus correct row in Likert component when clicking on error report', () => {
+    cy.goto('likert');
+    cy.findByRole('button', { name: /Send inn/ }).click();
+
+    cy.findByRole('row', {
+      name: /Hører skolen på elevenes forslag\?\*/i,
+    }).within(() => {
+      cy.findByRole('radio', { name: /Alltid/ }).should('not.be.focused');
+    });
+
+    cy.findByRole('button', { name: /Du må fylle ut hører skolen på elevenes forslag/ }).click();
+
+    cy.findByRole('row', {
+      name: /Hører skolen på elevenes forslag\?\*/i,
+    }).within(() => {
+      cy.findByRole('radio', { name: /Alltid/ }).should('be.focused');
+    });
+  });
+
+  it('Existing validations should not disappear when a backend validator is not executed', () => {
+    cy.goto('changename');
+    cy.findByRole('textbox', { name: newFirstName }).type('test');
+    cy.get(appFrontend.fieldValidation(appFrontend.changeOfName.newFirstName)).should(
+      'have.text',
+      texts.testIsNotValidValue,
+    );
+
+    cy.intercept('PATCH', '**/data/**', (req) =>
+      req.reply((res) => res.send(JSON.stringify({ ...res.body, validationIssues: {} }))),
+    ).as('patchData');
+
+    cy.get(appFrontend.changeOfName.newMiddleName).type('hei');
+    cy.wait('@patchData');
+
+    cy.get(appFrontend.fieldValidation(appFrontend.changeOfName.newFirstName)).should(
+      'have.text',
+      texts.testIsNotValidValue,
+    );
+  });
+
+  it('Datepicker should show component validation instead of format error from schema', () => {
+    cy.interceptLayout('changename', (component) => {
+      if (component.type === 'Datepicker' && component.id === 'dateOfEffect') {
+        component.showValidations = ['AllExceptRequired'];
+      }
+    });
+
+    cy.goto('changename');
+    cy.waitForLoad();
+
+    let c = 0;
+    cy.intercept('PATCH', '**/data/**', () => {
+      c++;
+    }).as('patchData');
+
+    cy.get(appFrontend.changeOfName.dateOfEffect).type('01/01/2020');
+    cy.get(appFrontend.changeOfName.dateOfEffect).blur();
+    cy.wait('@patchData').then(() => {
+      expect(c).to.be.eq(1);
+    });
+
+    cy.get(appFrontend.fieldValidation(appFrontend.changeOfName.dateOfEffect)).should('not.exist');
+
+    cy.get(appFrontend.changeOfName.dateOfEffect).clear();
+    cy.get(appFrontend.changeOfName.dateOfEffect).type('45/45/1234');
+    cy.get(appFrontend.changeOfName.dateOfEffect).blur();
+    cy.wait('@patchData').then(() => {
+      expect(c).to.be.eq(2);
+    });
+
+    cy.get(appFrontend.fieldValidation(appFrontend.changeOfName.dateOfEffect)).should(
+      'contain.text',
+      'Ugyldig datoformat',
+    );
+    cy.get(appFrontend.fieldValidation(appFrontend.changeOfName.dateOfEffect)).should(
+      'not.contain.text',
+      'Feil format',
+    );
+  });
+
+  it('should not show required validation when data is invalid and not saveable', () => {
+    cy.interceptLayout('changename', (component) => {
+      if (component.type === 'Input' && component.id === 'int32AsNumber') {
+        component.showValidations = ['All'];
+        component.required = true;
+      }
+    });
+
+    // Prevent patch response from setting the value to zero when empty
+    cy.intercept('PATCH', '**/data/**', (req) => {
+      req.on('response', (res) => {
+        const body = res.body as IDataModelPatchResponse;
+        if (body.newDataModel['Numeric']?.Int32 === 0) {
+          delete body.newDataModel['Numeric'].Int32;
         }
       });
-      cy.goto('message');
-
-      cy.findByRole('radio', { name: 'False' }).click();
-      cy.findByRole('button', { name: 'Send inn' }).click();
-
-      // content from next page
-      cy.findByText('Nåværende navn').should('exist');
     });
 
-    it('should validate number fields as set in the data model when a falsy value is input', () => {
-      cy.interceptLayout('message', (component) => {
-        if (component.id === 'falsyInput') {
-          component.hidden = false;
-        }
-      });
-      cy.goto('message');
+    cy.gotoHiddenPage('numeric-fields');
 
-      cy.findByRole('textbox', { name: 'Input with falsy value*' }).type('0');
-      cy.findByRole('button', { name: 'Send inn' }).click();
+    cy.get(appFrontend.fieldValidation('int32AsNumber')).should('contain.text', 'Du må fylle ut int32');
 
-      // Content from next page
-      cy.findByText('Nåværende navn').should('exist');
-    });
-
-    it('Should navigate and focus correct row in Likert component when clicking on error report', () => {
-      cy.goto('likert');
-      cy.findByRole('button', { name: /Send inn/ }).click();
-
-      cy.findByRole('row', {
-        name: /Hører skolen på elevenes forslag\?\*/i,
-      }).within(() => {
-        cy.findByRole('radio', { name: /Alltid/ }).should('not.be.focused');
-      });
-
-      cy.findByRole('button', { name: /Du må fylle ut hører skolen på elevenes forslag/ }).click();
-
-      cy.findByRole('row', {
-        name: /Hører skolen på elevenes forslag\?\*/i,
-      }).within(() => {
-        cy.findByRole('radio', { name: /Alltid/ }).should('be.focused');
-      });
-    });
-
-    it('Existing validations should not disappear when a backend validator is not executed', () => {
-      cy.goto('changename');
-      cy.findByRole('textbox', { name: newFirstName }).type('test');
-      cy.get(appFrontend.fieldValidation(appFrontend.changeOfName.newFirstName)).should(
-        'have.text',
-        texts.testIsNotValidValue,
-      );
-
-      cy.intercept('PATCH', '**/data/**', (req) =>
-        req.reply((res) => res.send(JSON.stringify({ ...res.body, validationIssues: {} }))),
-      ).as('patchData');
-
-      cy.get(appFrontend.changeOfName.newMiddleName).type('hei');
-      cy.wait('@patchData');
-
-      cy.get(appFrontend.fieldValidation(appFrontend.changeOfName.newFirstName)).should(
-        'have.text',
-        texts.testIsNotValidValue,
-      );
-    });
-
-    it('Datepicker should show component validation instead of format error from schema', () => {
-      cy.interceptLayout('changename', (component) => {
-        if (component.type === 'Datepicker' && component.id === 'dateOfEffect') {
-          component.showValidations = ['AllExceptRequired'];
-        }
-      });
-
-      cy.goto('changename');
-      cy.waitForLoad();
-
-      let c = 0;
-      cy.intercept('PATCH', '**/data/**', () => {
-        c++;
-      }).as('patchData');
-
-      cy.get(appFrontend.changeOfName.dateOfEffect).type('01/01/2020');
-      cy.get(appFrontend.changeOfName.dateOfEffect).blur();
-      cy.wait('@patchData').then(() => {
-        expect(c).to.be.eq(1);
-      });
-
-      cy.get(appFrontend.fieldValidation(appFrontend.changeOfName.dateOfEffect)).should('not.exist');
-
-      cy.get(appFrontend.changeOfName.dateOfEffect).clear();
-      cy.get(appFrontend.changeOfName.dateOfEffect).type('45/45/1234');
-      cy.get(appFrontend.changeOfName.dateOfEffect).blur();
-      cy.wait('@patchData').then(() => {
-        expect(c).to.be.eq(2);
-      });
-
-      cy.get(appFrontend.fieldValidation(appFrontend.changeOfName.dateOfEffect)).should(
-        'contain.text',
-        'Ugyldig datoformat',
-      );
-      cy.get(appFrontend.fieldValidation(appFrontend.changeOfName.dateOfEffect)).should(
-        'not.contain.text',
-        'Feil format',
-      );
-    });
-
-    it('should not show required validation when data is invalid and not saveable', () => {
-      cy.interceptLayout('changename', (component) => {
-        if (component.type === 'Input' && component.id === 'int32AsNumber') {
-          component.showValidations = ['All'];
-          component.required = true;
-        }
-      });
-
-      // Prevent patch response from setting the value to zero when empty
-      cy.intercept('PATCH', '**/data/**', (req) => {
-        req.on('response', (res) => {
-          const body = res.body as IDataModelPatchResponse;
-          if (body.newDataModel['Numeric']?.Int32 === 0) {
-            delete body.newDataModel['Numeric'].Int32;
-          }
-        });
-      });
-
-      cy.gotoHiddenPage('numeric-fields');
-
-      cy.get(appFrontend.fieldValidation('int32AsNumber')).should('contain.text', 'Du må fylle ut int32');
-
-      cy.findByRole('textbox', { name: /int32.*/i }).type('999999999999999');
-      cy.get(appFrontend.fieldValidation('int32AsNumber')).should('contain.text', 'Feil format eller verdi');
-      cy.get(appFrontend.fieldValidation('int32AsNumber')).should('not.contain.text', 'Du må fylle ut int32');
-    });
+    cy.findByRole('textbox', { name: /int32.*/i }).type('999999999999999');
+    cy.get(appFrontend.fieldValidation('int32AsNumber')).should('contain.text', 'Feil format eller verdi');
+    cy.get(appFrontend.fieldValidation('int32AsNumber')).should('not.contain.text', 'Du må fylle ut int32');
   });
 });

--- a/test/e2e/integration/frontend-test/validation.ts
+++ b/test/e2e/integration/frontend-test/validation.ts
@@ -389,9 +389,10 @@ describe('Validation', () => {
     cy.get(appFrontend.group.saveSubGroup).click();
     cy.get(appFrontend.group.addNewItemSubGroup).click();
     cy.get(appFrontend.group.saveSubGroup).click();
-    cy.findByRole('button', { name: 'Rediger comment' }).click();
-    cy.get(appFrontend.group.editContainer).find(appFrontend.group.back).click();
-    cy.findByRole('button', { name: 'Lukk NOK 1' }).click();
+    cy.get(appFrontend.errorReport).should('contain.text', texts.requiredComment);
+    cy.gotoNavPage('prefill');
+    cy.get(appFrontend.group.prefill.liten).should('be.visible');
+    cy.gotoNavPage('repeating');
     cy.findByRole('button', { name: 'Se innhold NOK 1 233' }).click();
     cy.get(appFrontend.errorReport).findByText(texts.requiredComment).click();
     cy.get(appFrontend.group.row(0).nestedGroup.row(1).comments).should('be.focused');

--- a/test/e2e/pageobjects/app-frontend.ts
+++ b/test/e2e/pageobjects/app-frontend.ts
@@ -227,6 +227,7 @@ export class AppFrontend {
     hideCommentField: '[id^="hideComment"]',
     hiddenRowsInfoMsg: '[data-componentid="info-msg"]',
     row: (idx: number) => ({
+      tableRow: `#group-mainGroup-table-body > tr:nth-child(${idx + 1})`,
       currentValue: `#currentValue-${idx}`,
       newValue: `#newValue-${idx}`,
       uploadSingle: makeUploaderSelectors('mainUploaderSingle', idx, 3, 'untagged'),
@@ -235,6 +236,7 @@ export class AppFrontend {
       deleteBtn: `#group-mainGroup-table-body > tr:nth-child(${idx + 1}) > td:last-of-type button`,
       nestedGroup: {
         row: (subIdx: number) => ({
+          tableRow: `#group-subGroup-${idx}-table-body > tr:nth-child(${subIdx + 1})`,
           comments: `#comments-${idx}-${subIdx}`,
           uploadTagMulti: makeUploaderSelectors('subUploader', `${idx}-${subIdx}`, 2, 'tagged'),
           nestedDynamics: `#nestedDynamics-${idx}-${subIdx} input[type=checkbox]`,


### PR DESCRIPTION
## Description

This bug was introduced because I didn't understand the concept in `useDeepValidationsForNode()` when refactoring, so I turned `onlyChildren = true` into "stop at depth 1" (i.e. only immediate children, not nested children) instead of the correct interpretation of "don't include validations on the node itself" (i.e. only get validations for children).

Added a cypress test for this as well, so that we don't end up doing the same mistake again. I removed the `describe('Falsy values', () => {` grouping in this test, because it's wrapping lots of tests that doesn't have to do with falsy values - ignore all the indent-changes in the cypress test.

## Related Issue(s)

- closes #2702

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
