### PR TITLE
Cleanup in Date component + formatDate expression

### DIFF
--- a/src/app-components/Date/DisplayDate.tsx
+++ b/src/app-components/Date/DisplayDate.tsx
@@ -1,38 +1,23 @@
 import React from 'react';
 
-import { formatDate, isValid, parseISO } from 'date-fns';
-
 import classes from 'src/app-components/Date/Date.module.css';
 
 interface DateProps {
-  format?: string;
-  value: string;
+  value: React.ReactNode;
   iconUrl?: string;
   iconAltText?: string;
   labelId?: string;
 }
 
-export const DisplayDate = ({ value, format, iconUrl, iconAltText, labelId }: DateProps) => {
-  const parsedValue = parseISO(value);
-  let displayData = parsedValue.toDateString();
-  if (!isValid(parsedValue)) {
-    window.logErrorOnce(`Ugyldig datoformat gitt til Date-komponent: "${value}"`);
-    displayData = '';
-  } else if (format) {
-    displayData = formatDate(parsedValue, format);
-  }
-
-  return (
-    <>
-      {iconUrl && (
-        <img
-          src={iconUrl}
-          className={classes.icon}
-          alt={iconAltText}
-        />
-      )}
-      {labelId && <span aria-labelledby={labelId}>{displayData}</span>}
-      {!labelId && <span>{displayData}</span>}
-    </>
-  );
-};
+export const DisplayDate = ({ value, iconUrl, iconAltText, labelId }: DateProps) => (
+  <>
+    {iconUrl && (
+      <img
+        src={iconUrl}
+        className={classes.icon}
+        alt={iconAltText}
+      />
+    )}
+    <span aria-labelledby={labelId}>{value}</span>
+  </>
+);

--- a/src/codegen/dataTypes/GenerateExpressionOr.ts
+++ b/src/codegen/dataTypes/GenerateExpressionOr.ts
@@ -9,6 +9,7 @@ const toTsMap: { [key in ExprVal]: string } = {
   [ExprVal.Boolean]: 'ExprValToActualOrExpr<ExprVal.Boolean>',
   [ExprVal.Number]: 'ExprValToActualOrExpr<ExprVal.Number>',
   [ExprVal.String]: 'ExprValToActualOrExpr<ExprVal.String>',
+  [ExprVal.Date]: 'ExprValToActualOrExpr<ExprVal.Date>',
 };
 
 const toSchemaMap: { [key in ExprVal]: JSONSchema7 } = {
@@ -16,6 +17,7 @@ const toSchemaMap: { [key in ExprVal]: JSONSchema7 } = {
   [ExprVal.Boolean]: { $ref: 'expression.schema.v1.json#/definitions/boolean' },
   [ExprVal.Number]: { $ref: 'expression.schema.v1.json#/definitions/number' },
   [ExprVal.String]: { $ref: 'expression.schema.v1.json#/definitions/string' },
+  [ExprVal.Date]: { $ref: 'expression.schema.v1.json#/definitions/string' },
 };
 
 type TypeMap<Val extends ExprVal> = Val extends ExprVal.Boolean

--- a/src/features/expressions/expression-functions.ts
+++ b/src/features/expressions/expression-functions.ts
@@ -1,6 +1,5 @@
 import dot from 'dot-object';
 
-import { isDate } from 'src/app-components/Datepicker/utils/dateHelpers';
 import { ExprRuntimeError, NodeNotFound, NodeNotFoundWithoutContext } from 'src/features/expressions/errors';
 import { ExprVal } from 'src/features/expressions/types';
 import { addError } from 'src/features/expressions/validation';
@@ -153,7 +152,7 @@ export const ExprFunctionDefinitions = {
     returns: ExprVal.String,
   },
   formatDate: {
-    args: args(required(ExprVal.String), optional(ExprVal.String)),
+    args: args(required(ExprVal.Date), optional(ExprVal.String)),
     returns: ExprVal.String,
   },
   round: {
@@ -468,10 +467,10 @@ export const ExprFunctionImplementations: { [K in Names]: Implementation<K> } = 
     });
   },
   formatDate(date, format) {
-    if (date === null || !isDate(date)) {
+    if (date === null) {
       return null;
     }
-    const result = formatDateLocale(this.dataSources.currentLanguage, new Date(date), format ?? undefined);
+    const result = formatDateLocale(this.dataSources.currentLanguage, date, format ?? undefined);
     if (result.includes('Unsupported: ')) {
       throw new ExprRuntimeError(this.expr, this.path, `Unsupported date format token in '${format}'`);
     }

--- a/src/features/expressions/index.test.ts
+++ b/src/features/expressions/index.test.ts
@@ -45,6 +45,14 @@ describe('Expressions', () => {
         }
       }
 
+      if (def.returns === ExprVal.Date) {
+        throw new Error(
+          'Date is not a valid return type for an expression function. It is only possible to receive a Date as ' +
+            'an argument, and if you need to return a Date, you should return it as a string (formatted in a way ' +
+            'that lets the date parser parse it).',
+        );
+      }
+
       expect(def.returns).toBeDefined();
       expect(def.args).toBeDefined();
     });

--- a/src/features/expressions/index.ts
+++ b/src/features/expressions/index.ts
@@ -1,3 +1,4 @@
+import { isValid, parseISO } from 'date-fns';
 import dot from 'dot-object';
 
 import {
@@ -325,4 +326,87 @@ export const ExprTypes: {
     accepts: [ExprVal.Boolean, ExprVal.String, ExprVal.Number, ExprVal.Any],
     impl: (arg) => arg,
   },
+  [ExprVal.Date]: {
+    nullable: true,
+    accepts: [ExprVal.String, ExprVal.Number, ExprVal.Date, ExprVal.Any],
+    impl(arg) {
+      if (typeof arg === 'number') {
+        return exprParseDate(this, String(arg)); // Might be just a 4-digit year
+      }
+
+      if (typeof arg === 'string') {
+        return arg ? exprParseDate(this, arg) : null;
+      }
+
+      throw new UnexpectedType(this.expr, this.path, 'date', arg);
+    },
+  },
 };
+
+/**
+ * Strict date parser. We don't want to support all the formats that Date.parse() supports, because that
+ * would make it more difficult to implement the same functionality on the backend. For that reason, we
+ * limit ourselves to simple ISO 8601 dates + the format DateTime is serialized to JSON in.
+ */
+const datePatterns = [
+  /^(\d{4})$/,
+  /^(\d{4})-(\d{2})-(\d{2})T?$/,
+  /^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})Z?([+-]\d{2}:\d{2})?$/,
+  /^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2}):(\d{2})Z?([+-]\d{2}:\d{2})?$/,
+  /^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2}):(\d{2})\.(\d+)Z?([+-]\d{2}:\d{2})?$/,
+];
+
+function exprParseDate(ctx: EvaluateExpressionParams, _date: string): Date | null {
+  const date = _date.toUpperCase();
+  for (const regexIdx in datePatterns) {
+    const regex = datePatterns[regexIdx];
+    const match = regex.exec(date);
+    if (!match) {
+      // To maintain compatibility with the backend, we only allow the above regexes to be parsed
+      continue;
+    }
+
+    // Special case that parseISO doesn't catch: Time zone offset cannot be +- >= 24 hours
+    const lastGroup = match[match.length - 1];
+    if (lastGroup && (lastGroup.startsWith('-') || lastGroup.startsWith('+'))) {
+      const offsetHours = parseInt(lastGroup.substring(1, 3), 10);
+      if (offsetHours >= 24) {
+        throw new ExprRuntimeError(
+          ctx.expr,
+          ctx.path,
+          `Unable to parse date "${date}": Format was recognized, but the date/time is invalid`,
+        );
+      }
+    }
+
+    const parsed = parseISO(date);
+    if (!isValid(parsed.getTime())) {
+      throw new ExprRuntimeError(
+        ctx.expr,
+        ctx.path,
+        `Unable to parse date "${date}": Format was recognized, but the date/time is invalid`,
+      );
+    }
+
+    // Special case that parseISO gets wrong: Fractional seconds with more than 3 digits
+    // https://github.com/date-fns/date-fns/issues/3194
+    // https://github.com/date-fns/date-fns/pull/3199
+    if (regexIdx === '4' && match[7] && match[7].length > 3) {
+      // This is a sloppy workaround, and not really a fix. By just setting the correct amount of milliseconds we
+      // fix our shared tests to match the backend, but if you have an edge-case like 31.12.2021 23:59:59.9999999
+      // the parseISO function will think it's 2022. Saying it's really 01.01.2022 00:00:00.999 (like we're doing here)
+      // may look like we're just making things worse, but in most cases high precision fractionals will not roll you
+      // over to the next second (let alone the next year).
+      const ms = parseInt(match[7].substring(0, 3), 10);
+      parsed.setMilliseconds(ms);
+    }
+
+    return parsed;
+  }
+
+  if (date.trim() !== '') {
+    throw new ExprRuntimeError(ctx.expr, ctx.path, `Unable to parse date "${date}": Unknown format`);
+  }
+
+  return null;
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/formats-date-english.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/formats-date-english.json
@@ -1,0 +1,8 @@
+{
+  "name": "Should format date when only given a year",
+  "expression": ["formatDate", "2023"],
+  "expects": "1/1/23",
+  "profileSettings": {
+    "language": "en"
+  }
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/formats-date-english2.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/formats-date-english2.json
@@ -1,0 +1,8 @@
+{
+  "name": "Should format date in english",
+  "expression": ["formatDate", "2023-10-26T13:12:38.069Z"],
+  "expects": "10/26/23",
+  "profileSettings": {
+    "language": "en"
+  }
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/formats-date-in-format-specified2.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/formats-date-in-format-specified2.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should format date in format specified (2)",
+  "expression": ["formatDate", "2023-10-26T13:12:38.069Z", "dd.MM"],
+  "expects": "26.10"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/formats-date-time.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/formats-date-time.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should format date-time from backend",
+  "expression": ["formatDate", "2025-01-23T10:25:33.9729397+01:00"],
+  "expects": "23.01.2025"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/formats-date-with-offset.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/formats-date-with-offset.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should format date when only a date + offset is given",
+  "expression": ["formatDate", "2023-01-01-08:00", "yyyy-MM-dd HH:mm:ss"],
+  "expectsFailure": "Unable to parse date \"2023-01-01-08:00\": Unknown format"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/formats-date-year-only.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/formats-date-year-only.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should format date when only given a year",
+  "expression": ["formatDate", "2023"],
+  "expects": "01.01.2023"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-2020-is-a-leap-year.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-2020-is-a-leap-year.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date.json",
+  "name": "Compliance: 2020 is a leap year",
+  "expression": [
+    "formatDate",
+    "2020-02-29",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expects": "e.Kr. 2020-02-29 lørdag 00:00:00.000 a.m."
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-2021-is-not-a-leap-year.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-2021-is-not-a-leap-year.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date.json",
+  "name": "Compliance: 2021 is not a leap year",
+  "expression": [
+    "formatDate",
+    "2021-02-29",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expectsFailure": "Unable to parse date \"2021-02-29\": Format was recognized, but the date/time is invalid"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-invalid-date-string-with-29-days-in-february-normal-.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-invalid-date-string-with-29-days-in-february-normal-.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date.json",
+  "name": "Compliance: a invalid date string with 29 days in February (normal)",
+  "expression": [
+    "formatDate",
+    "2021-02-29",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expectsFailure": "Unable to parse date \"2021-02-29\": Format was recognized, but the date/time is invalid"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-invalid-date-string-with-30-days-in-february-leap-.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-invalid-date-string-with-30-days-in-february-leap-.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date.json",
+  "name": "Compliance: a invalid date string with 30 days in February (leap)",
+  "expression": [
+    "formatDate",
+    "2020-02-30",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expectsFailure": "Unable to parse date \"2020-02-30\": Format was recognized, but the date/time is invalid"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-invalid-date-string-with-31-days-in-april.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-invalid-date-string-with-31-days-in-april.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date.json",
+  "name": "Compliance: a invalid date string with 31 days in April",
+  "expression": [
+    "formatDate",
+    "2020-04-31",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expectsFailure": "Unable to parse date \"2020-04-31\": Format was recognized, but the date/time is invalid"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-invalid-date-string-with-31-days-in-june.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-invalid-date-string-with-31-days-in-june.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date.json",
+  "name": "Compliance: a invalid date string with 31 days in June",
+  "expression": [
+    "formatDate",
+    "2020-06-31",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expectsFailure": "Unable to parse date \"2020-06-31\": Format was recognized, but the date/time is invalid"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-invalid-date-string-with-31-days-in-november.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-invalid-date-string-with-31-days-in-november.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date.json",
+  "name": "Compliance: a invalid date string with 31 days in November",
+  "expression": [
+    "formatDate",
+    "2020-11-31",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expectsFailure": "Unable to parse date \"2020-11-31\": Format was recognized, but the date/time is invalid"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-invalid-date-string-with-31-days-in-september.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-invalid-date-string-with-31-days-in-september.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date.json",
+  "name": "Compliance: a invalid date string with 31 days in September",
+  "expression": [
+    "formatDate",
+    "2020-09-31",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expectsFailure": "Unable to parse date \"2020-09-31\": Format was recognized, but the date/time is invalid"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-invalid-date-string-with-32-days-in-august.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-invalid-date-string-with-32-days-in-august.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date.json",
+  "name": "Compliance: a invalid date string with 32 days in August",
+  "expression": [
+    "formatDate",
+    "2020-08-32",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expectsFailure": "Unable to parse date \"2020-08-32\": Format was recognized, but the date/time is invalid"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-invalid-date-string-with-32-days-in-december.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-invalid-date-string-with-32-days-in-december.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date.json",
+  "name": "Compliance: a invalid date string with 32 days in December",
+  "expression": [
+    "formatDate",
+    "2020-12-32",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expectsFailure": "Unable to parse date \"2020-12-32\": Format was recognized, but the date/time is invalid"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-invalid-date-string-with-32-days-in-january.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-invalid-date-string-with-32-days-in-january.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date.json",
+  "name": "Compliance: a invalid date string with 32 days in January",
+  "expression": [
+    "formatDate",
+    "2020-01-32",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expectsFailure": "Unable to parse date \"2020-01-32\": Format was recognized, but the date/time is invalid"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-invalid-date-string-with-32-days-in-july.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-invalid-date-string-with-32-days-in-july.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date.json",
+  "name": "Compliance: a invalid date string with 32 days in July",
+  "expression": [
+    "formatDate",
+    "2020-07-32",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expectsFailure": "Unable to parse date \"2020-07-32\": Format was recognized, but the date/time is invalid"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-invalid-date-string-with-32-days-in-march.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-invalid-date-string-with-32-days-in-march.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date.json",
+  "name": "Compliance: a invalid date string with 32 days in March",
+  "expression": [
+    "formatDate",
+    "2020-03-32",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expectsFailure": "Unable to parse date \"2020-03-32\": Format was recognized, but the date/time is invalid"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-invalid-date-string-with-32-days-in-may.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-invalid-date-string-with-32-days-in-may.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date.json",
+  "name": "Compliance: a invalid date string with 32 days in May",
+  "expression": [
+    "formatDate",
+    "2020-05-32",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expectsFailure": "Unable to parse date \"2020-05-32\": Format was recognized, but the date/time is invalid"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-invalid-date-string-with-32-days-in-october.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-invalid-date-string-with-32-days-in-october.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date.json",
+  "name": "Compliance: a invalid date string with 32 days in October",
+  "expression": [
+    "formatDate",
+    "2020-10-32",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expectsFailure": "Unable to parse date \"2020-10-32\": Format was recognized, but the date/time is invalid"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-invalid-date-string-with-invalid-month.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-invalid-date-string-with-invalid-month.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date.json",
+  "name": "Compliance: a invalid date string with invalid month",
+  "expression": [
+    "formatDate",
+    "2020-13-01",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expectsFailure": "Unable to parse date \"2020-13-01\": Format was recognized, but the date/time is invalid"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-valid-date-string-with-28-days-in-february-normal-.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-valid-date-string-with-28-days-in-february-normal-.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date.json",
+  "name": "Compliance: a valid date string with 28 days in February (normal)",
+  "expression": [
+    "formatDate",
+    "2021-02-28",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expects": "e.Kr. 2021-02-28 søndag 00:00:00.000 a.m."
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-valid-date-string-with-29-days-in-february-leap-.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-valid-date-string-with-29-days-in-february-leap-.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date.json",
+  "name": "Compliance: a valid date string with 29 days in February (leap)",
+  "expression": [
+    "formatDate",
+    "2020-02-29",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expects": "e.Kr. 2020-02-29 lørdag 00:00:00.000 a.m."
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-valid-date-string-with-30-days-in-april.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-valid-date-string-with-30-days-in-april.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date.json",
+  "name": "Compliance: a valid date string with 30 days in April",
+  "expression": [
+    "formatDate",
+    "2020-04-30",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expects": "e.Kr. 2020-04-30 torsdag 00:00:00.000 a.m."
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-valid-date-string-with-30-days-in-june.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-valid-date-string-with-30-days-in-june.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date.json",
+  "name": "Compliance: a valid date string with 30 days in June",
+  "expression": [
+    "formatDate",
+    "2020-06-30",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expects": "e.Kr. 2020-06-30 tirsdag 00:00:00.000 a.m."
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-valid-date-string-with-30-days-in-november.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-valid-date-string-with-30-days-in-november.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date.json",
+  "name": "Compliance: a valid date string with 30 days in November",
+  "expression": [
+    "formatDate",
+    "2020-11-30",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expects": "e.Kr. 2020-11-30 mandag 00:00:00.000 a.m."
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-valid-date-string-with-30-days-in-september.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-valid-date-string-with-30-days-in-september.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date.json",
+  "name": "Compliance: a valid date string with 30 days in September",
+  "expression": [
+    "formatDate",
+    "2020-09-30",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expects": "e.Kr. 2020-09-30 onsdag 00:00:00.000 a.m."
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-valid-date-string-with-31-days-in-august.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-valid-date-string-with-31-days-in-august.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date.json",
+  "name": "Compliance: a valid date string with 31 days in August",
+  "expression": [
+    "formatDate",
+    "2020-08-31",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expects": "e.Kr. 2020-08-31 mandag 00:00:00.000 a.m."
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-valid-date-string-with-31-days-in-december.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-valid-date-string-with-31-days-in-december.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date.json",
+  "name": "Compliance: a valid date string with 31 days in December",
+  "expression": [
+    "formatDate",
+    "2020-12-31",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expects": "e.Kr. 2020-12-31 torsdag 00:00:00.000 a.m."
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-valid-date-string-with-31-days-in-january.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-valid-date-string-with-31-days-in-january.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date.json",
+  "name": "Compliance: a valid date string with 31 days in January",
+  "expression": [
+    "formatDate",
+    "2020-01-31",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expects": "e.Kr. 2020-01-31 fredag 00:00:00.000 a.m."
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-valid-date-string-with-31-days-in-july.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-valid-date-string-with-31-days-in-july.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date.json",
+  "name": "Compliance: a valid date string with 31 days in July",
+  "expression": [
+    "formatDate",
+    "2020-07-31",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expects": "e.Kr. 2020-07-31 fredag 00:00:00.000 a.m."
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-valid-date-string-with-31-days-in-march.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-valid-date-string-with-31-days-in-march.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date.json",
+  "name": "Compliance: a valid date string with 31 days in March",
+  "expression": [
+    "formatDate",
+    "2020-03-31",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expects": "e.Kr. 2020-03-31 tirsdag 00:00:00.000 a.m."
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-valid-date-string-with-31-days-in-may.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-valid-date-string-with-31-days-in-may.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date.json",
+  "name": "Compliance: a valid date string with 31 days in May",
+  "expression": [
+    "formatDate",
+    "2020-05-31",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expects": "e.Kr. 2020-05-31 søndag 00:00:00.000 a.m."
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-valid-date-string-with-31-days-in-october.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-valid-date-string-with-31-days-in-october.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date.json",
+  "name": "Compliance: a valid date string with 31 days in October",
+  "expression": [
+    "formatDate",
+    "2020-10-31",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expects": "e.Kr. 2020-10-31 lørdag 00:00:00.000 a.m."
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-valid-date-string.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-a-valid-date-string.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date.json",
+  "name": "Compliance: a valid date string",
+  "expression": [
+    "formatDate",
+    "1963-06-19",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expects": "e.Kr. 1963-06-19 onsdag 00:00:00.000 a.m."
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-an-invalid-date-string.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-an-invalid-date-string.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date.json",
+  "name": "Compliance: an invalid date string",
+  "expression": [
+    "formatDate",
+    "06/19/1963",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expectsFailure": "Unable to parse date \"06/19/1963\": Unknown format"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-invalid-month-day-combination.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-invalid-month-day-combination.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date.json",
+  "name": "Compliance: invalid month-day combination",
+  "expression": [
+    "formatDate",
+    "1998-04-31",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expectsFailure": "Unable to parse date \"1998-04-31\": Format was recognized, but the date/time is invalid"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-invalid-month.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-invalid-month.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date.json",
+  "name": "Compliance: invalid month",
+  "expression": [
+    "formatDate",
+    "1998-13-01",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expectsFailure": "Unable to parse date \"1998-13-01\": Format was recognized, but the date/time is invalid"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-invalid-non-ascii-a-bengali-4-.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-invalid-non-ascii-a-bengali-4-.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date.json",
+  "name": "Compliance: invalid non-ASCII '৪' (a Bengali 4)",
+  "expression": [
+    "formatDate",
+    "1963-06-1৪",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expectsFailure": "Unable to parse date \"1963-06-1৪\": Unknown format"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-iso8601-non-rfc3339-week-number-implicit-day-of-week-2023-01-02-.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-iso8601-non-rfc3339-week-number-implicit-day-of-week-2023-01-02-.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date.json",
+  "name": "Compliance: ISO8601 / non-RFC3339: week number implicit day of week (2023-01-02)",
+  "expression": [
+    "formatDate",
+    "2023-W01",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expectsFailure": "Unable to parse date \"2023-W01\": Unknown format"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-iso8601-non-rfc3339-week-number-rollover-to-next-year-2023-01-01-.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-iso8601-non-rfc3339-week-number-rollover-to-next-year-2023-01-01-.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date.json",
+  "name": "Compliance: ISO8601 / non-RFC3339: week number rollover to next year (2023-01-01)",
+  "expression": [
+    "formatDate",
+    "2022W527",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expectsFailure": "Unable to parse date \"2022W527\": Unknown format"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-iso8601-non-rfc3339-week-number-with-day-of-week-2023-03-28-.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-iso8601-non-rfc3339-week-number-with-day-of-week-2023-03-28-.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date.json",
+  "name": "Compliance: ISO8601 / non-RFC3339: week number with day of week (2023-03-28)",
+  "expression": [
+    "formatDate",
+    "2023-W13-2",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expectsFailure": "Unable to parse date \"2023-W13-2\": Unknown format"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-iso8601-non-rfc3339-yyyymmdd-without-dashes-2023-03-28-.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-iso8601-non-rfc3339-yyyymmdd-without-dashes-2023-03-28-.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date.json",
+  "name": "Compliance: ISO8601 / non-RFC3339: YYYYMMDD without dashes (2023-03-28)",
+  "expression": [
+    "formatDate",
+    "20230328",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expectsFailure": "Unable to parse date \"20230328\": Unknown format"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-non-padded-day-dates-are-not-valid.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-non-padded-day-dates-are-not-valid.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date.json",
+  "name": "Compliance: non-padded day dates are not valid",
+  "expression": [
+    "formatDate",
+    "1998-01-1",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expectsFailure": "Unable to parse date \"1998-01-1\": Unknown format"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-non-padded-month-dates-are-not-valid.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-non-padded-month-dates-are-not-valid.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date.json",
+  "name": "Compliance: non-padded month dates are not valid",
+  "expression": [
+    "formatDate",
+    "1998-1-20",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expectsFailure": "Unable to parse date \"1998-1-20\": Unknown format"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-only-rfc3339-not-all-of-iso-8601-are-valid.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-only-rfc3339-not-all-of-iso-8601-are-valid.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date.json",
+  "name": "Compliance: only RFC3339 not all of ISO 8601 are valid",
+  "expression": [
+    "formatDate",
+    "2013-350",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expectsFailure": "Unable to parse date \"2013-350\": Unknown format"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-time-a-valid-date-time-string-with-minus-offset.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-time-a-valid-date-time-string-with-minus-offset.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date-time format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date-time.json",
+  "name": "Compliance: a valid date-time string with minus offset",
+  "expression": [
+    "formatDate",
+    "1990-12-31T15:59:50.123-08:00",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expects": "e.Kr. 1990-12-31 mandag 23:59:50.123 p.m."
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-time-a-valid-date-time-string-with-plus-offset.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-time-a-valid-date-time-string-with-plus-offset.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date-time format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date-time.json",
+  "name": "Compliance: a valid date-time string with plus offset",
+  "expression": [
+    "formatDate",
+    "1937-01-01T12:00:27.87+00:20",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expects": "e.Kr. 1937-01-01 fredag 11:40:27.870 a.m."
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-time-a-valid-date-time-string-without-second-fraction.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-time-a-valid-date-time-string-without-second-fraction.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date-time format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date-time.json",
+  "name": "Compliance: a valid date-time string without second fraction",
+  "expression": [
+    "formatDate",
+    "1963-06-19T08:30:06Z",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expects": "e.Kr. 1963-06-19 onsdag 08:30:06.000 a.m."
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-time-a-valid-date-time-string.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-time-a-valid-date-time-string.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date-time format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date-time.json",
+  "name": "Compliance: a valid date-time string",
+  "expression": [
+    "formatDate",
+    "1963-06-19T08:30:06.283185Z",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expects": "e.Kr. 1963-06-19 onsdag 08:30:06.283 a.m."
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-time-an-invalid-closing-z-after-time-zone-offset.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-time-an-invalid-closing-z-after-time-zone-offset.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date-time format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date-time.json",
+  "name": "Compliance: an invalid closing Z after time-zone offset",
+  "expression": [
+    "formatDate",
+    "1963-06-19T08:30:06.28123+01:00Z",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expectsFailure": "Unable to parse date \"1963-06-19T08:30:06.28123+01:00Z\": Unknown format"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-time-an-invalid-date-time-past-leap-second-utc.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-time-an-invalid-date-time-past-leap-second-utc.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date-time format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date-time.json",
+  "name": "Compliance: an invalid date-time past leap second, UTC",
+  "expression": [
+    "formatDate",
+    "1998-12-31T23:59:61Z",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expectsFailure": "Unable to parse date \"1998-12-31T23:59:61Z\": Format was recognized, but the date/time is invalid"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-time-an-invalid-date-time-string.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-time-an-invalid-date-time-string.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date-time format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date-time.json",
+  "name": "Compliance: an invalid date-time string",
+  "expression": [
+    "formatDate",
+    "06/19/1963 08:30:06 PST",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expectsFailure": "Unable to parse date \"06/19/1963 08:30:06 PST\": Unknown format"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-time-an-invalid-date-time-with-a-leap-second-utc.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-time-an-invalid-date-time-with-a-leap-second-utc.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date-time format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date-time.json",
+  "name": "Compliance: an invalid date-time with a leap second, UTC",
+  "expression": [
+    "formatDate",
+    "1998-12-31T23:59:60Z",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expectsFailure": "Unable to parse date \"1998-12-31T23:59:60Z\": Format was recognized, but the date/time is invalid"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-time-an-invalid-date-time-with-a-leap-second-with-minus-offset.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-time-an-invalid-date-time-with-a-leap-second-with-minus-offset.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date-time format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date-time.json",
+  "name": "Compliance: an invalid date-time with a leap second, with minus offset",
+  "expression": [
+    "formatDate",
+    "1998-12-31T15:59:60.123-08:00",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expectsFailure": "Unable to parse date \"1998-12-31T15:59:60.123-08:00\": Format was recognized, but the date/time is invalid"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-time-an-invalid-date-time-with-leap-second-on-a-wrong-hour-utc.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-time-an-invalid-date-time-with-leap-second-on-a-wrong-hour-utc.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date-time format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date-time.json",
+  "name": "Compliance: an invalid date-time with leap second on a wrong hour, UTC",
+  "expression": [
+    "formatDate",
+    "1998-12-31T22:59:60Z",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expectsFailure": "Unable to parse date \"1998-12-31T22:59:60Z\": Format was recognized, but the date/time is invalid"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-time-an-invalid-date-time-with-leap-second-on-a-wrong-minute-utc.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-time-an-invalid-date-time-with-leap-second-on-a-wrong-minute-utc.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date-time format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date-time.json",
+  "name": "Compliance: an invalid date-time with leap second on a wrong minute, UTC",
+  "expression": [
+    "formatDate",
+    "1998-12-31T23:58:60Z",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expectsFailure": "Unable to parse date \"1998-12-31T23:58:60Z\": Format was recognized, but the date/time is invalid"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-time-an-invalid-day-in-date-time-string.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-time-an-invalid-day-in-date-time-string.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date-time format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date-time.json",
+  "name": "Compliance: an invalid day in date-time string",
+  "expression": [
+    "formatDate",
+    "1990-02-31T15:59:59.123-08:00",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expectsFailure": "Unable to parse date \"1990-02-31T15:59:59.123-08:00\": Format was recognized, but the date/time is invalid"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-time-an-invalid-offset-in-date-time-string.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-time-an-invalid-offset-in-date-time-string.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date-time format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date-time.json",
+  "name": "Compliance: an invalid offset in date-time string",
+  "expression": [
+    "formatDate",
+    "1990-12-31T15:59:59-24:00",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expectsFailure": "Unable to parse date \"1990-12-31T15:59:59-24:00\": Format was recognized, but the date/time is invalid"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-time-case-insensitive-t-and-z.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-time-case-insensitive-t-and-z.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date-time format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date-time.json",
+  "name": "Compliance: case-insensitive T and Z",
+  "expression": [
+    "formatDate",
+    "1963-06-19t08:30:06.283185z",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expects": "e.Kr. 1963-06-19 onsdag 08:30:06.283 a.m."
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-time-invalid-non-ascii-a-bengali-4-in-date-portion.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-time-invalid-non-ascii-a-bengali-4-in-date-portion.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date-time format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date-time.json",
+  "name": "Compliance: invalid non-ASCII '৪' (a Bengali 4) in date portion",
+  "expression": [
+    "formatDate",
+    "1963-06-1৪T00:00:00Z",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expectsFailure": "Unable to parse date \"1963-06-1৪T00:00:00Z\": Unknown format"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-time-invalid-non-ascii-a-bengali-4-in-time-portion.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-time-invalid-non-ascii-a-bengali-4-in-time-portion.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date-time format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date-time.json",
+  "name": "Compliance: invalid non-ASCII '৪' (a Bengali 4) in time portion",
+  "expression": [
+    "formatDate",
+    "1963-06-11T0৪:00:00Z",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expectsFailure": "Unable to parse date \"1963-06-11T0৪:00:00Z\": Unknown format"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-time-invalid-non-padded-day-dates.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-time-invalid-non-padded-day-dates.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date-time format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date-time.json",
+  "name": "Compliance: invalid non-padded day dates",
+  "expression": [
+    "formatDate",
+    "1963-06-1T08:30:06.283185Z",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expectsFailure": "Unable to parse date \"1963-06-1T08:30:06.283185Z\": Unknown format"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-time-invalid-non-padded-month-dates.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-time-invalid-non-padded-month-dates.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date-time format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date-time.json",
+  "name": "Compliance: invalid non-padded month dates",
+  "expression": [
+    "formatDate",
+    "1963-6-19T08:30:06.283185Z",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expectsFailure": "Unable to parse date \"1963-6-19T08:30:06.283185Z\": Unknown format"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/parse-date-time-only-rfc3339-not-all-of-iso-8601-are-valid.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/parse-date-time-only-rfc3339-not-all-of-iso-8601-are-valid.json
@@ -1,0 +1,11 @@
+{
+  "comment": "This tests our compliance to the date-time format from the JSON Schema Test Suite.",
+  "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/date-time.json",
+  "name": "Compliance: only RFC3339 not all of ISO 8601 are valid",
+  "expression": [
+    "formatDate",
+    "2013-350T01:01:01",
+    "G yyyy-MM-dd EEEE HH:mm:ss.SSS a"
+  ],
+  "expectsFailure": "Unable to parse date \"2013-350T01:01:01\": Unknown format"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-lowercase-a-en.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-lowercase-a-en.json
@@ -1,0 +1,12 @@
+{
+  "name": "Should format date with format 'a' as 'AM'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "a"
+  ],
+  "expects": "AM",
+  "profileSettings": {
+    "language": "en"
+  }
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-lowercase-a-nb.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-lowercase-a-nb.json
@@ -1,0 +1,9 @@
+{
+  "name": "Should format date with format 'a' as 'a.m.'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "a"
+  ],
+  "expects": "a.m."
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-lowercase-a-nn.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-lowercase-a-nn.json
@@ -1,0 +1,12 @@
+{
+  "name": "Should format date with format 'a' as 'f.m.'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "a"
+  ],
+  "expects": "f.m.",
+  "profileSettings": {
+    "language": "nn"
+  }
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-lowercase-d.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-lowercase-d.json
@@ -1,0 +1,9 @@
+{
+  "name": "Should format date with format 'd' as '4'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "d"
+  ],
+  "expects": "4"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-lowercase-dd.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-lowercase-dd.json
@@ -1,0 +1,9 @@
+{
+  "name": "Should format date with format 'dd' as '04'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "dd"
+  ],
+  "expects": "04"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-lowercase-h.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-lowercase-h.json
@@ -1,0 +1,9 @@
+{
+  "name": "Should format date with format 'h' as '5'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "h"
+  ],
+  "expects": "5"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-lowercase-hh.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-lowercase-hh.json
@@ -1,0 +1,9 @@
+{
+  "name": "Should format date with format 'hh' as '05'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "hh"
+  ],
+  "expects": "05"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-lowercase-m.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-lowercase-m.json
@@ -1,0 +1,9 @@
+{
+  "name": "Should format date with format 'm' as '6'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "m"
+  ],
+  "expects": "6"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-lowercase-mm.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-lowercase-mm.json
@@ -1,0 +1,9 @@
+{
+  "name": "Should format date with format 'mm' as '06'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "mm"
+  ],
+  "expects": "06"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-lowercase-s.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-lowercase-s.json
@@ -1,0 +1,9 @@
+{
+  "name": "Should format date with format 's' as '7'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "s"
+  ],
+  "expects": "7"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-lowercase-ss.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-lowercase-ss.json
@@ -1,0 +1,9 @@
+{
+  "name": "Should format date with format 'ss' as '07'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "ss"
+  ],
+  "expects": "07"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-lowercase-u.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-lowercase-u.json
@@ -1,0 +1,9 @@
+{
+  "name": "Should format date with format 'u' as '2023'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "u"
+  ],
+  "expects": "2023"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-lowercase-uu.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-lowercase-uu.json
@@ -1,0 +1,9 @@
+{
+  "name": "Should format date with format 'uu' as '2023'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "uu"
+  ],
+  "expects": "2023"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-lowercase-uuu.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-lowercase-uuu.json
@@ -1,0 +1,9 @@
+{
+  "name": "Should format date with format 'uuu' as '2023'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "uuu"
+  ],
+  "expects": "2023"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-lowercase-uuuu.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-lowercase-uuuu.json
@@ -1,0 +1,9 @@
+{
+  "name": "Should format date with format 'uuuu' as '2023'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "uuuu"
+  ],
+  "expects": "2023"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-lowercase-y.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-lowercase-y.json
@@ -1,0 +1,9 @@
+{
+  "name": "Should format date with format 'y' as '2023'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "y"
+  ],
+  "expects": "2023"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-lowercase-yy.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-lowercase-yy.json
@@ -1,0 +1,9 @@
+{
+  "name": "Should format date with format 'yy' as '23'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "yy"
+  ],
+  "expects": "23"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-lowercase-yyy.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-lowercase-yyy.json
@@ -1,0 +1,9 @@
+{
+  "name": "Should format date with format 'yyy' as '2023'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "yyy"
+  ],
+  "expects": "2023"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-lowercase-yyyy.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-lowercase-yyyy.json
@@ -1,0 +1,9 @@
+{
+  "name": "Should format date with format 'yyyy' as '2023'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "yyyy"
+  ],
+  "expects": "2023"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-e-en.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-e-en.json
@@ -1,0 +1,12 @@
+{
+  "name": "Should format date with format 'E' as 'Sat'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "E"
+  ],
+  "expects": "Sat",
+  "profileSettings": {
+    "language": "en"
+  }
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-e-nb.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-e-nb.json
@@ -1,0 +1,9 @@
+{
+  "name": "Should format date with format 'E' as 'lør'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "E"
+  ],
+  "expects": "lør"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-e-nn.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-e-nn.json
@@ -1,0 +1,12 @@
+{
+  "name": "Should format date with format 'E' as 'lau'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "E"
+  ],
+  "expects": "lau",
+  "profileSettings": {
+    "language": "nn"
+  }
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-ee-en.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-ee-en.json
@@ -1,0 +1,12 @@
+{
+  "name": "Should format date with format 'EE' as 'Sat'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "EE"
+  ],
+  "expects": "Sat",
+  "profileSettings": {
+    "language": "en"
+  }
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-ee-nb.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-ee-nb.json
@@ -1,0 +1,9 @@
+{
+  "name": "Should format date with format 'EE' as 'lør'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "EE"
+  ],
+  "expects": "lør"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-ee-nn.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-ee-nn.json
@@ -1,0 +1,12 @@
+{
+  "name": "Should format date with format 'EE' as 'lau'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "EE"
+  ],
+  "expects": "lau",
+  "profileSettings": {
+    "language": "nn"
+  }
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-eee-en.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-eee-en.json
@@ -1,0 +1,12 @@
+{
+  "name": "Should format date with format 'EEE' as 'Sat'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "EEE"
+  ],
+  "expects": "Sat",
+  "profileSettings": {
+    "language": "en"
+  }
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-eee-nb.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-eee-nb.json
@@ -1,0 +1,9 @@
+{
+  "name": "Should format date with format 'EEE' as 'lør'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "EEE"
+  ],
+  "expects": "lør"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-eee-nn.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-eee-nn.json
@@ -1,0 +1,12 @@
+{
+  "name": "Should format date with format 'EEE' as 'lau'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "EEE"
+  ],
+  "expects": "lau",
+  "profileSettings": {
+    "language": "nn"
+  }
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-eeee-en.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-eeee-en.json
@@ -1,0 +1,12 @@
+{
+  "name": "Should format date with format 'EEEE' as 'Saturday'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "EEEE"
+  ],
+  "expects": "Saturday",
+  "profileSettings": {
+    "language": "en"
+  }
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-eeee-nb.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-eeee-nb.json
@@ -1,0 +1,9 @@
+{
+  "name": "Should format date with format 'EEEE' as 'lørdag'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "EEEE"
+  ],
+  "expects": "lørdag"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-eeee-nn.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-eeee-nn.json
@@ -1,0 +1,12 @@
+{
+  "name": "Should format date with format 'EEEE' as 'laurdag'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "EEEE"
+  ],
+  "expects": "laurdag",
+  "profileSettings": {
+    "language": "nn"
+  }
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-eeeee-en.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-eeeee-en.json
@@ -1,0 +1,12 @@
+{
+  "name": "Should format date with format 'EEEEE' as 'S'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "EEEEE"
+  ],
+  "expects": "S",
+  "profileSettings": {
+    "language": "en"
+  }
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-eeeee-nb.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-eeeee-nb.json
@@ -1,0 +1,9 @@
+{
+  "name": "Should format date with format 'EEEEE' as 'L'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "EEEEE"
+  ],
+  "expects": "L"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-eeeee-nn.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-eeeee-nn.json
@@ -1,0 +1,12 @@
+{
+  "name": "Should format date with format 'EEEEE' as 'L'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "EEEEE"
+  ],
+  "expects": "L",
+  "profileSettings": {
+    "language": "nn"
+  }
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-g-en.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-g-en.json
@@ -1,0 +1,12 @@
+{
+  "name": "Should format date with format 'G' as 'AD'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "G"
+  ],
+  "expects": "AD",
+  "profileSettings": {
+    "language": "en"
+  }
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-g-nb.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-g-nb.json
@@ -1,0 +1,9 @@
+{
+  "name": "Should format date with format 'G' as 'e.Kr.'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "G"
+  ],
+  "expects": "e.Kr."
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-g-nn.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-g-nn.json
@@ -1,0 +1,12 @@
+{
+  "name": "Should format date with format 'G' as 'e.Kr.'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "G"
+  ],
+  "expects": "e.Kr.",
+  "profileSettings": {
+    "language": "nn"
+  }
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-gg-en.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-gg-en.json
@@ -1,0 +1,12 @@
+{
+  "name": "Should format date with format 'GG' as 'AD'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "GG"
+  ],
+  "expects": "AD",
+  "profileSettings": {
+    "language": "en"
+  }
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-gg-nb.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-gg-nb.json
@@ -1,0 +1,9 @@
+{
+  "name": "Should format date with format 'GG' as 'e.Kr.'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "GG"
+  ],
+  "expects": "e.Kr."
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-gg-nn.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-gg-nn.json
@@ -1,0 +1,12 @@
+{
+  "name": "Should format date with format 'GG' as 'e.Kr.'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "GG"
+  ],
+  "expects": "e.Kr.",
+  "profileSettings": {
+    "language": "nn"
+  }
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-ggg-en.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-ggg-en.json
@@ -1,0 +1,12 @@
+{
+  "name": "Should format date with format 'GGG' as 'AD'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "GGG"
+  ],
+  "expects": "AD",
+  "profileSettings": {
+    "language": "en"
+  }
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-ggg-nb.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-ggg-nb.json
@@ -1,0 +1,9 @@
+{
+  "name": "Should format date with format 'GGG' as 'e.Kr.'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "GGG"
+  ],
+  "expects": "e.Kr."
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-ggg-nn.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-ggg-nn.json
@@ -1,0 +1,12 @@
+{
+  "name": "Should format date with format 'GGG' as 'e.Kr.'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "GGG"
+  ],
+  "expects": "e.Kr.",
+  "profileSettings": {
+    "language": "nn"
+  }
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-gggg-en.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-gggg-en.json
@@ -1,0 +1,12 @@
+{
+  "name": "Should format date with format 'GGGG' as 'Anno Domini'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "GGGG"
+  ],
+  "expects": "Anno Domini",
+  "profileSettings": {
+    "language": "en"
+  }
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-gggg-nb.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-gggg-nb.json
@@ -1,0 +1,9 @@
+{
+  "name": "Should format date with format 'GGGG' as 'etter Kristus'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "GGGG"
+  ],
+  "expects": "etter Kristus"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-gggg-nn.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-gggg-nn.json
@@ -1,0 +1,12 @@
+{
+  "name": "Should format date with format 'GGGG' as 'etter Kristus'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "GGGG"
+  ],
+  "expects": "etter Kristus",
+  "profileSettings": {
+    "language": "nn"
+  }
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-ggggg-en.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-ggggg-en.json
@@ -1,0 +1,12 @@
+{
+  "name": "Should format date with format 'GGGGG' as 'A'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "GGGGG"
+  ],
+  "expects": "A",
+  "profileSettings": {
+    "language": "en"
+  }
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-ggggg-nb.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-ggggg-nb.json
@@ -1,0 +1,9 @@
+{
+  "name": "Should format date with format 'GGGGG' as 'e.Kr.'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "GGGGG"
+  ],
+  "expects": "e.Kr."
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-ggggg-nn.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-ggggg-nn.json
@@ -1,0 +1,12 @@
+{
+  "name": "Should format date with format 'GGGGG' as 'e.Kr.'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "GGGGG"
+  ],
+  "expects": "e.Kr.",
+  "profileSettings": {
+    "language": "nn"
+  }
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-h.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-h.json
@@ -1,0 +1,9 @@
+{
+  "name": "Should format date with format 'H' as '5'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "H"
+  ],
+  "expects": "5"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-hh.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-hh.json
@@ -1,0 +1,9 @@
+{
+  "name": "Should format date with format 'HH' as '05'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "HH"
+  ],
+  "expects": "05"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-m.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-m.json
@@ -1,0 +1,9 @@
+{
+  "name": "Should format date with format 'M' as '3'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "M"
+  ],
+  "expects": "3"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-mm.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-mm.json
@@ -1,0 +1,9 @@
+{
+  "name": "Should format date with format 'MM' as '03'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "MM"
+  ],
+  "expects": "03"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-mmm-en.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-mmm-en.json
@@ -1,0 +1,12 @@
+{
+  "name": "Should format date with format 'MMM' as 'Mar'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "MMM"
+  ],
+  "expects": "Mar",
+  "profileSettings": {
+    "language": "en"
+  }
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-mmm-nb.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-mmm-nb.json
@@ -1,0 +1,9 @@
+{
+  "name": "Should format date with format 'MMM' as 'mar'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "MMM"
+  ],
+  "expects": "mar"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-mmm-nn.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-mmm-nn.json
@@ -1,0 +1,12 @@
+{
+  "name": "Should format date with format 'MMM' as 'mar'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "MMM"
+  ],
+  "expects": "mar",
+  "profileSettings": {
+    "language": "nn"
+  }
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-mmmm-en.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-mmmm-en.json
@@ -1,0 +1,12 @@
+{
+  "name": "Should format date with format 'MMMM' as 'March'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "MMMM"
+  ],
+  "expects": "March",
+  "profileSettings": {
+    "language": "en"
+  }
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-mmmm-nb.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-mmmm-nb.json
@@ -1,0 +1,9 @@
+{
+  "name": "Should format date with format 'MMMM' as 'mars'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "MMMM"
+  ],
+  "expects": "mars"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-mmmm-nn.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-mmmm-nn.json
@@ -1,0 +1,12 @@
+{
+  "name": "Should format date with format 'MMMM' as 'mars'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "MMMM"
+  ],
+  "expects": "mars",
+  "profileSettings": {
+    "language": "nn"
+  }
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-s.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-s.json
@@ -1,0 +1,9 @@
+{
+  "name": "Should format date with format 'S' as '1'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "S"
+  ],
+  "expects": "1"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-ss.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-ss.json
@@ -1,0 +1,9 @@
+{
+  "name": "Should format date with format 'SS' as '12'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "SS"
+  ],
+  "expects": "12"
+}

--- a/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-sss.json
+++ b/src/features/expressions/shared-tests/functions/formatDate/valid-uppercase-sss.json
@@ -1,0 +1,9 @@
+{
+  "name": "Should format date with format 'SSS' as '120'",
+  "expression": [
+    "formatDate",
+    "2023-03-04T05:06:07.120Z",
+    "SSS"
+  ],
+  "expects": "120"
+}

--- a/src/features/expressions/types.ts
+++ b/src/features/expressions/types.ts
@@ -13,18 +13,21 @@ export enum ExprVal {
   Boolean = '__boolean__',
   String = '__string__',
   Number = '__number__',
+  Date = '__date__', // Actually just a string, but must be parsable as a date (ane lets us work with Date internally)
   Any = '__any__',
 }
 
-export type ExprValToActual<T extends ExprVal = ExprVal> = T extends ExprVal.String
-  ? string
-  : T extends ExprVal.Number
-    ? number
-    : T extends ExprVal.Boolean
-      ? boolean
-      : T extends ExprVal.Any
-        ? string | number | boolean | null
-        : unknown;
+export type ExprValToActual<T extends ExprVal = ExprVal> = T extends ExprVal.Date
+  ? Date
+  : T extends ExprVal.String
+    ? string
+    : T extends ExprVal.Number
+      ? number
+      : T extends ExprVal.Boolean
+        ? boolean
+        : T extends ExprVal.Any
+          ? string | number | boolean | null
+          : unknown;
 
 /**
  * This type replaces ExprVal with the actual value type, or expression that returns that type.

--- a/src/layout/Date/DateComponent.tsx
+++ b/src/layout/Date/DateComponent.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
 
 import cn from 'classnames';
+import { isValid, parseISO } from 'date-fns';
 
 import classes from 'src/app-components/Date/Date.module.css';
 import { DisplayDate } from 'src/app-components/Date/DisplayDate';
 import { getLabelId } from 'src/components/label/Label';
+import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
 import { useLanguage } from 'src/features/language/useLanguage';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
+import { formatDateLocale } from 'src/utils/formatDateLocale';
 import { useNodeItem } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 
@@ -17,14 +20,24 @@ export const DateComponent = ({ node }: PropsFromGenericComponent<'Date'>) => {
   const icon = useNodeItem(node, (i) => i.icon);
   const format = useNodeItem(node, (i) => i.format);
   const { langAsString } = useLanguage(node);
+  const language = useCurrentLanguage();
+  const parsedValue = parseISO(value);
+
+  let displayData: string | null = null;
+  try {
+    displayData = isValid(parsedValue) ? formatDateLocale(language, parsedValue, format) : null;
+    if (displayData?.includes('Unsupported: ')) {
+      displayData = null;
+      window.logErrorOnce(`Date component "${node.id}" failed to format using "${format}": Unsupported token(s)`);
+    }
+  } catch (err) {
+    if (value?.trim() !== '') {
+      window.logErrorOnce(`Date component "${node.id}" failed to parse date "${value}":`, err);
+    }
+  }
 
   if (!textResourceBindings?.title) {
-    return (
-      <DisplayDate
-        value={value}
-        format={format}
-      />
-    );
+    return <DisplayDate value={displayData} />;
   }
 
   return (
@@ -37,11 +50,10 @@ export const DateComponent = ({ node }: PropsFromGenericComponent<'Date'>) => {
       }}
     >
       <DisplayDate
-        value={value}
+        value={displayData}
         iconUrl={icon}
         iconAltText={langAsString(textResourceBindings.title)}
         labelId={getLabelId(node.id)}
-        format={format}
       />
     </ComponentStructureWrapper>
   );


### PR DESCRIPTION
## Description

When implementing #1299 and #2122, I found a few problems with both the `Date` component and our `formatDate` expression function. Both fixed here:

1. The `Date` component did not properly use the current language to format the date (that matters for format tokens that print out the day of the week, for example). It was also lacking some error handling for when the format was unsupported (this was printed out to the user, not the developer).
2. The `formatDate` expression parsed dates by passing them to the `new Date(str)` constructor and hoping for the best. That works allright on frontend, but it makes it nearly impossible to implement the exact same date parsing on the backend. Instead I set up a list of regexes for input-formats we support, added lots of shared tests (including tests copied over from the JSON Schema project), along with tests for all the output-formats possible (according to our docs).
3. I added fairly generic support for a `Date` data type in the expression engine for this, so that the upcoming expressions for comparing dates can use the same functionality that is now used to parse dates for use in `formatDate`.

## Related Issue(s)

- #1299
- #2122

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
