### PR TITLE
Warning about `FileUpload` components with duplicate bindings

### DIFF
--- a/src/hooks/useShallowObjectMemo.ts
+++ b/src/hooks/useShallowObjectMemo.ts
@@ -4,7 +4,7 @@ import { useRef } from 'react';
  * Similar to useShallow from zustand: https://zustand.docs.pmnd.rs/guides/prevent-rerenders-with-use-shallow
  * only this works on objects directly instead of selectors.
  */
-export function useShallowObjectMemo<T extends Object>(next: T): T {
+export function useShallowObjectMemo<T extends Object | unknown[]>(next: T): T {
   const prev = useRef<T>();
   return objectShallowEqual(next, prev.current) ? prev.current : (prev.current = next);
 }
@@ -14,7 +14,7 @@ type Object = { [key: string]: unknown };
 /**
  * Assumes that both prev and next are objects with the exact same keys
  */
-function objectShallowEqual<T extends Object>(next: T, prev?: T): prev is T {
+function objectShallowEqual<T extends Object | unknown[]>(next: T, prev?: T): prev is T {
   if (!prev) {
     return false;
   }

--- a/src/hooks/useShallowObjectMemo.ts
+++ b/src/hooks/useShallowObjectMemo.ts
@@ -4,17 +4,15 @@ import { useRef } from 'react';
  * Similar to useShallow from zustand: https://zustand.docs.pmnd.rs/guides/prevent-rerenders-with-use-shallow
  * only this works on objects directly instead of selectors.
  */
-export function useShallowObjectMemo<T extends Object | unknown[]>(next: T): T {
+export function useShallowObjectMemo<T extends ObjectOrArray>(next: T): T {
   const prev = useRef<T>();
   return objectShallowEqual(next, prev.current) ? prev.current : (prev.current = next);
 }
 
-type Object = { [key: string]: unknown };
-
 /**
  * Assumes that both prev and next are objects with the exact same keys
  */
-function objectShallowEqual<T extends Object | unknown[]>(next: T, prev?: T): prev is T {
+function objectShallowEqual<T extends ObjectOrArray>(next: T, prev?: T): prev is T {
   if (!prev) {
     return false;
   }

--- a/src/language/texts/en.ts
+++ b/src/language/texts/en.ts
@@ -426,6 +426,8 @@ export function en() {
       subform_no_datatype_appmetadata: "Data type '{0}' was not found in applicationmetadata.json",
       subform_misconfigured_add_button:
         "Data type '{0}' is marked as 'disallowUserCreate=true', but the subform component is configured with 'showAddButton=true'. This is a contradiction, as the user will never be permitted to perform the add-button operation.",
+      file_upload_same_binding:
+        'There are multiple FileUpload components with the same data model binding. Each component must have a unique binding. Other components with the same binding: {0}',
     },
     version_error: {
       version_mismatch: 'Version mismatch',

--- a/src/language/texts/nb.ts
+++ b/src/language/texts/nb.ts
@@ -427,6 +427,8 @@ export function nb(): FixedLanguageList {
       subform_no_datatype_appmetadata: "Datatype '{0}' ble ikke funnet i applicationmetadata.json.",
       subform_misconfigured_add_button:
         "Datatype '{0}' er markert som 'disallowUserCreate=true', men underskjema-komponenten er konfigurert med 'showAddButton=true'. Dette er en motsetning, siden brukeren aldri vil få lov til å utføre handlingene bak legg-til knappen.",
+      file_upload_same_binding:
+        'Det er flere filopplastingskomponenter med samme datamodell-binding. Hver komponent må ha en unik binding. Andre komponenter med samme binding: {0}',
     },
     version_error: {
       version_mismatch: 'Versjonsfeil',

--- a/src/language/texts/nn.ts
+++ b/src/language/texts/nn.ts
@@ -427,6 +427,8 @@ export function nn(): FixedLanguageList {
       subform_no_datatype_appmetadata: "Datatype '{0}' vart ikkje funnen i applicationmetadata.json.",
       subform_misconfigured_add_button:
         "Datatype '{0}' er markert som 'disallowUserCreate=true', men underskjema-komponenten er konfigurert med 'showAddButton=true'. Dette er ei motseiing, Sidan brukaren aldri vil få lov til å utføre handlingane bak legg-til knappen.",
+      file_upload_same_binding:
+        'Det er fleire filopplastingskomponentar med same datamodellbinding. Kvar komponent må ha ein unik binding. Andre komponentar med same binding: {0}',
     },
     version_error: {
       version_mismatch: 'Versjonsfeil',

--- a/src/layout/FileUpload/FileUploadLayoutValidator.tsx
+++ b/src/layout/FileUpload/FileUploadLayoutValidator.tsx
@@ -1,0 +1,63 @@
+import { useEffect } from 'react';
+import type { JSX } from 'react';
+
+import { useLayouts } from 'src/features/form/layout/LayoutsContext';
+import { useLanguage } from 'src/features/language/useLanguage';
+import { useShallowObjectMemo } from 'src/hooks/useShallowObjectMemo';
+import { NodesInternal } from 'src/utils/layout/NodesContext';
+import type { IDataModelReference } from 'src/layout/common.generated';
+import type { CompExternal, NodeValidationProps } from 'src/layout/layout';
+
+export function FileUploadLayoutValidator(
+  props: NodeValidationProps<'FileUpload' | 'FileUploadWithTag'>,
+): JSX.Element | null {
+  const { node, externalItem } = props;
+  const allPages = useLayouts();
+  const binding = extractBinding(externalItem);
+  const { langAsString } = useLanguage();
+  const addError = NodesInternal.useAddError();
+
+  const othersWithSameBinding: string[] = [];
+  if (binding) {
+    for (const page of Object.values(allPages)) {
+      for (const component of page ?? []) {
+        if (component.id === node.baseId) {
+          continue;
+        }
+        if (component.type !== 'FileUpload' && component.type !== 'FileUploadWithTag') {
+          continue;
+        }
+        const otherBinding = extractBinding(component);
+        if (otherBinding && otherBinding.dataType === binding.dataType && otherBinding.field === binding.field) {
+          othersWithSameBinding.push(component.id);
+        }
+      }
+    }
+  }
+
+  const othersWithSameBindingMemo = useShallowObjectMemo(othersWithSameBinding);
+
+  useEffect(() => {
+    let error: string | null = null;
+    if (othersWithSameBindingMemo.length >= 1) {
+      const othersList = othersWithSameBindingMemo.map((id) => `'${id}'`).join(', ');
+      error = langAsString('config_error.file_upload_same_binding', [othersList]);
+    }
+
+    if (error) {
+      addError(error, node);
+      window.logErrorOnce(`Validation error for '${node.id}': ${error}`);
+    }
+  }, [addError, langAsString, node, othersWithSameBindingMemo]);
+
+  return null;
+}
+
+function extractBinding(component: CompExternal<'FileUpload' | 'FileUploadWithTag'>): IDataModelReference | undefined {
+  if (component.dataModelBindings && 'simpleBinding' in component.dataModelBindings) {
+    return component.dataModelBindings.simpleBinding;
+  } else if (component.dataModelBindings && 'list' in component.dataModelBindings) {
+    return component.dataModelBindings.list;
+  }
+  return undefined;
+}

--- a/src/layout/FileUpload/index.tsx
+++ b/src/layout/FileUpload/index.tsx
@@ -5,12 +5,14 @@ import { FrontendValidationSource, ValidationMask } from 'src/features/validatio
 import { AttachmentSummaryComponent2 } from 'src/layout/FileUpload/AttachmentSummaryComponent2';
 import { FileUploadDef } from 'src/layout/FileUpload/config.def.generated';
 import { FileUploadComponent } from 'src/layout/FileUpload/FileUploadComponent';
+import { FileUploadLayoutValidator } from 'src/layout/FileUpload/FileUploadLayoutValidator';
 import { AttachmentSummaryComponent } from 'src/layout/FileUpload/Summary/AttachmentSummaryComponent';
 import { LayoutPage } from 'src/utils/layout/LayoutPage';
 import type { LayoutValidationCtx } from 'src/features/devtools/layoutValidation/types';
 import type { DisplayDataProps } from 'src/features/displayData';
 import type { ComponentValidation, ValidationDataSources } from 'src/features/validation';
 import type { PropsFromGenericComponent, ValidateComponent } from 'src/layout';
+import type { NodeValidationProps } from 'src/layout/layout';
 import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
@@ -42,6 +44,10 @@ export class FileUpload extends FileUploadDef implements ValidateComponent<'File
 
   shouldRenderInAutomaticPDF() {
     return true;
+  }
+
+  renderLayoutValidators(props: NodeValidationProps<'FileUpload'>): JSX.Element | null {
+    return <FileUploadLayoutValidator {...props} />;
   }
 
   // This component does not have empty field validation, so has to override its inherited method

--- a/src/layout/FileUploadWithTag/index.tsx
+++ b/src/layout/FileUploadWithTag/index.tsx
@@ -4,6 +4,7 @@ import { isAttachmentUploaded } from 'src/features/attachments';
 import { FrontendValidationSource, ValidationMask } from 'src/features/validation';
 import { AttachmentSummaryComponent2 } from 'src/layout/FileUpload/AttachmentSummaryComponent2';
 import { FileUploadComponent } from 'src/layout/FileUpload/FileUploadComponent';
+import { FileUploadLayoutValidator } from 'src/layout/FileUpload/FileUploadLayoutValidator';
 import { AttachmentSummaryComponent } from 'src/layout/FileUpload/Summary/AttachmentSummaryComponent';
 import { FileUploadWithTagDef } from 'src/layout/FileUploadWithTag/config.def.generated';
 import { LayoutPage } from 'src/utils/layout/LayoutPage';
@@ -11,6 +12,7 @@ import type { LayoutValidationCtx } from 'src/features/devtools/layoutValidation
 import type { DisplayDataProps } from 'src/features/displayData';
 import type { AttachmentValidation, ComponentValidation, ValidationDataSources } from 'src/features/validation';
 import type { PropsFromGenericComponent, ValidateComponent } from 'src/layout';
+import type { NodeValidationProps } from 'src/layout/layout';
 import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
@@ -38,6 +40,10 @@ export class FileUploadWithTag extends FileUploadWithTagDef implements ValidateC
 
   renderSummary2(props: Summary2Props<'FileUploadWithTag'>): JSX.Element | null {
     return <AttachmentSummaryComponent2 targetNode={props.target} />;
+  }
+
+  renderLayoutValidators(props: NodeValidationProps<'FileUploadWithTag'>): JSX.Element | null {
+    return <FileUploadLayoutValidator {...props} />;
   }
 
   // This component does not have empty field validation, so has to override its inherited method

--- a/src/utils/layout/NodesContext.tsx
+++ b/src/utils/layout/NodesContext.tsx
@@ -1155,6 +1155,15 @@ export const NodesInternal = {
     });
   },
 
+  useNodeErrors(node: LayoutNode | undefined) {
+    return Store.useSelector((s) => {
+      if (!node) {
+        return undefined;
+      }
+      return s.nodeData[node.id]?.errors;
+    });
+  },
+
   useNodeData<N extends LayoutNode | undefined, Out>(
     node: N,
     selector: (nodeData: NodeDataFromNode<N>, readiness: NodesReadiness, fullState: NodesContext) => Out,


### PR DESCRIPTION
## Description

When binding multiple `FileUpload` or `FileUploadWithTag` components to the same path in the data model, you'd end up with components fighting over which one manages the binding, and they'd make infinite loops that crash app-frontend. Throwing errors about this instead.

## Related Issue(s)

- https://altinn.slack.com/archives/C02EJ9HKQA3/p1738582214908209
- https://altinn.slack.com/archives/C02FK32SFA4/p1738759699145159

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
