### PR TITLE
Adding tests for re-instantiation, fixing rare eternal loading 

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -66,7 +66,7 @@ jobs:
           (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
         with:
           projectBaseDir: app-frontend
-        uses: SonarSource/sonarcloud-github-action@master
+        uses: SonarSource/sonarqube-scan-action@v4.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/src/features/instantiate/containers/InstantiateContainer.tsx
+++ b/src/features/instantiate/containers/InstantiateContainer.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import { Loader } from 'src/core/loading/Loader';
 import { InstantiateValidationError } from 'src/features/instantiate/containers/InstantiateValidationError';
@@ -6,6 +6,7 @@ import { MissingRolesError } from 'src/features/instantiate/containers/MissingRo
 import { UnknownError } from 'src/features/instantiate/containers/UnknownError';
 import { useInstantiation } from 'src/features/instantiate/InstantiationContext';
 import { useCurrentParty } from 'src/features/party/PartiesProvider';
+import { useAsRef } from 'src/hooks/useAsRef';
 import { AltinnPalette } from 'src/theme/altinnAppTheme';
 import { changeBodyBackground } from 'src/utils/bodyStyling';
 import { isAxiosError } from 'src/utils/isAxiosError';
@@ -15,13 +16,20 @@ export const InstantiateContainer = () => {
   changeBodyBackground(AltinnPalette.greyLight);
   const party = useCurrentParty();
   const instantiation = useInstantiation();
+  const clearRef = useAsRef(instantiation.clear);
 
-  React.useEffect(() => {
-    const shouldCreateInstance = !!party && !instantiation.lastResult && !instantiation.isLoading;
+  useEffect(() => {
+    const shouldCreateInstance = !!party;
     if (shouldCreateInstance) {
       instantiation.instantiate(undefined, party.partyId);
     }
   }, [instantiation, party]);
+
+  // Clear the instantiation when the component is unmounted, to allow users to start a new instance later
+  useEffect(() => {
+    const clear = clearRef.current;
+    return () => clear();
+  }, [clearRef]);
 
   if (isAxiosError(instantiation.error)) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/test/e2e/integration/stateless-app/party-selection.ts
+++ b/test/e2e/integration/stateless-app/party-selection.ts
@@ -1,9 +1,6 @@
 import texts from 'test/e2e/fixtures/texts.json';
 import { AppFrontend } from 'test/e2e/pageobjects/app-frontend';
-import { cyMockResponses } from 'test/e2e/pageobjects/party-mocks';
-
-import { PartyType } from 'src/types/shared';
-import type { IParty } from 'src/types/shared';
+import { cyMockResponses, removeAllButOneOrg } from 'test/e2e/pageobjects/party-mocks';
 
 const appFrontend = new AppFrontend();
 
@@ -16,22 +13,7 @@ describe('Stateless party selection', () => {
         bankruptcyEstate: false,
         organisation: false,
       },
-      allowedToInstantiate: (parties) => {
-        // The user in tt02 has so many valid parties that we get pagination. Remove all except the first organisation
-        // and all the persons.
-        const toKeep: IParty[] = [];
-        let foundOrganisation = false;
-        for (const party of parties) {
-          if (party.partyTypeName === PartyType.Organisation && !foundOrganisation) {
-            toKeep.push(party);
-            foundOrganisation = true;
-          }
-          if (party.partyTypeName === PartyType.Person) {
-            toKeep.push(party);
-          }
-        }
-        return toKeep;
-      },
+      allowedToInstantiate: removeAllButOneOrg,
       doNotPromptForParty: false,
     });
 

--- a/test/e2e/pageobjects/party-mocks.ts
+++ b/test/e2e/pageobjects/party-mocks.ts
@@ -155,3 +155,20 @@ export function cyMockResponses(whatToMock: Mockable) {
     cy.intercept('**/active', []).as('noActiveInstances');
   }
 }
+
+export function removeAllButOneOrg(parties: IParty[]): IParty[] {
+  // Some users in tt02 have so many valid parties that we get pagination. Remove all
+  // except the first organisation, but keep all the persons.
+  const toKeep: IParty[] = [];
+  let foundOrganisation = false;
+  for (const party of parties) {
+    if (party.partyTypeName === PartyType.Organisation && !foundOrganisation) {
+      toKeep.push(party);
+      foundOrganisation = true;
+    }
+    if (party.partyTypeName === PartyType.Person) {
+      toKeep.push(party);
+    }
+  }
+  return toKeep;
+}


### PR DESCRIPTION
## Description

Adding automated tests for re-instantiation. Also removing ref-states and trying to simplify how this works, and making sure to clear an ongoing/failed instantiation when the user leaves the page (such as navigating back to party selection manually) which previously made the app display the loading-spinner indefintely.

## Related Issue(s)

- closes #2862
- closes #2997
- tests functionality implemented in #2985

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
