### PR TITLE
try to fix map loading before snapshot

### DIFF
--- a/test/e2e/integration/frontend-test/components.ts
+++ b/test/e2e/integration/frontend-test/components.ts
@@ -827,7 +827,9 @@ describe('UI Components', () => {
     cy.get(component('map')).should('be.visible');
 
     // Make sure tiles are not faded before taking the snapshot
-    cy.get('.leaflet-layer img').each((layer) => cy.wrap(layer).should('have.css', 'opacity', '1'));
+    cy.get('.leaflet-tile').each((tile) =>
+      cy.wrap(tile).should('have.class', 'leaflet-tile-loaded').and('have.css', 'opacity', '1'),
+    );
 
     cy.snapshot('components:map-simpleBinding');
   });
@@ -871,6 +873,7 @@ describe('UI Components', () => {
 
     cy.findByRole('checkbox', { name: /hankabakken 2/i }).dsUncheck();
     cy.findByRole('checkbox', { name: /hankabakken 4/i }).dsUncheck();
+    cy.waitUntilSaved();
 
     // prettier-ignore
     {
@@ -891,6 +894,11 @@ describe('UI Components', () => {
     cy.get(component('mapSummary')).findByRole('tooltip', { name: /hankabakken 4/i }).should('not.exist');
     cy.get(component('mapSummary')).findByRole('tooltip', { name: /hankabakken 5/i }).should('be.visible');
     }
+
+    // Make sure tiles are not faded before taking the snapshot
+    cy.get('.leaflet-tile').each((tile) =>
+      cy.wrap(tile).should('have.class', 'leaflet-tile-loaded').and('have.css', 'opacity', '1'),
+    );
 
     cy.snapshot('components:map-geometries');
   });


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

The part that waited for the map tiles to fade in was apparently not sufficient. It used to just check that all tiles have `opacity: 1`. However, it turns out that tiles have `opacity: 1` before they are loaded, and then they start fading from 0 after loading. Leaflet sets a class `leaflet-tile-loaded` when they have loaded so I now check that both have to be true at the same time. Even though percy did not report a diff in this test, I suspect it works better as you can still tell that the tiles are slightly faded in the before snapshot. The gray color of the tiles in the before snapshot has a hex value of `c6c6c6`, and in the after snapshot they are `c0c0c0` which is exactly what the actual image has. Maybe its random, but I hope its less flaky now.

