### PR TITLE
DX: Fixing broken memoization

### DIFF
--- a/src/core/contexts/zustandContext.tsx
+++ b/src/core/contexts/zustandContext.tsx
@@ -7,10 +7,10 @@ import type { StoreApi } from 'zustand';
 
 import { ContextNotProvided, createContext } from 'src/core/contexts/context';
 import { SelectorStrictness, useDelayedSelector } from 'src/hooks/delayedSelectors';
-import { useShallow } from 'src/hooks/useShallowObjectMemo';
+import { useShallow } from 'src/hooks/useShallowMemo';
 import type { CreateContextProps } from 'src/core/contexts/context';
 import type { DSConfig, DSMode, DSProps, DSReturn } from 'src/hooks/delayedSelectors';
-import type { ObjectOrArray } from 'src/hooks/useShallowObjectMemo';
+import type { ObjectOrArray } from 'src/hooks/useShallowMemo';
 
 type ExtractFromStoreApi<T> = T extends StoreApi<infer U> ? Exclude<U, void> : never;
 

--- a/src/hooks/useShallowMemo.ts
+++ b/src/hooks/useShallowMemo.ts
@@ -4,24 +4,9 @@ import { useRef } from 'react';
  * Similar to useShallow from zustand: https://zustand.docs.pmnd.rs/guides/prevent-rerenders-with-use-shallow
  * only this works on objects directly instead of selectors.
  */
-export function useShallowObjectMemo<T extends ObjectOrArray>(next: T): T {
+export function useShallowMemo<T extends ObjectOrArray>(next: T): T {
   const prev = useRef<T>();
-  return objectShallowEqual(next, prev.current) ? prev.current : (prev.current = next);
-}
-
-/**
- * Assumes that both prev and next are objects with the exact same keys
- */
-function objectShallowEqual<T extends ObjectOrArray>(next: T, prev?: T): prev is T {
-  if (!prev) {
-    return false;
-  }
-  for (const key in next) {
-    if (next[key] !== prev[key]) {
-      return false;
-    }
-  }
-  return true;
+  return objectOrArrayShallowEqual(next, prev.current) ? prev.current : (prev.current = next);
 }
 
 /**

--- a/src/layout/FileUpload/FileUploadLayoutValidator.tsx
+++ b/src/layout/FileUpload/FileUploadLayoutValidator.tsx
@@ -3,7 +3,7 @@ import type { JSX } from 'react';
 
 import { useLayouts } from 'src/features/form/layout/LayoutsContext';
 import { useLanguage } from 'src/features/language/useLanguage';
-import { useShallowObjectMemo } from 'src/hooks/useShallowObjectMemo';
+import { useShallowMemo } from 'src/hooks/useShallowMemo';
 import { NodesInternal } from 'src/utils/layout/NodesContext';
 import type { IDataModelReference } from 'src/layout/common.generated';
 import type { CompExternal, NodeValidationProps } from 'src/layout/layout';
@@ -35,7 +35,7 @@ export function FileUploadLayoutValidator(
     }
   }
 
-  const othersWithSameBindingMemo = useShallowObjectMemo(othersWithSameBinding);
+  const othersWithSameBindingMemo = useShallowMemo(othersWithSameBinding);
 
   useEffect(() => {
     let error: string | null = null;

--- a/src/utils/layout/generator/GeneratorDataSources.tsx
+++ b/src/utils/layout/generator/GeneratorDataSources.tsx
@@ -14,7 +14,7 @@ import { useInnerLanguageWithForcedNodeSelector } from 'src/features/language/us
 import { useCurrentPartyRoles } from 'src/features/useCurrentPartyRoles';
 import { Validation } from 'src/features/validation/validationContext';
 import { useMultipleDelayedSelectors } from 'src/hooks/delayedSelectors';
-import { useShallowObjectMemo } from 'src/hooks/useShallowObjectMemo';
+import { useShallowMemo } from 'src/hooks/useShallowMemo';
 import { useCommitWhenFinished } from 'src/utils/layout/generator/CommitQueue';
 import { Hidden, NodesInternal, useNodes } from 'src/utils/layout/NodesContext';
 import { useInnerDataModelBindingTranspose } from 'src/utils/layout/useDataModelBindingTranspose';
@@ -83,7 +83,7 @@ function useExpressionDataSources(): ExpressionDataSources {
     nodeDataSelector,
   );
 
-  return useShallowObjectMemo({
+  return useShallowMemo({
     roles,
     formDataSelector,
     formDataRowsSelector,
@@ -126,7 +126,7 @@ function useValidationDataSources(): ValidationDataSources {
   const applicationMetadata = useApplicationMetadata();
   const layoutSets = useLayoutSets();
 
-  return useShallowObjectMemo({
+  return useShallowMemo({
     formDataSelector,
     invalidDataSelector,
     attachmentsSelector,

--- a/src/utils/layout/generator/useEvalExpression.ts
+++ b/src/utils/layout/generator/useEvalExpression.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 
 import { evalExpr } from 'src/features/expressions';
 import { ExprValidation } from 'src/features/expressions/validation';
-import { useShallowObjectMemo } from 'src/hooks/useShallowObjectMemo';
+import { useShallowMemo } from 'src/hooks/useShallowMemo';
 import { GeneratorData } from 'src/utils/layout/generator/GeneratorDataSources';
 import { GeneratorStages } from 'src/utils/layout/generator/GeneratorStages';
 import { LayoutPage } from 'src/utils/layout/LayoutPage';
@@ -49,7 +49,7 @@ export function useEvalExpression<V extends ExprVal>(
   _options?: Omit<EvalExprOptions, 'config' | 'errorIntroText'>,
   enabled = true,
 ) {
-  const options = useShallowObjectMemo(_options ?? {});
+  const options = useShallowMemo(_options ?? {});
   return useMemo(() => {
     if (!enabled) {
       return defaultValue;

--- a/src/utils/layout/useExpressionDataSources.ts
+++ b/src/utils/layout/useExpressionDataSources.ts
@@ -10,7 +10,7 @@ import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
 import { useInnerLanguageWithForcedNodeSelector } from 'src/features/language/useLanguage';
 import { useCurrentPartyRoles } from 'src/features/useCurrentPartyRoles';
 import { useMultipleDelayedSelectors } from 'src/hooks/delayedSelectors';
-import { useShallowObjectMemo } from 'src/hooks/useShallowObjectMemo';
+import { useShallowMemo } from 'src/hooks/useShallowMemo';
 import { Hidden, NodesInternal, useNodes } from 'src/utils/layout/NodesContext';
 import { useInnerDataModelBindingTranspose } from 'src/utils/layout/useDataModelBindingTranspose';
 import { useInnerNodeFormDataSelector } from 'src/utils/layout/useNodeItem';
@@ -90,7 +90,7 @@ export function useExpressionDataSources(): ExpressionDataSources {
 
   const roles = useCurrentPartyRoles();
 
-  return useShallowObjectMemo({
+  return useShallowMemo({
     roles,
     formDataSelector,
     formDataRowsSelector,


### PR DESCRIPTION
## Description

In #2982 @bjosttveit correctly pointed out a mistake I did when assigning a new possible type for `useShallowObjectMemo()`. Right after this was merged to main I noticed something else, and possibly worse: That memo function didn't properly check that both objects had the exact same keys. The other function did, however, and supported both objects and arrays. Using that all the time seems better to me, so this removes the slightly broken first function.

## Related Issue(s)

- #2982

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [x] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
