### PR TITLE
Fix page navigation when using returnUrl

### DIFF
--- a/src/features/formData/FormData.test.tsx
+++ b/src/features/formData/FormData.test.tsx
@@ -467,7 +467,7 @@ describe('FormData', () => {
 
       expect(mutations.doPatchFormData.mock).toHaveBeenCalledTimes(0);
       await user.click(screen.getByRole('button', { name: 'Lock form data' }));
-      expect(mutations.doPatchFormData.mock).toHaveBeenCalledTimes(1);
+      await waitFor(() => expect(mutations.doPatchFormData.mock).toHaveBeenCalledTimes(1));
       expect(screen.getByTestId('isLocked')).toHaveTextContent('false'); // The save has not finished yet
 
       const patchReq = (mutations.doPatchFormData.mock as jest.Mock).mock.calls[0][1] as IDataModelPatchRequest;

--- a/src/hooks/useIsProcessing.ts
+++ b/src/hooks/useIsProcessing.ts
@@ -1,0 +1,25 @@
+import { useCallback, useState } from 'react';
+
+/**
+ * Utility hook for giving feedback to the user when a process takes time
+ * @see NavigationButtonsComponent
+ */
+export function useIsProcessing<T extends string>() {
+  const [isProcessing, setIsProcessing] = useState<T | null>(null);
+  const processing = useCallback(
+    async (key: T, callback: () => Promise<void>) => {
+      if (isProcessing) {
+        return;
+      }
+      try {
+        setIsProcessing(key);
+        await callback();
+      } finally {
+        setIsProcessing(null);
+      }
+    },
+    [isProcessing],
+  );
+
+  return [isProcessing, processing] as const;
+}

--- a/src/layout/NavigationBar/NavigationBarComponent.module.css
+++ b/src/layout/NavigationBar/NavigationBarComponent.module.css
@@ -22,8 +22,15 @@
   margin: 2px;
 }
 
-.containerBase:active {
-  background-color: var(--colors-primary-blueDark);
+.buttonContent {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.spinner {
+  width: 17px !important;
+  height: 17px !important;
 }
 
 .buttonBase {
@@ -41,14 +48,26 @@
   font-size: 1rem;
 }
 
-.buttonBase:hover {
-  outline: 3px solid var(--colors-primary-blueMedium);
-}
-
 .buttonBase:focus-within {
   outline: var(--fds-focus-border-width) solid var(--fds-outer-focus-border-color);
   outline-offset: var(--fds-focus-border-width);
   box-shadow: 0 0 0 var(--fds-focus-border-width) var(--fds-inner-focus-border-color);
+}
+
+.buttonBase:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.buttonBase:active:not(:disabled) {
+  background-color: var(--colors-primary-blueLight);
+  outline: 3px solid var(--colors-primary-blueMedium);
+  outline-offset: 0;
+  box-shadow: none;
+}
+
+.buttonBase:hover:not(:disabled) {
+  outline: 3px solid var(--colors-primary-blueMedium);
 }
 
 .buttonSelected {

--- a/src/utils/layout/NodesContext.tsx
+++ b/src/utils/layout/NodesContext.tsx
@@ -1083,7 +1083,7 @@ export const NodesInternal = {
   useWaitUntilReady() {
     const store = Store.useLaxStore();
     const waitForState = useWaitForState<undefined, NodesContext | typeof ContextNotProvided>(store);
-    const waitForCommits = Store.useSelector((s) => s.waitForCommits);
+    const waitForCommits = Store.useLaxSelector((s) => s.waitForCommits);
     return useCallback(async () => {
       await waitForState((state) => {
         if (state === ContextNotProvided) {
@@ -1091,7 +1091,7 @@ export const NodesInternal = {
         }
         return state.readiness === NodesReadiness.Ready && state.hiddenViaRulesRan;
       });
-      if (waitForCommits) {
+      if (waitForCommits && waitForCommits !== ContextNotProvided) {
         await waitForCommits();
       }
     }, [waitForState, waitForCommits]);

--- a/test/e2e/integration/component-library/summary-of-previous-task.ts
+++ b/test/e2e/integration/component-library/summary-of-previous-task.ts
@@ -29,7 +29,7 @@ describe('Render summary of previous task', () => {
     cy.findByRole('button', { name: /Datepicker/i }).click();
     cy.findByRole('textbox', { name: /datofeltet/i }).type('01.01.2022');
 
-    cy.get('#navigation-menu').find('button').contains('Oppsummering 2.0').click();
+    cy.gotoNavPage('Oppsummering 2.0');
 
     cy.changeLayout((component) => {
       if (component.type === 'PersonLookup') {
@@ -51,7 +51,7 @@ describe('Render summary of previous task', () => {
     cy.contains(fileName);
     cy.contains(fileType);
 
-    cy.get('#navigation-menu').find('button').contains('Oppsummering av side fra tidligere Task').click();
+    cy.gotoNavPage('Oppsummering av side fra tidligere Task');
 
     // Assert that the address data is rendered on the next page as we are showing the Address page.
     // None of the other data should be shown
@@ -69,7 +69,7 @@ describe('Render summary of previous task', () => {
 
     // Assert that the input field data is rendered on the next page as we are showing the Input component.
     // None of the other data should be shown
-    cy.get('#navigation-menu').find('button').contains('Oppsummering av komponent fra tidligere Task').click();
+    cy.gotoNavPage('Oppsummering av komponent fra tidligere Task');
 
     cy.get('body').should('not.contain', inputText);
     cy.contains(address);

--- a/test/e2e/integration/frontend-test/summary.ts
+++ b/test/e2e/integration/frontend-test/summary.ts
@@ -104,6 +104,7 @@ describe('Summary', () => {
         cy.wrap(summaryDate).contains('button', texts.goToRightPage).click();
         cy.get(`${appFrontend.changeOfName.dateOfEffect}-button`).click();
         cy.get('button[aria-label*="Today"]').click();
+        cy.get(appFrontend.errorReport).should('not.exist');
         cy.findByRole('button', { name: /Tilbake til oppsummering/ }).click();
       });
 

--- a/test/e2e/support/custom.ts
+++ b/test/e2e/support/custom.ts
@@ -89,7 +89,7 @@ Cypress.Commands.add('navPage', (page: string) => {
     if (win.innerWidth < 768) {
       cy.get(appFrontend.navMobileMenu).should('have.attr', 'aria-expanded', 'false').click();
     }
-    cy.get(appFrontend.navMenu).findByText(page).parent();
+    cy.get(appFrontend.navMenu).findByRole('button', { name: new RegExp(`^\\d+\\. ${page}$`) });
   });
 });
 

--- a/test/e2e/support/custom.ts
+++ b/test/e2e/support/custom.ts
@@ -1,5 +1,6 @@
 import 'cypress-wait-until';
 
+import escapeRegex from 'escape-string-regexp';
 import deepEqual from 'fast-deep-equal';
 import type axe from 'axe-core';
 import type { Options as AxeOptions } from 'cypress-axe';
@@ -89,7 +90,7 @@ Cypress.Commands.add('navPage', (page: string) => {
     if (win.innerWidth < 768) {
       cy.get(appFrontend.navMobileMenu).should('have.attr', 'aria-expanded', 'false').click();
     }
-    cy.get(appFrontend.navMenu).findByRole('button', { name: new RegExp(`^\\d+\\. ${page}$`) });
+    cy.get(appFrontend.navMenu).findByRole('button', { name: new RegExp(`^\\d+\\. ${escapeRegex(page)}$`) });
   });
 });
 


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

The problem in the linked issue stemmed from how we figured out the next page when using `navigateToNextPage`. It would look at the raw url and split on `?` and take the first part, assuming those only appear in the end of the hash part. But, when using a returnUrl, that is a "real" queryParameter before the hash even begins, so it would effectively remove all of the information in the hash and the next page could not be determined.

I cleaned up the logic surrounding this, and also made some other changes. I tried to address the issues that caused us to add the hotfix where we disable the navigation buttons while saving. Instead, I now wait for saving after the button is clicked, showing a spinner on the one you clicked (next / previous) and disabling the other. Another issue I noticed when doing this is that the page order can change due to expressions after clicking the button now. Since we used to navigate directly to the page that was "next at the time of clicking the button", we would then potentially try to navigate to a page that was no longer visible. So I made some changes in `useNavigatePage` so that we always use the "current" next page there, and now use `navigateToNextPage` in the navigation buttons instead. I did a similar thing to the NavigationBar


https://github.com/user-attachments/assets/7e90121c-afe1-4b24-a409-5d11f4cc2e6e

I then had some issues with `autoSaveBehavior: onChangePage`. This used to be just "fire and forget", but now I wait until we don't have any unsaved changes here as well. Since this does not auto save, I had to make sure we keep requesting a manual save if there are new changes that need to be saved, or the waitForSave could get stuck since a new save does not get triggered automatically.

## Related Issue(s)

- closes #2664 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [x] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
