### PR TITLE
Removing more node traversal usages

### DIFF
--- a/src/features/devtools/components/ExpressionPlayground/ExpressionPlayground.tsx
+++ b/src/features/devtools/components/ExpressionPlayground/ExpressionPlayground.tsx
@@ -14,7 +14,6 @@ import { useNavigationParam } from 'src/features/routing/AppRoutingContext';
 import comboboxClasses from 'src/styles/combobox.module.css';
 import { NodesInternal, useNodes } from 'src/utils/layout/NodesContext';
 import { useExpressionDataSources } from 'src/utils/layout/useExpressionDataSources';
-import { useNodeTraversalSelector } from 'src/utils/layout/useNodeTraversal';
 import type { ExprConfig, Expression, ExprFunctionName, LayoutReference } from 'src/features/expressions/types';
 
 interface ExpressionResult {
@@ -71,8 +70,6 @@ export const ExpressionPlayground = () => {
   // This is OK if this function is called from places that immediately evaluates the expression again, thus
   // populating the output history with a fresh value.
   const resetOutputHistory = () => setOutputs([]);
-
-  const traversalSelector = useNodeTraversalSelector();
 
   const componentOptions = NodesInternal.useMemoSelector((state) =>
     Object.values(state.nodeData).map((nodeData) => ({
@@ -131,18 +128,7 @@ export const ExpressionPlayground = () => {
         setOutputs([{ value: e.message, isError: true }]);
       }
     }
-  }, [
-    input,
-    forPage,
-    forComponentId,
-    dataSources,
-    nodes,
-    showAllSteps,
-    outputs,
-    setOutputWithHistory,
-    currentPageId,
-    traversalSelector,
-  ]);
+  }, [input, forPage, forComponentId, dataSources, nodes, showAllSteps, outputs, setOutputWithHistory, currentPageId]);
 
   return (
     <div className={classes.container}>

--- a/src/features/devtools/components/ExpressionPlayground/ExpressionPlayground.tsx
+++ b/src/features/devtools/components/ExpressionPlayground/ExpressionPlayground.tsx
@@ -15,9 +15,7 @@ import comboboxClasses from 'src/styles/combobox.module.css';
 import { NodesInternal, useNodes } from 'src/utils/layout/NodesContext';
 import { useExpressionDataSources } from 'src/utils/layout/useExpressionDataSources';
 import { useNodeTraversalSelector } from 'src/utils/layout/useNodeTraversal';
-import type { ExprConfig, Expression, ExprFunctionName } from 'src/features/expressions/types';
-import type { LayoutNode } from 'src/utils/layout/LayoutNode';
-import type { LayoutPage } from 'src/utils/layout/LayoutPage';
+import type { ExprConfig, Expression, ExprFunctionName, LayoutReference } from 'src/features/expressions/types';
 
 interface ExpressionResult {
   value: string;
@@ -109,27 +107,9 @@ export const ExpressionPlayground = () => {
 
       ExprValidation.throwIfInvalid(maybeExpression);
 
-      let evalContext: LayoutPage | LayoutNode | undefined = traversalSelector(
-        (t) => t.findPage(currentPageId),
-        [currentPageId],
-      );
-      if (!evalContext) {
-        throw new Error('Fant ikke nåværende side/layout');
-      }
-
+      let evalContext: LayoutReference = currentPageId ? { type: 'page', id: currentPageId } : { type: 'none' };
       if (forPage && forComponentId) {
-        const foundNode = traversalSelector(
-          (t) => {
-            const page = t.findPage(forPage);
-            return page
-              ? t.with(page).children((i) => i.type === 'node' && i.item?.id === forComponentId)[0]
-              : undefined;
-          },
-          [forPage, forComponentId],
-        );
-        if (foundNode) {
-          evalContext = foundNode;
-        }
+        evalContext = { type: 'node', id: forComponentId };
       }
 
       const calls: string[] = [];

--- a/src/features/expressions/errors.ts
+++ b/src/features/expressions/errors.ts
@@ -40,14 +40,6 @@ export class NodeNotFound extends Error {
   }
 }
 
-export class NodeNotFoundWithoutContext {
-  public constructor(private nodeId: string | undefined) {}
-
-  public getId() {
-    return this.nodeId;
-  }
-}
-
 export interface PrettyErrorsOptions {
   config?: ExprConfig;
   introText?: string;

--- a/src/features/expressions/index.test.ts
+++ b/src/features/expressions/index.test.ts
@@ -1,4 +1,3 @@
-import { NodeNotFoundWithoutContext } from 'src/features/expressions/errors';
 import { ExprFunctionDefinitions } from 'src/features/expressions/expression-functions';
 import { evalExpr } from 'src/features/expressions/index';
 import { ExprVal } from 'src/features/expressions/types';
@@ -16,7 +15,7 @@ describe('Expressions', () => {
     expect(
       evalExpr(
         ['frontendSettings', 'whatever'],
-        new NodeNotFoundWithoutContext('test'),
+        { type: 'none' },
         {
           applicationSettings: {},
         } as ExpressionDataSources,

--- a/src/features/expressions/index.ts
+++ b/src/features/expressions/index.ts
@@ -11,7 +11,6 @@ import {
 } from 'src/features/expressions/errors';
 import { ExprFunctionDefinitions, ExprFunctionImplementations } from 'src/features/expressions/expression-functions';
 import { ExprVal } from 'src/features/expressions/types';
-import type { NodeNotFoundWithoutContext } from 'src/features/expressions/errors';
 import type {
   ExprConfig,
   ExprDate,
@@ -22,9 +21,8 @@ import type {
   ExprValToActual,
   ExprValToActualOrExpr,
   ExprValueArgs,
+  LayoutReference,
 } from 'src/features/expressions/types';
-import type { LayoutNode } from 'src/utils/layout/LayoutNode';
-import type { LayoutPage } from 'src/utils/layout/LayoutPage';
 import type { ExpressionDataSources } from 'src/utils/layout/useExpressionDataSources';
 
 type BeforeFuncCallback = (path: string[], func: ExprFunctionName, args: unknown[]) => void;
@@ -49,7 +47,7 @@ export type EvaluateExpressionParams = {
   expr: Expression;
   path: string[];
   callbacks: { onBeforeFunctionCall?: BeforeFuncCallback; onAfterFunctionCall?: AfterFuncCallback };
-  node: LayoutNode | LayoutPage | NodeNotFoundWithoutContext;
+  reference: LayoutReference;
   dataSources: ExpressionDataSources;
   positionalArguments?: ExprPositionalArgs;
   valueArguments?: ExprValueArgs;
@@ -74,7 +72,7 @@ function isExpression(input: unknown): input is Expression {
  */
 export function evalExpr<V extends ExprVal = ExprVal>(
   expr: ExprValToActualOrExpr<V> | undefined,
-  node: LayoutNode | LayoutPage | NodeNotFoundWithoutContext,
+  reference: LayoutReference,
   dataSources: ExpressionDataSources,
   options?: EvalExprOptions,
 ) {
@@ -90,7 +88,7 @@ export function evalExpr<V extends ExprVal = ExprVal>(
     expr,
     path: [],
     callbacks,
-    node,
+    reference,
     dataSources,
     positionalArguments: options?.positionalArguments,
     valueArguments: options?.valueArguments,

--- a/src/features/expressions/shared-functions.test.tsx
+++ b/src/features/expressions/shared-functions.test.tsx
@@ -18,7 +18,12 @@ import { fetchApplicationMetadata, fetchProcessState } from 'src/queries/queries
 import { renderWithNode } from 'src/test/renderWithProviders';
 import { useEvalExpression } from 'src/utils/layout/generator/useEvalExpression';
 import { useExpressionDataSources } from 'src/utils/layout/useExpressionDataSources';
-import type { ExprPositionalArgs, ExprValToActualOrExpr, ExprValueArgs } from 'src/features/expressions/types';
+import type {
+  ExprPositionalArgs,
+  ExprValToActualOrExpr,
+  ExprValueArgs,
+  LayoutReference,
+} from 'src/features/expressions/types';
 import type { ExternalApisResult } from 'src/features/externalApi/useExternalApi';
 import type { RoleResult } from 'src/features/useCurrentPartyRoles';
 import type { IRawOption } from 'src/layout/common.generated';
@@ -30,15 +35,15 @@ jest.mock('src/features/externalApi/useExternalApi');
 jest.mock('src/features/useCurrentPartyRoles');
 
 interface Props {
-  node: LayoutNode;
+  reference: LayoutReference;
   expression: ExprValToActualOrExpr<ExprVal.Any>;
   positionalArguments?: ExprPositionalArgs;
   valueArguments?: ExprValueArgs;
 }
 
-function ExpressionRunner({ node, expression, positionalArguments, valueArguments }: Props) {
+function ExpressionRunner({ reference, expression, positionalArguments, valueArguments }: Props) {
   const dataSources = useExpressionDataSources();
-  const result = useEvalExpression(ExprVal.Any, node, expression, null, dataSources, {
+  const result = useEvalExpression(ExprVal.Any, reference, expression, null, dataSources, {
     positionalArguments,
     valueArguments,
   });
@@ -276,7 +281,7 @@ describe('Expressions shared function tests', () => {
           node = _node;
           return (
             <ExpressionRunner
-              node={node}
+              reference={{ type: 'node', id: _node.id }}
               expression={expression}
               positionalArguments={positionalArguments}
               valueArguments={valueArguments}
@@ -314,7 +319,7 @@ describe('Expressions shared function tests', () => {
         for (const testCase of testCases) {
           rerender(
             <ExpressionRunner
-              node={node!}
+              reference={{ type: 'node', id: node!.id }}
               expression={testCase.expression}
               positionalArguments={positionalArguments}
               valueArguments={valueArguments}

--- a/src/features/expressions/types.ts
+++ b/src/features/expressions/types.ts
@@ -132,3 +132,27 @@ export interface ExprDateExtensions {
 }
 
 export type ExprDate = Date & { exprDateExtensions: ExprDateExtensions };
+
+export interface PageReference {
+  type: 'page';
+  id: string;
+}
+
+export interface NodeReference {
+  type: 'node';
+  id: string;
+}
+
+interface NoReference {
+  type: 'none';
+}
+
+export type LayoutReference = PageReference | NodeReference | NoReference;
+
+export function refAsSuffix(reference: LayoutReference) {
+  return reference.type === 'page'
+    ? ` for page '${reference.id}'`
+    : reference.type === 'node'
+      ? ` for component '${reference.id}'`
+      : '';
+}

--- a/src/features/language/useLanguage.ts
+++ b/src/features/language/useLanguage.ts
@@ -62,7 +62,7 @@ export interface IUseLanguage {
 }
 
 export interface TextResourceVariablesDataSources {
-  node: LayoutNode | undefined;
+  node: LayoutNode | string | undefined;
   applicationSettings: IApplicationSettings | null;
   instanceDataSources: IInstanceDataSources | null;
   dataModelPath?: IDataModelReference;
@@ -150,7 +150,7 @@ export function useInnerLanguageWithForcedNodeSelector(
   const transposeSelector = useInnerDataModelBindingTranspose(nodeDataSelector);
 
   return useCallback(
-    (node: LayoutNode | undefined) => {
+    (node: LayoutNode | string | undefined) => {
       const { textResources, language, selectedLanguage, ...dataSources } = sources || ({} as LangDataSources);
       if (!textResources || !language || !selectedLanguage) {
         throw new Error('useLanguage must be used inside a LangToolsStoreProvider');

--- a/src/features/options/evalQueryParameters.ts
+++ b/src/features/options/evalQueryParameters.ts
@@ -1,8 +1,8 @@
 import { evalExpr } from 'src/features/expressions';
-import { type ExprResolved, ExprVal } from 'src/features/expressions/types';
+import { ExprVal, refAsSuffix } from 'src/features/expressions/types';
+import type { ExprResolved, LayoutReference } from 'src/features/expressions/types';
 import type { IQueryParameters } from 'src/layout/common.generated';
 import type { ExprResolver } from 'src/layout/LayoutComponent';
-import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 import type { ExpressionDataSources } from 'src/utils/layout/useExpressionDataSources';
 
 export function evalQueryParameters(props: ExprResolver<'List'>) {
@@ -20,17 +20,17 @@ export function evalQueryParameters(props: ExprResolver<'List'>) {
 
 export function resolveQueryParameters(
   queryParameters: IQueryParameters | undefined,
-  node: LayoutNode,
+  reference: LayoutReference,
   dataSources: ExpressionDataSources,
 ): Record<string, string> | undefined {
   return queryParameters
     ? Object.entries(queryParameters).reduce((obj, [key, expr]) => {
-        obj[key] = evalExpr(expr, node, dataSources, {
+        obj[key] = evalExpr(expr, reference, dataSources, {
           config: {
             returnType: ExprVal.String,
             defaultValue: '',
           },
-          errorIntroText: `Invalid expression for component '${node.baseId}'`,
+          errorIntroText: `Invalid expression${refAsSuffix(reference)}`,
         });
         return obj;
       }, {})

--- a/src/features/options/useGetOptions.ts
+++ b/src/features/options/useGetOptions.ts
@@ -11,7 +11,7 @@ import { useNodeOptions } from 'src/features/options/useNodeOptions';
 import { useSourceOptions } from 'src/features/options/useSourceOptions';
 import { useNodeItem } from 'src/utils/layout/useNodeItem';
 import { verifyAndDeduplicateOptions } from 'src/utils/options';
-import type { ExprValueArgs } from 'src/features/expressions/types';
+import type { ExprValueArgs, LayoutReference } from 'src/features/expressions/types';
 import type { IUseLanguage } from 'src/features/language/useLanguage';
 import type { IOptionInternal } from 'src/features/options/castOptionsToStrings';
 import type { IDataModelBindingsOptionsSimple } from 'src/layout/common.generated';
@@ -186,9 +186,10 @@ export function useFilteredAndSortedOptions({
           data: option,
           defaultKey: 'value',
         };
+        const reference: LayoutReference = { type: 'node', id: rowNode?.id ?? node.id };
         const keep = evalExpr(
           optionFilter,
-          rowNode ?? node,
+          reference,
           { ...dataSources, currentDataModelPath: dataModelLocation },
           { valueArguments },
         );

--- a/src/features/options/useGetOptionsQuery.ts
+++ b/src/features/options/useGetOptionsQuery.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import { skipToken, useQuery } from '@tanstack/react-query';
 import type { UseQueryResult } from '@tanstack/react-query';
 import type { AxiosError, AxiosResponse } from 'axios';
@@ -10,6 +12,7 @@ import { castOptionsToStrings } from 'src/features/options/castOptionsToStrings'
 import { resolveQueryParameters } from 'src/features/options/evalQueryParameters';
 import { GeneratorData } from 'src/utils/layout/generator/GeneratorDataSources';
 import { getOptionsUrl } from 'src/utils/urls/appUrlHelper';
+import type { LayoutReference } from 'src/features/expressions/types';
 import type { IOptionInternal } from 'src/features/options/castOptionsToStrings';
 import type { IMapping, IQueryParameters } from 'src/layout/common.generated';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
@@ -43,7 +46,8 @@ export const useGetOptionsUrl = (
   const mappingResult = FD.useMapping(mapping, GeneratorData.useDefaultDataType());
   const language = useCurrentLanguage();
   const instanceId = useLaxInstanceId();
-  const resolvedQueryParameters = resolveQueryParameters(queryParameters, node, dataSources);
+  const reference: LayoutReference = useMemo(() => ({ type: 'node', id: node.id }), [node]);
+  const resolvedQueryParameters = resolveQueryParameters(queryParameters, reference, dataSources);
 
   return optionsId
     ? getOptionsUrl({

--- a/src/features/options/useSourceOptions.ts
+++ b/src/features/options/useSourceOptions.ts
@@ -3,7 +3,7 @@ import { ExprValidation } from 'src/features/expressions/validation';
 import { useMemoDeepEqual } from 'src/hooks/useStateDeepEqual';
 import { getKeyWithoutIndexIndicators } from 'src/utils/databindings';
 import { transposeDataBinding } from 'src/utils/databindings/DataBinding';
-import type { ExprVal, ExprValToActualOrExpr } from 'src/features/expressions/types';
+import type { ExprVal, ExprValToActualOrExpr, NodeReference } from 'src/features/expressions/types';
 import type { IOptionInternal } from 'src/features/options/castOptionsToStrings';
 import type { IDataModelReference, IOptionSource } from 'src/layout/common.generated';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
@@ -27,6 +27,7 @@ export const useSourceOptions = ({
       return undefined;
     }
 
+    const nodeReference: NodeReference = { type: 'node', id: node.id };
     const { formDataRowsSelector, formDataSelector, langToolsSelector, nodeTraversal } = dataSources;
     const output: IOptionInternal[] = [];
     const langTools = langToolsSelector(node);
@@ -103,9 +104,9 @@ export const useSourceOptions = ({
 
       output.push({
         value: String(formDataSelector(transposed)),
-        label: resolveText(label, node, modifiedDataSources, nonTransposed) as string,
-        description: resolveText(description, node, modifiedDataSources, nonTransposed),
-        helpText: resolveText(helpText, node, modifiedDataSources, nonTransposed),
+        label: resolveText(label, nodeReference, modifiedDataSources, nonTransposed) as string,
+        description: resolveText(description, nodeReference, modifiedDataSources, nonTransposed),
+        helpText: resolveText(helpText, nodeReference, modifiedDataSources, nonTransposed),
         rowNode,
         dataModelLocation: addRowInfo ? transposed : undefined,
       });
@@ -116,15 +117,15 @@ export const useSourceOptions = ({
 
 function resolveText(
   text: ExprValToActualOrExpr<ExprVal.String> | undefined,
-  node: LayoutNode,
+  nodeReference: NodeReference,
   dataSources: ExpressionDataSources,
   reference: IDataModelReference,
 ): string | undefined {
   if (text && ExprValidation.isValid(text)) {
-    return evalExpr(text, node, dataSources);
+    return evalExpr(text, nodeReference, dataSources);
   }
   if (text) {
-    return dataSources.langToolsSelector(node).langAsStringUsingPathInDataModel(text as string, reference);
+    return dataSources.langToolsSelector(nodeReference.id).langAsStringUsingPathInDataModel(text as string, reference);
   }
   return undefined;
 }

--- a/src/features/validation/expressionValidation/ExpressionValidation.tsx
+++ b/src/features/validation/expressionValidation/ExpressionValidation.tsx
@@ -9,8 +9,7 @@ import { Validation } from 'src/features/validation/validationContext';
 import { getKeyWithoutIndex } from 'src/utils/databindings';
 import { NodesInternal } from 'src/utils/layout/NodesContext';
 import { useExpressionDataSources } from 'src/utils/layout/useExpressionDataSources';
-import { useNodeTraversal } from 'src/utils/layout/useNodeTraversal';
-import type { Expression, ExprValueArgs } from 'src/features/expressions/types';
+import type { Expression, ExprValueArgs, NodeReference } from 'src/features/expressions/types';
 import type { IDataModelReference, ILayoutSet } from 'src/layout/common.generated';
 import type { ExpressionDataSources } from 'src/utils/layout/useExpressionDataSources';
 
@@ -29,25 +28,37 @@ export function ExpressionValidation() {
   );
 }
 
+interface NodeWithBindings {
+  nodeReference: NodeReference;
+  dmb: Record<string, IDataModelReference>;
+}
+
 function IndividualExpressionValidation({ dataType }: { dataType: string }) {
   const updateDataModelValidations = Validation.useUpdateDataModelValidations();
   const formData = FD.useDebounced(dataType);
   const expressionValidationConfig = DataModels.useExpressionValidationConfig(dataType);
   const dataSources = useExpressionDataSources();
-  const allNodes = useNodeTraversal((t) => t.allNodes());
-  const nodeDataSelector = NodesInternal.useNodeDataSelector();
   const dataElementId = DataModels.useDataElementIdForDataType(dataType) ?? dataType; // stateless does not have dataElementId
+  const allBindings = NodesInternal.useMemoSelector((state) => {
+    const out: NodeWithBindings[] = [];
+
+    for (const nodeData of Object.values(state.nodeData)) {
+      if (nodeData.layout.dataModelBindings) {
+        out.push({
+          nodeReference: { type: 'node', id: nodeData.layout.id },
+          dmb: nodeData.layout.dataModelBindings as Record<string, IDataModelReference>,
+        });
+      }
+    }
+
+    return out;
+  });
 
   useEffect(() => {
-    if (expressionValidationConfig && Object.keys(expressionValidationConfig).length > 0 && formData && allNodes) {
+    if (expressionValidationConfig && Object.keys(expressionValidationConfig).length > 0 && formData) {
       const validations = {};
 
-      for (const node of allNodes) {
-        const dmb = nodeDataSelector((picker) => picker(node)?.layout.dataModelBindings, [node]);
-        if (!dmb) {
-          continue;
-        }
-
+      for (const { nodeReference, dmb } of allBindings) {
         // Modify the hierarchy data sources to make the current dataModel the default one when running expression validations
         const currentLayoutSet = dataSources.currentLayoutSet;
         const modifiedCurrentLayoutSet: ILayoutSet | null = currentLayoutSet
@@ -83,7 +94,7 @@ function IndividualExpressionValidation({ dataType }: { dataType: string }) {
 
           for (const validationDef of validationDefs) {
             const valueArguments: ExprValueArgs<{ field: string }> = { data: { field }, defaultKey: 'field' };
-            const isInvalid = evalExpr(validationDef.condition as Expression, node, modifiedDataSources, {
+            const isInvalid = evalExpr(validationDef.condition as Expression, nodeReference, modifiedDataSources, {
               positionalArguments: [field],
               valueArguments,
             });
@@ -111,10 +122,9 @@ function IndividualExpressionValidation({ dataType }: { dataType: string }) {
     formData,
     dataElementId,
     updateDataModelValidations,
-    allNodes,
-    nodeDataSelector,
     dataSources,
     dataType,
+    allBindings,
   ]);
 
   return null;

--- a/src/utils/layout/all.test.tsx
+++ b/src/utils/layout/all.test.tsx
@@ -9,12 +9,11 @@ import type { JSONSchema7 } from 'json-schema';
 import { ignoredConsoleMessages } from 'test/e2e/support/fail-on-console-log';
 
 import { quirks } from 'src/features/form/layout/quirks';
-import { GenericComponent } from 'src/layout/GenericComponent';
+import { GenericComponentById } from 'src/layout/GenericComponent';
 import { fetchApplicationMetadata } from 'src/queries/queries';
 import { ensureAppsDirIsSet, getAllApps } from 'src/test/allApps';
 import { renderWithInstanceAndLayout } from 'src/test/renderWithProviders';
 import { NodesInternal, useNodes } from 'src/utils/layout/NodesContext';
-import { TraversalTask } from 'src/utils/layout/useNodeTraversal';
 import type { ExternalAppLayoutSet } from 'src/test/allApps';
 
 const env = dotenv.config();
@@ -59,14 +58,16 @@ function RenderAllComponents() {
   if (!nodes) {
     throw new Error('No nodes found');
   }
-  const all = nodes.allNodes(new TraversalTask(state, nodes, undefined, undefined));
+  const all = Object.values(state.nodeData)
+    .filter((nodeData) => nodeData.isValid)
+    .map((nodeData) => nodeData.layout.id);
 
   return (
     <>
-      {all.map((node) => (
-        <GenericComponent
-          node={node}
-          key={node.id}
+      {all.map((id) => (
+        <GenericComponentById
+          id={id}
+          key={id}
         />
       ))}
       <TestApp />

--- a/src/utils/layout/generator/LayoutSetGenerator.tsx
+++ b/src/utils/layout/generator/LayoutSetGenerator.tsx
@@ -16,6 +16,7 @@ import { GeneratorCondition, StageAddNodes, StageMarkHidden } from 'src/utils/la
 import { useEvalExpressionInGenerator } from 'src/utils/layout/generator/useEvalExpression';
 import { LayoutPage } from 'src/utils/layout/LayoutPage';
 import { Hidden, NodesInternal, NodesStore, useNodes } from 'src/utils/layout/NodesContext';
+import type { LayoutReference } from 'src/features/expressions/types';
 import type { CompExternal, CompExternalExact, CompTypes, ILayout } from 'src/layout/layout';
 import type { ChildClaimerProps, ComponentProto, NodeGeneratorProps } from 'src/layout/LayoutComponent';
 import type { ChildClaim, ChildClaims, ChildClaimsMap } from 'src/utils/layout/generator/GeneratorContext';
@@ -357,7 +358,8 @@ function GenerateNodeChildrenInternal({ claims, layoutMap }: NodeChildrenInterna
 
 function useIsHiddenPage(page: LayoutPage): boolean {
   const hiddenExpr = useHiddenLayoutsExpressions();
-  return useEvalExpressionInGenerator(ExprVal.Boolean, page, hiddenExpr[page.pageKey], false) ?? false;
+  const reference: LayoutReference = useMemo(() => ({ type: 'page', id: page.pageKey }), [page.pageKey]);
+  return useEvalExpressionInGenerator(ExprVal.Boolean, reference, hiddenExpr[page.pageKey], false) ?? false;
 }
 
 interface ComponentClaimChildrenProps {

--- a/src/utils/layout/generator/useEvalExpression.ts
+++ b/src/utils/layout/generator/useEvalExpression.ts
@@ -1,25 +1,30 @@
 import { useMemo } from 'react';
 
 import { evalExpr } from 'src/features/expressions';
+import { refAsSuffix } from 'src/features/expressions/types';
 import { ExprValidation } from 'src/features/expressions/validation';
 import { useShallowMemo } from 'src/hooks/useShallowMemo';
 import { GeneratorData } from 'src/utils/layout/generator/GeneratorDataSources';
 import { GeneratorStages } from 'src/utils/layout/generator/GeneratorStages';
-import { LayoutPage } from 'src/utils/layout/LayoutPage';
 import type { EvalExprOptions } from 'src/features/expressions';
-import type { ExprConfig, ExprVal, ExprValToActual, ExprValToActualOrExpr } from 'src/features/expressions/types';
-import type { LayoutNode } from 'src/utils/layout/LayoutNode';
+import type {
+  ExprConfig,
+  ExprVal,
+  ExprValToActual,
+  ExprValToActualOrExpr,
+  LayoutReference,
+} from 'src/features/expressions/types';
 import type { ExpressionDataSources } from 'src/utils/layout/useExpressionDataSources';
 
 export function useEvalExpressionInGenerator<V extends ExprVal>(
   type: V,
-  node: LayoutNode | LayoutPage,
+  reference: LayoutReference,
   expr: ExprValToActualOrExpr<V> | undefined,
   defaultValue: ExprValToActual<V>,
 ) {
   const dataSources = GeneratorData.useExpressionDataSources();
   const enabled = GeneratorStages.useIsDoneAddingNodes();
-  return useEvalExpression(type, node, expr, defaultValue, dataSources, undefined, enabled);
+  return useEvalExpression(type, reference, expr, defaultValue, dataSources, undefined, enabled);
 }
 
 /**
@@ -42,7 +47,7 @@ export function useEvalExpressionInGenerator<V extends ExprVal>(
  */
 export function useEvalExpression<V extends ExprVal>(
   type: V,
-  node: LayoutNode | LayoutPage,
+  reference: LayoutReference,
   expr: ExprValToActualOrExpr<V> | undefined,
   defaultValue: ExprValToActual<V>,
   dataSources: ExpressionDataSources,
@@ -55,8 +60,7 @@ export function useEvalExpression<V extends ExprVal>(
       return defaultValue;
     }
 
-    const identifier = node instanceof LayoutPage ? `page '${node.pageKey}'` : `component '${node.baseId}'`;
-    const errorIntroText = `Invalid expression for ${identifier}`;
+    const errorIntroText = `Invalid expression${refAsSuffix(reference)}`;
     if (!ExprValidation.isValidOrScalar(expr, type, errorIntroText)) {
       return defaultValue;
     }
@@ -66,6 +70,6 @@ export function useEvalExpression<V extends ExprVal>(
       defaultValue,
     };
 
-    return evalExpr(expr, node, dataSources, { ...options, config, errorIntroText });
-  }, [enabled, dataSources, defaultValue, expr, node, type, options]);
+    return evalExpr(expr, reference, dataSources, { ...options, config, errorIntroText });
+  }, [enabled, dataSources, defaultValue, expr, reference, type, options]);
 }

--- a/src/utils/layout/useExpressionDataSources.ts
+++ b/src/utils/layout/useExpressionDataSources.ts
@@ -42,7 +42,7 @@ export interface ExpressionDataSources {
   formDataRowsSelector: FormDataRowsSelector;
   attachmentsSelector: AttachmentsSelector;
   optionsSelector: NodeOptionsSelector;
-  langToolsSelector: (node: LayoutNode | undefined) => IUseLanguage;
+  langToolsSelector: (node: LayoutNode | string | undefined) => IUseLanguage;
   currentLanguage: string;
   currentLayoutSet: ILayoutSet | null;
   isHiddenSelector: ReturnType<typeof Hidden.useIsHiddenSelector>;

--- a/src/utils/layout/useNodeTraversal.ts
+++ b/src/utils/layout/useNodeTraversal.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from 'react';
+import { useCallback } from 'react';
 
 import { ContextNotProvided } from 'src/core/contexts/context';
 import { BaseLayoutNode } from 'src/utils/layout/LayoutNode';
@@ -222,7 +222,6 @@ export type NodeTraversalFrom<N extends Node> = N extends LayoutPages
       ? NodeTraversalFromNode<N>
       : never;
 
-export type NodeTraversalFromAny = NodeTraversalFromRoot | NodeTraversalFromPage | NodeTraversalFromNode<LayoutNode>;
 export type NodeTraversalFromRoot = Omit<NodeTraversal, 'parents'>;
 export type NodeTraversalFromPage = Omit<NodeTraversal<LayoutPage>, 'allNodes' | 'findPage'>;
 export type NodeTraversalFromNode<N extends LayoutNode> = Omit<NodeTraversal<N>, 'allNodes' | 'findPage' | 'findById'>;
@@ -238,72 +237,6 @@ enum Strictness {
 type InnerSelectorReturns<Strict extends Strictness, U> = Strict extends Strictness.returnContextNotProvided
   ? U | typeof ContextNotProvided
   : U;
-
-function useNodeTraversalProto<Out>(selector: (traverser: never) => Out, node?: never, strictness?: Strictness): Out {
-  const nodes = useNodesLax();
-  const isReady = NodesInternal.useIsReady();
-  const dataSelector = NodesInternal.useDataSelectorForTraversal();
-
-  // We use the selector here, but we need it to re-render and re-select whenever we re-render. Otherwise the hook
-  // would be treated as the same hook that was used in the previous render, and with the only deps being
-  // 'nodes' and 'node', the previous value would be selected. We bust that caching by including a counter as
-  // a dependency.
-  const counterRef = useRef(0);
-  if (isReady) {
-    counterRef.current++;
-  }
-
-  const out = dataSelector(
-    (state) => {
-      if (!nodes) {
-        return ContextNotProvided;
-      }
-
-      return node === undefined
-        ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (selector as any)(new NodeTraversal(state, nodes, nodes))
-        : // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (selector as any)(new NodeTraversal(state, nodes, node));
-    },
-    [counterRef.current],
-  );
-
-  if (out === ContextNotProvided) {
-    if (strictness === Strictness.throwError) {
-      throw new Error('useNodeTraversal() must be used inside a NodesProvider');
-    }
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return (selector as any)(ContextNotProvided);
-  }
-
-  return out;
-}
-
-export function useNodeTraversal<Out>(selector: (traverser: NodeTraversalFromRoot) => Out): Out;
-// eslint-disable-next-line no-redeclare
-export function useNodeTraversal<N extends LayoutPage, Out>(
-  selector: (traverser: NodeTraversalFromPage) => Out,
-  node: N,
-): Out;
-// eslint-disable-next-line no-redeclare
-export function useNodeTraversal<N extends LayoutPage, Out>(
-  selector: (traverser: NodeTraversalFromPage | NodeTraversalFromRoot) => Out,
-  node: N | undefined,
-): Out;
-// eslint-disable-next-line no-redeclare
-export function useNodeTraversal<N extends LayoutNode, Out>(
-  selector: (traverser: NodeTraversalFromNode<N>) => Out,
-  node: N,
-): Out;
-// eslint-disable-next-line no-redeclare
-export function useNodeTraversal<N extends LayoutNode, Out>(
-  selector: (traverser: NodeTraversalFromNode<N> | NodeTraversalFromRoot) => Out,
-  node: N | undefined,
-): Out;
-// eslint-disable-next-line no-redeclare
-export function useNodeTraversal<Out>(selector: (traverser: never) => Out, node?: never): Out {
-  return useNodeTraversalProto(selector, node, Strictness.throwError);
-}
 
 function throwOrReturn<R>(value: R, strictness: Strictness) {
   if (value === ContextNotProvided) {

--- a/src/utils/layout/useNodeTraversal.ts
+++ b/src/utils/layout/useNodeTraversal.ts
@@ -4,10 +4,10 @@ import { ContextNotProvided } from 'src/core/contexts/context';
 import { BaseLayoutNode } from 'src/utils/layout/LayoutNode';
 import { LayoutPage } from 'src/utils/layout/LayoutPage';
 import { LayoutPages } from 'src/utils/layout/LayoutPages';
-import { NodesInternal, NodesReadiness, useNodesLax } from 'src/utils/layout/NodesContext';
+import { NodesReadiness } from 'src/utils/layout/NodesContext';
 import type { ParentNode } from 'src/layout/layout';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
-import type { NodesContext, PageData, PagesData } from 'src/utils/layout/NodesContext';
+import type { NodesContext, NodesInternal, PageData, PagesData, useNodesLax } from 'src/utils/layout/NodesContext';
 import type { NodeData } from 'src/utils/layout/types';
 
 type AnyData = PagesData | PageData | NodeData;
@@ -252,16 +252,6 @@ function throwOrReturn<R>(value: R, strictness: Strictness) {
   return value;
 }
 
-/**
- * Hook that returns a selector that lets you traverse the hierarchy at a later time. Will re-render your
- * component when any of the traversals you did would return a different result.
- */
-function useNodeTraversalSelectorProto<Strict extends Strictness>(strictness: Strict) {
-  const nodes = useNodesLax();
-  const nodeDataSelectorForTraversal = NodesInternal.useDataSelectorForTraversal();
-  return useInnerNodeTraversalSelectorProto(strictness, nodes, nodeDataSelectorForTraversal);
-}
-
 function useInnerNodeTraversalSelectorProto<Strict extends Strictness>(
   strictness: Strict,
   nodes: ReturnType<typeof useNodesLax>,
@@ -287,10 +277,6 @@ function useInnerNodeTraversalSelectorProto<Strict extends Strictness>(
   );
 }
 
-export function useNodeTraversalSelector() {
-  return useNodeTraversalSelectorProto(Strictness.throwError);
-}
-
 export function useInnerNodeTraversalSelector(
   nodes: ReturnType<typeof useNodesLax>,
   nodeDataSelectorForTraversal: ReturnType<typeof NodesInternal.useDataSelectorForTraversal>,
@@ -298,4 +284,4 @@ export function useInnerNodeTraversalSelector(
   return useInnerNodeTraversalSelectorProto(Strictness.throwError, nodes, nodeDataSelectorForTraversal);
 }
 
-export type NodeTraversalSelector = ReturnType<typeof useNodeTraversalSelector>;
+export type NodeTraversalSelector = <U>(selector: (t: NodeTraversalFromRoot) => U, deps?: unknown[]) => U;


### PR DESCRIPTION
## Description

In #3009 I removed most simple usages of node traversal. This removes a few larger ones, in:

- `ExpressionValidation`
- `ExpressionPlayground` (devtools)
- `HiddenComponentsProvider`

To make some of these work, I had to introduce something else to refer to nodes (so that I could pass strings instead of `LayoutNode`/`LayoutPage` objects to functions that could take both). I introduced a `LayoutReference` object as a stop-gap solution that's leaner than `LayoutNode`/`LayoutPage`, although it might not get all the way where we want.

## Related Issue(s)

- #3009

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
