### PR TITLE
Pin chrome version for cypress workflow

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -26,6 +26,8 @@ jobs:
   install:
     name: Install
     runs-on: ubuntu-latest
+    container:
+      image: cypress/browsers:node-22.13.1-chrome-133.0.6943.53-1-ff-135.0-edge-132.0.2957.140-1
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -54,6 +56,8 @@ jobs:
       (github.event_name != 'pull_request' && github.event.repository.fork == false) ||
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
     runs-on: ubuntu-latest
+    container:
+      image: cypress/browsers:node-22.13.1-chrome-133.0.6943.53-1-ff-135.0-edge-132.0.2957.140-1
     timeout-minutes: 60
     needs: install
     strategy:
@@ -117,6 +121,8 @@ jobs:
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true)
 
     runs-on: ubuntu-latest
+    container:
+      image: cypress/browsers:node-22.13.1-chrome-133.0.6943.53-1-ff-135.0-edge-132.0.2957.140-1
     needs: install
 
     steps:


### PR DESCRIPTION
## Description

According to the [cypress docs](https://docs.cypress.io/app/continuous-integration/github-actions#Testing-with-Cypress-Docker-Images) you can use a cypress docker image to pin the chrome version used in workflows to avoid workflows failing due to mismatch between chrome versions in parallel cypress runners.

## Related Issue(s)

- https://github.com/cypress-io/cypress/issues/9744#issuecomment-2608354211
