### PR TITLE
Removes empty space under video and audio in cards on position bottom

### DIFF
--- a/src/layout/Audio/Audio.tsx
+++ b/src/layout/Audio/Audio.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
 import { useLanguage } from 'src/features/language/useLanguage';
 import { useParentCard } from 'src/layout/Cards/CardContext';
-import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
 import { useNodeItem } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 
@@ -19,24 +18,22 @@ export function AudioComponent({ node }: IAudioProps) {
   const cardMediaHeight = useParentCard()?.minMediaHeight;
 
   return (
-    <ComponentStructureWrapper node={node}>
-      <audio
-        controls
-        id={id}
-        style={{
-          height: renderedInCardMedia ? cardMediaHeight : undefined,
-          letterSpacing: '0.3px',
-          width: '100%',
-        }}
-      >
-        <source src={audioSrc} />
-        <track
-          kind='captions'
-          src={audioSrc}
-          srcLang={languageKey}
-          label={altText}
-        />
-      </audio>
-    </ComponentStructureWrapper>
+    <audio
+      controls
+      id={id}
+      style={{
+        height: renderedInCardMedia ? cardMediaHeight : undefined,
+        letterSpacing: '0.3px',
+        width: '100%',
+      }}
+    >
+      <source src={audioSrc} />
+      <track
+        kind='captions'
+        src={audioSrc}
+        srcLang={languageKey}
+        label={altText}
+      />
+    </audio>
   );
 }

--- a/src/layout/ComponentStructureWrapper.tsx
+++ b/src/layout/ComponentStructureWrapper.tsx
@@ -8,7 +8,6 @@ import { useFormComponentCtx } from 'src/layout/FormComponentContext';
 import { useNodeItem } from 'src/utils/layout/useNodeItem';
 import type { LabelProps } from 'src/components/label/Label';
 import type { CompTypes } from 'src/layout/layout';
-import type { LayoutComponent } from 'src/layout/LayoutComponent';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 type ComponentStructureWrapperProps<Type extends CompTypes> = {
@@ -28,7 +27,7 @@ export function ComponentStructureWrapper<Type extends CompTypes = CompTypes>({
   const overrideItemProps = useFormComponentCtx()?.overrideItemProps;
   const _grid = useNodeItem(node, (i) => i.grid);
   const grid = overrideItemProps?.grid ?? _grid;
-  const layoutComponent = node.def as unknown as LayoutComponent<Type>;
+  const layoutComponent = node.def;
   const showValidationMessages = layoutComponent.renderDefaultValidations();
 
   const componentWithValidations = (

--- a/src/layout/Video/Video.tsx
+++ b/src/layout/Video/Video.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
 import { useLanguage } from 'src/features/language/useLanguage';
 import { useParentCard } from 'src/layout/Cards/CardContext';
-import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
 import { useNodeItem } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 
@@ -19,24 +18,22 @@ export function VideoComponent({ node }: IVideoProps) {
   const cardMediaHeight = useParentCard()?.minMediaHeight;
 
   return (
-    <ComponentStructureWrapper node={node}>
-      <video
-        controls
-        id={id}
-        style={{
-          height: renderedInCardMedia ? cardMediaHeight : undefined,
-          letterSpacing: '0.3px',
-          width: '100%',
-        }}
-      >
-        <source src={videoSrc} />
-        <track
-          kind='captions'
-          src={videoSrc}
-          srcLang={languageKey}
-          label={altText}
-        />
-      </video>
-    </ComponentStructureWrapper>
+    <video
+      controls
+      id={id}
+      style={{
+        height: renderedInCardMedia ? cardMediaHeight : undefined,
+        letterSpacing: '0.3px',
+        width: '100%',
+      }}
+    >
+      <source src={videoSrc} />
+      <track
+        kind='captions'
+        src={videoSrc}
+        srcLang={languageKey}
+        label={altText}
+      />
+    </video>
   );
 }


### PR DESCRIPTION
## Description
Removed unnecessary `ComponentStructureWrapper` around `Video` and `Audio` components in order to remove white space under them when inside cards. `Image` did not have this wrapper.

Before: 
![image](https://github.com/user-attachments/assets/fdd09bd3-80e6-4d3e-9a1c-73d3a0bfefd1)

Now: 
![image](https://github.com/user-attachments/assets/94492bf0-e53d-4fbd-8060-b8feb7a885a2)

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
