### PR TITLE
Handle missing profile when the logged in client in not a user (e.g. service owner)

### DIFF
--- a/src/__mocks__/getPartyMock.ts
+++ b/src/__mocks__/getPartyMock.ts
@@ -13,6 +13,19 @@ export const getPartyMock = (): IParty => ({
   childParties: undefined,
 });
 
+export const ServiceOwnerPartyId = 414234123;
+export const getServiceOwnerPartyMock = (): IParty => ({
+  partyId: ServiceOwnerPartyId,
+  name: 'Brønnøysundregistrene',
+  ssn: null,
+  partyTypeName: PartyType.Organisation,
+  orgNumber: '974760673',
+  unitType: 'BEDR',
+  isDeleted: false,
+  onlyHierarchyElementWithNoAccess: false,
+  childParties: undefined,
+});
+
 export type PartyWithSubunit = { org: IParty & { childParties: IParty[] }; person: IParty };
 export const getPartyWithSubunitMock = (): PartyWithSubunit => ({
   org: {

--- a/src/features/instantiate/containers/InstantiateContainer.tsx
+++ b/src/features/instantiate/containers/InstantiateContainer.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import { isAxiosError } from 'axios';
-
 import { Loader } from 'src/core/loading/Loader';
 import { InstantiateValidationError } from 'src/features/instantiate/containers/InstantiateValidationError';
 import { MissingRolesError } from 'src/features/instantiate/containers/MissingRolesError';
@@ -10,6 +8,7 @@ import { useInstantiation } from 'src/features/instantiate/InstantiationContext'
 import { useCurrentParty } from 'src/features/party/PartiesProvider';
 import { AltinnAppTheme } from 'src/theme/altinnAppTheme';
 import { changeBodyBackground } from 'src/utils/bodyStyling';
+import { isAxiosError } from 'src/utils/isAxiosError';
 import { HttpStatusCodes } from 'src/utils/network/networking';
 
 export const InstantiateContainer = () => {

--- a/src/features/language/LanguageProvider.tsx
+++ b/src/features/language/LanguageProvider.tsx
@@ -8,6 +8,7 @@ interface LanguageCtx {
   current: string;
   profileLoaded: boolean;
   updateProfile: (profile: IProfile) => void;
+  noProfileFound: () => void;
   setWithLanguageSelector: (language: string) => void;
 }
 
@@ -18,6 +19,9 @@ const { Provider, useCtx } = createContext<LanguageCtx>({
     current: 'nb',
     profileLoaded: false,
     updateProfile: () => {
+      throw new Error('LanguageProvider not initialized');
+    },
+    noProfileFound: () => {
       throw new Error('LanguageProvider not initialized');
     },
     setWithLanguageSelector: () => {
@@ -46,19 +50,28 @@ export const LanguageProvider = ({ children }: PropsWithChildren) => {
     localStorage.setItem(localStorageKey, newLanguage);
   };
 
+  const noProfileFound = () => {
+    // Just mark it as loaded, so we can continue loading language resources
+    setProfileLoaded(true);
+  };
+
   const setWithLanguageSelector = (language: string) => {
     setCurrent(language);
     localStorage.setItem(`selectedAppLanguage${window.app}${userId}`, language);
   };
 
-  return <Provider value={{ current, profileLoaded, updateProfile, setWithLanguageSelector }}>{children}</Provider>;
+  return (
+    <Provider value={{ current, profileLoaded, updateProfile, setWithLanguageSelector, noProfileFound }}>
+      {children}
+    </Provider>
+  );
 };
 
 export const useCurrentLanguage = () => useCtx().current;
 export const useIsProfileLanguageLoaded = () => useCtx().profileLoaded;
 export const useSetCurrentLanguage = () => {
-  const { setWithLanguageSelector, updateProfile } = useCtx();
-  return { setWithLanguageSelector, updateProfile };
+  const { setWithLanguageSelector, updateProfile, noProfileFound } = useCtx();
+  return { setWithLanguageSelector, updateProfile, noProfileFound };
 };
 
 function getLanguageQueryParam() {

--- a/src/features/pdf/PDFWrapper.test.tsx
+++ b/src/features/pdf/PDFWrapper.test.tsx
@@ -1,0 +1,127 @@
+import React from 'react';
+
+import { jest } from '@jest/globals';
+import { screen, waitFor } from '@testing-library/react';
+import type { AxiosError } from 'axios';
+
+import { getIncomingApplicationMetadataMock } from 'src/__mocks__/getApplicationMetadataMock';
+import { getInstanceDataMock } from 'src/__mocks__/getInstanceDataMock';
+import { getPartyMock, getServiceOwnerPartyMock } from 'src/__mocks__/getPartyMock';
+import { getProcessDataMock } from 'src/__mocks__/getProcessDataMock';
+import { getProfileMock } from 'src/__mocks__/getProfileMock';
+import { ProcessWrapper } from 'src/components/wrappers/ProcessWrapper';
+import { InstanceProvider } from 'src/features/instance/InstanceContext';
+import { fetchApplicationMetadata, fetchProcessState } from 'src/queries/queries';
+import { InstanceRouter, renderWithoutInstanceAndLayout } from 'src/test/renderWithProviders';
+import type { AppQueries } from 'src/queries/types';
+
+const exampleGuid = '75154373-aed4-41f7-95b4-e5b5115c2edc';
+const exampleInstanceId = `512345/${exampleGuid}`;
+
+enum RenderAs {
+  User,
+  ServiceOwner,
+}
+
+const axios400Error: AxiosError = {
+  isAxiosError: true,
+  code: 'ERR_BAD_REQUEST',
+  status: 400,
+  response: {
+    status: 400,
+    statusText: 'Bad Request',
+    headers: {},
+    config: null!,
+    data: undefined,
+  },
+  name: 'AxiosError',
+  message: 'Request failed with status code 400',
+  toJSON: () => ({}),
+};
+
+const buildInstance = () =>
+  getInstanceDataMock((i) => {
+    i.org = 'brg';
+    i.id = exampleInstanceId;
+    i.lastChanged = '2022-02-05T09:19:32.8858042Z';
+  });
+
+const render = async (renderAs: RenderAs, queriesOverride?: Partial<AppQueries>) => {
+  jest.mocked(fetchApplicationMetadata).mockImplementationOnce(async () =>
+    getIncomingApplicationMetadataMock((m) => {
+      m.org = 'brg';
+      m.partyTypesAllowed.person = true;
+      m.partyTypesAllowed.organisation = true;
+    }),
+  );
+  jest.mocked(fetchProcessState).mockImplementation(async () =>
+    getProcessDataMock((p) => {
+      p.processTasks = [p.currentTask!];
+    }),
+  );
+
+  const party = renderAs === RenderAs.User ? getPartyMock() : getServiceOwnerPartyMock();
+
+  return await renderWithoutInstanceAndLayout({
+    renderer: () => (
+      <InstanceProvider>
+        <ProcessWrapper />
+      </InstanceProvider>
+    ),
+    router: ({ children }) => (
+      <InstanceRouter
+        instanceId={exampleInstanceId}
+        taskId='Task_1'
+        initialPage=''
+        query='pdf=1'
+      >
+        {children}
+      </InstanceRouter>
+    ),
+    queries: {
+      fetchOrgs: async () => ({
+        orgs: {
+          brg: {
+            name: {
+              en: 'Brønnøysund Register Centre',
+              nb: 'Brønnøysundregistrene',
+              nn: 'Brønnøysundregistera',
+            },
+            logo: 'https://altinncdn.no/orgs/brg/brreg.png',
+            orgnr: '974760673',
+            homepage: 'https://www.brreg.no',
+            environments: ['tt02', 'production'],
+          },
+        },
+      }),
+      fetchInstanceData: async () => buildInstance(),
+      fetchFormData: async () => ({}),
+      fetchLayouts: async () => ({}),
+      fetchCurrentParty: async () => party,
+      fetchParties: async () => [party],
+      fetchUserProfile: async () => {
+        if (renderAs === RenderAs.User) {
+          return getProfileMock();
+        }
+        throw axios400Error;
+      },
+      ...queriesOverride,
+    },
+  });
+};
+
+describe('PDFWrapper', () => {
+  it.each([RenderAs.User, RenderAs.ServiceOwner])(`should render PDF - %s`, async (renderAs) => {
+    const result = await render(renderAs);
+
+    await waitFor(() => expect(result.container.querySelector('#readyForPrint')).not.toBeNull(), { timeout: 5000 });
+
+    if (renderAs === RenderAs.ServiceOwner) {
+      expect(await screen.queryByText('Avsender:')).toBeNull();
+      expect(await screen.queryByText('01017512345-Ola Privatperson')).toBeNull();
+    } else if (renderAs === RenderAs.User) {
+      expect(await screen.queryByText('Avsender:')).not.toBeNull();
+      expect(await screen.queryByText('01017512345-Ola Privatperson')).not.toBeNull();
+    }
+  });
+});

--- a/src/test/renderWithProviders.tsx
+++ b/src/test/renderWithProviders.tsx
@@ -75,6 +75,7 @@ interface InstanceRouterProps {
   taskId?: string;
   instanceId?: string;
   alwaysRouteToChildren?: boolean;
+  query?: string;
 }
 
 interface ExtendedRenderOptionsWithInstance extends ExtendedRenderOptions, InstanceRouterProps {}
@@ -246,11 +247,13 @@ export function InstanceRouter({
   taskId = 'Task_1',
   initialPage = 'FormLayout',
   alwaysRouteToChildren = false,
+  query,
 }: PropsWithChildren<InstanceRouterProps>) {
+  const path = `/ttd/test/instance/${instanceId}/${taskId}/${initialPage}`;
   return (
     <MemoryRouter
       basename='/ttd/test'
-      initialEntries={[`/ttd/test/instance/${instanceId}/${taskId}/${initialPage}`]}
+      initialEntries={[query ? `${path}?${query}` : path]}
     >
       <Routes>
         <Route


### PR DESCRIPTION
## Description
 
Handles missing profile without breaking the UI. Required to be able to process/next an instance in the context of a service owner token when the current step is datautfylling

## Related Issue(s)

- https://github.com/Altinn/app-lib-dotnet/issues/908
- Related PR: https://github.com/Altinn/app-lib-dotnet/pull/880
- To make testing easier locally: https://github.com/Altinn/app-localtest/pull/133

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
