### PR TITLE
Fixing mutation of options causing broken `optionFilter` when used along with `source` options

### DIFF
--- a/src/features/options/useGetOptions.ts
+++ b/src/features/options/useGetOptions.ts
@@ -219,9 +219,10 @@ export function useFilteredAndSortedOptions({
 
     // Always remove the rowNode and dataModelLocation at this point. It is only to be used in the filtering
     // process, and will not ruin the comparison later to make sure the state is set in zustand.
-    for (const option of options) {
-      delete option.rowNode;
-      delete option.dataModelLocation;
+    for (const idx in options) {
+      // If we mutate the existing option (possibly coming from useSourceOptions) it will break things.
+      const { rowNode: _1, dataModelLocation: _2, ...option } = options[idx];
+      options[idx] = option;
     }
 
     return { options, preselectedOption };


### PR DESCRIPTION
## Description

When working on the new `Option` component, I wanted to use (and improve) the `pets` page in `ttd/frontend-test`. When fixing that page, using some of the newer functionality, I found a bug which caused the `optionFilter` expression to break when running on options from `source`. As `rowNode` and `dataModelLocation` are removed, they would mutate the objects received from `useSourceOptions()`, breaking future updates.

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
