### PR TITLE
Issues in Custom component

### DIFF
--- a/src/layout/Custom/CustomWebComponent.tsx
+++ b/src/layout/Custom/CustomWebComponent.tsx
@@ -15,7 +15,10 @@ export type ICustomComponentProps = PropsFromGenericComponent<'Custom'> & {
   summaryMode?: boolean;
 };
 
-export type IPassedOnProps = Omit<PropsFromGenericComponent<'Custom'>, 'node' | 'componentValidations'> &
+export type IPassedOnProps = Omit<
+  PropsFromGenericComponent<'Custom'>,
+  'node' | 'componentValidations' | 'containerDivRef'
+> &
   Omit<CompInternal<'Custom'>, 'tagName' | 'textResourceBindings'> & {
     [key: string]: string | number | boolean | object | null | undefined;
     text: string | undefined;
@@ -31,8 +34,11 @@ export function CustomWebComponent({
   const langTools = useLanguage();
   const { language, langAsString } = langTools;
   const { tagName, textResourceBindings, dataModelBindings, ...passThroughPropsFromNode } = useNodeItem(node);
+
+  const { containerDivRef: _unused, ...restFromGeneric } = passThroughPropsFromGenericComponent;
+
   const passThroughProps: IPassedOnProps = {
-    ...passThroughPropsFromGenericComponent,
+    ...restFromGeneric,
     ...passThroughPropsFromNode,
     text: langAsString(textResourceBindings?.title),
     getTextResourceAsString: (textResource: string) => langAsString(textResource),
@@ -56,6 +62,7 @@ export function CustomWebComponent({
         }
         if (field) {
           setValue(field, value);
+          return;
         }
         setValue('simpleBinding', value);
       };


### PR DESCRIPTION
Allowing not including field when using simple binding, fixed bug when generating passThroughProps

## Description

- According to docs you should not have to pass a field in the custom event when using simplebinding, this is now fixed and giving you an error if you are not using simpleBinding _and_ not passing field in the event.
- Fixed an issue where you get a JSON circular dependency error when generating passThroughProps because we tried to include the div ref.

## Related Issue(s)

- closes https://github.com/Altinn/app-frontend-react/issues/2027

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [x] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
