### PR TITLE
Fixing Summary2 + Subform with option-components

### DIFF
--- a/src/core/loading/LoadingRegistry.tsx
+++ b/src/core/loading/LoadingRegistry.tsx
@@ -25,7 +25,7 @@ function initialCreateStore() {
   }));
 }
 
-const { Provider, useShallowSelector, useStaticSelector } = createZustandContext({
+const { Provider, useShallowSelector, useStaticSelector, useHasProvider } = createZustandContext({
   name: 'LoadingRegistry',
   required: true,
   initialCreateStore,
@@ -63,6 +63,13 @@ export function BlockUntilAllLoaded({ children }: PropsWithChildren) {
  * the form can be rendered.
  */
 export function useMarkAsLoading(key: (string | number)[], value: boolean) {
+  const hasProvider = useHasProvider();
+  if (!hasProvider) {
+    throw new Error(
+      'useMarkAsLoading must be used within a LoadingRegistryProvider (currently only supported inside a FormProvider)',
+    );
+  }
+
   const keyStr = key.join('/');
   const setLoadingState = useStaticSelector((state) => state.setLoadingState);
 

--- a/src/features/form/FormContext.tsx
+++ b/src/features/form/FormContext.tsx
@@ -1,7 +1,7 @@
 import React, { useRef } from 'react';
 
 import { ContextNotProvided, createContext } from 'src/core/contexts/context';
-import { BlockUntilAllLoaded } from 'src/core/loading/LoadingRegistry';
+import { BlockUntilAllLoaded, LoadingRegistryProvider } from 'src/core/loading/LoadingRegistry';
 import { DataModelsProvider } from 'src/features/datamodel/DataModelsProvider';
 import { DynamicsProvider } from 'src/features/form/dynamics/DynamicsContext';
 import { LayoutsProvider } from 'src/features/form/layout/LayoutsContext';
@@ -61,7 +61,7 @@ export function FormProvider({ children }: React.PropsWithChildren) {
 
 function Outer({ children }: React.PropsWithChildren) {
   return (
-    <>
+    <LoadingRegistryProvider>
       <FormPrefetcher />
       <LayoutsProvider>
         <CodeListsProvider>
@@ -88,7 +88,7 @@ function Outer({ children }: React.PropsWithChildren) {
           </DataModelsProvider>
         </CodeListsProvider>
       </LayoutsProvider>
-    </>
+    </LoadingRegistryProvider>
   );
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -22,7 +22,6 @@ import { ViewportWrapper } from 'src/components/ViewportWrapper';
 import { KeepAliveProvider } from 'src/core/auth/KeepAliveProvider';
 import { AppQueriesProvider } from 'src/core/contexts/AppQueriesProvider';
 import { TaskStoreProvider } from 'src/core/contexts/taskStoreContext';
-import { LoadingRegistryProvider } from 'src/core/loading/LoadingRegistry';
 import { ApplicationMetadataProvider } from 'src/features/applicationMetadata/ApplicationMetadataProvider';
 import { ApplicationSettingsProvider } from 'src/features/applicationSettings/ApplicationSettingsProvider';
 import { UiConfigProvider } from 'src/features/form/layout/UiConfigContext';
@@ -66,20 +65,18 @@ document.addEventListener('DOMContentLoaded', () => {
   root?.render(
     <AppQueriesProvider {...queries}>
       <ErrorBoundary>
-        <LoadingRegistryProvider>
-          <AppPrefetcher />
-          <AppWrapper>
-            <LanguageProvider>
-              <LangToolsStoreProvider>
-                <ViewportWrapper>
-                  <UiConfigProvider>
-                    <RouterProvider router={router} />
-                  </UiConfigProvider>
-                </ViewportWrapper>
-              </LangToolsStoreProvider>
-            </LanguageProvider>
-          </AppWrapper>
-        </LoadingRegistryProvider>
+        <AppPrefetcher />
+        <AppWrapper>
+          <LanguageProvider>
+            <LangToolsStoreProvider>
+              <ViewportWrapper>
+                <UiConfigProvider>
+                  <RouterProvider router={router} />
+                </UiConfigProvider>
+              </ViewportWrapper>
+            </LangToolsStoreProvider>
+          </LanguageProvider>
+        </AppWrapper>
       </ErrorBoundary>
     </AppQueriesProvider>,
   );

--- a/src/test/renderWithProviders.tsx
+++ b/src/test/renderWithProviders.tsx
@@ -24,7 +24,6 @@ import { getTextResourcesMock } from 'src/__mocks__/getTextResourcesMock';
 import { AppQueriesProvider } from 'src/core/contexts/AppQueriesProvider';
 import { DataLoadingProvider } from 'src/core/contexts/dataLoadingContext';
 import { TaskStoreProvider } from 'src/core/contexts/taskStoreContext';
-import { LoadingRegistryProvider } from 'src/core/loading/LoadingRegistry';
 import { RenderStart } from 'src/core/ui/RenderStart';
 import { ApplicationMetadataProvider } from 'src/features/applicationMetadata/ApplicationMetadataProvider';
 import { ApplicationSettingsProvider } from 'src/features/applicationSettings/ApplicationSettingsProvider';
@@ -284,41 +283,39 @@ function DefaultProviders({ children, queries, queryClient, Router = DefaultRout
       {...queries}
       queryClient={queryClient}
     >
-      <LoadingRegistryProvider>
-        <LanguageProvider>
-          <DataLoadingProvider>
-            <TaskStoreProvider>
-              <LangToolsStoreProvider>
-                <UiConfigProvider>
-                  <PageNavigationProvider>
-                    <Router>
-                      <AppRoutingProvider>
-                        <ApplicationMetadataProvider>
-                          <GlobalFormDataReadersProvider>
-                            <OrgsProvider>
-                              <ApplicationSettingsProvider>
-                                <LayoutSetsProvider>
-                                  <ProfileProvider>
-                                    <PartyProvider>
-                                      <TextResourcesProvider>
-                                        <InstantiationProvider>{children}</InstantiationProvider>
-                                      </TextResourcesProvider>
-                                    </PartyProvider>
-                                  </ProfileProvider>
-                                </LayoutSetsProvider>
-                              </ApplicationSettingsProvider>
-                            </OrgsProvider>
-                          </GlobalFormDataReadersProvider>
-                        </ApplicationMetadataProvider>
-                      </AppRoutingProvider>
-                    </Router>
-                  </PageNavigationProvider>
-                </UiConfigProvider>
-              </LangToolsStoreProvider>
-            </TaskStoreProvider>
-          </DataLoadingProvider>
-        </LanguageProvider>
-      </LoadingRegistryProvider>
+      <LanguageProvider>
+        <DataLoadingProvider>
+          <TaskStoreProvider>
+            <LangToolsStoreProvider>
+              <UiConfigProvider>
+                <PageNavigationProvider>
+                  <Router>
+                    <AppRoutingProvider>
+                      <ApplicationMetadataProvider>
+                        <GlobalFormDataReadersProvider>
+                          <OrgsProvider>
+                            <ApplicationSettingsProvider>
+                              <LayoutSetsProvider>
+                                <ProfileProvider>
+                                  <PartyProvider>
+                                    <TextResourcesProvider>
+                                      <InstantiationProvider>{children}</InstantiationProvider>
+                                    </TextResourcesProvider>
+                                  </PartyProvider>
+                                </ProfileProvider>
+                              </LayoutSetsProvider>
+                            </ApplicationSettingsProvider>
+                          </OrgsProvider>
+                        </GlobalFormDataReadersProvider>
+                      </ApplicationMetadataProvider>
+                    </AppRoutingProvider>
+                  </Router>
+                </PageNavigationProvider>
+              </UiConfigProvider>
+            </LangToolsStoreProvider>
+          </TaskStoreProvider>
+        </DataLoadingProvider>
+      </LanguageProvider>
     </AppQueriesProvider>
   );
 }

--- a/test/e2e/integration/subform-test/subform.ts
+++ b/test/e2e/integration/subform-test/subform.ts
@@ -94,6 +94,65 @@ describe('Subform test', () => {
       cy.wrap($toast).should('contain', 'Maks antall moped oppføringer har blitt nådd');
       cy.wrap($toast).should('have.class', 'Toastify__toast--error');
     });
+
+    cy.get('#Input-Age').type('30');
+    cy.get(appFrontend.errorReport).should('not.exist');
+
+    // Delete the last two mopeds (those with errors)
+    cy.get('#subform-subform-mopeder-table tbody tr').should('have.length', 3);
+    cy.get('#subform-subform-mopeder-table tbody tr').eq(1).findByText('Slett').clickAndGone();
+    cy.get('#subform-subform-mopeder-table tbody tr').should('have.length', 2);
+    cy.get('#subform-subform-mopeder-table tbody tr').eq(1).findByText('Slett').clickAndGone();
+    cy.get('#subform-subform-mopeder-table tbody tr').should('have.length', 1);
+    cy.get('[data-testid="NavigationButtons"] button.fds-btn--primary').clickAndGone();
+
+    // Verify summary fields
+    cy.get('[data-testid=summary-single-value-component]').eq(0).should('contain.text', name);
+    cy.get('[data-testid=summary-single-value-component]').eq(1).should('contain.text', '30 år');
+    cy.get('#label-attachment-summary2-attachments')
+      .next()
+      .should('contain.text', 'Du har ikke lagt inn informasjon her');
+
+    cy.get('#form-content-subform-mopeder table tbody tr').should('have.length', 1);
+    cy.get('#form-content-subform-mopeder table tbody tr').within(() => {
+      cy.get('td').eq(0).should('have.text', regno);
+      cy.get('td').eq(1).should('have.text', merke);
+      cy.get('td').eq(2).should('have.text', extrainfo);
+    });
+
+    cy.get('#label-subform-boker').next().should('contain.text', 'Du har ikke lagt inn informasjon her');
+
+    cy.findByRole('button', { name: 'Vis Summary2 for hele steget' }).clickAndGone();
+
+    cy.get('.fds-paragraph')
+      .eq(0)
+      .should(
+        'contain.text',
+        'Subform komponentene finner du nederst på denne siden, under et par felter med personalia.',
+      );
+    cy.get('[data-testid=summary-single-value-component]').eq(0).should('contain.text', name);
+    cy.get('[data-testid=summary-single-value-component]').eq(1).should('contain.text', '30 år');
+    cy.get('#label-attachment-summary2-attachments')
+      .next()
+      .should('contain.text', 'Du har ikke lagt inn informasjon her');
+
+    // There is probably room for improvement in the way Summary generates ids here, and we probably want
+    // to change the subform title to something other than the data model UUID.
+    cy.get('#label-undefined').should('contain.text', 'Dine mopeder');
+    cy.get('#label-undefined')
+      .next()
+      .invoke('text')
+      .should('match', /^[a-f0-9-]+$/);
+
+    cy.get('[data-testid=summary-single-value-component]').eq(2).should('contain.text', regno);
+    cy.get('[data-testid=summary-single-value-component]').eq(3).should('contain.text', merke);
+    cy.get('[data-testid=summary-single-value-component]').eq(4).should('contain.text', model);
+    cy.get('[data-testid=summary-single-value-component]').eq(5).should('contain.text', 'Har du ekstra info?');
+    cy.get('[data-testid=summary-single-value-component]').eq(5).should('contain.text', 'Ja');
+    cy.get('[data-testid=summary-single-value-component]').eq(6).should('contain.text', extrainfo);
+    cy.get('[data-testid=summary-single-value-component]').eq(7).should('contain.text', year);
+
+    cy.get('#label-subform-boker').next().should('contain.text', 'Du har ikke lagt inn informasjon her');
   });
 
   it('subform validation', () => {


### PR DESCRIPTION
## Description

When loading a full task Summary2 component, it will add new `FormProvider` contexts for subforms. However, this failed badly when loading static options from inside those subforms, as the new `LoadingRegistry` was shared among all `FormProvider` instances. Adding this provider to every `FormProvider` instead fixes the infinite loading problem that was introduced in this case.

## Related Issue(s)

- closes #3019

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
