### PR TITLE
Allowing more components to show up inside an Accordion

### DIFF
--- a/src/layout/ActionButton/config.ts
+++ b/src/layout/ActionButton/config.ts
@@ -6,7 +6,7 @@ export const Config = new CG.component({
   capabilities: {
     renderInTable: true,
     renderInButtonGroup: true,
-    renderInAccordion: false,
+    renderInAccordion: true,
     renderInAccordionGroup: false,
     renderInCards: true,
     renderInCardsMedia: false,

--- a/src/layout/AddToList/config.ts
+++ b/src/layout/AddToList/config.ts
@@ -6,9 +6,9 @@ export const Config = new CG.component({
   capabilities: {
     renderInTable: false,
     renderInButtonGroup: false,
-    renderInAccordion: false,
+    renderInAccordion: true,
     renderInAccordionGroup: false,
-    renderInCards: false,
+    renderInCards: true,
     renderInCardsMedia: false,
     renderInTabs: true,
   },

--- a/src/layout/Address/config.ts
+++ b/src/layout/Address/config.ts
@@ -6,9 +6,9 @@ export const Config = new CG.component({
   capabilities: {
     renderInTable: false,
     renderInButtonGroup: false,
-    renderInAccordion: false,
+    renderInAccordion: true,
     renderInAccordionGroup: false,
-    renderInCards: false,
+    renderInCards: true,
     renderInCardsMedia: false,
     renderInTabs: true,
   },

--- a/src/layout/Alert/config.ts
+++ b/src/layout/Alert/config.ts
@@ -6,7 +6,7 @@ export const Config = new CG.component({
   capabilities: {
     renderInTable: false,
     renderInButtonGroup: false,
-    renderInAccordion: false,
+    renderInAccordion: true,
     renderInAccordionGroup: false,
     renderInCards: true,
     renderInCardsMedia: false,

--- a/src/layout/AttachmentList/config.ts
+++ b/src/layout/AttachmentList/config.ts
@@ -6,7 +6,7 @@ export const Config = new CG.component({
   capabilities: {
     renderInTable: false,
     renderInButtonGroup: false,
-    renderInAccordion: false,
+    renderInAccordion: true,
     renderInAccordionGroup: false,
     renderInCards: false,
     renderInCardsMedia: false,

--- a/src/layout/ButtonGroup/config.ts
+++ b/src/layout/ButtonGroup/config.ts
@@ -7,7 +7,7 @@ export const Config = new CG.component({
   capabilities: {
     renderInTable: false,
     renderInButtonGroup: false,
-    renderInAccordion: false,
+    renderInAccordion: true,
     renderInAccordionGroup: false,
     renderInCards: true,
     renderInCardsMedia: false,

--- a/src/layout/Checkboxes/config.ts
+++ b/src/layout/Checkboxes/config.ts
@@ -23,7 +23,7 @@ export const Config = new CG.component({
   capabilities: {
     renderInTable: true,
     renderInButtonGroup: false,
-    renderInAccordion: false,
+    renderInAccordion: true,
     renderInAccordionGroup: false,
     renderInCards: true,
     renderInCardsMedia: false,

--- a/src/layout/Custom/config.ts
+++ b/src/layout/Custom/config.ts
@@ -6,7 +6,7 @@ export const Config = new CG.component({
   capabilities: {
     renderInTable: true,
     renderInButtonGroup: true,
-    renderInAccordion: false,
+    renderInAccordion: true,
     renderInAccordionGroup: false,
     renderInCards: true,
     renderInCardsMedia: true,

--- a/src/layout/CustomButton/config.ts
+++ b/src/layout/CustomButton/config.ts
@@ -6,7 +6,7 @@ export const Config = new CG.component({
   capabilities: {
     renderInTable: true,
     renderInButtonGroup: true,
-    renderInAccordion: false,
+    renderInAccordion: true,
     renderInAccordionGroup: false,
     renderInCards: true,
     renderInCardsMedia: false,

--- a/src/layout/Datepicker/config.ts
+++ b/src/layout/Datepicker/config.ts
@@ -13,7 +13,7 @@ export const Config = new CG.component({
   capabilities: {
     renderInTable: true,
     renderInButtonGroup: false,
-    renderInAccordion: false,
+    renderInAccordion: true,
     renderInAccordionGroup: false,
     renderInCards: true,
     renderInCardsMedia: false,

--- a/src/layout/Dropdown/config.ts
+++ b/src/layout/Dropdown/config.ts
@@ -16,7 +16,7 @@ export const Config = new CG.component({
   capabilities: {
     renderInTable: true,
     renderInButtonGroup: false,
-    renderInAccordion: false,
+    renderInAccordion: true,
     renderInAccordionGroup: false,
     renderInCards: true,
     renderInCardsMedia: false,

--- a/src/layout/FileUpload/config.ts
+++ b/src/layout/FileUpload/config.ts
@@ -10,7 +10,7 @@ export const Config = asUploaderComponent(
     capabilities: {
       renderInTable: false,
       renderInButtonGroup: false,
-      renderInAccordion: false,
+      renderInAccordion: true,
       renderInAccordionGroup: false,
       renderInCards: false,
       renderInCardsMedia: false,

--- a/src/layout/FileUploadWithTag/config.ts
+++ b/src/layout/FileUploadWithTag/config.ts
@@ -9,7 +9,7 @@ export const Config = asUploaderComponent(
     capabilities: {
       renderInTable: false,
       renderInButtonGroup: false,
-      renderInAccordion: false,
+      renderInAccordion: true,
       renderInAccordionGroup: false,
       renderInCards: false,
       renderInCardsMedia: false,

--- a/src/layout/Grid/config.ts
+++ b/src/layout/Grid/config.ts
@@ -7,7 +7,7 @@ export const Config = new CG.component({
   capabilities: {
     renderInTable: false,
     renderInButtonGroup: false,
-    renderInAccordion: false,
+    renderInAccordion: true,
     renderInAccordionGroup: false,
     renderInCards: false,
     renderInCardsMedia: false,

--- a/src/layout/Group/config.ts
+++ b/src/layout/Group/config.ts
@@ -23,7 +23,7 @@ export const Config = new CG.component({
   capabilities: {
     renderInTable: false,
     renderInButtonGroup: false,
-    renderInAccordion: false,
+    renderInAccordion: true,
     renderInAccordionGroup: false,
     renderInCards: true,
     renderInCardsMedia: false,

--- a/src/layout/Header/config.ts
+++ b/src/layout/Header/config.ts
@@ -13,7 +13,7 @@ export const Config = new CG.component({
   capabilities: {
     renderInTable: true,
     renderInButtonGroup: false,
-    renderInAccordion: false,
+    renderInAccordion: true,
     renderInAccordionGroup: false,
     renderInCards: true,
     renderInCardsMedia: false,

--- a/src/layout/IFrame/config.ts
+++ b/src/layout/IFrame/config.ts
@@ -6,7 +6,7 @@ export const Config = new CG.component({
   capabilities: {
     renderInTable: true,
     renderInButtonGroup: false,
-    renderInAccordion: false,
+    renderInAccordion: true,
     renderInAccordionGroup: false,
     renderInCards: true,
     renderInCardsMedia: false,

--- a/src/layout/Input/config.ts
+++ b/src/layout/Input/config.ts
@@ -14,7 +14,7 @@ export const Config = new CG.component({
   capabilities: {
     renderInTable: true,
     renderInButtonGroup: false,
-    renderInAccordion: false,
+    renderInAccordion: true,
     renderInAccordionGroup: false,
     renderInCards: true,
     renderInCardsMedia: false,

--- a/src/layout/InstanceInformation/config.ts
+++ b/src/layout/InstanceInformation/config.ts
@@ -6,7 +6,7 @@ export const Config = new CG.component({
   capabilities: {
     renderInTable: false,
     renderInButtonGroup: false,
-    renderInAccordion: false,
+    renderInAccordion: true,
     renderInAccordionGroup: false,
     renderInCards: false,
     renderInCardsMedia: false,

--- a/src/layout/InstantiationButton/config.ts
+++ b/src/layout/InstantiationButton/config.ts
@@ -6,7 +6,7 @@ export const Config = new CG.component({
   capabilities: {
     renderInTable: true,
     renderInButtonGroup: true,
-    renderInAccordion: false,
+    renderInAccordion: true,
     renderInAccordionGroup: false,
     renderInCards: true,
     renderInCardsMedia: false,

--- a/src/layout/Likert/config.ts
+++ b/src/layout/Likert/config.ts
@@ -16,7 +16,7 @@ export const Config = new CG.component({
   capabilities: {
     renderInTable: false,
     renderInButtonGroup: false,
-    renderInAccordion: false,
+    renderInAccordion: true,
     renderInAccordionGroup: false,
     renderInCards: false,
     renderInCardsMedia: false,

--- a/src/layout/Link/config.ts
+++ b/src/layout/Link/config.ts
@@ -6,7 +6,7 @@ export const Config = new CG.component({
   capabilities: {
     renderInTable: true,
     renderInButtonGroup: false,
-    renderInAccordion: false,
+    renderInAccordion: true,
     renderInAccordionGroup: false,
     renderInCards: true,
     renderInCardsMedia: false,

--- a/src/layout/List/config.ts
+++ b/src/layout/List/config.ts
@@ -13,7 +13,7 @@ export const Config = new CG.component({
   capabilities: {
     renderInTable: false,
     renderInButtonGroup: false,
-    renderInAccordion: false,
+    renderInAccordion: true,
     renderInAccordionGroup: false,
     renderInCards: false,
     renderInCardsMedia: false,

--- a/src/layout/Map/config.ts
+++ b/src/layout/Map/config.ts
@@ -13,7 +13,7 @@ export const Config = new CG.component({
   capabilities: {
     renderInTable: false,
     renderInButtonGroup: false,
-    renderInAccordion: false,
+    renderInAccordion: true,
     renderInAccordionGroup: false,
     renderInCards: false,
     renderInCardsMedia: false,

--- a/src/layout/MultipleSelect/config.ts
+++ b/src/layout/MultipleSelect/config.ts
@@ -24,7 +24,7 @@ export const Config = new CG.component({
   capabilities: {
     renderInTable: true,
     renderInButtonGroup: false,
-    renderInAccordion: false,
+    renderInAccordion: true,
     renderInAccordionGroup: false,
     renderInCards: true,
     renderInCardsMedia: false,

--- a/src/layout/PDFPreviewButton/config.ts
+++ b/src/layout/PDFPreviewButton/config.ts
@@ -6,7 +6,7 @@ export const Config = new CG.component({
   capabilities: {
     renderInTable: true,
     renderInButtonGroup: true,
-    renderInAccordion: false,
+    renderInAccordion: true,
     renderInAccordionGroup: false,
     renderInCards: true,
     renderInCardsMedia: false,

--- a/src/layout/Panel/config.ts
+++ b/src/layout/Panel/config.ts
@@ -7,7 +7,7 @@ export const Config = new CG.component({
   capabilities: {
     renderInTable: false,
     renderInButtonGroup: false,
-    renderInAccordion: false,
+    renderInAccordion: true,
     renderInAccordionGroup: false,
     renderInCards: false,
     renderInCardsMedia: false,

--- a/src/layout/PaymentDetails/config.ts
+++ b/src/layout/PaymentDetails/config.ts
@@ -6,7 +6,7 @@ export const Config = new CG.component({
   capabilities: {
     renderInTable: false,
     renderInButtonGroup: false,
-    renderInAccordion: false,
+    renderInAccordion: true,
     renderInAccordionGroup: false,
     renderInCards: true,
     renderInCardsMedia: false,

--- a/src/layout/PrintButton/config.ts
+++ b/src/layout/PrintButton/config.ts
@@ -6,7 +6,7 @@ export const Config = new CG.component({
   capabilities: {
     renderInTable: true,
     renderInButtonGroup: true,
-    renderInAccordion: false,
+    renderInAccordion: true,
     renderInAccordionGroup: false,
     renderInCards: true,
     renderInCardsMedia: false,

--- a/src/layout/RadioButtons/config.ts
+++ b/src/layout/RadioButtons/config.ts
@@ -15,7 +15,7 @@ export const Config = new CG.component({
   capabilities: {
     renderInTable: true,
     renderInButtonGroup: false,
-    renderInAccordion: false,
+    renderInAccordion: true,
     renderInAccordionGroup: false,
     renderInTabs: true,
     renderInCards: true,

--- a/src/layout/RepeatingGroup/config.ts
+++ b/src/layout/RepeatingGroup/config.ts
@@ -25,7 +25,7 @@ export const Config = new CG.component({
   capabilities: {
     renderInTable: false,
     renderInButtonGroup: false,
-    renderInAccordion: false,
+    renderInAccordion: true,
     renderInAccordionGroup: false,
     renderInCards: false,
     renderInCardsMedia: false,

--- a/src/layout/SimpleTable/config.ts
+++ b/src/layout/SimpleTable/config.ts
@@ -6,7 +6,7 @@ export const Config = new CG.component({
   capabilities: {
     renderInTable: false,
     renderInButtonGroup: false,
-    renderInAccordion: false,
+    renderInAccordion: true,
     renderInAccordionGroup: false,
     renderInCards: false,
     renderInCardsMedia: false,

--- a/src/layout/Subform/config.ts
+++ b/src/layout/Subform/config.ts
@@ -21,7 +21,7 @@ export const Config = new CG.component({
   capabilities: {
     renderInTable: false,
     renderInButtonGroup: false,
-    renderInAccordion: false,
+    renderInAccordion: true,
     renderInAccordionGroup: false,
     renderInCards: false,
     renderInCardsMedia: false,

--- a/src/layout/Summary/config.ts
+++ b/src/layout/Summary/config.ts
@@ -7,7 +7,7 @@ export const Config = new CG.component({
   capabilities: {
     renderInTable: false,
     renderInButtonGroup: false,
-    renderInAccordion: false,
+    renderInAccordion: true,
     renderInAccordionGroup: false,
     renderInCards: true,
     renderInCardsMedia: false,

--- a/src/layout/TextArea/config.ts
+++ b/src/layout/TextArea/config.ts
@@ -13,7 +13,7 @@ export const Config = new CG.component({
   capabilities: {
     renderInTable: true,
     renderInButtonGroup: false,
-    renderInAccordion: false,
+    renderInAccordion: true,
     renderInAccordionGroup: false,
     renderInCards: true,
     renderInCardsMedia: false,

--- a/src/utils/layout/generator/NodeGenerator.tsx
+++ b/src/utils/layout/generator/NodeGenerator.tsx
@@ -7,7 +7,7 @@ import { evalExpr } from 'src/features/expressions';
 import { ExprVal } from 'src/features/expressions/types';
 import { ExprValidation } from 'src/features/expressions/validation';
 import { useAsRef } from 'src/hooks/useAsRef';
-import { getComponentDef, getNodeConstructor } from 'src/layout';
+import { getComponentCapabilities, getComponentDef, getNodeConstructor } from 'src/layout';
 import { NodesStateQueue } from 'src/utils/layout/generator/CommitQueue';
 import { GeneratorDebug } from 'src/utils/layout/generator/debug';
 import { GeneratorInternal, GeneratorNodeProvider } from 'src/utils/layout/generator/GeneratorContext';
@@ -113,12 +113,16 @@ function AddRemoveNode<T extends CompTypes>({ node, intermediateItem }: CommonPr
   const rowIndex = GeneratorInternal.useRowIndex();
   const pageKey = GeneratorInternal.usePage()?.pageKey ?? '';
   const idMutators = GeneratorInternal.useIdMutators() ?? [];
+  const layoutMap = GeneratorInternal.useLayoutMap();
+  const getCapabilities = (type: CompTypes) => getComponentCapabilities(type);
   const stateFactoryProps = {
     item: intermediateItem,
     parent,
     rowIndex,
     pageKey,
     idMutators,
+    layoutMap,
+    getCapabilities,
   } satisfies StateFactoryProps<T>;
   const isAdded = NodesInternal.useIsAdded(node);
 

--- a/src/utils/layout/types.ts
+++ b/src/utils/layout/types.ts
@@ -1,5 +1,13 @@
+import type { CompCapabilities } from 'src/codegen/Config';
 import type { CompDef } from 'src/layout';
-import type { CompIntermediate, CompIntermediateExact, CompInternal, CompTypes, TypeFromNode } from 'src/layout/layout';
+import type {
+  CompExternal,
+  CompIntermediate,
+  CompIntermediateExact,
+  CompInternal,
+  CompTypes,
+  TypeFromNode,
+} from 'src/layout/layout';
 import type { ChildIdMutator } from 'src/utils/layout/generator/GeneratorContext';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 import type { LayoutPage } from 'src/utils/layout/LayoutPage';
@@ -21,6 +29,8 @@ export interface StateFactoryProps<Type extends CompTypes> {
   parent: LayoutNode | LayoutPage;
   rowIndex: number | undefined;
   idMutators: ChildIdMutator[];
+  layoutMap: Record<string, CompExternal>;
+  getCapabilities: (type: CompTypes) => CompCapabilities;
 }
 
 export interface GeneratorErrors {


### PR DESCRIPTION
## Description

When presenting during Altinn Kaffe today, I made a demo-app with Accordion and AccordionGroup to show off different new features. Surprisingly, the `RadioButtons` components I added to the Accordion didn't work properly - they showed up both inside the Accordion and outside it - which I didn't even think was possible.

The bug here was that unsupported component types in children were logged, the component was not claimed, but the component was also added to children anyway (🤦). I fixed this now by not including them in the node state list of children when the component was not claimed correctly.

Also, I don't think it's right to deny most components the ability to `renderInAccordion`, so I allowed most of them to do that. There's no point in using the capabilities feature to gatekeep - it was meant for things like _making sure you don't put a table inside a table cell_.

## Related Issue(s)

- closes #2954

## Verification/QA

- Manual functionality testing
  - [X] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [X] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [X] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [X] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [X] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [X] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
