### PR TITLE
Fix map not centered in PDF

### DIFF
--- a/src/layout/Map/Map.tsx
+++ b/src/layout/Map/Map.tsx
@@ -119,7 +119,7 @@ export function Map({
   return (
     <MapContainer
       ref={map}
-      className={cn(classes.map, { [classes.mapReadOnly]: !isInteractive, [classes.printHack]: isPdf }, className)}
+      className={cn(classes.map, { [classes.mapReadOnly]: !isInteractive, [classes.print]: isPdf }, className)}
       center={center}
       zoom={zoom}
       bounds={bounds}

--- a/src/layout/Map/MapComponent.module.css
+++ b/src/layout/Map/MapComponent.module.css
@@ -4,11 +4,11 @@
 
 .map {
   position: relative;
-  height: 40rem;
+  height: 600px;
 }
 
 /**
-* This will give the map an (almost) square aspect ratio when loading the print page
+* This will give the map an (almost) correct width for A4 paper before calling print.
 * Since it has @media only screen it will still scale to fit the page,
 * but the initial fitBounds will not depend on the PDF-service's browser viewport
 * Ideally, the browser's viewport would match the pages aspect ratio, as
@@ -19,9 +19,15 @@
 * load before the page prints, but you should at least see the relevant area.
 **/
 @media only screen {
-  .print-hack {
-    width: 42rem;
+  .print {
+    width: 670px;
   }
+}
+/**
+* This will give the map approximately the same aspect ratio in the PDF as it is shown on a desktop screen
+*/
+.print {
+  height: 470px;
 }
 
 /* We do not want the map to look faded in PDF, so using @media only screen */

--- a/test/e2e/support/custom.ts
+++ b/test/e2e/support/custom.ts
@@ -548,7 +548,7 @@ Cypress.Commands.add('getSummary', (label) => {
 type ImageData = { path: string; dataUrl: string };
 Cypress.Commands.add('directSnapshot', (snapshotName, { width, minHeight }, reset = true) => {
   // Store initial viewport size for later
-  cy.getCurrentViewportSize().as('viewportSize');
+  cy.getCurrentViewportSize().as('directSnapshotViewportSize');
   cy.viewport(width, minHeight);
 
   // cy.screenshot's blackout property does not ensure that text is monospace which causes unecessary visual changes, so using our own percy css instead
@@ -606,7 +606,7 @@ Cypress.Commands.add('directSnapshot', (snapshotName, { width, minHeight }, rese
   // Revert to original viewport
   if (reset) {
     cy.go('back');
-    cy.get<Size>('@viewportSize').then(({ width, height }) => {
+    cy.get<Size>('@directSnapshotViewportSize').then(({ width, height }) => {
       cy.viewport(width, height);
     });
   }
@@ -616,7 +616,7 @@ Cypress.Commands.add(
   'testPdf',
   ({ snapshotName = false, beforeReload, callback, returnToForm = false, enableResponseFuzzing = false }) => {
     // Store initial viewport size for later
-    cy.getCurrentViewportSize().as('viewportSize');
+    cy.getCurrentViewportSize().as('testPdfViewportSize');
 
     // Make sure instantiation is completed before we get the url
     cy.location('hash', { log: false }).should('contain', '#/instance/');
@@ -690,7 +690,8 @@ Cypress.Commands.add(
       // Disable media emulation and revert to original viewport
       cy.clock().invoke('restore');
       cy.setEmulatedMedia();
-      cy.get<Size>('@viewportSize').then(({ width, height }) => {
+      cy.get<Size>('@testPdfViewportSize').then(({ width, height }) => {
+        cy.log(`Viewport size: ${width}x${height}`);
         cy.viewport(width, height);
       });
       cy.get('body').invoke('css', 'margin', '');


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

In the PDF, the map component has been rendering with its bounds off center for some time, and it appears that the problem was introduced in https://github.com/Altinn/app-frontend-react/pull/2487. This change scaled down the global font-size when using `@media print`, and since the map component's height was defined in `rem` this caused the height to get much smaller when the browser calls print, which results in the bottom part getting cut off like this (the pin should be roughly in the center of the map):

<img width="776" alt="bilde" src="https://github.com/user-attachments/assets/4297c3be-e499-400b-ba02-131b76f334e4" />

In general we cannot change the bounds of the map at this point since we cannot load new tiles or do anything else asynchronously in the `beforePrint` event, so we have to make sure that the bounds are fit correctly before the browser prints. Changing the size to use `px` instead restores the correct behavior.

This problem was not caught by percy until https://github.com/Altinn/app-frontend-react/pull/2965 where the `cy.clock()` call prevents the map from updating after we change the viewport which better matches the actual behavior of the PDF generator.


The changes in `custom.ts` are unrelated, I noticed that the viewport did not get restored correctly when returning to the form after calling `testPdf`.

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
