### PR TITLE
Fixes to RepeatingGroup Table Summary2 CSS

### DIFF
--- a/src/layout/RepeatingGroup/Summary2/RepeatingGroupTableSummary/RepeatingGroupTableSummary.module.css
+++ b/src/layout/RepeatingGroup/Summary2/RepeatingGroupTableSummary/RepeatingGroupTableSummary.module.css
@@ -76,3 +76,7 @@
   clip-path: inset(50%);
   white-space: nowrap;
 }
+
+.narrowLastColumn {
+  width: 1%;
+}

--- a/src/layout/RepeatingGroup/Summary2/RepeatingGroupTableSummary/RepeatingGroupTableSummary.tsx
+++ b/src/layout/RepeatingGroup/Summary2/RepeatingGroupTableSummary/RepeatingGroupTableSummary.tsx
@@ -13,6 +13,7 @@ import { useUnifiedValidationsForNode } from 'src/features/validation/selectors/
 import { validationsOfSeverity } from 'src/features/validation/utils';
 import { useIsMobile } from 'src/hooks/useDeviceWidths';
 import { useRepeatingGroupRowState } from 'src/layout/RepeatingGroup/Providers/RepeatingGroupContext';
+import repeatingGroupClasses from 'src/layout/RepeatingGroup/RepeatingGroup.module.css';
 import classes from 'src/layout/RepeatingGroup/Summary2/RepeatingGroupSummary.module.css';
 import tableClasses from 'src/layout/RepeatingGroup/Summary2/RepeatingGroupTableSummary/RepeatingGroupTableSummary.module.css';
 import { RepeatingGroupTableTitle, useTableTitle } from 'src/layout/RepeatingGroup/Table/RepeatingGroupTableTitle';
@@ -22,6 +23,7 @@ import { SingleValueSummary } from 'src/layout/Summary2/CommonSummaryComponents/
 import { useColumnStylesRepeatingGroups } from 'src/utils/formComponentUtils';
 import { useNodeItem } from 'src/utils/layout/useNodeItem';
 import type { ITableColumnFormatting } from 'src/layout/common.generated';
+import type { RepGroupRow } from 'src/layout/RepeatingGroup/types';
 import type { BaseLayoutNode, LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export const RepeatingGroupTableSummary = ({
@@ -63,7 +65,7 @@ export const RepeatingGroupTableSummary = ({
       className={cn(classes.summaryWrapper)}
       data-testid='summary-repeating-group-component'
     >
-      <Table className={isSmall ? tableClasses.mobileTable : undefined}>
+      <Table className={cn({ [tableClasses.mobileTable]: isSmall })}>
         <Caption title={<Lang id={title} />} />
         <Table.Head>
           <Table.Row>
@@ -75,7 +77,7 @@ export const RepeatingGroupTableSummary = ({
               />
             ))}
             {!pdfModeActive && !isSmall && (
-              <Table.HeaderCell>
+              <Table.HeaderCell className={tableClasses.narrowLastColumn}>
                 <span className={tableClasses.visuallyHidden}>
                   <Lang id='general.edit' />
                 </span>
@@ -91,6 +93,7 @@ export const RepeatingGroupTableSummary = ({
               node={componentNode}
               index={index}
               pdfModeActive={pdfModeActive}
+              columnSettings={columnSettings}
             />
           ))}
         </Table.Body>
@@ -124,7 +127,15 @@ function HeaderCell({ node, columnSettings }: { node: LayoutNode; columnSettings
   );
 }
 
-function DataRow({ row, node, index, pdfModeActive }) {
+type DataRowProps = {
+  row: RepGroupRow | undefined;
+  node: BaseLayoutNode<'RepeatingGroup'>;
+  index: number;
+  pdfModeActive: boolean;
+  columnSettings: ITableColumnFormatting;
+};
+
+function DataRow({ row, node, index, pdfModeActive, columnSettings }: DataRowProps) {
   const cellNodes = useTableNodes(node, index);
   const displayDataProps = useDisplayDataProps();
 
@@ -135,6 +146,7 @@ function DataRow({ row, node, index, pdfModeActive }) {
           key={node.id}
           node={node}
           displayData={('getDisplayData' in node.def && node.def.getDisplayData(node as never, displayDataProps)) ?? ''}
+          columnSettings={columnSettings}
         />
       ))}
       {!pdfModeActive && (
@@ -149,15 +161,28 @@ function DataRow({ row, node, index, pdfModeActive }) {
   );
 }
 
-function DataCell({ node, displayData }) {
+type DataCellProps = {
+  node: LayoutNode;
+  displayData: string | false;
+  columnSettings: ITableColumnFormatting;
+};
+
+function DataCell({ node, displayData, columnSettings }: DataCellProps) {
   const { langAsString } = useLanguage();
   const headerTitle = langAsString(useTableTitle(node));
+  const style = useColumnStylesRepeatingGroups(node, columnSettings);
+
   return (
     <Table.Cell
       key={node.id}
       data-header-title={headerTitle}
     >
-      {displayData}
+      <span
+        className={repeatingGroupClasses.contentFormatting}
+        style={style}
+      >
+        {displayData}
+      </span>
     </Table.Cell>
   );
 }


### PR DESCRIPTION
## Description
Propagerer `columnSettings` også ned til `<td>`-elementer.
Gjør også knappekolonnen "så liten som mulig".

Eksempel med og uten for 
```
{
  alignText: "right",
  width: "auto"
}
```

![Pasted Graphic](https://github.com/user-attachments/assets/246d2900-5d11-4a54-ba37-fdca9416b723)
![image](https://github.com/user-attachments/assets/7a728ede-0909-4a72-bd41-63201fbbf32e)


## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
