### PR TITLE
Better fuzz testing for PDF generation

### DIFF
--- a/test/e2e/integration/frontend-test/pdf.ts
+++ b/test/e2e/integration/frontend-test/pdf.ts
@@ -14,6 +14,7 @@ describe('PDF', () => {
 
     cy.testPdf({
       snapshotName: 'message',
+      enableResponseFuzzing: true,
       callback: () => {
         cy.findByRole('heading', { level: 1, name: /frontend-test/i }).should('be.visible');
         cy.findByRole('table').should('contain.text', 'Mottaker:Testdepartementet');
@@ -84,8 +85,7 @@ describe('PDF', () => {
       {}, // intercept this every time
     );
 
-    // Add a delay to simulate slow loading map tiles
-    cy.intercept('GET', '/map-tile/**', { delay: 50, fixture: 'map-tile.png' });
+    cy.intercept('GET', '/map-tile/**', { fixture: 'map-tile.png' });
 
     cy.goto('changename');
 
@@ -109,6 +109,7 @@ describe('PDF', () => {
     cy.testPdf({
       snapshotName: 'changeName 1',
       returnToForm: true,
+      enableResponseFuzzing: true,
       callback: () => {
         cy.findByRole('table').should('contain.text', 'Mottaker:Testdepartementet');
         cy.getSummary('Nytt fornavn').should('contain.text', 'Ola');
@@ -151,6 +152,7 @@ describe('PDF', () => {
 
     cy.testPdf({
       snapshotName: 'changeName 2',
+      enableResponseFuzzing: true,
       callback: () => {
         cy.findByRole('table').should('contain.text', 'Mottaker:Testdepartementet');
         cy.getSummary('Nytt fornavn').should('contain.text', 'Ola');
@@ -173,26 +175,6 @@ describe('PDF', () => {
         cy.getSummary('Velg lokasjon')
           .findByText(/Valgt lokasjon: 67(\.\d{1,6})?° nord, 16(\.\d{1,6})?° øst/)
           .should('be.visible');
-      },
-    });
-  });
-
-  it('options should load before #readyForPrint is shown', () => {
-    cy.goto('changename');
-    cy.dsSelect(appFrontend.changeOfName.sources, 'Digitaliseringsdirektoratet');
-    cy.dsSelect(appFrontend.changeOfName.reference, 'Sophie Salt');
-    cy.dsSelect(appFrontend.changeOfName.reference2, 'Dole');
-
-    cy.intercept(/.*\/options\/(list|references|test).*/, async (r) => {
-      await new Promise((resolve) => setTimeout(resolve, 3000));
-      r.continue();
-    });
-
-    cy.testPdf({
-      callback: () => {
-        cy.getSummary('hvor fikk du vite om skjemaet').should('contain.text', 'Digitaliseringsdirektoratet');
-        cy.getSummary('Referanse').should('contain.text', 'Sophie Salt');
-        cy.getSummary('Referanse 2').should('contain.text', 'Dole');
       },
     });
   });
@@ -226,6 +208,7 @@ describe('PDF', () => {
 
     cy.testPdf({
       snapshotName: 'group',
+      enableResponseFuzzing: true,
       callback: () => {
         cy.findByRole('table').should('contain.text', 'Mottaker:Testdepartementet');
 
@@ -256,6 +239,7 @@ describe('PDF', () => {
 
     cy.testPdf({
       snapshotName: 'likert',
+      enableResponseFuzzing: true,
       callback: () => {
         cy.findByRole('table').should('contain.text', 'Mottaker:Testdepartementet');
 
@@ -281,6 +265,7 @@ describe('PDF', () => {
 
     cy.testPdf({
       snapshotName: 'datalist',
+      enableResponseFuzzing: true,
       callback: () => {
         cy.findByRole('table').should('contain.text', 'Mottaker:Testdepartementet');
         cy.getSummary('Hvem gjelder saken?').should('contain.text', 'Caroline');

--- a/test/e2e/integration/subform-test/subform.ts
+++ b/test/e2e/integration/subform-test/subform.ts
@@ -188,6 +188,7 @@ describe('Subform test', () => {
 
     cy.testPdf({
       snapshotName: 'subform',
+      enableResponseFuzzing: true,
       callback: () => {
         cy.getSummary('Navn').should('contain.text', 'Per');
         cy.getSummary('Alder').should('contain.text', '28 år');

--- a/test/e2e/support/custom.ts
+++ b/test/e2e/support/custom.ts
@@ -12,6 +12,7 @@ import type { LayoutContextValue } from 'src/features/form/layout/LayoutsContext
 import JQueryWithSelector = Cypress.JQueryWithSelector;
 
 import { getTargetUrl } from 'test/e2e/support/start-app-instance';
+import type { ResponseFuzzing, Size } from 'test/e2e/support/global';
 
 import type { ILayoutFile } from 'src/layout/common.generated';
 
@@ -543,14 +544,10 @@ Cypress.Commands.add('getSummary', (label) => {
   cy.get(`[data-testid^=summary-]:has(span:contains(${label}))`);
 });
 
+type ImageData = { path: string; dataUrl: string };
 Cypress.Commands.add('directSnapshot', (snapshotName, { width, minHeight }, reset = true) => {
   // Store initial viewport size for later
-  const initialViewportSize = { width: 0, height: 0 };
-  cy.window().then((win) => {
-    initialViewportSize.width = win.innerWidth;
-    initialViewportSize.height = win.innerHeight;
-  });
-
+  cy.getCurrentViewportSize().as('viewportSize');
   cy.viewport(width, minHeight);
 
   // cy.screenshot's blackout property does not ensure that text is monospace which causes unecessary visual changes, so using our own percy css instead
@@ -565,21 +562,23 @@ Cypress.Commands.add('directSnapshot', (snapshotName, { width, minHeight }, rese
   cy.get('#percy-css').should('exist');
 
   // Take screenshot
-  const imageData = { path: '', dataUrl: '' };
-  cy.screenshot(snapshotName, {
-    overwrite: true,
-    onAfterScreenshot: (_, { path }) => {
-      imageData.path = path;
-    },
-  });
+  cy.wrap<ImageData>({ path: '', dataUrl: '' }).as('imageData');
+  cy.get<ImageData>('@imageData').then((imageData) =>
+    cy.screenshot(snapshotName, {
+      overwrite: true,
+      onAfterScreenshot: (_, { path }) => {
+        imageData.path = path;
+      },
+    }),
+  );
 
-  cy.then(() =>
+  cy.get<ImageData>('@imageData').then((imageData) =>
     cy.readFile(imageData.path, 'base64').then((data) => {
       imageData.dataUrl = `data:image/png;base64,${data}`;
     }),
   );
 
-  cy.then(() =>
+  cy.get<ImageData>('@imageData').then((imageData) =>
     cy.intercept(
       { url: '**/screenshot', times: 1 },
       `<!doctype html>
@@ -606,102 +605,103 @@ Cypress.Commands.add('directSnapshot', (snapshotName, { width, minHeight }, rese
   // Revert to original viewport
   if (reset) {
     cy.go('back');
-    cy.then(() => cy.viewport(initialViewportSize.width, initialViewportSize.height));
+    cy.get<Size>('@viewportSize').then(({ width, height }) => {
+      cy.viewport(width, height);
+    });
   }
 });
 
-Cypress.Commands.add('testPdf', ({ snapshotName = false, beforeReload, callback, returnToForm = false }) => {
-  cy.log('Testing PDF');
+Cypress.Commands.add(
+  'testPdf',
+  ({ snapshotName = false, beforeReload, callback, returnToForm = false, enableResponseFuzzing = false }) => {
+    // Store initial viewport size for later
+    cy.getCurrentViewportSize().as('viewportSize');
 
-  // Store initial viewport size for later
-  const size = { width: 0, height: 0 };
-  cy.window().then((win) => {
-    size.width = win.innerWidth;
-    size.height = win.innerHeight;
-  });
+    // Make sure instantiation is completed before we get the url
+    cy.location('hash', { log: false }).should('contain', '#/instance/');
 
-  // Make sure instantiation is completed before we get the url
-  cy.location('hash').should('contain', '#/instance/');
+    // Make sure we blur any selected component before reload to trigger save
+    cy.get('body').click({ log: false });
 
-  // Make sure we blur any selected component before reload to trigger save
-  cy.get('body').click();
+    // Wait for network to be idle before calling reload
+    cy.waitUntilSaved();
+    cy.waitForNetworkIdle('*', '*', 500);
 
-  // Wait for network to be idle before calling reload
-  cy.waitUntilSaved();
-  cy.waitForNetworkIdle('*', '*', 500);
+    // Build PDF url and visit
+    cy.location('href', { log: false }).then((href) => {
+      const regex = getInstanceIdRegExp();
+      const instanceId = regex.exec(href)?.[1];
+      const before = href.split(regex)[0];
+      const visitUrl = `${before}${instanceId}?pdf=1`;
 
-  // Visit the PDF page and reload
-  cy.location('href').then((href) => {
-    const regex = getInstanceIdRegExp();
-    const instanceId = regex.exec(href)?.[1];
-    const before = href.split(regex)[0];
-    const visitUrl = `${before}${instanceId}?pdf=1`;
+      // After the navigation rewrite where we now add the current task ID to the URL, this test is only realistic if
+      // we remove the task and page from the URL before rendering the PDF. This is because the real PDF generator
+      // won't know about the task and page, and will load this URL and assume the app will figure out how to display
+      // the current task as a PDF.
+      cy.visit(visitUrl, { log: false });
+    });
 
-    // After the navigation rewrite where we now add the current task ID to the URL, this test is only realistic if
-    // we remove the task and page from the URL before rendering the PDF. This is because the real PDF generator
-    // won't know about the task and page, and will load this URL and assume the app will figure out how to display
-    // the current task as a PDF.
-    cy.visit(visitUrl);
-  });
+    beforeReload?.();
 
-  beforeReload?.();
-  cy.reload();
+    // Disable caching, the real PDF generator does not have anything cached as it always runs in a fresh browser context
+    cy.setCacheDisabled(true);
+    cy.enableResponseFuzzing(enableResponseFuzzing).as('responseFuzzing');
 
-  // Wait for readyForPrint, after this everything should be rendered so using timeout: 0
-  cy.get('#readyForPrint')
-    .should('exist')
-    .then(() => {
-      // Enable print media emulation
-      cy.wrap(
-        Cypress.automation('remote:debugger:protocol', {
-          command: 'Emulation.setEmulatedMedia',
-          params: { media: 'print' },
-        }),
-        { log: false },
-      );
-      // Set viewport to A4 paper
-      cy.viewport(794, 1123);
-      cy.get('body').invoke('css', 'margin', '0.75in');
+    cy.log('Testing PDF');
+    cy.reload({ log: false });
 
-      cy.then(() => {
-        const timeout = setTimeout(() => {
-          throw 'PDF callback failed, print was not ready when #readyForPrint appeared';
-        }, 0);
-        // Verify that generic elements that should be hidden are not present
-        cy.findAllByRole('button').should('not.exist');
-        // Run tests from callback
-        callback();
-        cy.then(() => clearTimeout(timeout));
+    // Wait for readyForPrint, after this everything should be rendered so using timeout: 0
+    cy.get('#readyForPrint')
+      .should('exist')
+      .then(() => {
+        // Enable print media emulation
+        cy.setEmulatedMedia('print');
+
+        // Set viewport to A4 paper
+        cy.viewport(794, 1123);
+        cy.get('body').invoke('css', 'margin', '0.75in');
+
+        // Stops timers which helps in 'freezing' the page in its current state, makes it easier to see when data is missing
+        cy.clock();
+
+        cy.then(() => {
+          const timeout = setTimeout(() => {
+            throw 'PDF callback failed, print was not ready when #readyForPrint appeared';
+          }, 0);
+          // Verify that generic elements that should be hidden are not present
+          cy.findAllByRole('button').should('not.exist');
+          // Run tests from callback
+          callback();
+          cy.then(() => clearTimeout(timeout));
+        });
+
+        // Disable response fuzzing and re-enable caching
+        cy.get<ResponseFuzzing>('@responseFuzzing').invoke('disable');
+        cy.setCacheDisabled(false);
+
+        if (snapshotName) {
+          // Take snapshot of PDF
+          cy.directSnapshot(`${snapshotName} (PDF)`, { width: 794, minHeight: 1123 }, returnToForm);
+        }
       });
 
-      if (snapshotName) {
-        // Take snapshot of PDF
-        cy.directSnapshot(`${snapshotName} (PDF)`, { width: 794, minHeight: 1123 }, returnToForm);
-      }
-    });
+    if (returnToForm) {
+      // Disable media emulation and revert to original viewport
+      cy.clock().invoke('restore');
+      cy.setEmulatedMedia();
+      cy.get<Size>('@viewportSize').then(({ width, height }) => {
+        cy.viewport(width, height);
+      });
+      cy.get('body').invoke('css', 'margin', '');
 
-  if (returnToForm) {
-    // Disable media emulation and revert to original viewport
-    cy.then(() => {
-      cy.wrap(
-        Cypress.automation('remote:debugger:protocol', {
-          command: 'Emulation.setEmulatedMedia',
-          params: {},
-        }),
-        { log: false },
-      );
-      cy.viewport(size.width, size.height);
-    });
-
-    cy.get('body').invoke('css', 'margin', '');
-
-    cy.location('href').then((href) => {
-      cy.visit(href.replace('?pdf=1', ''));
-    });
-    cy.get('#readyForPrint').should('not.exist');
-    cy.get('#finishedLoading').should('exist');
-  }
-});
+      cy.location('href').then((href) => {
+        cy.visit(href.replace('?pdf=1', ''));
+      });
+      cy.get('#readyForPrint').should('not.exist');
+      cy.get('#finishedLoading').should('exist');
+    }
+  },
+);
 
 Cypress.Commands.add(
   'iframeCustom',
@@ -795,4 +795,64 @@ Cypress.Commands.add('expectValidationNotToExist', (result, group, predicate) =>
 Cypress.Commands.add('allowFailureOnEnd', function () {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (this.test as any).__allowFailureOnEnd = true;
+});
+
+Cypress.Commands.add('setEmulatedMedia', function (media) {
+  if (Cypress.isBrowser({ family: 'chromium' })) {
+    cy.log(`Setting emulated media to ${media ?? 'disabled'}`);
+    cy.wrap(
+      Cypress.automation('remote:debugger:protocol', {
+        command: 'Emulation.setEmulatedMedia',
+        params: media ? { media } : {},
+      }),
+      { log: false },
+    );
+  } else {
+    cy.log(`${Cypress.browser.name} does not support 'setEmulatedMedia'`);
+  }
+});
+
+Cypress.Commands.add('setCacheDisabled', function (cacheDisabled) {
+  if (Cypress.isBrowser({ family: 'chromium' })) {
+    cy.log(`Setting cache disabled to ${cacheDisabled}`);
+    cy.wrap(
+      Cypress.automation('remote:debugger:protocol', {
+        command: 'Network.setCacheDisabled',
+        params: { cacheDisabled },
+      }),
+      { log: false },
+    );
+  } else {
+    cy.log(`${Cypress.browser.name} does not support 'setCacheDisabled'`);
+  }
+});
+
+Cypress.Commands.add('enableResponseFuzzing', function (enable: boolean) {
+  let responseFuzzingEnabled = true;
+
+  if (enable) {
+    const [min, max] = [10, 1000];
+    const rand = () => Math.floor(Math.random() * (max - min + 1) + min);
+    cy.intercept({ resourceType: /fetch|xhr|stylesheet|image|font/ }, (req) => {
+      // Use response fuzzing if enabled, we need to be able to disable it after testing PDF if the test continues,
+      // but unfortunately you cannot remove request interceptors. We therefore need to set a boolean that is checked
+      // inside of the interceptor function that effectively disables it.
+      if (!responseFuzzingEnabled) {
+        return;
+      }
+      req.alias = 'responseFuzzingEnabled';
+      req.on('response', (res) => {
+        res.setDelay(rand());
+      });
+    });
+  }
+
+  return cy.wrap({ disable: () => (responseFuzzingEnabled = false) }, { log: false });
+});
+
+Cypress.Commands.add('getCurrentViewportSize', function () {
+  return cy.window({ log: false }).then((win) => ({
+    width: win.innerWidth,
+    height: win.innerHeight,
+  }));
 });

--- a/test/e2e/support/global.ts
+++ b/test/e2e/support/global.ts
@@ -27,6 +27,7 @@ export interface TestPdfOptions {
   beforeReload?: () => void;
   callback: () => void;
   returnToForm?: boolean;
+  enableResponseFuzzing?: boolean;
 }
 
 declare global {
@@ -275,9 +276,30 @@ declare global {
        * scenarios, and in those cases we don't want to fail the test if the test fails.
        */
       allowFailureOnEnd(): Chainable<null>;
+
+      /**
+       * This command uses the chrome dev tools protocol directly and has to be reset manually. Only works in chromium based browsers
+       */
+      setEmulatedMedia(media?: 'print' | 'screen'): Chainable<null>;
+      /**
+       * This command uses the chrome dev tools protocol directly and has to be reset manually. Only works in chromium based browsers
+       */
+      setCacheDisabled(cacheDisabled: boolean): Chainable<null>;
+
+      /**
+       * Enables response fuzzing for everything except documents and scripts. Returns a method to disable later.
+       * Setting enable = false does nothing, but is more convenient so you can keep the return value in scope.
+       */
+      enableResponseFuzzing(enable: boolean): Chainable<ResponseFuzzing>;
+
+      getCurrentViewportSize(): Chainable<Size>;
     }
   }
 }
+
+export type ResponseFuzzing = { disable: () => void };
+
+export type Size = { width: number; height: number };
 
 export type BackendValidationResult = {
   validations: BackendValidationIssueGroupListItem[] | null;

--- a/test/e2e/support/global.ts
+++ b/test/e2e/support/global.ts
@@ -1,3 +1,5 @@
+import type { RouteMatcher } from 'cypress/types/net-stubbing';
+
 import type { CyUser } from 'test/e2e/support/auth';
 
 import type { BackendValidationIssue, BackendValidationIssueGroupListItem } from 'src/features/validation';
@@ -290,13 +292,14 @@ declare global {
        * Enables response fuzzing for everything except documents and scripts. Returns a method to disable later.
        * Setting enable = false does nothing, but is more convenient so you can keep the return value in scope.
        */
-      enableResponseFuzzing(enable: boolean): Chainable<ResponseFuzzing>;
+      enableResponseFuzzing(options?: ResponseFuzzingOptions): Chainable<ResponseFuzzing>;
 
       getCurrentViewportSize(): Chainable<Size>;
     }
   }
 }
 
+export type ResponseFuzzingOptions = { enabled?: boolean; min?: number; max?: number; matchingRoutes?: RouteMatcher };
 export type ResponseFuzzing = { disable: () => void };
 
 export type Size = { width: number; height: number };

--- a/test/e2e/support/index.ts
+++ b/test/e2e/support/index.ts
@@ -24,13 +24,8 @@ before(() => {
 
 // Clear media emulation and reset default command timeout before each test
 beforeEach(() => {
-  cy.wrap(
-    Cypress.automation('remote:debugger:protocol', {
-      command: 'Emulation.setEmulatedMedia',
-      params: {},
-    }),
-    { log: false },
-  );
+  cy.setEmulatedMedia();
+  cy.setCacheDisabled(false);
 });
 
 afterEach(function () {

--- a/test/e2e/support/start-app-instance.ts
+++ b/test/e2e/support/start-app-instance.ts
@@ -1,5 +1,6 @@
 import dotenv from 'dotenv';
 import escapeRegex from 'escape-string-regexp';
+import type { RouteHandler } from 'cypress/types/net-stubbing';
 import type { SinonSpy } from 'cypress/types/sinon';
 
 import { cyUserCredentials } from 'test/e2e/support/auth';
@@ -122,7 +123,7 @@ Cypress.Commands.add('startAppInstance', (appName, options) => {
 
     const rand = () => Math.floor(Math.random() * (max - min + 1) + min);
 
-    const randomDelays = (req) => {
+    const randomDelays: RouteHandler = (req) => {
       req.on('response', (res) => {
         res.setDelay(rand());
       });

--- a/test/e2e/support/start-app-instance.ts
+++ b/test/e2e/support/start-app-instance.ts
@@ -1,6 +1,5 @@
 import dotenv from 'dotenv';
 import escapeRegex from 'escape-string-regexp';
-import type { RouteHandler } from 'cypress/types/net-stubbing';
 import type { SinonSpy } from 'cypress/types/sinon';
 
 import { cyUserCredentials } from 'test/e2e/support/auth';
@@ -120,16 +119,8 @@ Cypress.Commands.add('startAppInstance', (appName, options) => {
   if (Cypress.env('responseFuzzing') === 'on') {
     const [min, max] = [10, 1000];
     cy.log(`Response fuzzing on, will delay responses randomly between ${min}ms and ${max}ms`);
-
-    const rand = () => Math.floor(Math.random() * (max - min + 1) + min);
-
-    const randomDelays: RouteHandler = (req) => {
-      req.on('response', (res) => {
-        res.setDelay(rand());
-      });
-    };
-    cy.intercept('**/api/**', randomDelays);
-    cy.intercept('**/instances/**', randomDelays);
+    cy.enableResponseFuzzing({ min, max, matchingRoutes: '**/api/**' });
+    cy.enableResponseFuzzing({ min, max, matchingRoutes: '**/instances/**' });
   } else {
     cy.log(`Response fuzzing off, enable with --env responseFuzzing=on`);
   }


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

This is a follow-up of #2958, the changes here makes the test I added in the previous PR redundant as this makes random failure much more likely if the `#readyForPrint` logic is insufficient. Even though I could safely remove that test here, it's important to keep in mind that everything is not covered automatically now. For example, the `changeName` test with the map component will probably not fail for any other reason than the map since the tiles almost always load last and gives a lot of time for other things to load while waiting on those.

Changes:

- Added (optional) response fuzzing while loading the PDF layout. This delays all requests by a different random amount. If tests suddenly become flaky, that could be a sign that PDFs don't always load completely.
  - You cannot really remove a `cy.intercept()` after its been added, so the workaround is to check a variable if it has been disabled or not. This is only really relevant if you continue the test after running `testPdf()`
- Disable browsers memory cache while loading the PDF layout
  - The real PDF generator always runs a fresh browser instance and therefore has nothing cached, additionally, cached requests cannot be intercepted and delayed. This mostly affects fonts, stylesheets etc, as most of our API requests are not cached anyways.
- Calling `cy.clock()` immediately after `#readyForPrint` is visible. This will effectively pause all timers, which in many cases pauses things from updating in the UI which can make the snapshots a little more likely to fail if something is not quite ready. It is by no means a guarantee.
- Extracted some things into custom cypress commands for readability and using more aliases for storing variables since that is the "proper" way of doing that.
- Removed the specific options loading test as the first `testPdf` call in the `changeName` test now fails if options don't load in time.

## Related Issue(s)

- https://github.com/Altinn/app-frontend-react/issues/2947
