### PR TITLE
Re-enabling party selection before stateless

### DIFF
--- a/src/features/entrypoint/Entrypoint.tsx
+++ b/src/features/entrypoint/Entrypoint.tsx
@@ -6,9 +6,14 @@ import { useApplicationMetadata } from 'src/features/applicationMetadata/Applica
 import { FormProvider } from 'src/features/form/FormContext';
 import { InstantiateContainer } from 'src/features/instantiate/containers/InstantiateContainer';
 import { NoValidPartiesError } from 'src/features/instantiate/containers/NoValidPartiesError';
-import { UnknownError } from 'src/features/instantiate/containers/UnknownError';
-import { useCurrentPartyIsValid, useHasSelectedParty, useValidParties } from 'src/features/party/PartiesProvider';
+import {
+  useCurrentParty,
+  useCurrentPartyIsValid,
+  useHasSelectedParty,
+  useValidParties,
+} from 'src/features/party/PartiesProvider';
 import { useProfile } from 'src/features/profile/ProfileProvider';
+import { useAllowAnonymousIs } from 'src/features/stateless/getAllowAnonymous';
 import type { ShowTypes } from 'src/features/applicationMetadata/types';
 
 const ShowOrInstantiate: React.FC<{ show: ShowTypes }> = ({ show }) => {
@@ -25,7 +30,14 @@ const ShowOrInstantiate: React.FC<{ show: ShowTypes }> = ({ show }) => {
     return <InstantiateContainer />;
   }
 
-  return <UnknownError />;
+  // If the show type is something else, it points to a layout set that describes a stateless form.
+  return (
+    <DataLoadingProvider>
+      <FormProvider>
+        <Outlet />
+      </FormProvider>
+    </DataLoadingProvider>
+  );
 };
 
 export const Entrypoint = () => {
@@ -38,8 +50,13 @@ export const Entrypoint = () => {
   const validParties = useValidParties();
   const partyIsValid = useCurrentPartyIsValid();
   const userHasSelectedParty = useHasSelectedParty();
+  const allowAnonymous = useAllowAnonymousIs(true);
+  const party = useCurrentParty();
 
-  if (isStateless) {
+  if (isStateless && allowAnonymous && !party) {
+    // Anonymous stateless app. No need to log in and select party, but cannot create a new instance.
+    // The regular stateless mode (where you have to log in) is handled in ShowOrInstantiate, after the party is
+    // selected and valid.
     return (
       <DataLoadingProvider>
         <FormProvider>

--- a/test/e2e/integration/frontend-test/party-selection.ts
+++ b/test/e2e/integration/frontend-test/party-selection.ts
@@ -1,158 +1,14 @@
 import texts from 'test/e2e/fixtures/texts.json';
 import { AppFrontend } from 'test/e2e/pageobjects/app-frontend';
+import { cyMockResponses, CyPartyMocks } from 'test/e2e/pageobjects/party-mocks';
 
-import { PartyType } from 'src/types/shared';
-import type { IncomingApplicationMetadata } from 'src/features/applicationMetadata/types';
 import type { IParty } from 'src/types/shared';
 
 const appFrontend = new AppFrontend();
 
-const ExampleOrgWithSubUnit: IParty = {
-  partyId: 500000,
-  partyTypeName: PartyType.Organisation,
-  orgNumber: '897069650',
-  ssn: null,
-  unitType: 'AS',
-  name: 'DDG Fitness AS',
-  isDeleted: false,
-  onlyHierarchyElementWithNoAccess: false,
-  person: null,
-  organization: null,
-  childParties: [
-    {
-      partyId: 500001,
-      partyTypeName: PartyType.Organisation,
-      orgNumber: '897069651',
-      ssn: null,
-      unitType: 'BEDR',
-      name: 'DDG Fitness Bergen',
-      isDeleted: false,
-      onlyHierarchyElementWithNoAccess: false,
-      person: null,
-      organization: null,
-      childParties: null,
-    },
-  ],
-};
-
-const ExampleDeletedOrg: IParty = {
-  partyId: 500600,
-  partyTypeName: PartyType.Organisation,
-  orgNumber: '897069631',
-  ssn: null,
-  unitType: 'AS',
-  name: 'EAS Health Consulting',
-  isDeleted: true,
-  onlyHierarchyElementWithNoAccess: false,
-  person: null,
-  organization: null,
-  childParties: [],
-};
-
-const ExamplePerson1: IParty = {
-  partyId: 12345678,
-  partyTypeName: PartyType.Person,
-  ssn: '12312312345',
-  unitType: null,
-  name: 'Fake Party',
-  isDeleted: false,
-  onlyHierarchyElementWithNoAccess: false,
-  person: null,
-  organization: null,
-  childParties: null,
-};
-
-const ExamplePerson2: IParty = {
-  partyId: 12345679,
-  partyTypeName: PartyType.Person,
-  ssn: '12312312344',
-  unitType: null,
-  name: 'Fake Person2',
-  isDeleted: false,
-  onlyHierarchyElementWithNoAccess: false,
-  person: null,
-  organization: null,
-  childParties: null,
-};
-
-const InvalidParty: IParty = {
-  partyId: 50085642,
-  partyUuid: 'bb1aeb78-237e-47fb-b600-727803500985',
-  partyTypeName: 1,
-  orgNumber: '',
-  ssn: '23033600534',
-  unitType: null,
-  name: 'RISHAUG JULIUS',
-  isDeleted: false,
-  onlyHierarchyElementWithNoAccess: false,
-  person: null,
-  organization: null,
-  childParties: [],
-};
-
-interface Mockable {
-  preSelectedParty?: number;
-  currentParty?: IParty;
-  allowedToInstantiate?: IParty[] | ((parties: IParty[]) => IParty[]);
-  doNotPromptForParty?: boolean;
-  appPromptForPartyOverride?: IncomingApplicationMetadata['promptForParty'];
-  partyTypesAllowed?: IncomingApplicationMetadata['partyTypesAllowed'];
-}
-
-function mockResponses(whatToMock: Mockable) {
-  if (whatToMock.preSelectedParty !== undefined) {
-    // Sets the 'AltinnPartyId' cookie to emulate having selected a party when logging in to Altinn
-    cy.setCookie('AltinnPartyId', whatToMock.preSelectedParty.toString());
-  }
-
-  if (whatToMock.currentParty) {
-    cy.intercept('GET', `**/api/authorization/parties/current?returnPartyObject=true`, (req) => {
-      req.on('response', (res) => {
-        res.body = whatToMock.currentParty;
-      });
-    });
-  }
-
-  if (whatToMock.allowedToInstantiate) {
-    cy.intercept('GET', `**/api/v1/parties?allowedtoinstantiatefilter=true`, (req) => {
-      req.continue((res) => {
-        const body =
-          whatToMock.allowedToInstantiate instanceof Function
-            ? whatToMock.allowedToInstantiate(res.body)
-            : // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              (whatToMock.allowedToInstantiate as any);
-        res.send(body);
-      });
-    });
-  }
-  if (whatToMock.doNotPromptForParty !== undefined) {
-    cy.intercept('GET', '**/api/v1/profile/user', {
-      body: {
-        profileSettingPreference: {
-          doNotPromptForParty: whatToMock.doNotPromptForParty,
-        },
-      },
-    });
-  }
-  if (whatToMock.appPromptForPartyOverride !== undefined || whatToMock.partyTypesAllowed !== undefined) {
-    cy.intercept('GET', '**/api/v1/applicationmetadata', (req) => {
-      req.on('response', (res) => {
-        if (whatToMock.appPromptForPartyOverride !== undefined) {
-          res.body.promptForParty = whatToMock.appPromptForPartyOverride;
-        }
-        if (whatToMock.partyTypesAllowed !== undefined) {
-          res.body.partyTypesAllowed = whatToMock.partyTypesAllowed;
-        }
-      });
-    });
-  }
-
-  cy.intercept('**/active', []).as('noActiveInstances');
-}
-
 describe('Party selection', () => {
   it('Party selection filtering and search', () => {
-    mockResponses({ allowedToInstantiate: [ExampleOrgWithSubUnit, ExampleDeletedOrg] });
+    cyMockResponses({ allowedToInstantiate: [CyPartyMocks.ExampleOrgWithSubUnit, CyPartyMocks.ExampleDeletedOrg] });
     cy.startAppInstance(appFrontend.apps.frontendTest);
     cy.get(appFrontend.reporteeSelection.appHeader).should('be.visible');
     cy.get(appFrontend.reporteeSelection.error).contains(texts.selectNewReportee);
@@ -168,21 +24,22 @@ describe('Party selection', () => {
   });
 
   it('Should show the correct title', () => {
-    mockResponses({ allowedToInstantiate: [ExampleOrgWithSubUnit, ExampleDeletedOrg] });
+    cyMockResponses({ allowedToInstantiate: [CyPartyMocks.ExampleOrgWithSubUnit, CyPartyMocks.ExampleDeletedOrg] });
     cy.startAppInstance(appFrontend.apps.frontendTest);
     cy.get(appFrontend.reporteeSelection.appHeader).should('be.visible');
     cy.title().should('eq', 'Hvem vil du sende inn for? - frontend-test - Testdepartementet');
   });
 
   it('Should skip party selection if you can only represent one person', () => {
-    mockResponses({
-      preSelectedParty: ExamplePerson1.partyId,
-      currentParty: ExamplePerson1,
-      allowedToInstantiate: [ExamplePerson1],
+    cyMockResponses({
+      preSelectedParty: CyPartyMocks.ExamplePerson1.partyId,
+      currentParty: CyPartyMocks.ExamplePerson1,
+      allowedToInstantiate: [CyPartyMocks.ExamplePerson1],
     });
-    cy.intercept('POST', `/ttd/frontend-test/instances?instanceOwnerPartyId=${ExamplePerson1.partyId}*`).as(
-      'loadInstance',
-    );
+    cy.intercept(
+      'POST',
+      `/ttd/frontend-test/instances?instanceOwnerPartyId=${CyPartyMocks.ExamplePerson1.partyId}*`,
+    ).as('loadInstance');
     cy.startAppInstance(appFrontend.apps.frontendTest);
     cy.get(appFrontend.reporteeSelection.reportee).should('not.exist');
     cy.wait('@loadInstance');
@@ -193,12 +50,12 @@ describe('Party selection', () => {
   });
 
   it('Should show party selection with a warning when you cannot use the preselected party', () => {
-    mockResponses({
-      preSelectedParty: ExampleOrgWithSubUnit.partyId,
+    cyMockResponses({
+      preSelectedParty: CyPartyMocks.ExampleOrgWithSubUnit.partyId,
 
       // We'll only allow one party to be selected, and it's not the preselected one. Even though one-party-choices
       // normally won't show up as being selectable, we'll still show the warning in these cases.
-      allowedToInstantiate: [ExamplePerson2],
+      allowedToInstantiate: [CyPartyMocks.ExamplePerson2],
       partyTypesAllowed: {
         person: true,
         subUnit: false,
@@ -213,7 +70,7 @@ describe('Party selection', () => {
   });
 
   it('Should show an error if there are no parties to select from', () => {
-    mockResponses({
+    cyMockResponses({
       allowedToInstantiate: [],
       partyTypesAllowed: {
         person: false,
@@ -229,8 +86,13 @@ describe('Party selection', () => {
   });
 
   it('List of parties should show correct icon and org nr or ssn', () => {
-    mockResponses({
-      allowedToInstantiate: (parties) => [...parties, ExamplePerson1, InvalidParty, ExampleOrgWithSubUnit],
+    cyMockResponses({
+      allowedToInstantiate: (parties) => [
+        ...parties,
+        CyPartyMocks.ExamplePerson1,
+        CyPartyMocks.InvalidParty,
+        CyPartyMocks.ExampleOrgWithSubUnit,
+      ],
       doNotPromptForParty: false,
     });
     cy.startAppInstance(appFrontend.apps.frontendTest);
@@ -258,8 +120,8 @@ describe('Party selection', () => {
     it(`${
       doNotPromptForParty ? 'Does not prompt' : 'Prompts'
     } for party when doNotPromptForParty = ${doNotPromptForParty}, on instantiation with multiple possible parties`, () => {
-      mockResponses({
-        allowedToInstantiate: (parties) => [...parties, ExamplePerson1],
+      cyMockResponses({
+        allowedToInstantiate: (parties) => [...parties, CyPartyMocks.ExamplePerson1],
         doNotPromptForParty,
       });
       cy.startAppInstance(appFrontend.apps.frontendTest);
@@ -295,7 +157,7 @@ describe('Party selection', () => {
 
   [true, false].forEach((doNotPromptForParty) => {
     it(`Does not prompt for party when doNotPromptForParty = ${doNotPromptForParty}, on instantiation with only one possible party`, () => {
-      mockResponses({
+      cyMockResponses({
         doNotPromptForParty,
       });
 
@@ -355,10 +217,10 @@ describe('Party selection', () => {
     { doNotPromptForPartyPreference: false, appPromptForPartyOverride: 'never' as const },
   ].forEach(({ doNotPromptForPartyPreference, appPromptForPartyOverride }) => {
     it(`Correctly overrides the profile doNotPromptForPartyPreference when doNotPromptForPartyPreference=${doNotPromptForPartyPreference} and appPromptForPartyOverride=${appPromptForPartyOverride}`, () => {
-      mockResponses({
+      cyMockResponses({
         doNotPromptForParty: doNotPromptForPartyPreference,
         appPromptForPartyOverride,
-        allowedToInstantiate: (parties) => [...parties, ExamplePerson1],
+        allowedToInstantiate: (parties) => [...parties, CyPartyMocks.ExamplePerson1],
       });
       cy.startAppInstance(appFrontend.apps.frontendTest, { user: 'default' });
       cy.get(appFrontend.reporteeSelection.appHeader).should('be.visible');

--- a/test/e2e/integration/stateless-app/party-selection.ts
+++ b/test/e2e/integration/stateless-app/party-selection.ts
@@ -1,0 +1,58 @@
+import texts from 'test/e2e/fixtures/texts.json';
+import { AppFrontend } from 'test/e2e/pageobjects/app-frontend';
+import { cyMockResponses } from 'test/e2e/pageobjects/party-mocks';
+
+import { PartyType } from 'src/types/shared';
+import type { IParty } from 'src/types/shared';
+
+const appFrontend = new AppFrontend();
+
+describe('Stateless party selection', () => {
+  it('should show party selection before starting instance', () => {
+    cyMockResponses({
+      partyTypesAllowed: {
+        person: true,
+        subUnit: false,
+        bankruptcyEstate: false,
+        organisation: false,
+      },
+      allowedToInstantiate: (parties) => {
+        // The user in tt02 has so many valid parties that we get pagination. Remove all except the first organisation
+        // and all the persons.
+        const toKeep: IParty[] = [];
+        let foundOrganisation = false;
+        for (const party of parties) {
+          if (party.partyTypeName === PartyType.Organisation && !foundOrganisation) {
+            toKeep.push(party);
+            foundOrganisation = true;
+          }
+          if (party.partyTypeName === PartyType.Person) {
+            toKeep.push(party);
+          }
+        }
+        return toKeep;
+      },
+      doNotPromptForParty: false,
+    });
+
+    cy.startAppInstance(appFrontend.apps.stateless, { user: 'accountant' });
+    cy.get(appFrontend.reporteeSelection.appHeader).should('be.visible');
+
+    if (Cypress.env('type') === 'localtest') {
+      cy.get(appFrontend.reporteeSelection.error).contains(texts.selectNewReportee);
+      cy.findByText(
+        /Du har startet tjenesten som .*?. Denne tjenesten er kun tilgjengelig for privatperson. Velg ny aktør under./,
+      ).should('be.visible');
+    } else {
+      cy.findByText(/Jeg ønsker ikke å bli spurt om aktør hver gang/).should('be.visible');
+    }
+
+    cy.findAllByText(/personnr\. \d+/)
+      .first()
+      .click(); // Select the first person we find
+
+    cy.get(appFrontend.stateless.name).should('exist').and('be.visible');
+    cy.get(appFrontend.instantiationButton).click();
+    cy.get('#sendInButton').should('exist');
+  });
+});

--- a/test/e2e/pageobjects/party-mocks.ts
+++ b/test/e2e/pageobjects/party-mocks.ts
@@ -1,0 +1,157 @@
+import { PartyType } from 'src/types/shared';
+import type { IncomingApplicationMetadata } from 'src/features/applicationMetadata/types';
+import type { IParty } from 'src/types/shared';
+
+const ExampleOrgWithSubUnit: IParty = {
+  partyId: 500000,
+  partyTypeName: PartyType.Organisation,
+  orgNumber: '897069650',
+  ssn: null,
+  unitType: 'AS',
+  name: 'DDG Fitness AS',
+  isDeleted: false,
+  onlyHierarchyElementWithNoAccess: false,
+  person: null,
+  organization: null,
+  childParties: [
+    {
+      partyId: 500001,
+      partyTypeName: PartyType.Organisation,
+      orgNumber: '897069651',
+      ssn: null,
+      unitType: 'BEDR',
+      name: 'DDG Fitness Bergen',
+      isDeleted: false,
+      onlyHierarchyElementWithNoAccess: false,
+      person: null,
+      organization: null,
+      childParties: null,
+    },
+  ],
+};
+
+const ExampleDeletedOrg: IParty = {
+  partyId: 500600,
+  partyTypeName: PartyType.Organisation,
+  orgNumber: '897069631',
+  ssn: null,
+  unitType: 'AS',
+  name: 'EAS Health Consulting',
+  isDeleted: true,
+  onlyHierarchyElementWithNoAccess: false,
+  person: null,
+  organization: null,
+  childParties: [],
+};
+
+const ExamplePerson1: IParty = {
+  partyId: 12345678,
+  partyTypeName: PartyType.Person,
+  ssn: '12312312345',
+  unitType: null,
+  name: 'Fake Party',
+  isDeleted: false,
+  onlyHierarchyElementWithNoAccess: false,
+  person: null,
+  organization: null,
+  childParties: null,
+};
+
+const ExamplePerson2: IParty = {
+  partyId: 12345679,
+  partyTypeName: PartyType.Person,
+  ssn: '12312312344',
+  unitType: null,
+  name: 'Fake Person2',
+  isDeleted: false,
+  onlyHierarchyElementWithNoAccess: false,
+  person: null,
+  organization: null,
+  childParties: null,
+};
+
+const InvalidParty: IParty = {
+  partyId: 50085642,
+  partyUuid: 'bb1aeb78-237e-47fb-b600-727803500985',
+  partyTypeName: 1,
+  orgNumber: '',
+  ssn: '23033600534',
+  unitType: null,
+  name: 'RISHAUG JULIUS',
+  isDeleted: false,
+  onlyHierarchyElementWithNoAccess: false,
+  person: null,
+  organization: null,
+  childParties: [],
+};
+
+export const CyPartyMocks = {
+  ExampleOrgWithSubUnit,
+  ExampleDeletedOrg,
+  ExamplePerson1,
+  ExamplePerson2,
+  InvalidParty,
+};
+
+interface Mockable {
+  preSelectedParty?: number;
+  currentParty?: IParty;
+  allowedToInstantiate?: IParty[] | ((parties: IParty[]) => IParty[]);
+  doNotPromptForParty?: boolean;
+  appPromptForPartyOverride?: IncomingApplicationMetadata['promptForParty'];
+  partyTypesAllowed?: IncomingApplicationMetadata['partyTypesAllowed'];
+  noActiveInstances?: boolean; // Defaults to true
+}
+
+export function cyMockResponses(whatToMock: Mockable) {
+  if (whatToMock.preSelectedParty !== undefined) {
+    // Sets the 'AltinnPartyId' cookie to emulate having selected a party when logging in to Altinn
+    cy.setCookie('AltinnPartyId', whatToMock.preSelectedParty.toString());
+  }
+
+  if (whatToMock.currentParty) {
+    cy.intercept('GET', `**/api/authorization/parties/current?returnPartyObject=true`, (req) => {
+      req.on('response', (res) => {
+        res.body = whatToMock.currentParty;
+      });
+    });
+  }
+
+  if (whatToMock.allowedToInstantiate) {
+    cy.intercept('GET', `**/api/v1/parties?allowedtoinstantiatefilter=true`, (req) => {
+      req.continue((res) => {
+        const body =
+          whatToMock.allowedToInstantiate instanceof Function
+            ? whatToMock.allowedToInstantiate(res.body)
+            : // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              (whatToMock.allowedToInstantiate as any);
+        res.send(body);
+      });
+    });
+  }
+  if (whatToMock.doNotPromptForParty !== undefined) {
+    cy.intercept('GET', '**/api/v1/profile/user', {
+      body: {
+        profileSettingPreference: {
+          doNotPromptForParty: whatToMock.doNotPromptForParty,
+        },
+      },
+    });
+  }
+  if (whatToMock.appPromptForPartyOverride !== undefined || whatToMock.partyTypesAllowed !== undefined) {
+    cy.intercept('GET', '**/api/v1/applicationmetadata', (req) => {
+      req.on('response', (res) => {
+        if (whatToMock.appPromptForPartyOverride !== undefined) {
+          res.body.promptForParty = whatToMock.appPromptForPartyOverride;
+        }
+        if (whatToMock.partyTypesAllowed !== undefined) {
+          res.body.partyTypesAllowed = whatToMock.partyTypesAllowed;
+        }
+      });
+    });
+  }
+
+  if (whatToMock.noActiveInstances !== false) {
+    cy.intercept('**/active', []).as('noActiveInstances');
+  }
+}


### PR DESCRIPTION
## Description

When refactoring some routes, we accidentally broke non-anonymous stateless party-selection. When in a stateless app, and representing a party that is not valid, party-selection should still show up.

Most of the changes here are about moving some code from one cypress test to a file where I can re-use it when testing this stuff. The actual fix is limited to `Entrypoint.tsx`.

## Related Issue(s)

- https://digdir.slack.com/archives/C0760NPT2BE/p1738931979584499
- https://altinn.slack.com/archives/C02EJ9HKQA3/p1738920325322669

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
