### PR TITLE
Make sure options are loaded in PDF

### DIFF
--- a/src/features/options/OptionsPlugin.tsx
+++ b/src/features/options/OptionsPlugin.tsx
@@ -6,7 +6,12 @@ import type { IOptionInternal } from 'src/features/options/castOptionsToStrings'
 import type { OptionsValueType } from 'src/features/options/useGetOptions';
 import type { ISelectionComponent, ISelectionComponentFull } from 'src/layout/common.generated';
 import type { CompTypes } from 'src/layout/layout';
-import type { DefPluginExtraState, DefPluginStateFactoryProps } from 'src/utils/layout/plugins/NodeDefPlugin';
+import type { NodesContext } from 'src/utils/layout/NodesContext';
+import type {
+  DefPluginExtraState,
+  DefPluginState,
+  DefPluginStateFactoryProps,
+} from 'src/utils/layout/plugins/NodeDefPlugin';
 
 interface Config<SupportsPreselection extends boolean> {
   componentType: CompTypes;
@@ -70,5 +75,13 @@ export class OptionsPlugin<E extends ExternalConfig> extends NodeDefPlugin<ToInt
         valueType={'${this.settings!.type}'}
         allowEffects={${allowsEffects ? 'true' : 'false'}}
       />`.trim();
+  }
+
+  stateIsReady(state: DefPluginState<ToInternal<E>>, fullState: NodesContext): boolean {
+    if (!super.stateIsReady(state, fullState)) {
+      return false;
+    }
+
+    return !!state.options;
   }
 }

--- a/test/e2e/integration/frontend-test/pdf.ts
+++ b/test/e2e/integration/frontend-test/pdf.ts
@@ -177,6 +177,26 @@ describe('PDF', () => {
     });
   });
 
+  it('options should load before #readyForPrint is shown', () => {
+    cy.goto('changename');
+    cy.dsSelect(appFrontend.changeOfName.sources, 'Digitaliseringsdirektoratet');
+    cy.dsSelect(appFrontend.changeOfName.reference, 'Sophie Salt');
+    cy.dsSelect(appFrontend.changeOfName.reference2, 'Dole');
+
+    cy.intercept(/.*\/options\/(list|references|test).*/, async (r) => {
+      await new Promise((resolve) => setTimeout(resolve, 3000));
+      r.continue();
+    });
+
+    cy.testPdf({
+      callback: () => {
+        cy.getSummary('hvor fikk du vite om skjemaet').should('contain.text', 'Digitaliseringsdirektoratet');
+        cy.getSummary('Referanse').should('contain.text', 'Sophie Salt');
+        cy.getSummary('Referanse 2').should('contain.text', 'Dole');
+      },
+    });
+  });
+
   it('should generate PDF for group step', () => {
     cy.goto('group');
     cy.findByRole('checkbox', { name: /liten/i }).check();

--- a/test/e2e/support/index.ts
+++ b/test/e2e/support/index.ts
@@ -22,10 +22,8 @@ before(() => {
   chai.use(chaiExtensions);
 });
 
-const DEFAULT_COMMAND_TIMEOUT = Cypress.config().defaultCommandTimeout;
 // Clear media emulation and reset default command timeout before each test
 beforeEach(() => {
-  cy.then(() => Cypress.config('defaultCommandTimeout', DEFAULT_COMMAND_TIMEOUT));
   cy.wrap(
     Cypress.automation('remote:debugger:protocol', {
       command: 'Emulation.setEmulatedMedia',


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

Option plugin now implements `stateIsReady` to make sure all options have loaded before getting marked as ready. This causes the loading screen to appear while options are loading initially, but not when changing dynamically later. This means that #readyForPrint cannot be shown before options are finished loading.

Additionally, I discovered that the PDF testing was not working as intended. Even though the cypress runner appeared to use the new `defaultCommandTimeout` it did not actually work, and it would still wait up to 20 seconds. To actually test that the callback checks pass immediately, I use a `setTimeout` with 0 milliseconds that throws an exception unless the callbacks finish and clear the timer first.

## Related Issue(s)

- closes #2947 

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [x] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
