### PR TITLE
Cypress test for end-to-end testing dates and `formatDate`

### DIFF
--- a/test/e2e/integration/component-library/date-formatDate.ts
+++ b/test/e2e/integration/component-library/date-formatDate.ts
@@ -1,0 +1,166 @@
+import { AppFrontend } from 'test/e2e/pageobjects/app-frontend';
+
+const appFrontend = new AppFrontend();
+
+const Rows = {
+  Raw: { type: 'Text', backend: false, raw: true },
+  Date: { type: 'Date', backend: false, raw: false },
+  FormatDate: { type: 'TextFormat', backend: false, raw: false },
+  FormatDateBackend: { type: 'TextFormat', backend: true, raw: false },
+  DatePicker: { type: 'DatePicker', backend: false, raw: false },
+};
+
+const Cols = {
+  String: { type: 'String' },
+  DateTime: { type: 'DateTime' },
+  DateOnly: { type: 'DateOnly' },
+};
+
+type Row = (typeof Rows)[keyof typeof Rows];
+type Col = (typeof Cols)[keyof typeof Cols];
+
+function id(row: Row, col: Col) {
+  const baseId = `dates-${row.type}-${col.type}`;
+  if (row.backend) {
+    return `${baseId}-Backend`;
+  }
+  return baseId;
+}
+
+function textContent(row: Row, col: Col) {
+  return cy.get(`#form-content-${id(row, col)}`);
+}
+
+function datePickerContent(row: Row, col: Col) {
+  return cy.get(`#${id(row, col)}`);
+}
+
+const newYork = 'America/New_York';
+const tzOslo = 'Europe/Oslo';
+const timeZones = [newYork, tzOslo];
+
+describe('Date component and formatDate expression', () => {
+  Cypress.on('test:before:run', (test) => {
+    const timezoneId = test.title.replace('Should work in ', '');
+    Cypress.automation('remote:debugger:protocol', {
+      command: 'Emulation.setTimezoneOverride',
+      params: { timezoneId },
+    });
+  });
+  Cypress.on('test:after:run', () => {
+    Cypress.automation('remote:debugger:protocol', {
+      command: 'Emulation.setTimezoneOverride',
+      params: { timezoneId: '' }, // Reset to default
+    });
+  });
+
+  timeZones.forEach((tz) => {
+    it(`Should work in ${tz}`, () => {
+      cy.startAppInstance(appFrontend.apps.componentLibrary, { authenticationLevel: '2' });
+      cy.gotoNavPage('DateAndFormatDate');
+
+      // When we load the page, the date/time will be null, and form-content should be empty
+      for (const row of Object.values(Rows)) {
+        if (row.type !== 'DatePicker') {
+          for (const col of Object.values(Cols)) {
+            textContent(row, col).should('have.text', '');
+          }
+        }
+      }
+      for (const col of Object.values(Cols)) {
+        datePickerContent(Rows.DatePicker, col).should('have.value', '');
+      }
+
+      // This works the same in all timezones, as the raw timestamp has no timezone info, so it's assumed to be
+      // in the local timezone of the browser (and on backend). Thus input === output.
+      cy.dsSelect('#datesDate', 'Skuddårsdagen 2020');
+      textContent(Rows.Raw, Cols.String).should('have.text', '2020-02-29 12:00:00');
+      textContent(Rows.Raw, Cols.DateTime).should('have.text', '2020-02-29T12:00:00');
+      textContent(Rows.Raw, Cols.DateOnly).should('have.text', '2020-02-29T00:00:00');
+      const leapYearDay = '29.02.2020 12:00:00';
+      const leapYearDayZeroed = '29.02.2020 00:00:00';
+      textContent(Rows.Date, Cols.String).should('have.text', leapYearDay);
+      textContent(Rows.Date, Cols.DateTime).should('have.text', leapYearDay);
+      textContent(Rows.Date, Cols.DateOnly).should('have.text', leapYearDayZeroed);
+      textContent(Rows.FormatDate, Cols.String).should('have.text', leapYearDay);
+      textContent(Rows.FormatDate, Cols.DateTime).should('have.text', leapYearDay);
+      textContent(Rows.FormatDate, Cols.DateOnly).should('have.text', leapYearDayZeroed);
+      textContent(Rows.FormatDateBackend, Cols.String).should('have.text', leapYearDay);
+      textContent(Rows.FormatDateBackend, Cols.DateTime).should('have.text', leapYearDay);
+      textContent(Rows.FormatDateBackend, Cols.DateOnly).should('have.text', leapYearDayZeroed);
+      datePickerContent(Rows.DatePicker, Cols.String).should('have.value', '29.02.2020');
+      datePickerContent(Rows.DatePicker, Cols.DateTime).should('have.value', '29.02.2020');
+      datePickerContent(Rows.DatePicker, Cols.DateOnly).should('have.value', '29.02.2020');
+
+      // This demonstrates a bug that affects the date parsing in the frontend, but not the backend.
+      cy.dsSelect('#datesDate', 'Veldig tett på 2022');
+      textContent(Rows.Raw, Cols.String).should('have.text', '2021-12-31 23:59:59.9999999');
+      textContent(Rows.Raw, Cols.DateTime).should('have.text', '2021-12-31T23:59:59.9999999');
+      textContent(Rows.Raw, Cols.DateOnly).should('have.text', '2021-12-31T00:00:00');
+      const newYearsEve = '31.12.2021 23:59:59';
+      const newYearsEveZeroed = '31.12.2021 00:00:00';
+      const newYearsEveFail = '01.01.2022 00:00:00'; /** @see exprParseDate */
+      textContent(Rows.Date, Cols.String).should('have.text', newYearsEveFail);
+      textContent(Rows.Date, Cols.DateTime).should('have.text', newYearsEveFail);
+      textContent(Rows.Date, Cols.DateOnly).should('have.text', newYearsEveZeroed);
+      textContent(Rows.FormatDate, Cols.String).should('have.text', newYearsEveFail);
+      textContent(Rows.FormatDate, Cols.DateTime).should('have.text', newYearsEveFail);
+      textContent(Rows.FormatDate, Cols.DateOnly).should('have.text', newYearsEveZeroed);
+      textContent(Rows.FormatDateBackend, Cols.String).should('have.text', newYearsEve);
+      textContent(Rows.FormatDateBackend, Cols.DateTime).should('have.text', newYearsEve);
+      textContent(Rows.FormatDateBackend, Cols.DateOnly).should('have.text', newYearsEveZeroed);
+      datePickerContent(Rows.DatePicker, Cols.String).should('have.value', '01.01.2022');
+      datePickerContent(Rows.DatePicker, Cols.DateTime).should('have.value', '01.01.2022');
+      datePickerContent(Rows.DatePicker, Cols.DateOnly).should('have.value', '31.12.2021');
+
+      // At this point the browser timezone starts to matter, because the date/time has specified a timezone. Thus
+      // it needs to be converted to the local timezone before being displayed.
+      cy.dsSelect('#datesDate', 'Midnatt i en annen tidssone');
+      textContent(Rows.Raw, Cols.String).should('have.text', '2020-05-17 00:00:00-08:00');
+
+      // Backend local time is Europe/Oslo, so the date will be converted to that timezone
+      textContent(Rows.Raw, Cols.DateTime).should('have.text', '2020-05-17T10:00:00+02:00');
+      textContent(Rows.Raw, Cols.DateOnly).should('have.text', '2020-05-17T00:00:00+02:00');
+      const inOslo = '17.05.2020 10:00:00';
+      const inOsloZeroed = '17.05.2020 00:00:00';
+      const date = '17.05.2020';
+      const dateZeroed = tz === newYork ? '16.05.2020' : '17.05.2020';
+      const dependsOnTimezone = tz === newYork ? '17.05.2020 04:00:00' : inOslo;
+      const dependsOnTimezoneZeroed = tz === newYork ? '16.05.2020 18:00:00' : inOsloZeroed;
+      textContent(Rows.Date, Cols.String).should('have.text', dependsOnTimezone);
+      textContent(Rows.Date, Cols.DateTime).should('have.text', dependsOnTimezone);
+      textContent(Rows.Date, Cols.DateOnly).should('have.text', dependsOnTimezoneZeroed);
+      textContent(Rows.FormatDate, Cols.String).should('have.text', dependsOnTimezone);
+      textContent(Rows.FormatDate, Cols.DateTime).should('have.text', dependsOnTimezone);
+      textContent(Rows.FormatDate, Cols.DateOnly).should('have.text', dependsOnTimezoneZeroed);
+      textContent(Rows.FormatDateBackend, Cols.String).should('have.text', inOslo); // Backend local time
+      textContent(Rows.FormatDateBackend, Cols.DateTime).should('have.text', inOslo);
+      textContent(Rows.FormatDateBackend, Cols.DateOnly).should('have.text', inOsloZeroed);
+      datePickerContent(Rows.DatePicker, Cols.String).should('have.value', date);
+      datePickerContent(Rows.DatePicker, Cols.DateTime).should('have.value', date);
+      datePickerContent(Rows.DatePicker, Cols.DateOnly).should('have.value', dateZeroed);
+
+      cy.dsSelect('#datesDate', 'Midnatt i UTC');
+      textContent(Rows.Raw, Cols.String).should('have.text', '2020-05-17T00:00:00Z');
+      textContent(Rows.Raw, Cols.DateTime).should('have.text', '2020-05-17T02:00:00+02:00');
+      textContent(Rows.Raw, Cols.DateOnly).should('have.text', '2020-05-17T00:00:00+02:00');
+      const utcInOslo = '17.05.2020 02:00:00';
+      const utcInOsloZeroed = '17.05.2020 00:00:00';
+      const utcInBrowser = tz === newYork ? '16.05.2020 20:00:00' : utcInOslo;
+      const utcInBrowserZeroed = tz === newYork ? '16.05.2020 18:00:00' : utcInOsloZeroed;
+      const dateInUtc = tz === newYork ? '16.05.2020' : '17.05.2020';
+      textContent(Rows.Date, Cols.String).should('have.text', utcInBrowser);
+      textContent(Rows.Date, Cols.DateTime).should('have.text', utcInBrowser);
+      textContent(Rows.Date, Cols.DateOnly).should('have.text', utcInBrowserZeroed);
+      textContent(Rows.FormatDate, Cols.String).should('have.text', utcInBrowser);
+      textContent(Rows.FormatDate, Cols.DateTime).should('have.text', utcInBrowser);
+      textContent(Rows.FormatDate, Cols.DateOnly).should('have.text', utcInBrowserZeroed);
+      textContent(Rows.FormatDateBackend, Cols.String).should('have.text', utcInOslo);
+      textContent(Rows.FormatDateBackend, Cols.DateTime).should('have.text', utcInOslo);
+      textContent(Rows.FormatDateBackend, Cols.DateOnly).should('have.text', utcInOsloZeroed);
+      datePickerContent(Rows.DatePicker, Cols.String).should('have.value', dateInUtc);
+      datePickerContent(Rows.DatePicker, Cols.DateTime).should('have.value', dateInUtc);
+      datePickerContent(Rows.DatePicker, Cols.DateOnly).should('have.value', dateInUtc);
+    });
+  });
+});

--- a/test/e2e/integration/component-library/date-formatDate.ts
+++ b/test/e2e/integration/component-library/date-formatDate.ts
@@ -35,6 +35,36 @@ const browserTimezones = [tzNewYork, tzOslo] as const;
 type ValidTimezones = typeof tzNewYork | typeof tzOslo | typeof tzUtc;
 type TZ = { browser: ValidTimezones; backend: ValidTimezones };
 
+type Test = {
+  [key in keyof typeof Rows]: {
+    [key in keyof typeof Cols]: string;
+  };
+};
+
+function testAll(test: Test) {
+  cy.get(`#form-content-${id(Rows.Raw, Cols.String)}`).should('have.text', test.Raw.String);
+  cy.get(`#form-content-${id(Rows.Raw, Cols.DateTime)}`).should('have.text', test.Raw.DateTime);
+  cy.get(`#form-content-${id(Rows.Raw, Cols.DateOnly)}`).should('have.text', test.Raw.DateOnly);
+  cy.get(`#form-content-${id(Rows.Date, Cols.String)}`).should('have.text', test.Date.String);
+  cy.get(`#form-content-${id(Rows.Date, Cols.DateTime)}`).should('have.text', test.Date.DateTime);
+  cy.get(`#form-content-${id(Rows.Date, Cols.DateOnly)}`).should('have.text', test.Date.DateOnly);
+  cy.get(`#form-content-${id(Rows.FormatDate, Cols.String)}`).should('have.text', test.FormatDate.String);
+  cy.get(`#form-content-${id(Rows.FormatDate, Cols.DateTime)}`).should('have.text', test.FormatDate.DateTime);
+  cy.get(`#form-content-${id(Rows.FormatDate, Cols.DateOnly)}`).should('have.text', test.FormatDate.DateOnly);
+  cy.get(`#form-content-${id(Rows.FormatDateBackend, Cols.String)}`).should('have.text', test.FormatDateBackend.String);
+  cy.get(`#form-content-${id(Rows.FormatDateBackend, Cols.DateTime)}`).should(
+    'have.text',
+    test.FormatDateBackend.DateTime,
+  );
+  cy.get(`#form-content-${id(Rows.FormatDateBackend, Cols.DateOnly)}`).should(
+    'have.text',
+    test.FormatDateBackend.DateOnly,
+  );
+  cy.get(`#${id(Rows.DatePicker, Cols.String)}`).should('have.value', test.DatePicker.String);
+  cy.get(`#${id(Rows.DatePicker, Cols.DateTime)}`).should('have.value', test.DatePicker.DateTime);
+  cy.get(`#${id(Rows.DatePicker, Cols.DateOnly)}`).should('have.value', test.DatePicker.DateOnly);
+}
+
 describe('Date component and formatDate expression', () => {
   Cypress.on('test:before:run', (test) => {
     const timezoneId = test.title.replace('Should work in ', '');
@@ -73,16 +103,13 @@ describe('Date component and formatDate expression', () => {
  * When we load the page, the date/time will be null, and form-content should be empty
  */
 function testEmpty() {
-  for (const row of Object.values(Rows)) {
-    if (row.type !== 'DatePicker') {
-      for (const col of Object.values(Cols)) {
-        cy.get(`#form-content-${id(row, col)}`).should('have.text', '');
-      }
-    }
-  }
-  for (const col of Object.values(Cols)) {
-    cy.get(`#${id(Rows.DatePicker, col)}`).should('have.value', '');
-  }
+  testAll({
+    Raw: { String: '', DateTime: '', DateOnly: '' },
+    Date: { String: '', DateTime: '', DateOnly: '' },
+    FormatDate: { String: '', DateTime: '', DateOnly: '' },
+    FormatDateBackend: { String: '', DateTime: '', DateOnly: '' },
+    DatePicker: { String: '', DateTime: '', DateOnly: '' },
+  });
 }
 
 /**
@@ -94,27 +121,19 @@ function testLeapYearDay() {
 
   const rawString = '2020-02-29 12:00:00';
   const rawDateTime = '2020-02-29T12:00:00';
-  const rawDateOnly = '2020-02-29T00:00:00';
+  const rawDateOnly = '2020-02-29';
 
   const local = '29.02.2020 12:00:00';
   const zeroed = '29.02.2020 00:00:00';
   const inDatepicker = '29.02.2020';
 
-  cy.get(`#form-content-${id(Rows.Raw, Cols.String)}`).should('have.text', rawString);
-  cy.get(`#form-content-${id(Rows.Raw, Cols.DateTime)}`).should('have.text', rawDateTime);
-  cy.get(`#form-content-${id(Rows.Raw, Cols.DateOnly)}`).should('have.text', rawDateOnly);
-  cy.get(`#form-content-${id(Rows.Date, Cols.String)}`).should('have.text', local);
-  cy.get(`#form-content-${id(Rows.Date, Cols.DateTime)}`).should('have.text', local);
-  cy.get(`#form-content-${id(Rows.Date, Cols.DateOnly)}`).should('have.text', zeroed);
-  cy.get(`#form-content-${id(Rows.FormatDate, Cols.String)}`).should('have.text', local);
-  cy.get(`#form-content-${id(Rows.FormatDate, Cols.DateTime)}`).should('have.text', local);
-  cy.get(`#form-content-${id(Rows.FormatDate, Cols.DateOnly)}`).should('have.text', zeroed);
-  cy.get(`#form-content-${id(Rows.FormatDateBackend, Cols.String)}`).should('have.text', local);
-  cy.get(`#form-content-${id(Rows.FormatDateBackend, Cols.DateTime)}`).should('have.text', local);
-  cy.get(`#form-content-${id(Rows.FormatDateBackend, Cols.DateOnly)}`).should('have.text', zeroed);
-  cy.get(`#${id(Rows.DatePicker, Cols.String)}`).should('have.value', inDatepicker);
-  cy.get(`#${id(Rows.DatePicker, Cols.DateTime)}`).should('have.value', inDatepicker);
-  cy.get(`#${id(Rows.DatePicker, Cols.DateOnly)}`).should('have.value', inDatepicker);
+  testAll({
+    Raw: { String: rawString, DateTime: rawDateTime, DateOnly: rawDateOnly },
+    Date: { String: local, DateTime: local, DateOnly: zeroed },
+    FormatDate: { String: local, DateTime: local, DateOnly: zeroed },
+    FormatDateBackend: { String: local, DateTime: local, DateOnly: zeroed },
+    DatePicker: { String: inDatepicker, DateTime: inDatepicker, DateOnly: inDatepicker },
+  });
 }
 
 /**
@@ -125,7 +144,7 @@ function testCloseTo2022() {
 
   const rawString = '2021-12-31 23:59:59.9999999';
   const rawDateTime = '2021-12-31T23:59:59.9999999';
-  const rawDateOnly = '2021-12-31T00:00:00';
+  const rawDateOnly = '2021-12-31';
 
   const local = '31.12.2021 23:59:59';
   const zeroed = '31.12.2021 00:00:00';
@@ -134,21 +153,13 @@ function testCloseTo2022() {
   const buggy = '01.01.2022 00:00:00'; /** @see exprParseDate */
   const buggyDatepicker = '01.01.2022';
 
-  cy.get(`#form-content-${id(Rows.Raw, Cols.String)}`).should('have.text', rawString);
-  cy.get(`#form-content-${id(Rows.Raw, Cols.DateTime)}`).should('have.text', rawDateTime);
-  cy.get(`#form-content-${id(Rows.Raw, Cols.DateOnly)}`).should('have.text', rawDateOnly);
-  cy.get(`#form-content-${id(Rows.Date, Cols.String)}`).should('have.text', buggy);
-  cy.get(`#form-content-${id(Rows.Date, Cols.DateTime)}`).should('have.text', buggy);
-  cy.get(`#form-content-${id(Rows.Date, Cols.DateOnly)}`).should('have.text', zeroed);
-  cy.get(`#form-content-${id(Rows.FormatDate, Cols.String)}`).should('have.text', buggy);
-  cy.get(`#form-content-${id(Rows.FormatDate, Cols.DateTime)}`).should('have.text', buggy);
-  cy.get(`#form-content-${id(Rows.FormatDate, Cols.DateOnly)}`).should('have.text', zeroed);
-  cy.get(`#form-content-${id(Rows.FormatDateBackend, Cols.String)}`).should('have.text', local);
-  cy.get(`#form-content-${id(Rows.FormatDateBackend, Cols.DateTime)}`).should('have.text', local);
-  cy.get(`#form-content-${id(Rows.FormatDateBackend, Cols.DateOnly)}`).should('have.text', zeroed);
-  cy.get(`#${id(Rows.DatePicker, Cols.String)}`).should('have.value', buggyDatepicker);
-  cy.get(`#${id(Rows.DatePicker, Cols.DateTime)}`).should('have.value', buggyDatepicker);
-  cy.get(`#${id(Rows.DatePicker, Cols.DateOnly)}`).should('have.value', inDatepicker);
+  testAll({
+    Raw: { String: rawString, DateTime: rawDateTime, DateOnly: rawDateOnly },
+    Date: { String: buggy, DateTime: buggy, DateOnly: zeroed },
+    FormatDate: { String: buggy, DateTime: buggy, DateOnly: zeroed },
+    FormatDateBackend: { String: local, DateTime: local, DateOnly: zeroed },
+    DatePicker: { String: buggyDatepicker, DateTime: buggyDatepicker, DateOnly: inDatepicker },
+  });
 }
 
 /**
@@ -160,43 +171,25 @@ function midnightOtherTz(tz: TZ) {
 
   const rawString = '2020-05-17 00:00:00-08:00';
   const rawDateTime = tz.backend === tzOslo ? '2020-05-17T10:00:00+02:00' : '2020-05-17T08:00:00+00:00';
-  const rawDateOnly = tz.backend === tzOslo ? '2020-05-17T00:00:00+02:00' : '2020-05-17T00:00:00+00:00';
+  const rawDateOnly = '2020-05-17';
+
+  const zeroed = '17.05.2020 00:00:00';
 
   // Backend local time is Europe/Oslo, so the date will be converted to that timezone
   const inOslo = '17.05.2020 10:00:00';
-  const inOsloZeroed = '17.05.2020 00:00:00';
   const inUtc = '17.05.2020 08:00:00';
-  const inUtcZeroed = '17.05.2020 00:00:00';
   const beLocal = tz.backend === tzOslo ? inOslo : inUtc;
-  const beLocalZeroed = tz.backend === tzOslo ? inOsloZeroed : inUtcZeroed;
 
   const date = '17.05.2020';
-  const dateZeroed = tz.browser === tzNewYork ? '16.05.2020' : '17.05.2020';
   const dependsOnTimezone = tz.browser === tzNewYork ? '17.05.2020 04:00:00' : inOslo;
-  const dependsOnTimezoneZeroed =
-    tz.browser === tzNewYork
-      ? tz.backend === tzOslo
-        ? '16.05.2020 18:00:00'
-        : '16.05.2020 20:00:00'
-      : tz.backend === tzOslo
-        ? inOsloZeroed
-        : '17.05.2020 02:00:00';
 
-  cy.get(`#form-content-${id(Rows.Raw, Cols.String)}`).should('have.text', rawString);
-  cy.get(`#form-content-${id(Rows.Raw, Cols.DateTime)}`).should('have.text', rawDateTime);
-  cy.get(`#form-content-${id(Rows.Raw, Cols.DateOnly)}`).should('have.text', rawDateOnly);
-  cy.get(`#form-content-${id(Rows.Date, Cols.String)}`).should('have.text', dependsOnTimezone);
-  cy.get(`#form-content-${id(Rows.Date, Cols.DateTime)}`).should('have.text', dependsOnTimezone);
-  cy.get(`#form-content-${id(Rows.Date, Cols.DateOnly)}`).should('have.text', dependsOnTimezoneZeroed);
-  cy.get(`#form-content-${id(Rows.FormatDate, Cols.String)}`).should('have.text', dependsOnTimezone);
-  cy.get(`#form-content-${id(Rows.FormatDate, Cols.DateTime)}`).should('have.text', dependsOnTimezone);
-  cy.get(`#form-content-${id(Rows.FormatDate, Cols.DateOnly)}`).should('have.text', dependsOnTimezoneZeroed);
-  cy.get(`#form-content-${id(Rows.FormatDateBackend, Cols.String)}`).should('have.text', beLocal); // Backend local time
-  cy.get(`#form-content-${id(Rows.FormatDateBackend, Cols.DateTime)}`).should('have.text', beLocal);
-  cy.get(`#form-content-${id(Rows.FormatDateBackend, Cols.DateOnly)}`).should('have.text', beLocalZeroed);
-  cy.get(`#${id(Rows.DatePicker, Cols.String)}`).should('have.value', date);
-  cy.get(`#${id(Rows.DatePicker, Cols.DateTime)}`).should('have.value', date);
-  cy.get(`#${id(Rows.DatePicker, Cols.DateOnly)}`).should('have.value', dateZeroed);
+  testAll({
+    Raw: { String: rawString, DateTime: rawDateTime, DateOnly: rawDateOnly },
+    Date: { String: dependsOnTimezone, DateTime: dependsOnTimezone, DateOnly: zeroed },
+    FormatDate: { String: dependsOnTimezone, DateTime: dependsOnTimezone, DateOnly: zeroed },
+    FormatDateBackend: { String: beLocal, DateTime: beLocal, DateOnly: zeroed },
+    DatePicker: { String: date, DateTime: date, DateOnly: date },
+  });
 }
 
 function midnightUtc(tz: TZ) {
@@ -204,39 +197,22 @@ function midnightUtc(tz: TZ) {
 
   const rawString = '2020-05-17T00:00:00Z';
   const rawDateTime = tz.backend === tzOslo ? '2020-05-17T02:00:00+02:00' : '2020-05-17T00:00:00+00:00';
-  const rawDateOnly = tz.backend === tzOslo ? '2020-05-17T00:00:00+02:00' : '2020-05-17T00:00:00+00:00';
+  const rawDateOnly = '2020-05-17';
+
+  const date = '17.05.2020';
+  const zeroed = '17.05.2020 00:00:00';
 
   const utcInOslo = '17.05.2020 02:00:00';
-  const utcInOsloZeroed = '17.05.2020 00:00:00';
-  const inUtc = '17.05.2020 00:00:00';
-  const inUtcZeroed = '17.05.2020 00:00:00';
-  const beLocal = tz.backend === tzOslo ? utcInOslo : inUtc;
-  const beLocalZeroed = tz.backend === tzOslo ? utcInOsloZeroed : inUtcZeroed;
+  const beLocal = tz.backend === tzOslo ? utcInOslo : zeroed;
 
   const utcInBrowser = tz.browser === tzNewYork ? '16.05.2020 20:00:00' : utcInOslo;
-  const utcInBrowserZeroed =
-    tz.browser === tzNewYork
-      ? tz.backend === tzOslo
-        ? '16.05.2020 18:00:00'
-        : '16.05.2020 20:00:00'
-      : tz.backend === tzOslo
-        ? utcInOsloZeroed
-        : '17.05.2020 02:00:00';
-  const dateInUtc = tz.browser === tzNewYork ? '16.05.2020' : '17.05.2020';
+  const dateInUtc = tz.browser === tzNewYork ? '16.05.2020' : date;
 
-  cy.get(`#form-content-${id(Rows.Raw, Cols.String)}`).should('have.text', rawString);
-  cy.get(`#form-content-${id(Rows.Raw, Cols.DateTime)}`).should('have.text', rawDateTime);
-  cy.get(`#form-content-${id(Rows.Raw, Cols.DateOnly)}`).should('have.text', rawDateOnly);
-  cy.get(`#form-content-${id(Rows.Date, Cols.String)}`).should('have.text', utcInBrowser);
-  cy.get(`#form-content-${id(Rows.Date, Cols.DateTime)}`).should('have.text', utcInBrowser);
-  cy.get(`#form-content-${id(Rows.Date, Cols.DateOnly)}`).should('have.text', utcInBrowserZeroed);
-  cy.get(`#form-content-${id(Rows.FormatDate, Cols.String)}`).should('have.text', utcInBrowser);
-  cy.get(`#form-content-${id(Rows.FormatDate, Cols.DateTime)}`).should('have.text', utcInBrowser);
-  cy.get(`#form-content-${id(Rows.FormatDate, Cols.DateOnly)}`).should('have.text', utcInBrowserZeroed);
-  cy.get(`#form-content-${id(Rows.FormatDateBackend, Cols.String)}`).should('have.text', beLocal);
-  cy.get(`#form-content-${id(Rows.FormatDateBackend, Cols.DateTime)}`).should('have.text', beLocal);
-  cy.get(`#form-content-${id(Rows.FormatDateBackend, Cols.DateOnly)}`).should('have.text', beLocalZeroed);
-  cy.get(`#${id(Rows.DatePicker, Cols.String)}`).should('have.value', dateInUtc);
-  cy.get(`#${id(Rows.DatePicker, Cols.DateTime)}`).should('have.value', dateInUtc);
-  cy.get(`#${id(Rows.DatePicker, Cols.DateOnly)}`).should('have.value', dateInUtc);
+  testAll({
+    Raw: { String: rawString, DateTime: rawDateTime, DateOnly: rawDateOnly },
+    Date: { String: utcInBrowser, DateTime: utcInBrowser, DateOnly: zeroed },
+    FormatDate: { String: utcInBrowser, DateTime: utcInBrowser, DateOnly: zeroed },
+    FormatDateBackend: { String: beLocal, DateTime: beLocal, DateOnly: zeroed },
+    DatePicker: { String: dateInUtc, DateTime: dateInUtc, DateOnly: date },
+  });
 }


### PR DESCRIPTION
## Description

Now that all of this is out in a preview-release on backend, I can add the end-to-end test I made to compare and make sure dates and `formatDate` expressions work as expected (even when changing the browser timezone, which can't be done on the fly in our unit tests).

## Related Issue(s)

- #2961
- https://github.com/Altinn/app-lib-dotnet/pull/1067

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
