### PR TITLE
Reworking how expression functions are defined

### DIFF
--- a/src/features/expressions/expression-functions.ts
+++ b/src/features/expressions/expression-functions.ts
@@ -427,12 +427,10 @@ export const ExprFunctionImplementations: { [K in Names]: Implementation<K> } = 
     const externalApiData: unknown = this.dataSources.externalApis.data[externalApiId];
 
     const res =
-      path && externalApiData && typeof externalApiData === 'object'
-        ? dot.pick(path, externalApiData)
-        : externalApiData;
+      externalApiData && typeof externalApiData === 'object' ? dot.pick(path, externalApiData) : externalApiData;
 
     if (!res || typeof res === 'object') {
-      return null; // Print error?
+      return null; // Return objects when the expression language supports them
     }
 
     return String(res);

--- a/src/features/expressions/expression-functions.ts
+++ b/src/features/expressions/expression-functions.ts
@@ -1,5 +1,4 @@
 import dot from 'dot-object';
-import type { Mutable } from 'utility-types';
 
 import { isDate } from 'src/app-components/Datepicker/utils/dateHelpers';
 import { ExprRuntimeError, NodeNotFound, NodeNotFoundWithoutContext } from 'src/features/expressions/errors';
@@ -14,182 +13,616 @@ import { BaseLayoutNode } from 'src/utils/layout/LayoutNode';
 import { LayoutPage } from 'src/utils/layout/LayoutPage';
 import type { DisplayData } from 'src/features/displayData';
 import type { EvaluateExpressionParams } from 'src/features/expressions';
-import type { ExprValToActual } from 'src/features/expressions/types';
+import type { AnyExprArg, ExprArgDef, ExprValToActual } from 'src/features/expressions/types';
 import type { ValidationContext } from 'src/features/expressions/validation';
 import type { IDataModelReference } from 'src/layout/common.generated';
 import type { IAuthContext, IInstanceDataSources } from 'src/types/shared';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
-type ArgsToActualOrNull<T extends readonly ExprVal[]> = {
-  [Index in keyof T]: ExprValToActual<T[Index]> | null;
+type ArgsToActual<T extends readonly AnyExprArg[]> = {
+  [Index in keyof T]: T[Index]['variant'] extends 'optional'
+    ? ExprValToActual<T[Index]['type']> | null | undefined
+    : ExprValToActual<T[Index]['type']> | null;
 };
 
-export interface FuncDef<Args extends readonly ExprVal[], Ret extends ExprVal> {
-  impl: (this: EvaluateExpressionParams, ...params: ArgsToActualOrNull<Args>) => ExprValToActual<Ret> | null;
+export type AnyFuncDef = FuncDef<readonly AnyExprArg[], ExprVal>;
+export interface FuncDef<Args extends readonly AnyExprArg[], Ret extends ExprVal> {
   args: Args;
-  minArguments?: number;
   returns: Ret;
+}
 
-  // Optional: Set this to true if the last argument type is considered a '...spread' argument, meaning
-  // all the rest of the arguments should be cast to the last type (and that the function allows any
-  // amount  of parameters).
-  lastArgSpreads?: true;
-
+export interface FuncValidationDef {
   // Optional: Validator function which runs when the function is validated. This allows a function to add its own
   // validation requirements. Use the addError() function if any errors are found.
+  // This runs after the automatic 'number of arguments validator', and will not run if the automatic validator fails.
   validator?: (options: {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    rawArgs: any[];
+    rawArgs: unknown[];
     argTypes: (ExprVal | undefined)[];
     ctx: ValidationContext;
     path: string[];
   }) => void;
+
+  // Optional: Set this to false if the automatic 'number of arguments validator' should NOT be run for this function.
+  // Defaults to true.
+  runNumArgsValidator?: boolean;
 }
 
-function defineFunc<Args extends readonly ExprVal[], Ret extends ExprVal>(
-  def: FuncDef<Args, Ret>,
-): FuncDef<Mutable<Args>, Ret> {
-  return def;
+function required<T extends ExprVal>(type: T): ExprArgDef<T, 'required'> {
+  return { type, variant: 'required' };
+}
+
+function optional<T extends ExprVal>(type: T): ExprArgDef<T, 'optional'> {
+  return { type, variant: 'optional' };
+}
+
+function rest<T extends ExprVal>(type: T): ExprArgDef<T, 'rest'> {
+  return { type, variant: 'rest' };
+}
+
+function args<A extends readonly AnyExprArg[]>(...args: A): A {
+  return args;
 }
 
 /**
- * All the functions available to execute inside expressions
+ * All the function definitions available in expressions. The implementations themselves are located in
+ * @see ExprFunctionImplementations
  */
-export const ExprFunctions = {
-  argv: defineFunc({
-    impl(idx) {
-      if (!this.positionalArguments?.length) {
-        throw new ExprRuntimeError(this.expr, this.path, 'No positional arguments available');
-      }
-
-      if (typeof idx !== 'number' || idx < 0 || idx >= this.positionalArguments.length) {
-        throw new ExprRuntimeError(this.expr, this.path, `Index ${idx} out of range`);
-      }
-
-      return this.positionalArguments[idx];
-    },
-    args: [ExprVal.Number] as const,
+export const ExprFunctionDefinitions = {
+  argv: {
+    args: args(required(ExprVal.Number)),
     returns: ExprVal.Any,
-  }),
-  value: defineFunc({
-    impl(key) {
-      const config = this.valueArguments;
-      if (!config) {
-        throw new ExprRuntimeError(this.expr, this.path, 'No value arguments available');
-      }
-
-      const realKey = key ?? config.defaultKey;
-      if (!realKey || typeof realKey !== 'string') {
-        throw new ExprRuntimeError(
-          this.expr,
-          this.path,
-          `Invalid key (expected string, got ${realKey ? typeof realKey : 'null'})`,
-        );
-      }
-
-      if (!Object.prototype.hasOwnProperty.call(config.data, realKey)) {
-        throw new ExprRuntimeError(
-          this.expr,
-          this.path,
-          `Unknown key ${realKey}, Valid keys are: ${Object.keys(config.data).join(', ')}`,
-        );
-      }
-
-      const value = config.data[realKey];
-      return value ?? null;
-    },
-    minArguments: 0,
-    args: [ExprVal.String] as const,
+  },
+  value: {
+    args: args(optional(ExprVal.String)),
     returns: ExprVal.Any,
-  }),
-  equals: defineFunc({
-    impl: (arg1, arg2) => arg1 === arg2,
-    args: [ExprVal.String, ExprVal.String] as const,
+  },
+  equals: {
+    args: args(required(ExprVal.String), required(ExprVal.String)),
     returns: ExprVal.Boolean,
-  }),
-  notEquals: defineFunc({
-    impl: (arg1, arg2) => arg1 !== arg2,
-    args: [ExprVal.String, ExprVal.String] as const,
+  },
+  notEquals: {
+    args: args(required(ExprVal.String), required(ExprVal.String)),
     returns: ExprVal.Boolean,
-  }),
-  not: defineFunc({
-    impl: (arg) => !arg,
-    args: [ExprVal.Boolean] as const,
+  },
+  not: {
+    args: args(required(ExprVal.Boolean)),
     returns: ExprVal.Boolean,
-  }),
-  greaterThan: defineFunc({
-    impl: (arg1, arg2) => {
-      if (arg1 === null || arg2 === null) {
-        return false;
-      }
-
-      return arg1 > arg2;
-    },
-    args: [ExprVal.Number, ExprVal.Number] as const,
+  },
+  greaterThan: {
+    args: args(required(ExprVal.Number), required(ExprVal.Number)),
     returns: ExprVal.Boolean,
-  }),
-  greaterThanEq: defineFunc({
-    impl: (arg1, arg2) => {
-      if (arg1 === null || arg2 === null) {
-        return false;
-      }
-
-      return arg1 >= arg2;
-    },
-    args: [ExprVal.Number, ExprVal.Number] as const,
+  },
+  greaterThanEq: {
+    args: args(required(ExprVal.Number), required(ExprVal.Number)),
     returns: ExprVal.Boolean,
-  }),
-  lessThan: defineFunc({
-    impl: (arg1, arg2) => {
-      if (arg1 === null || arg2 === null) {
-        return false;
-      }
-
-      return arg1 < arg2;
-    },
-    args: [ExprVal.Number, ExprVal.Number] as const,
+  },
+  lessThan: {
+    args: args(required(ExprVal.Number), required(ExprVal.Number)),
     returns: ExprVal.Boolean,
-  }),
-  lessThanEq: defineFunc({
-    impl: (arg1, arg2) => {
-      if (arg1 === null || arg2 === null) {
-        return false;
-      }
-
-      return arg1 <= arg2;
-    },
-    args: [ExprVal.Number, ExprVal.Number] as const,
+  },
+  lessThanEq: {
+    args: args(required(ExprVal.Number), required(ExprVal.Number)),
     returns: ExprVal.Boolean,
-  }),
-  concat: defineFunc({
-    impl: (...args) => args.join(''),
-    args: [ExprVal.String],
-    minArguments: 0,
+  },
+  concat: {
+    args: args(rest(ExprVal.String)),
     returns: ExprVal.String,
-    lastArgSpreads: true,
-  }),
-  and: defineFunc({
-    impl: (...args) => args.reduce((prev, cur) => prev && !!cur, true),
-    args: [ExprVal.Boolean],
+  },
+  and: {
+    args: args(required(ExprVal.Boolean), rest(ExprVal.Boolean)),
     returns: ExprVal.Boolean,
-    lastArgSpreads: true,
-  }),
-  or: defineFunc({
-    impl: (...args) => args.reduce((prev, cur) => prev || !!cur, false),
-    args: [ExprVal.Boolean],
+  },
+  or: {
+    args: args(required(ExprVal.Boolean), rest(ExprVal.Boolean)),
     returns: ExprVal.Boolean,
-    lastArgSpreads: true,
-  }),
-  if: defineFunc({
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    impl(...args): any {
-      const [condition, result] = args;
-      if (condition === true) {
-        return result;
+  },
+  if: {
+    args: args(required(ExprVal.Boolean), required(ExprVal.Any), optional(ExprVal.String), optional(ExprVal.Any)),
+    returns: ExprVal.Any,
+  },
+  instanceContext: {
+    args: args(required(ExprVal.String)),
+    returns: ExprVal.String,
+  },
+  frontendSettings: {
+    args: args(required(ExprVal.String)),
+    returns: ExprVal.Any,
+  },
+  authContext: {
+    args: args(required(ExprVal.String)),
+    returns: ExprVal.Boolean,
+  },
+  component: {
+    args: args(required(ExprVal.String)),
+    returns: ExprVal.Any,
+  },
+  dataModel: {
+    args: args(required(ExprVal.String), optional(ExprVal.String)),
+    returns: ExprVal.Any,
+  },
+  hasRole: {
+    args: args(required(ExprVal.String)),
+    returns: ExprVal.Boolean,
+  },
+  externalApi: {
+    args: args(required(ExprVal.String), required(ExprVal.String)),
+    returns: ExprVal.String,
+  },
+  displayValue: {
+    args: args(required(ExprVal.String)),
+    returns: ExprVal.String,
+  },
+  formatDate: {
+    args: args(required(ExprVal.String), optional(ExprVal.String)),
+    returns: ExprVal.String,
+  },
+  round: {
+    args: args(required(ExprVal.Number), optional(ExprVal.Number)),
+    returns: ExprVal.String,
+  },
+  text: {
+    args: args(required(ExprVal.String)),
+    returns: ExprVal.String,
+  },
+  linkToComponent: {
+    args: args(required(ExprVal.String), required(ExprVal.String)),
+    returns: ExprVal.String,
+  },
+  linkToPage: {
+    args: args(required(ExprVal.String), required(ExprVal.String)),
+    returns: ExprVal.String,
+  },
+  language: {
+    args: args(),
+    returns: ExprVal.String,
+  },
+  contains: {
+    args: args(required(ExprVal.String), required(ExprVal.String)),
+    returns: ExprVal.Boolean,
+  },
+  notContains: {
+    args: args(required(ExprVal.String), required(ExprVal.String)),
+    returns: ExprVal.Boolean,
+  },
+  endsWith: {
+    args: args(required(ExprVal.String), required(ExprVal.String)),
+    returns: ExprVal.Boolean,
+  },
+  startsWith: {
+    args: args(required(ExprVal.String), required(ExprVal.String)),
+    returns: ExprVal.Boolean,
+  },
+  stringLength: {
+    args: args(required(ExprVal.String)),
+    returns: ExprVal.Number,
+  },
+  commaContains: {
+    args: args(required(ExprVal.String), required(ExprVal.String)),
+    returns: ExprVal.Boolean,
+  },
+  lowerCase: {
+    args: args(required(ExprVal.String)),
+    returns: ExprVal.String,
+  },
+  upperCase: {
+    args: args(required(ExprVal.String)),
+    returns: ExprVal.String,
+  },
+  _experimentalSelectAndMap: {
+    args: args(
+      required(ExprVal.String),
+      required(ExprVal.String),
+      optional(ExprVal.String),
+      optional(ExprVal.String),
+      optional(ExprVal.Boolean),
+    ),
+    returns: ExprVal.String,
+  },
+} satisfies { [key: string]: AnyFuncDef };
+
+type Defs = typeof ExprFunctionDefinitions;
+type Names = keyof Defs;
+type Implementation<Name extends Names> = (
+  this: EvaluateExpressionParams,
+  ...params: ArgsToActual<Defs[Name]['args']>
+) => ExprValToActual<Defs[Name]['returns']> | null;
+
+export const ExprFunctionImplementations: { [K in Names]: Implementation<K> } = {
+  argv(idx) {
+    if (!this.positionalArguments?.length) {
+      throw new ExprRuntimeError(this.expr, this.path, 'No positional arguments available');
+    }
+
+    if (idx === null || idx < 0 || idx >= this.positionalArguments.length) {
+      throw new ExprRuntimeError(this.expr, this.path, `Index ${idx} out of range`);
+    }
+
+    return this.positionalArguments[idx];
+  },
+  value(key) {
+    const config = this.valueArguments;
+    if (!config) {
+      throw new ExprRuntimeError(this.expr, this.path, 'No value arguments available');
+    }
+
+    const realKey = (key ?? config.defaultKey) as string | null;
+    if (!realKey) {
+      throw new ExprRuntimeError(
+        this.expr,
+        this.path,
+        `Invalid key (expected string, got ${realKey ? typeof realKey : 'null'})`,
+      );
+    }
+
+    if (!Object.prototype.hasOwnProperty.call(config.data, realKey)) {
+      throw new ExprRuntimeError(
+        this.expr,
+        this.path,
+        `Unknown key ${realKey}, Valid keys are: ${Object.keys(config.data).join(', ')}`,
+      );
+    }
+
+    const value = config.data[realKey];
+    return value ?? null;
+  },
+  equals(arg1, arg2) {
+    return arg1 === arg2;
+  },
+  notEquals(arg1, arg2) {
+    return arg1 !== arg2;
+  },
+  not: (arg) => !arg,
+  greaterThan(arg1, arg2) {
+    if (arg1 === null || arg2 === null) {
+      return false;
+    }
+
+    return arg1 > arg2;
+  },
+  greaterThanEq(arg1, arg2) {
+    if (arg1 === null || arg2 === null) {
+      return false;
+    }
+
+    return arg1 >= arg2;
+  },
+  lessThan(arg1, arg2) {
+    if (arg1 === null || arg2 === null) {
+      return false;
+    }
+
+    return arg1 < arg2;
+  },
+  lessThanEq(arg1, arg2) {
+    if (arg1 === null || arg2 === null) {
+      return false;
+    }
+
+    return arg1 <= arg2;
+  },
+  concat: (...args) => args.join(''),
+  and: (...args) => args.reduce((prev, cur) => prev && !!cur, true),
+  or: (...args) => args.reduce((prev, cur) => prev || !!cur, false),
+  if(condition, result, _, elseResult) {
+    if (condition === true) {
+      return result;
+    }
+
+    return elseResult === undefined ? null : elseResult;
+  },
+  instanceContext(key): string | null {
+    const instanceDataSourcesKeys: { [key in keyof IInstanceDataSources]: true } = {
+      instanceId: true,
+      appId: true,
+      instanceOwnerPartyId: true,
+      instanceOwnerPartyType: true,
+    };
+
+    if (key === null || instanceDataSourcesKeys[key] !== true) {
+      throw new ExprRuntimeError(this.expr, this.path, `Unknown Instance context property ${key}`);
+    }
+
+    return (this.dataSources.instanceDataSources && this.dataSources.instanceDataSources[key]) || null;
+  },
+  frontendSettings(key) {
+    if (key === null) {
+      throw new ExprRuntimeError(this.expr, this.path, `Value cannot be null. (Parameter 'key')`);
+    }
+
+    return (this.dataSources.applicationSettings && this.dataSources.applicationSettings[key]) || null;
+  },
+  authContext(key) {
+    const authContextKeys: { [key in keyof IAuthContext]: true } = {
+      read: true,
+      write: true,
+      instantiate: true,
+      confirm: true,
+      sign: true,
+      reject: true,
+    };
+
+    if (key === null || authContextKeys[key] !== true) {
+      throw new ExprRuntimeError(this.expr, this.path, `Unknown auth context property ${key}`);
+    }
+
+    const authContext = buildAuthContext(this.dataSources.process?.currentTask);
+    return Boolean(authContext?.[key]);
+  },
+  component(id) {
+    if (id === null) {
+      throw new ExprRuntimeError(this.expr, this.path, `Cannot lookup component null`);
+    }
+
+    const node = ensureNode(this.node);
+    const closest = this.dataSources.nodeTraversal((t) => t.with(node).closestId(id), [node, id]);
+
+    const dataModelBindings = closest
+      ? this.dataSources.nodeDataSelector((picker) => picker(closest)?.layout.dataModelBindings, [closest])
+      : undefined;
+
+    const simpleBinding =
+      dataModelBindings && 'simpleBinding' in dataModelBindings ? dataModelBindings.simpleBinding : undefined;
+    if (closest && simpleBinding) {
+      if (this.dataSources.isHiddenSelector(closest)) {
+        return null;
       }
 
-      return args.length === 4 ? args[3] : null;
-    },
+      return pickSimpleValue(simpleBinding, this);
+    }
+
+    // Expressions can technically be used without having all the layouts available, which might lead to unexpected
+    // results. We should note this in the error message, so we know the reason we couldn't find the component.
+    const hasAllLayouts = node instanceof LayoutPage ? !!node.layoutSet : !!node.page.layoutSet;
+    throw new ExprRuntimeError(
+      this.expr,
+      this.path,
+      hasAllLayouts
+        ? `Unable to find component with identifier ${id} or it does not have a simpleBinding`
+        : `Unable to find component with identifier ${id} in the current layout or it does not have a simpleBinding`,
+    );
+  },
+  dataModel(propertyPath, maybeDataType) {
+    if (propertyPath === null) {
+      throw new ExprRuntimeError(this.expr, this.path, `Cannot lookup dataModel null`);
+    }
+
+    const dataType = maybeDataType ?? this.dataSources.currentLayoutSet?.dataType;
+    if (!dataType) {
+      throw new ExprRuntimeError(this.expr, this.path, `Cannot lookup dataType undefined`);
+    }
+
+    const reference: IDataModelReference = { dataType, field: propertyPath };
+    if (this.dataSources.currentDataModelPath && this.dataSources.currentDataModelPath.dataType === dataType) {
+      const newReference = transposeDataBinding({
+        subject: reference,
+        currentLocation: this.dataSources.currentDataModelPath,
+      });
+      return pickSimpleValue(newReference, this);
+    }
+
+    const node = ensureNode(this.node);
+    if (node instanceof BaseLayoutNode) {
+      const newReference = this.dataSources.transposeSelector(node as LayoutNode, reference);
+      return pickSimpleValue(newReference, this);
+    }
+
+    // No need to transpose the data model according to the location inside a repeating group when the context is
+    // a LayoutPage (i.e., when we're resolving an expression directly on the layout definition).
+    return pickSimpleValue(reference, this);
+  },
+  hasRole(roleName) {
+    if (!this.dataSources.roles || !roleName) {
+      return false;
+    }
+    return this.dataSources.roles.data?.map((role) => role.value).includes(roleName) ?? null;
+  },
+  externalApi(externalApiId, path) {
+    if (externalApiId === null) {
+      throw new ExprRuntimeError(this.expr, this.path, `Expected an external API id`);
+    }
+    if (!path) {
+      return null;
+    }
+
+    const externalApiData: unknown = this.dataSources.externalApis.data[externalApiId];
+
+    const res =
+      path && externalApiData && typeof externalApiData === 'object'
+        ? dot.pick(path, externalApiData)
+        : externalApiData;
+
+    if (!res || typeof res === 'object') {
+      return null; // Print error?
+    }
+
+    return String(res);
+  },
+  displayValue(id) {
+    if (id === null) {
+      throw new ExprRuntimeError(this.expr, this.path, `Cannot lookup component null`);
+    }
+
+    const node = ensureNode(this.node);
+    const targetNode = this.dataSources.nodeTraversal((t) => t.with(node).closestId(id), [node, id]);
+
+    if (!targetNode) {
+      throw new ExprRuntimeError(this.expr, this.path, `Unable to find component with identifier ${id}`);
+    }
+
+    const def = targetNode.def;
+    if (!implementsDisplayData(def)) {
+      throw new ExprRuntimeError(this.expr, this.path, `Component with identifier ${id} does not have a displayValue`);
+    }
+
+    if (this.dataSources.isHiddenSelector(targetNode)) {
+      return null;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (def as DisplayData<any>).getDisplayData(targetNode, {
+      attachmentsSelector: this.dataSources.attachmentsSelector,
+      optionsSelector: this.dataSources.optionsSelector,
+      langTools: this.dataSources.langToolsSelector(node as LayoutNode),
+      currentLanguage: this.dataSources.currentLanguage,
+      formDataSelector: this.dataSources.formDataSelector,
+      nodeFormDataSelector: this.dataSources.nodeFormDataSelector,
+      nodeDataSelector: this.dataSources.nodeDataSelector,
+    });
+  },
+  formatDate(date, format) {
+    if (date === null || !isDate(date)) {
+      return null;
+    }
+    const result = formatDateLocale(this.dataSources.currentLanguage, new Date(date), format ?? undefined);
+    if (result.includes('Unsupported: ')) {
+      throw new ExprRuntimeError(this.expr, this.path, `Unsupported date format token in '${format}'`);
+    }
+
+    return result;
+  },
+  round(number, decimalPoints) {
+    const realNumber = number === null ? 0 : number;
+    const realDecimalPoints = decimalPoints === null || decimalPoints === undefined ? 0 : decimalPoints;
+    return parseFloat(`${realNumber}`).toFixed(realDecimalPoints);
+  },
+  text(key) {
+    if (key === null) {
+      return null;
+    }
+
+    const node = this.node instanceof BaseLayoutNode ? this.node : undefined;
+    return this.dataSources.langToolsSelector(node).langAsNonProcessedString(key);
+  },
+  linkToComponent(linkText, id) {
+    if (id == null) {
+      window.logWarn('Component id was empty but must be set for linkToComponent to work');
+      return null;
+    }
+    if (linkText == null) {
+      window.logWarn('Link text was empty but must be set for linkToComponent to work');
+      return null;
+    }
+
+    const node = ensureNode(this.node);
+    const closest = this.dataSources.nodeTraversal((t) => t.with(node).closestId(id), [node, id]);
+
+    if (!closest) {
+      throw new ExprRuntimeError(this.expr, this.path, `Unable to find component with identifier ${id}`);
+    }
+
+    const taskId = this.dataSources.process?.currentTask?.elementId;
+    const instanceId = this.dataSources.instanceDataSources?.instanceId;
+
+    let url = '';
+    if (taskId && instanceId) {
+      url = `/instance/${instanceId}/${taskId}/${closest.pageKey}`;
+    } else {
+      url = `/${closest.pageKey}`;
+    }
+
+    const searchParams = new URLSearchParams();
+    searchParams.set(SearchParams.FocusComponentId, closest.id);
+    const newUrl = `${url}?${searchParams.toString()}`;
+    return `<a href="${newUrl}" data-link-type="LinkToPotentialNode">${linkText}</a>`;
+  },
+  linkToPage(linkText, pageId) {
+    if (pageId == null) {
+      window.logWarn('Page id was empty but must be set for linkToPage to work');
+      return null;
+    }
+    if (linkText == null) {
+      window.logWarn('Link text was empty but must be set for linkToPage to work');
+      return null;
+    }
+    const taskId = this.dataSources.process?.currentTask?.elementId;
+    const instanceId = this.dataSources.instanceDataSources?.instanceId;
+
+    let url = '';
+    if (taskId && instanceId) {
+      url = `/instance/${instanceId}/${taskId}/${pageId}`;
+    } else {
+      url = `/${pageId}`;
+    }
+    return `<a href="${url}" data-link-type="LinkToPotentialPage">${linkText}</a>`;
+  },
+  language() {
+    return this.dataSources.currentLanguage;
+  },
+  contains(string, stringToContain) {
+    if (string === null || stringToContain === null) {
+      return false;
+    }
+
+    return string.includes(stringToContain);
+  },
+  notContains(string, stringToNotContain) {
+    if (string === null || stringToNotContain === null) {
+      return true;
+    }
+    return !string.includes(stringToNotContain);
+  },
+  endsWith(string: string, stringToMatch: string): boolean {
+    if (string === null || stringToMatch === null) {
+      return false;
+    }
+    return string.endsWith(stringToMatch);
+  },
+  startsWith(string: string, stringToMatch: string): boolean {
+    if (string === null || stringToMatch === null) {
+      return false;
+    }
+    return string.startsWith(stringToMatch);
+  },
+  stringLength: (string) => (string === null ? 0 : string.length),
+  commaContains(commaSeparatedString, stringToMatch) {
+    if (commaSeparatedString === null || stringToMatch === null) {
+      return false;
+    }
+
+    // Split the comma separated string into an array and remove whitespace from each part
+    const parsedToArray = commaSeparatedString.split(',').map((part) => part.trim());
+    return parsedToArray.includes(stringToMatch);
+  },
+  lowerCase(string) {
+    if (string === null) {
+      return null;
+    }
+    return string.toLowerCase();
+  },
+  upperCase(string) {
+    if (string === null) {
+      return null;
+    }
+    return string.toUpperCase();
+  },
+  _experimentalSelectAndMap(path, propertyToSelect, prepend, append, appendToLastElement = true) {
+    if (path === null || propertyToSelect == null) {
+      throw new ExprRuntimeError(this.expr, this.path, `Cannot lookup dataModel null`);
+    }
+
+    const dataType = this.dataSources.currentLayoutSet?.dataType;
+    if (!dataType) {
+      throw new ExprRuntimeError(this.expr, this.path, `Cannot lookup dataType undefined`);
+    }
+    const array = this.dataSources.formDataSelector({ field: path, dataType });
+    if (typeof array != 'object' || !Array.isArray(array)) {
+      return '';
+    }
+    return array
+      .map((x, i) => {
+        const hideLastElement = i == array.length - 1 && !appendToLastElement;
+
+        const valueToPrepend = prepend == null ? '' : prepend;
+        const valueToAppend = append == null || hideLastElement ? '' : append;
+
+        return `${valueToPrepend}${x[propertyToSelect]}${valueToAppend}`;
+      })
+      .join(' ');
+  },
+};
+
+export const ExprFunctionValidationExtensions: { [K in Names]?: FuncValidationDef } = {
+  if: {
     validator: ({ rawArgs, ctx, path }) => {
       if (rawArgs.length === 2) {
         return;
@@ -202,425 +635,15 @@ export const ExprFunctions = {
       }
       addError(ctx, path, 'Expected either 2 arguments (if) or 4 (if + else), got %s', `${rawArgs.length}`);
     },
-    args: [ExprVal.Boolean, ExprVal.Any, ExprVal.String, ExprVal.Any],
-    returns: ExprVal.Any,
-  }),
-  instanceContext: defineFunc({
-    impl(key): string | null {
-      const instanceDataSourcesKeys: { [key in keyof IInstanceDataSources]: true } = {
-        instanceId: true,
-        appId: true,
-        instanceOwnerPartyId: true,
-        instanceOwnerPartyType: true,
-      };
-
-      if (key === null || instanceDataSourcesKeys[key] !== true) {
-        throw new ExprRuntimeError(this.expr, this.path, `Unknown Instance context property ${key}`);
-      }
-
-      return (this.dataSources.instanceDataSources && this.dataSources.instanceDataSources[key]) || null;
-    },
-    args: [ExprVal.String] as const,
-    returns: ExprVal.String,
-  }),
-  frontendSettings: defineFunc({
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    impl(key): any {
-      if (key === null) {
-        throw new ExprRuntimeError(this.expr, this.path, `Value cannot be null. (Parameter 'key')`);
-      }
-
-      return (this.dataSources.applicationSettings && this.dataSources.applicationSettings[key]) || null;
-    },
-    args: [ExprVal.String] as const,
-    returns: ExprVal.Any,
-  }),
-  authContext: defineFunc({
-    impl(key): boolean | null {
-      const authContextKeys: { [key in keyof IAuthContext]: true } = {
-        read: true,
-        write: true,
-        instantiate: true,
-        confirm: true,
-        sign: true,
-        reject: true,
-      };
-
-      if (key === null || authContextKeys[key] !== true) {
-        throw new ExprRuntimeError(this.expr, this.path, `Unknown auth context property ${key}`);
-      }
-
-      const authContext = buildAuthContext(this.dataSources.process?.currentTask);
-      return Boolean(authContext?.[key]);
-    },
-    args: [ExprVal.String] as const,
-    returns: ExprVal.Boolean,
-  }),
-  component: defineFunc({
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    impl(id): any {
-      if (id === null) {
-        throw new ExprRuntimeError(this.expr, this.path, `Cannot lookup component null`);
-      }
-
-      const node = ensureNode(this.node);
-      const closest = this.dataSources.nodeTraversal((t) => t.with(node).closestId(id), [node, id]);
-
-      const dataModelBindings = closest
-        ? this.dataSources.nodeDataSelector((picker) => picker(closest)?.layout.dataModelBindings, [closest])
-        : undefined;
-
-      const simpleBinding =
-        dataModelBindings && 'simpleBinding' in dataModelBindings ? dataModelBindings.simpleBinding : undefined;
-      if (closest && simpleBinding) {
-        if (this.dataSources.isHiddenSelector(closest)) {
-          return null;
-        }
-
-        return pickSimpleValue(simpleBinding, this);
-      }
-
-      // Expressions can technically be used without having all the layouts available, which might lead to unexpected
-      // results. We should note this in the error message, so we know the reason we couldn't find the component.
-      const hasAllLayouts = node instanceof LayoutPage ? !!node.layoutSet : !!node.page.layoutSet;
-      throw new ExprRuntimeError(
-        this.expr,
-        this.path,
-        hasAllLayouts
-          ? `Unable to find component with identifier ${id} or it does not have a simpleBinding`
-          : `Unable to find component with identifier ${id} in the current layout or it does not have a simpleBinding`,
-      );
-    },
-    args: [ExprVal.String] as const,
-    returns: ExprVal.Any,
-  }),
-  dataModel: defineFunc({
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    impl(propertyPath, maybeDataType): any {
-      if (propertyPath === null) {
-        throw new ExprRuntimeError(this.expr, this.path, `Cannot lookup dataModel null`);
-      }
-
-      const dataType = maybeDataType ?? this.dataSources.currentLayoutSet?.dataType;
-      if (!dataType) {
-        throw new ExprRuntimeError(this.expr, this.path, `Cannot lookup dataType undefined`);
-      }
-
-      const reference: IDataModelReference = { dataType, field: propertyPath };
-      if (this.dataSources.currentDataModelPath && this.dataSources.currentDataModelPath.dataType === dataType) {
-        const newReference = transposeDataBinding({
-          subject: reference,
-          currentLocation: this.dataSources.currentDataModelPath,
-        });
-        return pickSimpleValue(newReference, this);
-      }
-
-      const node = ensureNode(this.node);
-      if (node instanceof BaseLayoutNode) {
-        const newReference = this.dataSources.transposeSelector(node as LayoutNode, reference);
-        return pickSimpleValue(newReference, this);
-      }
-
-      // No need to transpose the data model according to the location inside a repeating group when the context is
-      // a LayoutPage (i.e., when we're resolving an expression directly on the layout definition).
-      return pickSimpleValue(reference, this);
-    },
-    args: [ExprVal.String, ExprVal.String] as const,
-    minArguments: 1,
-    returns: ExprVal.Any,
-  }),
-  hasRole: defineFunc({
-    impl(roleName): boolean | null {
-      if (typeof roleName !== 'string') {
-        throw new ExprRuntimeError(this.expr, this.path, `Expected string argument.`);
-      }
-      if (!this.dataSources.roles) {
-        return false;
-      }
-      return this.dataSources.roles.data?.map((role) => role.value).includes(roleName) ?? null;
-    },
-    args: [ExprVal.String] as const,
-    returns: ExprVal.Boolean,
-  }),
-  externalApi: defineFunc({
-    impl(externalApiId, path): string | null {
-      if (typeof externalApiId !== 'string' || typeof path !== 'string') {
-        throw new ExprRuntimeError(this.expr, this.path, `Expected string arguments`);
-      }
-
-      const externalApiData: unknown = this.dataSources.externalApis.data[externalApiId];
-
-      const res =
-        path && externalApiData && typeof externalApiData === 'object'
-          ? dot.pick(path, externalApiData)
-          : externalApiData;
-
-      if (!res || typeof res === 'object') {
-        return null; // Print error?
-      }
-
-      return String(res);
-    },
-    args: [ExprVal.String, ExprVal.String] as const,
-    validator: ({ rawArgs, ctx, path }) => {
-      if (rawArgs.length !== 2) {
-        addError(ctx, path, 'Expected exactly 2 arguments, got %s', `${rawArgs.length}`);
+    runNumArgsValidator: false,
+  },
+  dataModel: {
+    validator({ rawArgs, ctx, path }) {
+      if (rawArgs.length > 1 && rawArgs[1] !== null && typeof rawArgs[1] !== 'string') {
+        addError(ctx, [...path, '[2]'], 'The data type must be a string (expressions cannot be used here)');
       }
     },
-    returns: ExprVal.String,
-  }),
-  displayValue: defineFunc({
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    impl(id): any {
-      if (id === null) {
-        throw new ExprRuntimeError(this.expr, this.path, `Cannot lookup component null`);
-      }
-
-      const node = ensureNode(this.node);
-      const targetNode = this.dataSources.nodeTraversal((t) => t.with(node).closestId(id), [node, id]);
-
-      if (!targetNode) {
-        throw new ExprRuntimeError(this.expr, this.path, `Unable to find component with identifier ${id}`);
-      }
-
-      const def = targetNode.def;
-      if (!implementsDisplayData(def)) {
-        throw new ExprRuntimeError(
-          this.expr,
-          this.path,
-          `Component with identifier ${id} does not have a displayValue`,
-        );
-      }
-
-      if (this.dataSources.isHiddenSelector(targetNode)) {
-        return null;
-      }
-
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      return (def as DisplayData<any>).getDisplayData(targetNode, {
-        attachmentsSelector: this.dataSources.attachmentsSelector,
-        optionsSelector: this.dataSources.optionsSelector,
-        langTools: this.dataSources.langToolsSelector(node as LayoutNode),
-        currentLanguage: this.dataSources.currentLanguage,
-        formDataSelector: this.dataSources.formDataSelector,
-        nodeFormDataSelector: this.dataSources.nodeFormDataSelector,
-        nodeDataSelector: this.dataSources.nodeDataSelector,
-      });
-    },
-    args: [ExprVal.String] as const,
-    returns: ExprVal.String,
-  }),
-  formatDate: defineFunc({
-    impl(date: string, format: string | null): string | null {
-      const selectedLanguage = this.dataSources.currentLanguage;
-      if (!isDate(date)) {
-        return null;
-      }
-      return formatDateLocale(selectedLanguage, new Date(date), format ?? undefined);
-    },
-    minArguments: 1,
-    args: [ExprVal.String, ExprVal.String] as const,
-    returns: ExprVal.String,
-  }),
-  round: defineFunc({
-    impl(number, decimalPoints) {
-      const realNumber = number === null ? 0 : number;
-      const realDecimalPoints = decimalPoints === null ? 0 : decimalPoints;
-      return parseFloat(`${realNumber}`).toFixed(realDecimalPoints);
-    },
-    args: [ExprVal.Number, ExprVal.Number] as const,
-    minArguments: 1,
-    returns: ExprVal.String,
-  }),
-  text: defineFunc({
-    impl(key) {
-      if (key === null) {
-        return null;
-      }
-
-      const node = this.node instanceof BaseLayoutNode ? this.node : undefined;
-      return this.dataSources.langToolsSelector(node).langAsNonProcessedString(key);
-    },
-    args: [ExprVal.String] as const,
-    returns: ExprVal.String,
-  }),
-  linkToComponent: defineFunc({
-    impl(linkText, id) {
-      if (id == null) {
-        window.logWarn('Component id was empty but must be set for linkToComponent to work');
-        return null;
-      }
-      if (linkText == null) {
-        window.logWarn('Link text was empty but must be set for linkToComponent to work');
-        return null;
-      }
-
-      const node = ensureNode(this.node);
-      const closest = this.dataSources.nodeTraversal((t) => t.with(node).closestId(id), [node, id]);
-
-      if (!closest) {
-        throw new ExprRuntimeError(this.expr, this.path, `Unable to find component with identifier ${id}`);
-      }
-
-      const taskId = this.dataSources.process?.currentTask?.elementId;
-      const instanceId = this.dataSources.instanceDataSources?.instanceId;
-
-      let url = '';
-      if (taskId && instanceId) {
-        url = `/instance/${instanceId}/${taskId}/${closest.pageKey}`;
-      } else {
-        url = `/${closest.pageKey}`;
-      }
-
-      const searchParams = new URLSearchParams();
-      searchParams.set(SearchParams.FocusComponentId, closest.id);
-      const newUrl = `${url}?${searchParams.toString()}`;
-      return `<a href="${newUrl}" data-link-type="LinkToPotentialNode">${linkText}</a>`;
-    },
-    args: [ExprVal.String, ExprVal.String] as const,
-    minArguments: 2,
-    returns: ExprVal.String,
-  }),
-  linkToPage: defineFunc({
-    impl(linkText, pageId) {
-      if (pageId == null) {
-        window.logWarn('Page id was empty but must be set for linkToPage to work');
-        return null;
-      }
-      if (linkText == null) {
-        window.logWarn('Link text was empty but must be set for linkToPage to work');
-        return null;
-      }
-      const taskId = this.dataSources.process?.currentTask?.elementId;
-      const instanceId = this.dataSources.instanceDataSources?.instanceId;
-
-      let url = '';
-      if (taskId && instanceId) {
-        url = `/instance/${instanceId}/${taskId}/${pageId}`;
-      } else {
-        url = `/${pageId}`;
-      }
-      return `<a href="${url}" data-link-type="LinkToPotentialPage">${linkText}</a>`;
-    },
-    args: [ExprVal.String, ExprVal.String] as const,
-    minArguments: 2,
-    returns: ExprVal.String,
-  }),
-  language: defineFunc({
-    impl() {
-      return this.dataSources.currentLanguage;
-    },
-    args: [] as const,
-    returns: ExprVal.String,
-  }),
-  contains: defineFunc({
-    impl(string, stringToContain): boolean {
-      if (string === null || stringToContain === null) {
-        return false;
-      }
-
-      return string.includes(stringToContain);
-    },
-    args: [ExprVal.String, ExprVal.String] as const,
-    returns: ExprVal.Boolean,
-  }),
-  notContains: defineFunc({
-    impl(string: string, stringToNotContain: string): boolean {
-      if (string === null || stringToNotContain === null) {
-        return true;
-      }
-      return !string.includes(stringToNotContain);
-    },
-    args: [ExprVal.String, ExprVal.String] as const,
-    returns: ExprVal.Boolean,
-  }),
-  endsWith: defineFunc({
-    impl(string: string, stringToMatch: string): boolean {
-      if (string === null || stringToMatch === null) {
-        return false;
-      }
-      return string.endsWith(stringToMatch);
-    },
-    args: [ExprVal.String, ExprVal.String] as const,
-    returns: ExprVal.Boolean,
-  }),
-  startsWith: defineFunc({
-    impl(string: string, stringToMatch: string): boolean {
-      if (string === null || stringToMatch === null) {
-        return false;
-      }
-      return string.startsWith(stringToMatch);
-    },
-    args: [ExprVal.String, ExprVal.String] as const,
-    returns: ExprVal.Boolean,
-  }),
-  stringLength: defineFunc({
-    impl: (string) => (string === null ? 0 : string.length),
-    args: [ExprVal.String] as const,
-    returns: ExprVal.Number,
-  }),
-  commaContains: defineFunc({
-    impl(commaSeparatedString, stringToMatch) {
-      if (commaSeparatedString === null || stringToMatch === null) {
-        return false;
-      }
-
-      // Split the comma separated string into an array and remove whitespace from each part
-      const parsedToArray = commaSeparatedString.split(',').map((part) => part.trim());
-      return parsedToArray.includes(stringToMatch);
-    },
-    args: [ExprVal.String, ExprVal.String] as const,
-    returns: ExprVal.Boolean,
-  }),
-  lowerCase: defineFunc({
-    impl(string) {
-      if (string === null) {
-        return null;
-      }
-      return string.toLowerCase();
-    },
-    args: [ExprVal.String] as const,
-    returns: ExprVal.String,
-  }),
-  upperCase: defineFunc({
-    impl(string) {
-      if (string === null) {
-        return null;
-      }
-      return string.toUpperCase();
-    },
-    args: [ExprVal.String] as const,
-    returns: ExprVal.String,
-  }),
-  _experimentalSelectAndMap: defineFunc({
-    args: [ExprVal.String, ExprVal.String, ExprVal.String, ExprVal.String, ExprVal.Boolean] as const,
-    impl(path, propertyToSelect, prepend, append, appendToLastElement = true) {
-      if (path === null || propertyToSelect == null) {
-        throw new ExprRuntimeError(this.expr, this.path, `Cannot lookup dataModel null`);
-      }
-
-      const dataType = this.dataSources.currentLayoutSet?.dataType;
-      if (!dataType) {
-        throw new ExprRuntimeError(this.expr, this.path, `Cannot lookup dataType undefined`);
-      }
-      const array = this.dataSources.formDataSelector({ field: path, dataType });
-      if (typeof array != 'object' || !Array.isArray(array)) {
-        return '';
-      }
-      return array
-        .map((x, i) => {
-          const hideLastElement = i == array.length - 1 && !appendToLastElement;
-
-          const valueToPrepend = prepend == null ? '' : prepend;
-          const valueToAppend = append == null || hideLastElement ? '' : append;
-
-          return `${valueToPrepend}${x[propertyToSelect]}${valueToAppend}`;
-        })
-        .join(' ');
-    },
-    minArguments: 2,
-    returns: ExprVal.String,
-  }),
+  },
 };
 
 function pickSimpleValue(path: IDataModelReference, params: EvaluateExpressionParams) {

--- a/src/features/expressions/schema.test.ts
+++ b/src/features/expressions/schema.test.ts
@@ -1,84 +1,85 @@
 import Ajv from 'ajv';
 import expressionSchema from 'schemas/json/layout/expression.schema.v1.json';
 
-import { ExprFunctions } from 'src/features/expressions/expression-functions';
+import { ExprFunctionDefinitions } from 'src/features/expressions/expression-functions';
 import { ExprVal } from 'src/features/expressions/types';
-import type { FuncDef } from 'src/features/expressions/expression-functions';
+import type { AnyFuncDef } from 'src/features/expressions/expression-functions';
 
-type Func = { name: string } & FuncDef<ExprVal[], ExprVal>;
+type Func = { name: string } & AnyFuncDef;
 
 describe('expression schema tests', () => {
   const functions: Func[] = [];
-  for (const name of Object.keys(ExprFunctions)) {
-    const func = ExprFunctions[name];
+  for (const name of Object.keys(ExprFunctionDefinitions)) {
+    const func = ExprFunctionDefinitions[name];
     functions.push({ name, ...func });
   }
 
-  it.each(functions)(
-    '$name should have a valid func-$name definition',
-    ({ name, args, minArguments, returns, lastArgSpreads }) => {
-      if (name === 'if') {
-        // if is a special case, we'll skip it here
-        return;
+  it.each(functions)('$name should have a valid func-$name definition', ({ name, args, returns }) => {
+    if (name === 'if') {
+      // if is a special case, we'll skip it here
+      return;
+    }
+
+    expect(expressionSchema.definitions[`func-${name}`]).toBeDefined();
+    expect(expressionSchema.definitions[`func-${name}`].type).toBe('array');
+    expect(expressionSchema.definitions[`func-${name}`].items[0]).toEqual({ const: name });
+
+    // It might be tempting to add these into the definitions to make the schema stricter and properly validate
+    // min/max arguments, but this would make the schema less useful for the user, as they would not get
+    // autocompletion in vscode until they had the minimum number of arguments.
+    expect(expressionSchema.definitions[`func-${name}`].minItems).toBe(undefined);
+    expect(expressionSchema.definitions[`func-${name}`].maxItems).toBe(undefined);
+
+    if (returns === ExprVal.Any) {
+      // At least one of the definitions should be a match
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const allTypes: any[] = [];
+      for (const type of ['number', 'string', 'boolean']) {
+        allTypes.push(...expressionSchema.definitions[`strict-${type}`].anyOf);
       }
+      expect(allTypes).toContainEqual({
+        $ref: `#/definitions/func-${name}`,
+      });
+    } else {
+      const returnString = exprValToString(returns);
+      expect(expressionSchema.definitions[`strict-${returnString}`].anyOf).toContainEqual({
+        $ref: `#/definitions/func-${name}`,
+      });
+    }
 
-      expect(expressionSchema.definitions[`func-${name}`]).toBeDefined();
-      expect(expressionSchema.definitions[`func-${name}`].type).toBe('array');
-      expect(expressionSchema.definitions[`func-${name}`].items[0]).toEqual({ const: name });
+    const minArguments = args.findIndex((arg) => arg.variant === 'optional' || arg.variant === 'rest');
+    const lastArgSpreads = args[args.length - 1]?.variant === 'rest';
 
-      // It might be tempting to add these into the definitions to make the schema stricter and properly validate
-      // min/max arguments, but this would make the schema less useful for the user, as they would not get
-      // autocompletion in vscode until they had the minimum number of arguments.
-      expect(expressionSchema.definitions[`func-${name}`].minItems).toBe(undefined);
-      expect(expressionSchema.definitions[`func-${name}`].maxItems).toBe(undefined);
+    if (minArguments === -1) {
+      expect(expressionSchema.definitions[`func-${name}`].items.length).toBe(args.length + 1);
+    } else {
+      expect(expressionSchema.definitions[`func-${name}`].items.length).toBeGreaterThanOrEqual(minArguments + 1);
+    }
 
-      if (returns === ExprVal.Any) {
-        // At least one of the definitions should be a match
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const allTypes: any[] = [];
-        for (const type of ['number', 'string', 'boolean']) {
-          allTypes.push(...expressionSchema.definitions[`strict-${type}`].anyOf);
-        }
-        expect(allTypes).toContainEqual({
-          $ref: `#/definitions/func-${name}`,
-        });
-      } else {
-        const returnString = exprValToString(returns);
-        expect(expressionSchema.definitions[`strict-${returnString}`].anyOf).toContainEqual({
-          $ref: `#/definitions/func-${name}`,
-        });
-      }
-
-      if (minArguments === undefined) {
-        expect(expressionSchema.definitions[`func-${name}`].items.length).toBe(args.length + 1);
-      } else {
-        expect(expressionSchema.definitions[`func-${name}`].items.length).toBeGreaterThanOrEqual(minArguments + 1);
-      }
-
-      if (lastArgSpreads) {
-        const lastArg = args[args.length - 1];
-        expect(expressionSchema.definitions[`func-${name}`].additionalItems).toEqual({ $ref: exprValToDef(lastArg) });
-      } else {
-        expect(expressionSchema.definitions[`func-${name}`].additionalItems).toBe(false);
-      }
-    },
-  );
+    if (lastArgSpreads) {
+      const lastArg = args[args.length - 1].type;
+      expect(expressionSchema.definitions[`func-${name}`].additionalItems).toEqual({ $ref: exprValToDef(lastArg) });
+    } else {
+      expect(expressionSchema.definitions[`func-${name}`].additionalItems).toBe(false);
+    }
+  });
 
   const ajv = new Ajv({ strict: false });
   const validate = ajv.compile(expressionSchema);
 
-  it.each(functions)('$name should validate against generated function calls', ({ name, args, lastArgSpreads }) => {
+  it.each(functions)('$name should validate against generated function calls', ({ name, args }) => {
     if (name === 'if') {
       // if is a special case, we'll skip it here
       return;
     }
 
     const funcDef = expressionSchema.definitions[`func-${name}`];
+    const lastArgSpreads = args[args.length - 1]?.variant === 'rest';
 
     // With exactly the right number of arguments
-    const funcCall = [name, ...args.map(exprValToString)];
+    const funcCall = [name, ...args.map((arg) => exprValToString(arg.type))];
     if (lastArgSpreads) {
-      funcCall.push(...args.map(exprValToString));
+      funcCall.push(...args.map((arg) => exprValToString(arg.type)));
     }
 
     // Use enum value, if defined in schema
@@ -105,7 +106,7 @@ describe('expression schema tests', () => {
     expect(validMinArguments).toBe(true);
 
     // With too many arguments
-    const funcCallExtra = [name, ...args.map(exprValToString), 'extra'];
+    const funcCallExtra = [name, ...args.map((arg) => exprValToString(arg.type)), 'extra'];
     const validExtra = validate(funcCallExtra);
     if (lastArgSpreads) {
       // This always validates, because the last argument spread
@@ -119,6 +120,14 @@ describe('expression schema tests', () => {
   it('invalid functions should not validate', () => {
     const valid = validate(['invalid_function']);
     expect(valid).toBe(false);
+  });
+
+  it('no other function definitions should be present', () => {
+    const hardcodedAllowed = new Set(['func-if-without-else', 'func-if-with-else']);
+    const functionDefs = Object.keys(expressionSchema.definitions).filter((key) => key.startsWith('func-'));
+    const validFunctionDefs = new Set(Object.keys(ExprFunctionDefinitions).map((name) => `func-${name}`));
+    const unknownFunctionDefs = functionDefs.filter((key) => !validFunctionDefs.has(key) && !hardcodedAllowed.has(key));
+    expect(unknownFunctionDefs).toEqual([]);
   });
 });
 

--- a/src/features/expressions/shared-functions-exist.test.ts
+++ b/src/features/expressions/shared-functions-exist.test.ts
@@ -1,4 +1,4 @@
-import { ExprFunctions } from 'src/features/expressions/expression-functions';
+import { ExprFunctionDefinitions } from 'src/features/expressions/expression-functions';
 import { getSharedTests } from 'src/features/expressions/shared';
 import { implementsDisplayData } from 'src/layout';
 import { getComponentConfigs } from 'src/layout/components.generated';
@@ -34,7 +34,7 @@ describe('Shared function tests should exist', () => {
   });
 
   describe('Function tests', () => {
-    for (const exprFunc of Object.keys(ExprFunctions)) {
+    for (const exprFunc of Object.keys(ExprFunctionDefinitions)) {
       it(`Expression function ${exprFunc} should have a test folder`, () => {
         expect(sharedTests?.content.find(({ folderName }) => folderName === exprFunc)).toBeTruthy();
       });

--- a/src/features/expressions/shared-functions.test.tsx
+++ b/src/features/expressions/shared-functions.test.tsx
@@ -8,7 +8,7 @@ import { getInstanceDataMock } from 'src/__mocks__/getInstanceDataMock';
 import { getSubFormLayoutSetMock } from 'src/__mocks__/getLayoutSetsMock';
 import { getProcessDataMock } from 'src/__mocks__/getProcessDataMock';
 import { getProfileMock } from 'src/__mocks__/getProfileMock';
-import { getSharedTests } from 'src/features/expressions/shared';
+import { getSharedTests, type SharedTestFunctionContext } from 'src/features/expressions/shared';
 import { ExprVal } from 'src/features/expressions/types';
 import { ExprValidation } from 'src/features/expressions/validation';
 import { useExternalApis } from 'src/features/externalApi/useExternalApi';
@@ -17,7 +17,6 @@ import { fetchApplicationMetadata, fetchProcessState } from 'src/queries/queries
 import { renderWithNode } from 'src/test/renderWithProviders';
 import { useEvalExpression } from 'src/utils/layout/generator/useEvalExpression';
 import { useExpressionDataSources } from 'src/utils/layout/useExpressionDataSources';
-import type { SharedTestFunctionContext } from 'src/features/expressions/shared';
 import type { ExprPositionalArgs, ExprValToActualOrExpr, ExprValueArgs } from 'src/features/expressions/types';
 import type { ExternalApisResult } from 'src/features/externalApi/useExternalApi';
 import type { RoleResult } from 'src/features/useCurrentPartyRoles';
@@ -267,7 +266,7 @@ describe('Expressions shared function tests', () => {
             valueArguments={valueArguments}
           />
         ),
-        inInstance: !!instance,
+        inInstance: !!instance || !!dataModels,
         queries: {
           fetchLayoutSets: async () => ({
             sets: [{ id: 'layout-set', dataType: 'default', tasks: ['Task_1'] }, getSubFormLayoutSetMock()],

--- a/src/features/expressions/shared-tests/functions/if/fail-else-as-expr.json
+++ b/src/features/expressions/shared-tests/functions/if/fail-else-as-expr.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should fail when given an expression instead of 'else'",
+  "expression": ["if", true, 123.456, ["if", true, "else", "else", "not-else?"], 654.321],
+  "expectsFailure": "Expected third argument to be \"else\""
+}

--- a/src/features/expressions/types.ts
+++ b/src/features/expressions/types.ts
@@ -1,8 +1,8 @@
 import type { PickByValue } from 'utility-types';
 
-import type { ExprFunctions } from 'src/features/expressions/expression-functions';
+import type { ExprFunctionDefinitions } from 'src/features/expressions/expression-functions';
 
-type Functions = typeof ExprFunctions;
+type Functions = typeof ExprFunctionDefinitions;
 
 /**
  * This union type includes all possible functions usable in expressions
@@ -52,7 +52,7 @@ type IndexHack<F extends ExprFunction> = ['Here goes the function name', ...Args
 type MaybeRecursive<
   F extends ExprFunction,
   Iterations extends Prev[number],
-  Args extends ('Here goes the function name' | ExprVal)[] = IndexHack<F>,
+  Args extends ('Here goes the function name' | AnyExprArg)[] = IndexHack<F>,
 > = [Iterations] extends [never]
   ? never
   : {
@@ -115,3 +115,10 @@ export type ExprValueArgs<T extends object = any> = {
   data: T;
   defaultKey: keyof T;
 };
+
+export type ExprArgVariant = 'required' | 'optional' | 'rest';
+export type ExprArgDef<T extends ExprVal, Variant extends ExprArgVariant> = {
+  type: T;
+  variant: Variant;
+};
+export type AnyExprArg = ExprArgDef<ExprVal, ExprArgVariant>;

--- a/test/e2e/integration/frontend-test/all-process-steps.ts
+++ b/test/e2e/integration/frontend-test/all-process-steps.ts
@@ -409,7 +409,6 @@ const knownDataModels: { [key: string]: unknown } = {
     ShiftingOptions: null,
     FilteredOptions: null,
     LinkedHidden: null,
-    PetsUseOptionComponent: null,
   },
   'nested-group': {
     skjemanummer: 1603,
@@ -472,6 +471,7 @@ const knownDataModels: { [key: string]: unknown } = {
     NumPets: 0,
     HiddenPets: null,
     PetSortOrder: null,
+    PetsUseOptionComponent: null,
   },
   likert: {
     Questions: [


### PR DESCRIPTION
## Description

This is the first PR in a series. When implementing the new `compare` function, date comparison functions, etc, I saw a few problems and common mistakes in `expression-functions.ts` that I'll clean up here.

1. Before an expression function is called, the expression engine will evaluate arguments (if they are function calls) and cast values to the data type you've said the function accepts. So when typescript tells you an argument is a `string | null` there's no need to both check it for null and if it's another type than string. Validation happens automatically, and before the function is called, so I removed some attempts to validate incoming arguments inside expression functions.
2. For some reason, the typing for the big object fell apart when I introduced multiple new functions. As this type seemed brittle, I restructured the types into 3 different objects (`ExprFunctionDefinitions`, `ExprFunctionImplementations` and `ExprFunctionValidationExtensions`).
3. When you implemented your won validator, the default 'number of arguments' validator wasn't called at all. If you just wanted to supplement validation (not override it), this was unfortunate - and you'd just have to know that your validator had to check the number of arguments as well. Now I've made this optional by making it possible to set `runNumArgsValidator: false` in cases where you don't want the default 'number of arguments' validator to be called.
4. Optional arguments would still be typed as (for example) `string | null`, but in reality they'd be `string | null | undefined` (undefined being the value when no argument was passed). Also, a few function definitions didn't properly use `as const` on their arguments definitions, so I've made this easier to get right with the new arguments definition that is much easier to get right (i.e. `args(required(ExprVal.String), optional(ExprVal.Number))`).

This also sneaks in a fix to a problem in `all-process-steps.ts` that I introduced late last week.

## Related Issue(s)

- #1299 

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [x] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
