### PR TITLE
Adding code for finding app frontend/backend versions

### DIFF
--- a/src/test/allApps.ts
+++ b/src/test/allApps.ts
@@ -66,6 +66,80 @@ export class ExternalApp {
     return fs.readdirSync(this.rootDir + path);
   }
 
+  getBackendVersion(): string | undefined {
+    let appFile = '';
+    try {
+      appFile = this.readFile('/App/App.csproj');
+    } catch (_e) {
+      return undefined;
+    }
+
+    const version = appFile.match(/<PackageReference Include="Altinn.App.Api(.Experimental)?" Version="([^"]*)"/i);
+    if (!version) {
+      return undefined;
+    }
+
+    const v = version[2];
+    if (v.match(/^\d+/)) {
+      return v;
+    }
+
+    // Some use variables, like <PackageReference Include="Altinn.App.Api" Version="$(AltinnAppApiVersion)" />
+    // In these cases we need to find the variable and replace it with the actual value
+    const propertyName = version[2].match(/\$\(([^)]*)\)/)?.[1];
+    const property = propertyName && appFile.match(`<${propertyName}>([^<]*)</${propertyName}>`);
+    if (!property) {
+      return undefined;
+    }
+
+    return property[1];
+  }
+
+  getBackendMajorVersion(): number | undefined {
+    const version = this.getBackendVersion();
+    if (!version) {
+      return undefined;
+    }
+    return parseInt(version.split('.')[0], 10);
+  }
+
+  getFrontendVersion(): string | undefined {
+    let indexFile = '';
+    try {
+      indexFile = this.readFile('/App/views/Home/Index.cshtml');
+    } catch (_e) {
+      return undefined;
+    }
+
+    const cleaned = indexFile.replace(/<!--[\s\S]*?-->/g, '').replace(/@[\s\S]*?@/g, '');
+    const scriptTags = cleaned.match(/<script src="(.*?)"/g);
+    if (!scriptTags) {
+      return undefined;
+    }
+
+    for (const tag of scriptTags) {
+      const url = tag.split('src=')[1].replace(/"/g, '');
+      if (!url.startsWith('https://altinncdn.no')) {
+        continue;
+      }
+      const version = url.match(/altinn-app-frontend\/(\d[^/]*)/);
+      if (!version) {
+        continue;
+      }
+      return version[1];
+    }
+
+    return undefined;
+  }
+
+  getFrontendMajorVersion(): number | undefined {
+    const version = this.getFrontendVersion();
+    if (!version) {
+      return undefined;
+    }
+    return parseInt(version.split('.')[0], 10);
+  }
+
   isValid(): boolean {
     if (!this.dirExists('/App')) {
       return false;

--- a/src/utils/layout/all.test.tsx
+++ b/src/utils/layout/all.test.tsx
@@ -163,6 +163,7 @@ describe('All known layout sets should evaluate as a hierarchy', () => {
 
     // Inject errors from console/window.logError into the full error list for this layout-set
     const devToolsLoggers = windowLoggers.map((func) => window[func] as jest.Mock);
+    // eslint-disable-next-line no-console
     const browserLoggers = consoleLoggers.map((func) => console[func] as jest.Mock);
     for (const _mock of [...devToolsLoggers, ...browserLoggers]) {
       const mock = _mock as jest.Mock;


### PR DESCRIPTION
## Description

I added some code to extract the frontend/backend versions from apps, when using the toolbox I've been using for (for example) `all.test.tsx`. To get a list of frontend/backend version combinations, I ran the following:

```typescript
describe('Count all apps', () => {
  it('should count all apps', () => {
    const dir = ensureAppsDirIsSet();
    if (!dir) {
      return;
    }

    function makeKey(frontendMajor: number, backendMajor: number) {
      return `v${frontendMajor}/v${backendMajor}`;
    }

    const counts = new Map<string, { count: number; apps: string[] }>();

    const all = getAllApps(dir)
      .filter((app) => app.getFrontendVersion())
      .filter((app) => app.getBackendVersion());

    for (const app of all) {
      const key = makeKey(app.getFrontendMajorVersion()!, app.getBackendMajorVersion()!);
      const orgApp = app.getOrgApp();
      const name = orgApp.join('/');

      if (!counts.has(key)) {
        counts.set(key, { count: 0, apps: [] });
      }
      const item = counts.get(key)!;
      item.count++;
      item.apps.push(name);
    }

    const sorted = [...counts.entries()].sort((a, b) => a[0].localeCompare(b[0]));
    let output = '';

    for (const [key, { count, apps }] of sorted) {
      output += `${key}: ${count}\n`;
      if (apps.length < 20) {
        output += `  ${apps.join(', ')}\n`;
      }
    }

    debugger; // Grab the output and copy as string
  });
});
```

## Related Issue(s)

- https://digdir.slack.com/archives/C076GU2QHCG/p1736776375996409?thread_ts=1736412824.298689&cid=C076GU2QHCG

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
