### PR TITLE
Fix flaky auto save test and add spinner to back button

### DIFF
--- a/src/features/formData/FormDataWrite.tsx
+++ b/src/features/formData/FormDataWrite.tsx
@@ -98,7 +98,7 @@ function useFormDataSaveMutation() {
     { prev: { [dataType: string]: object }; next: { [dataType: string]: object } },
     FormDataContext
   >(useStore());
-  const useIsSavingRef = useAsRef(useIsSaving());
+  const isSavingNow = useIsSavingNow();
   const queryClient = useQueryClient();
 
   // This updates the query cache with the new data models every time a save has finished. This means we won't have to
@@ -270,8 +270,8 @@ function useFormDataSaveMutation() {
   // Check if save has already started before calling mutate
   const _mutate = mutation.mutate;
   const mutate: typeof mutation.mutate = useCallback(
-    (...args) => !useIsSavingRef.current && _mutate(...args),
-    [useIsSavingRef, _mutate],
+    (...args) => !isSavingNow() && _mutate(...args),
+    [_mutate, isSavingNow],
   );
 
   return {

--- a/src/hooks/useNavigatePage.ts
+++ b/src/hooks/useNavigatePage.ts
@@ -275,7 +275,7 @@ export function useNavigatePage() {
       }
 
       if (options?.skipAutoSave !== true) {
-        maybeSaveOnPageChange();
+        await maybeSaveOnPageChange();
       }
 
       if (isStatelessApp) {


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

Cypress test for auto-save-behavior became a bit flaky after #2970. The reason was that when checking the box that show the repeating group in the test app, that repeating group contains a dropdown component with a preselectedOption index. This will run an effect that updates the data model with the default selected option, which sometimes caused two saves to happen when the test only expected one. I would argue the behavior now is better, as it would previously leave that change unsaved when changing page fast enough, whereas now additional changes like this are more likely to get saved. To get a consistent number of saves I added a wait for the repeating group to show up + 100ms so that the effect has time to fire so that the preselected option gets included in the save call.

Additionally, I added a spinner to the back button if it needs to finish saving before navigating so the user gets feedback. Since we now do this with the navigation buttons.

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
