### PR TITLE
Help text bubble size affected by component title length

### DIFF
--- a/src/app-components/Label/Label.module.css
+++ b/src/app-components/Label/Label.module.css
@@ -2,6 +2,7 @@
   display: flex;
   gap: var(--fds-spacing-2);
   align-items: center;
+  min-width: 28px;
 }
 
 .labelAndDescWrapper {

--- a/src/app-components/Label/Label.module.css
+++ b/src/app-components/Label/Label.module.css
@@ -2,7 +2,7 @@
   display: flex;
   gap: var(--fds-spacing-2);
   align-items: center;
-  min-width: 28px;
+  min-width: var(--fds-spacing-7);
 }
 
 .labelAndDescWrapper {


### PR DESCRIPTION
## Description

Helptext is wrapped with label on every form element with label. If the label is too large the space for the helptext icon is shrinking to a size that minifies the helptext icon. 

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes [#2470](https://github.com/Altinn/app-frontend-react/issues/2470)

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
