### PR TITLE
Bugfix: set maxzoom for bounds to avoid infinity

### DIFF
--- a/src/layout/Map/Map.tsx
+++ b/src/layout/Map/Map.tsx
@@ -123,7 +123,7 @@ export function Map({
       center={center}
       zoom={zoom}
       bounds={bounds}
-      boundsOptions={{ padding: DefaultBoundsPadding }}
+      boundsOptions={{ padding: DefaultBoundsPadding, maxZoom: DefaultFlyToZoomLevel }}
       minZoom={3}
       maxBounds={[
         [-90, -200],


### PR DESCRIPTION


## Description
Added a max-zoom value to initial boundsoptions for Map-component to avoid leaflet setting zoom to infinity on initial render of map-component.
Without a max-zoom value leaflet defaults max-zoom to infinity when bounds is a singular point, causing the map to fail because the bounds are calculated to infinity. After first render this is no longer a problem.

## Related Issue(s)

- closes #2955 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [x] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` label to this PR for proper release notes grouping
  - [x] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
