### PR TITLE
Making component validation plain hooks

### DIFF
--- a/src/features/form/layout/LayoutsContext.tsx
+++ b/src/features/form/layout/LayoutsContext.tsx
@@ -16,12 +16,10 @@ import { useHasInstance } from 'src/features/instance/InstanceContext';
 import { useLaxProcessData } from 'src/features/instance/ProcessContext';
 import { useNavigationParam } from 'src/features/routing/AppRoutingContext';
 import type { QueryDefinition } from 'src/core/queries/usePrefetchQuery';
-import type { LayoutLookups } from 'src/features/form/layout/makeLayoutLookups';
 import type { ILayoutCollection, ILayouts } from 'src/layout/layout';
 import type { IExpandedWidthLayouts, IHiddenLayoutsExternal } from 'src/types';
 
 export interface LayoutContextValue {
-  lookups: LayoutLookups;
   layouts: ILayouts;
   hiddenLayoutsExpressions: IHiddenLayoutsExternal;
   expandedWidthLayouts: IExpandedWidthLayouts;
@@ -57,7 +55,15 @@ function useLayoutQuery() {
     utils.error && window.logError('Fetching form layout failed:\n', utils.error);
   }, [utils.error]);
 
-  return utils;
+  return utils.data
+    ? {
+        ...utils,
+        data: {
+          ...utils.data,
+          lookups: makeLayoutLookups(utils.data.layouts),
+        },
+      }
+    : utils;
 }
 const { Provider, useCtx } = delayedContext(() =>
   createQueryContext({
@@ -119,10 +125,7 @@ function processLayouts(input: ILayoutCollection, layoutSetId: string, dataModel
   const withQuirksFixed = applyLayoutQuirks(layouts, layoutSetId);
   removeDuplicateComponentIds(withQuirksFixed, layoutSetId);
 
-  const lookups = makeLayoutLookups(withQuirksFixed);
-
   return {
-    lookups,
     layouts: withQuirksFixed,
     hiddenLayoutsExpressions,
     expandedWidthLayouts,

--- a/src/features/formData/FormDataWrite.tsx
+++ b/src/features/formData/FormDataWrite.tsx
@@ -721,13 +721,6 @@ export const FD = {
     });
   },
 
-  useInvalidDebouncedSelectorProps() {
-    return useDelayedSelectorProps({
-      mode: 'simple',
-      selector: invalidDebouncedSelector,
-    });
-  },
-
   /**
    * This will return the form data as a deep object, just like the server sends it to us (and the way we send it back).
    * This will always give you the debounced data, which may or may not be saved to the backend yet.
@@ -829,6 +822,15 @@ export const FD = {
    */
   useInvalidDebounced(dataType: string): object {
     return useSelector((v) => v.dataModels[dataType].invalidDebouncedCurrentData);
+  },
+
+  /**
+   * This returns the current invalid data which cannot be saved to backend
+   */
+  useInvalidDebouncedPick(reference: IDataModelReference | undefined): FDValue {
+    return useSelector((v) =>
+      reference ? dot.pick(reference.field, v.dataModels[reference.dataType].invalidDebouncedCurrentData) : undefined,
+    );
   },
 
   /**

--- a/src/features/validation/StoreValidationsInNode.tsx
+++ b/src/features/validation/StoreValidationsInNode.tsx
@@ -31,14 +31,25 @@ function StoreValidationsInNodeWorker() {
   const node = GeneratorInternal.useParent() as Node;
   const shouldValidate = shouldValidateNode(item);
 
-  const freshValidations = useNodeValidation(node, shouldValidate);
+  // We intentionally break the rules of hooks here. The shouldValidateNode function depends on the
+  // component configuration (specifically, the renderAsSummary property), which cannot
+  // change over time (it is not an expression). Therefore, we can safely ignore rule of hooks here, as we'll always
+  // re-render with the same number of hooks. If the property changes (from DevTools, for example), the entire form
+  // will re-render anyway.
+  if (shouldValidate) {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    useStoreValidations(node, item);
+  }
+
+  return null;
+}
+
+function useStoreValidations(node: Node, item: CompIntermediate) {
+  const freshValidations = useNodeValidation(node);
   const validations = useUpdatedValidations(freshValidations, node);
 
   const shouldSetValidations = NodesInternal.useNodeData(node, (data) => !deepEqual(data.validations, validations));
-  NodesStateQueue.useSetNodeProp(
-    { node, prop: 'validations', value: validations },
-    shouldSetValidations && shouldValidate,
-  );
+  NodesStateQueue.useSetNodeProp({ node, prop: 'validations', value: validations }, shouldSetValidations);
 
   // Reduce visibility as validations are fixed
   const initialVisibility = getInitialMaskFromNodeItem(item);
@@ -55,8 +66,6 @@ function StoreValidationsInNodeWorker() {
     { node, prop: 'validationVisibility', value: visibilityToSet },
     visibilityToSet !== undefined,
   );
-
-  return null;
 }
 
 function useUpdatedValidations(validations: AnyValidation[], node: Node) {

--- a/src/features/validation/StoreValidationsInNode.tsx
+++ b/src/features/validation/StoreValidationsInNode.tsx
@@ -31,11 +31,10 @@ function StoreValidationsInNodeWorker() {
   const node = GeneratorInternal.useParent() as Node;
   const shouldValidate = shouldValidateNode(item);
 
-  // We intentionally break the rules of hooks here. The shouldValidateNode function depends on the
-  // component configuration (specifically, the renderAsSummary property), which cannot
-  // change over time (it is not an expression). Therefore, we can safely ignore rule of hooks here, as we'll always
-  // re-render with the same number of hooks. If the property changes (from DevTools, for example), the entire form
-  // will re-render anyway.
+  // We intentionally break the rules of hooks eslint rule here. The shouldValidateNode function depends on the
+  // component configuration (specifically, the renderAsSummary property), which cannot change over time (it is not an
+  // expression). Therefore, we can safely ignore lint rule here, as we'll always re-render with the same number of
+  // hooks. If the property changes (from DevTools, for example), the entire form will re-render anyway.
   if (shouldValidate) {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     useStoreValidations(node, item);

--- a/src/features/validation/ValidationPlugin.tsx
+++ b/src/features/validation/ValidationPlugin.tsx
@@ -14,6 +14,8 @@ interface Config {
   };
 }
 
+const emptyArray = [];
+
 /**
  * Adds validation support to a form or container component. This is added to your component by default
  * when one of these categories are selected.
@@ -41,7 +43,7 @@ export class ValidationPlugin extends NodeDefPlugin<Config> {
 
   stateFactory(_props: DefPluginStateFactoryProps<Config>): DefPluginExtraState<Config> {
     return {
-      validations: [],
+      validations: emptyArray,
       validationVisibility: 0,
     };
   }

--- a/src/features/validation/index.ts
+++ b/src/features/validation/index.ts
@@ -1,8 +1,5 @@
-import type { AttachmentsSelector } from 'src/features/attachments/tools';
 import type { Expression, ExprValToActual } from 'src/features/expressions/types';
-import type { DataElementSelector } from 'src/features/instance/InstanceContext';
 import type { TextReference, ValidLangParam } from 'src/features/language/useLanguage';
-import type { DataElementHasErrorsSelector } from 'src/features/validation/validationContext';
 import type { FormDataSelector } from 'src/layout';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
@@ -225,9 +222,6 @@ export type ValidationsProcessedLast = {
 export type ValidationDataSources = {
   formDataSelector: FormDataSelector;
   invalidDataSelector: FormDataSelector;
-  attachmentsSelector: AttachmentsSelector;
-  dataElementsSelector: DataElementSelector;
-  dataElementHasErrorsSelector: DataElementHasErrorsSelector;
 };
 
 /**

--- a/src/features/validation/index.ts
+++ b/src/features/validation/index.ts
@@ -1,13 +1,10 @@
-import type { ApplicationMetadata } from 'src/features/applicationMetadata/types';
 import type { AttachmentsSelector } from 'src/features/attachments/tools';
 import type { Expression, ExprValToActual } from 'src/features/expressions/types';
 import type { DataElementSelector } from 'src/features/instance/InstanceContext';
 import type { TextReference, ValidLangParam } from 'src/features/language/useLanguage';
 import type { DataElementHasErrorsSelector } from 'src/features/validation/validationContext';
 import type { FormDataSelector } from 'src/layout';
-import type { ILayoutSet } from 'src/layout/common.generated';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
-import type { NodeDataSelector } from 'src/utils/layout/NodesContext';
 
 export enum FrontendValidationSource {
   EmptyField = '__empty_field__',
@@ -226,14 +223,10 @@ export type ValidationsProcessedLast = {
  * Contains all the necessary elements from the store to run frontend validations.
  */
 export type ValidationDataSources = {
-  currentLanguage: string;
   formDataSelector: FormDataSelector;
   invalidDataSelector: FormDataSelector;
   attachmentsSelector: AttachmentsSelector;
-  nodeDataSelector: NodeDataSelector;
-  applicationMetadata: ApplicationMetadata;
   dataElementsSelector: DataElementSelector;
-  layoutSets: ILayoutSet[];
   dataElementHasErrorsSelector: DataElementHasErrorsSelector;
 };
 

--- a/src/features/validation/index.ts
+++ b/src/features/validation/index.ts
@@ -1,6 +1,5 @@
 import type { Expression, ExprValToActual } from 'src/features/expressions/types';
 import type { TextReference, ValidLangParam } from 'src/features/language/useLanguage';
-import type { FormDataSelector } from 'src/layout';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export enum FrontendValidationSource {
@@ -214,14 +213,6 @@ export type NodeRefValidation<Validation extends AnyValidation<any> = AnyValidat
 export type ValidationsProcessedLast = {
   incremental: BackendValidationIssueGroups | undefined;
   initial: BackendValidationIssue[] | undefined;
-};
-
-/**
- * Contains all the necessary elements from the store to run frontend validations.
- */
-export type ValidationDataSources = {
-  formDataSelector: FormDataSelector;
-  invalidDataSelector: FormDataSelector;
 };
 
 /**

--- a/src/features/validation/nodeValidation/emptyFieldValidation.ts
+++ b/src/features/validation/nodeValidation/emptyFieldValidation.ts
@@ -1,22 +1,18 @@
-import {
-  type ComponentValidation,
-  FrontendValidationSource,
-  type ValidationDataSources,
-  ValidationMask,
-} from 'src/features/validation';
+import { type ComponentValidation, FrontendValidationSource, ValidationMask } from 'src/features/validation';
 import { getFieldNameKey } from 'src/utils/formComponentUtils';
+import { GeneratorData } from 'src/utils/layout/generator/GeneratorDataSources';
 import type { IDataModelReference } from 'src/layout/common.generated';
 import type { CompTypes, CompWithBinding } from 'src/layout/layout';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 /**
- * Default implementation of runEmptyFieldValidation
- * Checks all of the component's dataModelBindings and returns one error for each one missing data
+ * Default implementation of useEmptyFieldValidation
+ * Checks all the component's dataModelBindings and returns one error for each one missing data
  */
-export function runEmptyFieldValidationAllBindings<Type extends CompTypes>(
+export function useEmptyFieldValidationAllBindings<Type extends CompTypes>(
   node: LayoutNode<Type>,
-  { formDataSelector, invalidDataSelector, nodeDataSelector }: ValidationDataSources,
 ): ComponentValidation[] {
+  const { nodeDataSelector, formDataSelector, invalidDataSelector } = GeneratorData.useValidationDataSources();
   const required = nodeDataSelector(
     (picker) => {
       const item = picker(node.id, node.type)?.item;
@@ -57,14 +53,14 @@ export function runEmptyFieldValidationAllBindings<Type extends CompTypes>(
 }
 
 /**
- * Special implementation of runEmptyFieldValidation
+ * Special implementation of useEmptyFieldValidation
  * Only checks simpleBinding, this is useful for components that may save additional data which is not directly controlled by the user,
- * like options-based components that can store the label and metadata about the options along side the actual value
+ * like options-based components that can store the label and metadata about the options alongside the actual value
  */
-export function runEmptyFieldValidationOnlySimpleBinding<Type extends CompWithBinding<'simpleBinding'>>(
+export function useEmptyFieldValidationOnlySimpleBinding<Type extends CompWithBinding<'simpleBinding'>>(
   node: LayoutNode<Type>,
-  { formDataSelector, invalidDataSelector, nodeDataSelector }: ValidationDataSources,
 ): ComponentValidation[] {
+  const { formDataSelector, invalidDataSelector, nodeDataSelector } = GeneratorData.useValidationDataSources();
   const required = nodeDataSelector(
     (picker) => {
       const item = picker(node.id, node.type)?.item;

--- a/src/features/validation/nodeValidation/emptyFieldValidation.ts
+++ b/src/features/validation/nodeValidation/emptyFieldValidation.ts
@@ -1,6 +1,6 @@
+import { FD } from 'src/features/formData/FormDataWrite';
 import { type ComponentValidation, FrontendValidationSource, ValidationMask } from 'src/features/validation';
 import { getFieldNameKey } from 'src/utils/formComponentUtils';
-import { GeneratorData } from 'src/utils/layout/generator/GeneratorDataSources';
 import { NodesInternal } from 'src/utils/layout/NodesContext';
 import type { IDataModelReference } from 'src/layout/common.generated';
 import type { CompTypes, CompWithBinding } from 'src/layout/layout';
@@ -18,7 +18,8 @@ export function useEmptyFieldValidationAllBindings<Type extends CompTypes>(
     state.item && 'required' in state.item ? state.item.required : false,
   );
   const trb = NodesInternal.useNodeData(node, (state) => state.item?.textResourceBindings);
-  const { formDataSelector, invalidDataSelector } = GeneratorData.useValidationDataSources();
+  const formDataSelector = FD.useDebouncedSelector();
+  const invalidDataSelector = FD.useInvalidDebouncedSelector();
   if (!required || !dataModelBindings) {
     return [];
   }
@@ -62,14 +63,15 @@ export function useEmptyFieldValidationOnlySimpleBinding<Type extends CompWithBi
   );
   const reference = NodesInternal.useNodeData(node, (state) => state.layout.dataModelBindings.simpleBinding);
   const trb = NodesInternal.useNodeData(node, (state) => state.item?.textResourceBindings);
-  const { formDataSelector, invalidDataSelector } = GeneratorData.useValidationDataSources();
+  const validData = FD.useDebouncedPick(reference);
+  const invalidData = FD.useInvalidDebouncedPick(reference);
+  const data = validData ?? invalidData;
   if (!required || !reference) {
     return [];
   }
 
   const validations: ComponentValidation[] = [];
 
-  const data = formDataSelector(reference) ?? invalidDataSelector(reference);
   const asString =
     typeof data === 'string' || typeof data === 'number' || typeof data === 'boolean' ? String(data) : '';
 

--- a/src/features/validation/nodeValidation/useNodeValidation.ts
+++ b/src/features/validation/nodeValidation/useNodeValidation.ts
@@ -49,14 +49,18 @@ export function useNodeValidation(node: LayoutNode): AnyValidation[] {
         validations.push(...fieldValidations.map((v) => ({ ...v, bindingKey })));
       }
     }
+
+    // This is set in the selector because the validation system will wait until all nodes (that validate) have set it.
+    // If we set this during render, all components using this hook would have to re-render after saving data, but now
+    // they only have to re-run the selector. The downside here is that empty validations and component validations will
+    // run outside the selector, so they _may_ have new validations that are not yet processed.
+    registry.current.validationsProcessed[node.id] = state.processedLast;
     return validations;
   });
 
   unfiltered.push(...fieldValidations);
 
   const filtered = filter(unfiltered, node, layoutLookups);
-  registry.current.validationsProcessed[node.id] = Validation.useFullState((state) => state.processedLast);
-
   if (filtered.length === 0) {
     return emptyArray;
   }

--- a/src/features/validation/nodeValidation/useNodeValidation.ts
+++ b/src/features/validation/nodeValidation/useNodeValidation.ts
@@ -1,3 +1,4 @@
+import { useLayoutLookups } from 'src/features/form/layout/LayoutsContext';
 import { Validation } from 'src/features/validation/validationContext';
 import {
   type CompDef,
@@ -7,10 +8,10 @@ import {
 } from 'src/layout';
 import { GeneratorInternal } from 'src/utils/layout/generator/GeneratorContext';
 import { GeneratorData } from 'src/utils/layout/generator/GeneratorDataSources';
+import type { LayoutLookups } from 'src/features/form/layout/makeLayoutLookups';
 import type { AnyValidation, BaseValidation } from 'src/features/validation';
 import type { IDataModelReference } from 'src/layout/common.generated';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
-import type { NodeDataSelector } from 'src/utils/layout/NodesContext';
 
 const emptyArray: AnyValidation[] = [];
 
@@ -20,7 +21,7 @@ const emptyArray: AnyValidation[] = [];
  */
 export function useNodeValidation(node: LayoutNode): AnyValidation[] {
   const registry = GeneratorInternal.useRegistry();
-  const dataSources = GeneratorData.useValidationDataSources();
+  const layoutLookups = useLayoutLookups();
   const dataModelBindings = GeneratorInternal.useIntermediateItem()?.dataModelBindings;
   const bindings = Object.entries((dataModelBindings ?? {}) as Record<string, IDataModelReference>);
 
@@ -53,7 +54,7 @@ export function useNodeValidation(node: LayoutNode): AnyValidation[] {
 
   unfiltered.push(...fieldValidations);
 
-  const filtered = filter(unfiltered, node, dataSources.nodeDataSelector);
+  const filtered = filter(unfiltered, node, layoutLookups);
   registry.current.validationsProcessed[node.id] = Validation.useFullState((state) => state.processedLast);
 
   if (filtered.length === 0) {
@@ -69,14 +70,14 @@ export function useNodeValidation(node: LayoutNode): AnyValidation[] {
 function filter<Validation extends BaseValidation>(
   validations: Validation[],
   node: LayoutNode,
-  selector: NodeDataSelector,
+  layoutLookups: LayoutLookups,
 ): Validation[] {
   if (!implementsValidationFilter(node.def)) {
     return validations;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const filters = node.def.getValidationFilters(node as any, selector);
+  const filters = node.def.getValidationFilters(node as any, layoutLookups);
   if (filters.length == 0) {
     return validations;
   }

--- a/src/features/validation/nodeValidation/useNodeValidation.ts
+++ b/src/features/validation/nodeValidation/useNodeValidation.ts
@@ -14,7 +14,7 @@ const emptyArray: AnyValidation[] = [];
  * Runs validations defined in the component classes. This runs from the node generator, and will collect all
  * validations for a node and return them.
  */
-export function useNodeValidation(node: LayoutNode, shouldValidate: boolean): AnyValidation[] {
+export function useNodeValidation(node: LayoutNode): AnyValidation[] {
   const registry = GeneratorInternal.useRegistry();
   const dataSources = GeneratorData.useValidationDataSources();
   const getDataElementIdForDataType = GeneratorData.useGetDataElementIdForDataType();
@@ -22,10 +22,6 @@ export function useNodeValidation(node: LayoutNode, shouldValidate: boolean): An
   const bindings = Object.entries((dataModelBindings ?? {}) as Record<string, IDataModelReference>);
 
   return Validation.useFullState((state) => {
-    if (!shouldValidate) {
-      return emptyArray;
-    }
-
     const validations: AnyValidation[] = [];
     if (implementsValidateEmptyField(node.def)) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/features/validation/nodeValidation/useNodeValidation.ts
+++ b/src/features/validation/nodeValidation/useNodeValidation.ts
@@ -25,9 +25,9 @@ export function useNodeValidation(node: LayoutNode): AnyValidation[] {
   const dataModelBindings = GeneratorInternal.useIntermediateItem()?.dataModelBindings;
   const bindings = Object.entries((dataModelBindings ?? {}) as Record<string, IDataModelReference>);
 
-  // We intentionally break the rules of hooks here. All nodes have a type, and that type never changes in the lifetime
-  // of the node. Therefore, we can safely ignore the rule of hooks here, as we'll always re-render with the same
-  // validator hooks.
+  // We intentionally break the rules of hooks eslint rule here. All nodes have a type, and that type never changes
+  // in the lifetime of the node. Therefore, we can safely ignore the linting rule, as we'll always re-render with
+  // the same validator hooks (and thus in practice we will never actually break the rule of hooks, only the linter).
   const unfiltered: AnyValidation[] = [];
   if (implementsValidateEmptyField(node.def)) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/layout/Address/index.tsx
+++ b/src/layout/Address/index.tsx
@@ -2,14 +2,14 @@ import React, { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { useDisplayData } from 'src/features/displayData/useDisplayData';
-import { FrontendValidationSource, ValidationMask } from 'src/features/validation';
 import { AddressComponent } from 'src/layout/Address/AddressComponent';
 import { AddressSummary } from 'src/layout/Address/AddressSummary/AddressSummary';
 import { AddressDef } from 'src/layout/Address/config.def.generated';
+import { useAddressValidation } from 'src/layout/Address/useAddressValidation';
 import { SummaryItemSimple } from 'src/layout/Summary/SummaryItemSimple';
 import type { LayoutValidationCtx } from 'src/features/devtools/layoutValidation/types';
 import type { DisplayDataProps } from 'src/features/displayData';
-import type { ComponentValidation, ValidationDataSources } from 'src/features/validation';
+import type { ComponentValidation } from 'src/features/validation';
 import type { PropsFromGenericComponent, ValidateComponent } from 'src/layout';
 import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types';
@@ -39,50 +39,8 @@ export class Address extends AddressDef implements ValidateComponent<'Address'> 
     return false;
   }
 
-  runComponentValidation(
-    node: LayoutNode<'Address'>,
-    { formDataSelector, nodeDataSelector }: ValidationDataSources,
-  ): ComponentValidation[] {
-    const dataModelBindings = nodeDataSelector(
-      (picker) => picker(node.id, 'Address')?.layout.dataModelBindings,
-      [node.id],
-    );
-    if (!dataModelBindings) {
-      return [];
-    }
-    const validations: ComponentValidation[] = [];
-
-    const zipCodeField = dataModelBindings.zipCode;
-    const zipCode = zipCodeField ? formDataSelector(zipCodeField) : undefined;
-    const zipCodeAsString = typeof zipCode === 'string' || typeof zipCode === 'number' ? String(zipCode) : undefined;
-
-    // TODO(Validation): Add better message for the special case of 0000 or add better validation for zipCodes that the API says are invalid
-    if (zipCodeAsString && (!zipCodeAsString.match(/^\d{4}$/) || zipCodeAsString === '0000')) {
-      validations.push({
-        message: { key: 'address_component.validation_error_zipcode' },
-        severity: 'error',
-        bindingKey: 'zipCode',
-        source: FrontendValidationSource.Component,
-        category: ValidationMask.Component,
-      });
-    }
-
-    const houseNumberField = dataModelBindings.houseNumber;
-    const houseNumber = houseNumberField ? formDataSelector(houseNumberField) : undefined;
-    const houseNumberAsString =
-      typeof houseNumber === 'string' || typeof houseNumber === 'number' ? String(houseNumber) : undefined;
-
-    if (houseNumberAsString && !houseNumberAsString.match(/^[a-z,A-Z]\d{4}$/)) {
-      validations.push({
-        message: { key: 'address_component.validation_error_house_number' },
-        severity: 'error',
-        bindingKey: 'houseNumber',
-        source: FrontendValidationSource.Component,
-        category: ValidationMask.Component,
-      });
-    }
-
-    return validations;
+  useComponentValidation(node: LayoutNode<'Address'>): ComponentValidation[] {
+    return useAddressValidation(node);
   }
 
   validateDataModelBindings(ctx: LayoutValidationCtx<'Address'>): string[] {

--- a/src/layout/Address/useAddressValidation.ts
+++ b/src/layout/Address/useAddressValidation.ts
@@ -1,0 +1,48 @@
+import { FrontendValidationSource, ValidationMask } from 'src/features/validation';
+import { GeneratorData } from 'src/utils/layout/generator/GeneratorDataSources';
+import type { ComponentValidation } from 'src/features/validation';
+import type { LayoutNode } from 'src/utils/layout/LayoutNode';
+
+export function useAddressValidation(node: LayoutNode<'Address'>): ComponentValidation[] {
+  const { nodeDataSelector, formDataSelector } = GeneratorData.useValidationDataSources();
+  const dataModelBindings = nodeDataSelector(
+    (picker) => picker(node.id, 'Address')?.layout.dataModelBindings,
+    [node.id],
+  );
+  if (!dataModelBindings) {
+    return [];
+  }
+  const validations: ComponentValidation[] = [];
+
+  const zipCodeField = dataModelBindings.zipCode;
+  const zipCode = zipCodeField ? formDataSelector(zipCodeField) : undefined;
+  const zipCodeAsString = typeof zipCode === 'string' || typeof zipCode === 'number' ? String(zipCode) : undefined;
+
+  // TODO(Validation): Add better message for the special case of 0000 or add better validation for zipCodes that the API says are invalid
+  if (zipCodeAsString && (!zipCodeAsString.match(/^\d{4}$/) || zipCodeAsString === '0000')) {
+    validations.push({
+      message: { key: 'address_component.validation_error_zipcode' },
+      severity: 'error',
+      bindingKey: 'zipCode',
+      source: FrontendValidationSource.Component,
+      category: ValidationMask.Component,
+    });
+  }
+
+  const houseNumberField = dataModelBindings.houseNumber;
+  const houseNumber = houseNumberField ? formDataSelector(houseNumberField) : undefined;
+  const houseNumberAsString =
+    typeof houseNumber === 'string' || typeof houseNumber === 'number' ? String(houseNumber) : undefined;
+
+  if (houseNumberAsString && !houseNumberAsString.match(/^[a-z,A-Z]\d{4}$/)) {
+    validations.push({
+      message: { key: 'address_component.validation_error_house_number' },
+      severity: 'error',
+      bindingKey: 'houseNumber',
+      source: FrontendValidationSource.Component,
+      category: ValidationMask.Component,
+    });
+  }
+
+  return validations;
+}

--- a/src/layout/Address/useAddressValidation.ts
+++ b/src/layout/Address/useAddressValidation.ts
@@ -1,14 +1,12 @@
 import { FrontendValidationSource, ValidationMask } from 'src/features/validation';
 import { GeneratorData } from 'src/utils/layout/generator/GeneratorDataSources';
+import { NodesInternal } from 'src/utils/layout/NodesContext';
 import type { ComponentValidation } from 'src/features/validation';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export function useAddressValidation(node: LayoutNode<'Address'>): ComponentValidation[] {
-  const { nodeDataSelector, formDataSelector } = GeneratorData.useValidationDataSources();
-  const dataModelBindings = nodeDataSelector(
-    (picker) => picker(node.id, 'Address')?.layout.dataModelBindings,
-    [node.id],
-  );
+  const dataModelBindings = NodesInternal.useNodeData(node, (d) => d.layout.dataModelBindings);
+  const { formDataSelector } = GeneratorData.useValidationDataSources();
   if (!dataModelBindings) {
     return [];
   }

--- a/src/layout/Address/useAddressValidation.ts
+++ b/src/layout/Address/useAddressValidation.ts
@@ -1,19 +1,18 @@
+import { FD } from 'src/features/formData/FormDataWrite';
 import { FrontendValidationSource, ValidationMask } from 'src/features/validation';
-import { GeneratorData } from 'src/utils/layout/generator/GeneratorDataSources';
 import { NodesInternal } from 'src/utils/layout/NodesContext';
 import type { ComponentValidation } from 'src/features/validation';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export function useAddressValidation(node: LayoutNode<'Address'>): ComponentValidation[] {
   const dataModelBindings = NodesInternal.useNodeData(node, (d) => d.layout.dataModelBindings);
-  const { formDataSelector } = GeneratorData.useValidationDataSources();
+  const zipCode = FD.useDebouncedPick(dataModelBindings?.zipCode);
+  const houseNumber = FD.useDebouncedPick(dataModelBindings?.houseNumber);
   if (!dataModelBindings) {
     return [];
   }
   const validations: ComponentValidation[] = [];
 
-  const zipCodeField = dataModelBindings.zipCode;
-  const zipCode = zipCodeField ? formDataSelector(zipCodeField) : undefined;
   const zipCodeAsString = typeof zipCode === 'string' || typeof zipCode === 'number' ? String(zipCode) : undefined;
 
   // TODO(Validation): Add better message for the special case of 0000 or add better validation for zipCodes that the API says are invalid
@@ -27,8 +26,6 @@ export function useAddressValidation(node: LayoutNode<'Address'>): ComponentVali
     });
   }
 
-  const houseNumberField = dataModelBindings.houseNumber;
-  const houseNumber = houseNumberField ? formDataSelector(houseNumberField) : undefined;
   const houseNumberAsString =
     typeof houseNumber === 'string' || typeof houseNumber === 'number' ? String(houseNumber) : undefined;
 

--- a/src/layout/Checkboxes/index.tsx
+++ b/src/layout/Checkboxes/index.tsx
@@ -2,14 +2,14 @@ import React, { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { getCommaSeparatedOptionsToText } from 'src/features/options/getCommaSeparatedOptionsToText';
-import { runEmptyFieldValidationOnlySimpleBinding } from 'src/features/validation/nodeValidation/emptyFieldValidation';
+import { useEmptyFieldValidationOnlySimpleBinding } from 'src/features/validation/nodeValidation/emptyFieldValidation';
 import { CheckboxContainerComponent } from 'src/layout/Checkboxes/CheckboxesContainerComponent';
 import { CheckboxesSummary } from 'src/layout/Checkboxes/CheckboxesSummary';
 import { CheckboxesDef } from 'src/layout/Checkboxes/config.def.generated';
 import { MultipleChoiceSummary } from 'src/layout/Checkboxes/MultipleChoiceSummary';
 import type { LayoutValidationCtx } from 'src/features/devtools/layoutValidation/types';
 import type { DisplayDataProps } from 'src/features/displayData';
-import type { ComponentValidation, ValidationDataSources } from 'src/features/validation';
+import type { ComponentValidation } from 'src/features/validation';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { CheckboxSummaryOverrideProps } from 'src/layout/Summary2/config.generated';
@@ -47,11 +47,8 @@ export class Checkboxes extends CheckboxesDef {
     );
   }
 
-  runEmptyFieldValidation(
-    node: BaseLayoutNode<'Checkboxes'>,
-    validationDataSources: ValidationDataSources,
-  ): ComponentValidation[] {
-    return runEmptyFieldValidationOnlySimpleBinding(node, validationDataSources);
+  useEmptyFieldValidation(node: BaseLayoutNode<'Checkboxes'>): ComponentValidation[] {
+    return useEmptyFieldValidationOnlySimpleBinding(node);
   }
 
   validateDataModelBindings(ctx: LayoutValidationCtx<'Checkboxes'>): string[] {

--- a/src/layout/Datepicker/index.tsx
+++ b/src/layout/Datepicker/index.tsx
@@ -11,6 +11,7 @@ import { useDatepickerValidation } from 'src/layout/Datepicker/useDatepickerVali
 import { SummaryItemSimple } from 'src/layout/Summary/SummaryItemSimple';
 import type { LayoutValidationCtx } from 'src/features/devtools/layoutValidation/types';
 import type { DisplayDataProps } from 'src/features/displayData';
+import type { LayoutLookups } from 'src/features/form/layout/makeLayoutLookups';
 import type { BaseValidation, ComponentValidation } from 'src/features/validation';
 import type {
   PropsFromGenericComponent,
@@ -21,7 +22,6 @@ import type {
 import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
-import type { NodeDataSelector } from 'src/utils/layout/NodesContext';
 
 export class Datepicker extends DatepickerDef implements ValidateComponent<'Datepicker'>, ValidationFilter {
   render = forwardRef<HTMLElement, PropsFromGenericComponent<'Datepicker'>>(
@@ -95,14 +95,15 @@ export class Datepicker extends DatepickerDef implements ValidateComponent<'Date
     );
   }
 
-  getValidationFilters(node: LayoutNode<'Datepicker'>, selector: NodeDataSelector): ValidationFilterFunction[] {
+  getValidationFilters(node: LayoutNode<'Datepicker'>, layoutLookups: LayoutLookups): ValidationFilterFunction[] {
     const filters = [Datepicker.schemaFormatFilter];
+    const component = layoutLookups.getComponent(node.baseId, 'Datepicker');
 
-    if (selector((picker) => picker(node.id, 'Datepicker')?.item?.minDate, [node.id])) {
+    if (component.minDate) {
       filters.push(Datepicker.schemaFormatMinimumFilter);
     }
 
-    if (selector((picker) => picker(node.id, 'Datepicker')?.item?.maxDate, [node.id])) {
+    if (component.maxDate) {
       filters.push(Datepicker.schemaFormatMaximumFilter);
     }
 

--- a/src/layout/Datepicker/index.tsx
+++ b/src/layout/Datepicker/index.tsx
@@ -1,24 +1,17 @@
 import React, { forwardRef } from 'react';
 import type { JSX } from 'react';
 
-import { isAfter, isBefore } from 'date-fns';
-
-import {
-  formatISOString,
-  getDateConstraint,
-  getDateFormat,
-  strictParseISO,
-} from 'src/app-components/Datepicker/utils/dateHelpers';
+import { formatISOString, getDateFormat } from 'src/app-components/Datepicker/utils/dateHelpers';
 import { useDisplayData } from 'src/features/displayData/useDisplayData';
-import { FrontendValidationSource, ValidationMask } from 'src/features/validation';
+import { FrontendValidationSource } from 'src/features/validation';
 import { DatepickerDef } from 'src/layout/Datepicker/config.def.generated';
 import { DatepickerComponent } from 'src/layout/Datepicker/DatepickerComponent';
 import { DatepickerSummary } from 'src/layout/Datepicker/DatepickerSummary';
+import { useDatepickerValidation } from 'src/layout/Datepicker/useDatepickerValidation';
 import { SummaryItemSimple } from 'src/layout/Summary/SummaryItemSimple';
-import { getDatepickerFormat } from 'src/utils/formatDateLocale';
 import type { LayoutValidationCtx } from 'src/features/devtools/layoutValidation/types';
 import type { DisplayDataProps } from 'src/features/displayData';
-import type { BaseValidation, ComponentValidation, ValidationDataSources } from 'src/features/validation';
+import type { BaseValidation, ComponentValidation } from 'src/features/validation';
 import type {
   PropsFromGenericComponent,
   ValidateComponent,
@@ -68,62 +61,8 @@ export class Datepicker extends DatepickerDef implements ValidateComponent<'Date
     );
   }
 
-  runComponentValidation(
-    node: LayoutNode<'Datepicker'>,
-    { formDataSelector, currentLanguage, nodeDataSelector }: ValidationDataSources,
-  ): ComponentValidation[] {
-    const field = nodeDataSelector(
-      (picker) => picker(node.id, 'Datepicker')?.layout.dataModelBindings?.simpleBinding,
-      [node.id],
-    );
-    const data = field ? formDataSelector(field) : undefined;
-    const dataAsString = typeof data === 'string' || typeof data === 'number' ? String(data) : undefined;
-    if (!dataAsString) {
-      return [];
-    }
-
-    const minDate = getDateConstraint(
-      nodeDataSelector((picker) => picker(node.id, 'Datepicker')?.item?.minDate, [node.id]),
-      'min',
-    );
-    const maxDate = getDateConstraint(
-      nodeDataSelector((picker) => picker(node.id, 'Datepicker')?.item?.maxDate, [node.id]),
-      'max',
-    );
-    const format = getDateFormat(
-      nodeDataSelector((picker) => picker(node.id, 'Datepicker')?.item?.format, [node.id]),
-      currentLanguage,
-    );
-    const datePickerFormat = getDatepickerFormat(format).toUpperCase();
-
-    const validations: ComponentValidation[] = [];
-    const date = strictParseISO(dataAsString);
-    if (!date) {
-      validations.push({
-        message: { key: 'date_picker.invalid_date_message', params: [datePickerFormat] },
-        severity: 'error',
-        source: FrontendValidationSource.Component,
-        category: ValidationMask.Component,
-      });
-    }
-
-    if (date && isBefore(date, minDate)) {
-      validations.push({
-        message: { key: 'date_picker.min_date_exeeded' },
-        severity: 'error',
-        source: FrontendValidationSource.Component,
-        category: ValidationMask.Component,
-      });
-    } else if (date && isAfter(date, maxDate)) {
-      validations.push({
-        message: { key: 'date_picker.max_date_exeeded' },
-        severity: 'error',
-        source: FrontendValidationSource.Component,
-        category: ValidationMask.Component,
-      });
-    }
-
-    return validations;
+  useComponentValidation(node: LayoutNode<'Datepicker'>): ComponentValidation[] {
+    return useDatepickerValidation(node);
   }
 
   /**

--- a/src/layout/Datepicker/useDatepickerValidation.ts
+++ b/src/layout/Datepicker/useDatepickerValidation.ts
@@ -1,0 +1,63 @@
+import { isAfter, isBefore } from 'date-fns';
+
+import { getDateConstraint, getDateFormat, strictParseISO } from 'src/app-components/Datepicker/utils/dateHelpers';
+import { type ComponentValidation, FrontendValidationSource, ValidationMask } from 'src/features/validation';
+import { getDatepickerFormat } from 'src/utils/formatDateLocale';
+import { GeneratorData } from 'src/utils/layout/generator/GeneratorDataSources';
+import type { LayoutNode } from 'src/utils/layout/LayoutNode';
+
+export function useDatepickerValidation(node: LayoutNode<'Datepicker'>): ComponentValidation[] {
+  const { nodeDataSelector, formDataSelector, currentLanguage } = GeneratorData.useValidationDataSources();
+  const field = nodeDataSelector(
+    (picker) => picker(node.id, 'Datepicker')?.layout.dataModelBindings?.simpleBinding,
+    [node.id],
+  );
+  const data = field ? formDataSelector(field) : undefined;
+  const dataAsString = typeof data === 'string' || typeof data === 'number' ? String(data) : undefined;
+  if (!dataAsString) {
+    return [];
+  }
+
+  const minDate = getDateConstraint(
+    nodeDataSelector((picker) => picker(node.id, 'Datepicker')?.item?.minDate, [node.id]),
+    'min',
+  );
+  const maxDate = getDateConstraint(
+    nodeDataSelector((picker) => picker(node.id, 'Datepicker')?.item?.maxDate, [node.id]),
+    'max',
+  );
+  const format = getDateFormat(
+    nodeDataSelector((picker) => picker(node.id, 'Datepicker')?.item?.format, [node.id]),
+    currentLanguage,
+  );
+  const datePickerFormat = getDatepickerFormat(format).toUpperCase();
+
+  const validations: ComponentValidation[] = [];
+  const date = strictParseISO(dataAsString);
+  if (!date) {
+    validations.push({
+      message: { key: 'date_picker.invalid_date_message', params: [datePickerFormat] },
+      severity: 'error',
+      source: FrontendValidationSource.Component,
+      category: ValidationMask.Component,
+    });
+  }
+
+  if (date && isBefore(date, minDate)) {
+    validations.push({
+      message: { key: 'date_picker.min_date_exeeded' },
+      severity: 'error',
+      source: FrontendValidationSource.Component,
+      category: ValidationMask.Component,
+    });
+  } else if (date && isAfter(date, maxDate)) {
+    validations.push({
+      message: { key: 'date_picker.max_date_exeeded' },
+      severity: 'error',
+      source: FrontendValidationSource.Component,
+      category: ValidationMask.Component,
+    });
+  }
+
+  return validations;
+}

--- a/src/layout/Datepicker/useDatepickerValidation.ts
+++ b/src/layout/Datepicker/useDatepickerValidation.ts
@@ -1,17 +1,17 @@
 import { isAfter, isBefore } from 'date-fns';
 
 import { getDateConstraint, getDateFormat, strictParseISO } from 'src/app-components/Datepicker/utils/dateHelpers';
+import { FD } from 'src/features/formData/FormDataWrite';
 import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
 import { type ComponentValidation, FrontendValidationSource, ValidationMask } from 'src/features/validation';
 import { getDatepickerFormat } from 'src/utils/formatDateLocale';
-import { GeneratorData } from 'src/utils/layout/generator/GeneratorDataSources';
 import { NodesInternal } from 'src/utils/layout/NodesContext';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export function useDatepickerValidation(node: LayoutNode<'Datepicker'>): ComponentValidation[] {
   const currentLanguage = useCurrentLanguage();
-  const { formDataSelector } = GeneratorData.useValidationDataSources();
   const field = NodesInternal.useNodeData(node, (data) => data.layout.dataModelBindings?.simpleBinding);
+  const data = FD.useDebouncedPick(field);
   const minDate = getDateConstraint(
     NodesInternal.useNodeData(node, (data) => data.layout.minDate),
     'min',
@@ -24,7 +24,6 @@ export function useDatepickerValidation(node: LayoutNode<'Datepicker'>): Compone
     NodesInternal.useNodeData(node, (data) => data.layout.format),
     currentLanguage,
   );
-  const data = field ? formDataSelector(field) : undefined;
   const dataAsString = typeof data === 'string' || typeof data === 'number' ? String(data) : undefined;
   if (!dataAsString) {
     return [];

--- a/src/layout/Datepicker/useDatepickerValidation.ts
+++ b/src/layout/Datepicker/useDatepickerValidation.ts
@@ -1,16 +1,28 @@
 import { isAfter, isBefore } from 'date-fns';
 
 import { getDateConstraint, getDateFormat, strictParseISO } from 'src/app-components/Datepicker/utils/dateHelpers';
+import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
 import { type ComponentValidation, FrontendValidationSource, ValidationMask } from 'src/features/validation';
 import { getDatepickerFormat } from 'src/utils/formatDateLocale';
 import { GeneratorData } from 'src/utils/layout/generator/GeneratorDataSources';
+import { NodesInternal } from 'src/utils/layout/NodesContext';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export function useDatepickerValidation(node: LayoutNode<'Datepicker'>): ComponentValidation[] {
-  const { nodeDataSelector, formDataSelector, currentLanguage } = GeneratorData.useValidationDataSources();
-  const field = nodeDataSelector(
-    (picker) => picker(node.id, 'Datepicker')?.layout.dataModelBindings?.simpleBinding,
-    [node.id],
+  const currentLanguage = useCurrentLanguage();
+  const { formDataSelector } = GeneratorData.useValidationDataSources();
+  const field = NodesInternal.useNodeData(node, (data) => data.layout.dataModelBindings?.simpleBinding);
+  const minDate = getDateConstraint(
+    NodesInternal.useNodeData(node, (data) => data.layout.minDate),
+    'min',
+  );
+  const maxDate = getDateConstraint(
+    NodesInternal.useNodeData(node, (data) => data.layout.maxDate),
+    'max',
+  );
+  const format = getDateFormat(
+    NodesInternal.useNodeData(node, (data) => data.layout.format),
+    currentLanguage,
   );
   const data = field ? formDataSelector(field) : undefined;
   const dataAsString = typeof data === 'string' || typeof data === 'number' ? String(data) : undefined;
@@ -18,18 +30,6 @@ export function useDatepickerValidation(node: LayoutNode<'Datepicker'>): Compone
     return [];
   }
 
-  const minDate = getDateConstraint(
-    nodeDataSelector((picker) => picker(node.id, 'Datepicker')?.item?.minDate, [node.id]),
-    'min',
-  );
-  const maxDate = getDateConstraint(
-    nodeDataSelector((picker) => picker(node.id, 'Datepicker')?.item?.maxDate, [node.id]),
-    'max',
-  );
-  const format = getDateFormat(
-    nodeDataSelector((picker) => picker(node.id, 'Datepicker')?.item?.format, [node.id]),
-    currentLanguage,
-  );
   const datePickerFormat = getDatepickerFormat(format).toUpperCase();
 
   const validations: ComponentValidation[] = [];

--- a/src/layout/Dropdown/index.tsx
+++ b/src/layout/Dropdown/index.tsx
@@ -3,14 +3,14 @@ import type { JSX } from 'react';
 
 import { useDisplayData } from 'src/features/displayData/useDisplayData';
 import { getSelectedValueToText } from 'src/features/options/getSelectedValueToText';
-import { runEmptyFieldValidationOnlySimpleBinding } from 'src/features/validation/nodeValidation/emptyFieldValidation';
+import { useEmptyFieldValidationOnlySimpleBinding } from 'src/features/validation/nodeValidation/emptyFieldValidation';
 import { DropdownDef } from 'src/layout/Dropdown/config.def.generated';
 import { DropdownComponent } from 'src/layout/Dropdown/DropdownComponent';
 import { DropdownSummary } from 'src/layout/Dropdown/DropdownSummary';
 import { SummaryItemSimple } from 'src/layout/Summary/SummaryItemSimple';
 import type { LayoutValidationCtx } from 'src/features/devtools/layoutValidation/types';
 import type { DisplayDataProps } from 'src/features/displayData';
-import type { ComponentValidation, ValidationDataSources } from 'src/features/validation';
+import type { ComponentValidation } from 'src/features/validation';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types';
@@ -48,11 +48,8 @@ export class Dropdown extends DropdownDef {
     );
   }
 
-  runEmptyFieldValidation(
-    node: BaseLayoutNode<'Dropdown'>,
-    validationDataSources: ValidationDataSources,
-  ): ComponentValidation[] {
-    return runEmptyFieldValidationOnlySimpleBinding(node, validationDataSources);
+  useEmptyFieldValidation(node: BaseLayoutNode<'Dropdown'>): ComponentValidation[] {
+    return useEmptyFieldValidationOnlySimpleBinding(node);
   }
 
   validateDataModelBindings(ctx: LayoutValidationCtx<'Dropdown'>): string[] {

--- a/src/layout/FileUpload/index.tsx
+++ b/src/layout/FileUpload/index.tsx
@@ -1,16 +1,16 @@
 import React, { forwardRef } from 'react';
 import type { JSX } from 'react';
 
-import { FrontendValidationSource, ValidationMask } from 'src/features/validation';
 import { AttachmentSummaryComponent2 } from 'src/layout/FileUpload/AttachmentSummaryComponent2';
 import { FileUploadDef } from 'src/layout/FileUpload/config.def.generated';
 import { FileUploadComponent } from 'src/layout/FileUpload/FileUploadComponent';
 import { FileUploadLayoutValidator } from 'src/layout/FileUpload/FileUploadLayoutValidator';
 import { AttachmentSummaryComponent } from 'src/layout/FileUpload/Summary/AttachmentSummaryComponent';
+import { useValidateMinNumberOfAttachments } from 'src/layout/FileUpload/useValidateMinNumberOfAttachments';
 import { LayoutPage } from 'src/utils/layout/LayoutPage';
 import type { LayoutValidationCtx } from 'src/features/devtools/layoutValidation/types';
 import type { DisplayDataProps } from 'src/features/displayData';
-import type { ComponentValidation, ValidationDataSources } from 'src/features/validation';
+import type { ComponentValidation } from 'src/features/validation';
 import type { PropsFromGenericComponent, ValidateComponent } from 'src/layout';
 import type { NodeValidationProps } from 'src/layout/layout';
 import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
@@ -51,40 +51,12 @@ export class FileUpload extends FileUploadDef implements ValidateComponent<'File
   }
 
   // This component does not have empty field validation, so has to override its inherited method
-  runEmptyFieldValidation(): ComponentValidation[] {
+  useEmptyFieldValidation(): ComponentValidation[] {
     return [];
   }
 
-  runComponentValidation(
-    node: LayoutNode<'FileUpload'>,
-    { attachmentsSelector, nodeDataSelector }: ValidationDataSources,
-  ): ComponentValidation[] {
-    const validations: ComponentValidation[] = [];
-    const minNumberOfAttachments = nodeDataSelector(
-      (picker) => picker(node.id, 'FileUpload')?.item?.minNumberOfAttachments,
-      [node.id],
-    );
-
-    // Validate minNumberOfAttachments
-    const attachments = attachmentsSelector(node.id);
-    if (
-      minNumberOfAttachments !== undefined &&
-      minNumberOfAttachments > 0 &&
-      attachments.length < minNumberOfAttachments
-    ) {
-      validations.push({
-        message: {
-          key: 'form_filler.file_uploader_validation_error_file_number',
-          params: [minNumberOfAttachments],
-        },
-        severity: 'error',
-        source: FrontendValidationSource.Component,
-        // Treat visibility of minNumberOfAttachments the same as required to prevent showing an error immediately
-        category: ValidationMask.Required,
-      });
-    }
-
-    return validations;
+  useComponentValidation(node: LayoutNode<'FileUpload'>): ComponentValidation[] {
+    return useValidateMinNumberOfAttachments(node);
   }
 
   isDataModelBindingsRequired(node: LayoutNode<'FileUpload'>): boolean {

--- a/src/layout/FileUpload/useValidateMinNumberOfAttachments.ts
+++ b/src/layout/FileUpload/useValidateMinNumberOfAttachments.ts
@@ -1,0 +1,35 @@
+import { FrontendValidationSource, ValidationMask } from 'src/features/validation';
+import { GeneratorData } from 'src/utils/layout/generator/GeneratorDataSources';
+import type { ComponentValidation } from 'src/features/validation';
+import type { LayoutNode } from 'src/utils/layout/LayoutNode';
+
+export function useValidateMinNumberOfAttachments(
+  node: LayoutNode<'FileUpload' | 'FileUploadWithTag'>,
+): ComponentValidation[] {
+  const { nodeDataSelector, attachmentsSelector } = GeneratorData.useValidationDataSources();
+  const validations: ComponentValidation[] = [];
+  const minNumberOfAttachments = nodeDataSelector(
+    (picker) => picker(node.id, 'FileUploadWithTag')?.item?.minNumberOfAttachments,
+    [node.id],
+  );
+
+  const attachments = attachmentsSelector(node.id);
+  if (
+    minNumberOfAttachments !== undefined &&
+    minNumberOfAttachments > 0 &&
+    attachments.length < minNumberOfAttachments
+  ) {
+    validations.push({
+      message: {
+        key: 'form_filler.file_uploader_validation_error_file_number',
+        params: [minNumberOfAttachments],
+      },
+      severity: 'error',
+      source: FrontendValidationSource.Component,
+      // Treat visibility of minNumberOfAttachments the same as required to prevent showing an error immediately
+      category: ValidationMask.Required,
+    });
+  }
+
+  return validations;
+}

--- a/src/layout/FileUpload/useValidateMinNumberOfAttachments.ts
+++ b/src/layout/FileUpload/useValidateMinNumberOfAttachments.ts
@@ -1,17 +1,15 @@
 import { FrontendValidationSource, ValidationMask } from 'src/features/validation';
 import { GeneratorData } from 'src/utils/layout/generator/GeneratorDataSources';
+import { NodesInternal } from 'src/utils/layout/NodesContext';
 import type { ComponentValidation } from 'src/features/validation';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export function useValidateMinNumberOfAttachments(
   node: LayoutNode<'FileUpload' | 'FileUploadWithTag'>,
 ): ComponentValidation[] {
-  const { nodeDataSelector, attachmentsSelector } = GeneratorData.useValidationDataSources();
+  const minNumberOfAttachments = NodesInternal.useNodeData(node, (d) => d.layout.minNumberOfAttachments);
+  const { attachmentsSelector } = GeneratorData.useValidationDataSources();
   const validations: ComponentValidation[] = [];
-  const minNumberOfAttachments = nodeDataSelector(
-    (picker) => picker(node.id, 'FileUploadWithTag')?.item?.minNumberOfAttachments,
-    [node.id],
-  );
 
   const attachments = attachmentsSelector(node.id);
   if (

--- a/src/layout/FileUpload/useValidateMinNumberOfAttachments.ts
+++ b/src/layout/FileUpload/useValidateMinNumberOfAttachments.ts
@@ -1,5 +1,4 @@
 import { FrontendValidationSource, ValidationMask } from 'src/features/validation';
-import { GeneratorData } from 'src/utils/layout/generator/GeneratorDataSources';
 import { NodesInternal } from 'src/utils/layout/NodesContext';
 import type { ComponentValidation } from 'src/features/validation';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
@@ -8,10 +7,9 @@ export function useValidateMinNumberOfAttachments(
   node: LayoutNode<'FileUpload' | 'FileUploadWithTag'>,
 ): ComponentValidation[] {
   const minNumberOfAttachments = NodesInternal.useNodeData(node, (d) => d.layout.minNumberOfAttachments);
-  const { attachmentsSelector } = GeneratorData.useValidationDataSources();
+  const attachments = NodesInternal.useAttachments(node.id);
   const validations: ComponentValidation[] = [];
 
-  const attachments = attachmentsSelector(node.id);
   if (
     minNumberOfAttachments !== undefined &&
     minNumberOfAttachments > 0 &&

--- a/src/layout/FileUploadWithTag/useValidateMissingTag.ts
+++ b/src/layout/FileUploadWithTag/useValidateMissingTag.ts
@@ -1,0 +1,41 @@
+import { isAttachmentUploaded } from 'src/features/attachments';
+import { FrontendValidationSource, ValidationMask } from 'src/features/validation';
+import { GeneratorData } from 'src/utils/layout/generator/GeneratorDataSources';
+import type { AttachmentValidation, ComponentValidation } from 'src/features/validation';
+import type { LayoutNode } from 'src/utils/layout/LayoutNode';
+
+export function useValidateMissingTag(node: LayoutNode<'FileUploadWithTag'>): ComponentValidation[] {
+  const { attachmentsSelector, nodeDataSelector } = GeneratorData.useValidationDataSources();
+  const attachments = attachmentsSelector(node.id);
+  const validations: ComponentValidation[] = [];
+
+  for (const attachment of attachments) {
+    if (isAttachmentUploaded(attachment) && (attachment.data.tags === undefined || attachment.data.tags.length === 0)) {
+      const tagKey = nodeDataSelector(
+        (picker) => picker(node.id, 'FileUploadWithTag')?.item?.textResourceBindings?.tagTitle,
+        [node.id],
+      );
+      const tagReference = tagKey
+        ? {
+            key: tagKey,
+            makeLowerCase: true,
+          }
+        : 'tag';
+
+      const validation: AttachmentValidation = {
+        message: {
+          key: 'form_filler.file_uploader_validation_error_no_chosen_tag',
+          params: [tagReference],
+        },
+        severity: 'error',
+        source: FrontendValidationSource.Component,
+        attachmentId: attachment.data.id,
+        // Treat visibility of missing tag the same as required to prevent showing an error immediately
+        category: ValidationMask.Required,
+      };
+      validations.push(validation);
+    }
+  }
+
+  return validations;
+}

--- a/src/layout/FileUploadWithTag/useValidateMissingTag.ts
+++ b/src/layout/FileUploadWithTag/useValidateMissingTag.ts
@@ -1,14 +1,12 @@
 import { isAttachmentUploaded } from 'src/features/attachments';
 import { FrontendValidationSource, ValidationMask } from 'src/features/validation';
-import { GeneratorData } from 'src/utils/layout/generator/GeneratorDataSources';
 import { NodesInternal } from 'src/utils/layout/NodesContext';
 import type { AttachmentValidation, ComponentValidation } from 'src/features/validation';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export function useValidateMissingTag(node: LayoutNode<'FileUploadWithTag'>): ComponentValidation[] {
   const tagKey = NodesInternal.useNodeData(node, (d) => d.item?.textResourceBindings?.tagTitle);
-  const { attachmentsSelector } = GeneratorData.useValidationDataSources();
-  const attachments = attachmentsSelector(node.id);
+  const attachments = NodesInternal.useAttachments(node.id);
   const validations: ComponentValidation[] = [];
 
   for (const attachment of attachments) {

--- a/src/layout/FileUploadWithTag/useValidateMissingTag.ts
+++ b/src/layout/FileUploadWithTag/useValidateMissingTag.ts
@@ -1,20 +1,18 @@
 import { isAttachmentUploaded } from 'src/features/attachments';
 import { FrontendValidationSource, ValidationMask } from 'src/features/validation';
 import { GeneratorData } from 'src/utils/layout/generator/GeneratorDataSources';
+import { NodesInternal } from 'src/utils/layout/NodesContext';
 import type { AttachmentValidation, ComponentValidation } from 'src/features/validation';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export function useValidateMissingTag(node: LayoutNode<'FileUploadWithTag'>): ComponentValidation[] {
-  const { attachmentsSelector, nodeDataSelector } = GeneratorData.useValidationDataSources();
+  const tagKey = NodesInternal.useNodeData(node, (d) => d.item?.textResourceBindings?.tagTitle);
+  const { attachmentsSelector } = GeneratorData.useValidationDataSources();
   const attachments = attachmentsSelector(node.id);
   const validations: ComponentValidation[] = [];
 
   for (const attachment of attachments) {
     if (isAttachmentUploaded(attachment) && (attachment.data.tags === undefined || attachment.data.tags.length === 0)) {
-      const tagKey = nodeDataSelector(
-        (picker) => picker(node.id, 'FileUploadWithTag')?.item?.textResourceBindings?.tagTitle,
-        [node.id],
-      );
       const tagReference = tagKey
         ? {
             key: tagKey,

--- a/src/layout/LayoutComponent.tsx
+++ b/src/layout/LayoutComponent.tsx
@@ -7,7 +7,7 @@ import type { JSONSchema7 } from 'json-schema';
 import { lookupErrorAsText } from 'src/features/datamodel/lookupErrorAsText';
 import { DefaultNodeInspector } from 'src/features/devtools/components/NodeInspector/DefaultNodeInspector';
 import { useDisplayData } from 'src/features/displayData/useDisplayData';
-import { runEmptyFieldValidationAllBindings } from 'src/features/validation/nodeValidation/emptyFieldValidation';
+import { useEmptyFieldValidationAllBindings } from 'src/features/validation/nodeValidation/emptyFieldValidation';
 import { CompCategory } from 'src/layout/common';
 import { getComponentCapabilities } from 'src/layout/index';
 import { SummaryItemCompact } from 'src/layout/Summary/SummaryItemCompact';
@@ -16,7 +16,7 @@ import type { CompCapabilities } from 'src/codegen/Config';
 import type { LayoutValidationCtx } from 'src/features/devtools/layoutValidation/types';
 import type { SimpleEval } from 'src/features/expressions';
 import type { ExprResolved, ExprVal } from 'src/features/expressions/types';
-import type { ComponentValidation, ValidationDataSources } from 'src/features/validation';
+import type { ComponentValidation } from 'src/features/validation';
 import type {
   ComponentBase,
   FormComponentProps,
@@ -350,8 +350,8 @@ export abstract class FormComponent<Type extends CompTypes>
 {
   readonly category = CompCategory.Form;
 
-  runEmptyFieldValidation(node: LayoutNode<Type>, ValidationDataSources: ValidationDataSources): ComponentValidation[] {
-    return runEmptyFieldValidationAllBindings(node, ValidationDataSources);
+  useEmptyFieldValidation(node: LayoutNode<Type>): ComponentValidation[] {
+    return useEmptyFieldValidationAllBindings(node);
   }
 }
 

--- a/src/layout/Likert/index.tsx
+++ b/src/layout/Likert/index.tsx
@@ -38,7 +38,7 @@ export class Likert extends LikertDef {
   }
 
   // This component does not have empty field validation, so has to override its inherited method
-  runEmptyFieldValidation(): ComponentValidation[] {
+  useEmptyFieldValidation(): ComponentValidation[] {
     return [];
   }
 

--- a/src/layout/LikertItem/index.tsx
+++ b/src/layout/LikertItem/index.tsx
@@ -3,14 +3,14 @@ import type { JSX } from 'react';
 
 import { useDisplayData } from 'src/features/displayData/useDisplayData';
 import { getSelectedValueToText } from 'src/features/options/getSelectedValueToText';
-import { runEmptyFieldValidationOnlySimpleBinding } from 'src/features/validation/nodeValidation/emptyFieldValidation';
+import { useEmptyFieldValidationOnlySimpleBinding } from 'src/features/validation/nodeValidation/emptyFieldValidation';
 import { LikertItemDef } from 'src/layout/LikertItem/config.def.generated';
 import { LikertItemComponent } from 'src/layout/LikertItem/LikertItemComponent';
 import { SummaryItemSimple } from 'src/layout/Summary/SummaryItemSimple';
 import { BaseLayoutNode } from 'src/utils/layout/LayoutNode';
 import type { LayoutValidationCtx } from 'src/features/devtools/layoutValidation/types';
 import type { DisplayDataProps } from 'src/features/displayData';
-import type { ComponentValidation, ValidationDataSources } from 'src/features/validation';
+import type { ComponentValidation } from 'src/features/validation';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 
@@ -41,11 +41,8 @@ export class LikertItem extends LikertItemDef {
     return <SummaryItemSimple formDataAsString={displayData} />;
   }
 
-  runEmptyFieldValidation(
-    node: BaseLayoutNode<'LikertItem'>,
-    validationDataSources: ValidationDataSources,
-  ): ComponentValidation[] {
-    return runEmptyFieldValidationOnlySimpleBinding(node, validationDataSources);
+  useEmptyFieldValidation(node: BaseLayoutNode<'LikertItem'>): ComponentValidation[] {
+    return useEmptyFieldValidationOnlySimpleBinding(node);
   }
 
   validateDataModelBindings(ctx: LayoutValidationCtx<'LikertItem'>): string[] {

--- a/src/layout/List/index.tsx
+++ b/src/layout/List/index.tsx
@@ -5,15 +5,14 @@ import type { JSONSchema7Definition } from 'json-schema';
 
 import { useDisplayData } from 'src/features/displayData/useDisplayData';
 import { evalQueryParameters } from 'src/features/options/evalQueryParameters';
-import { FrontendValidationSource, ValidationMask } from 'src/features/validation';
 import { ListDef } from 'src/layout/List/config.def.generated';
 import { ListComponent } from 'src/layout/List/ListComponent';
 import { ListSummary } from 'src/layout/List/ListSummary';
+import { useValidateListIsEmpty } from 'src/layout/List/useValidateListIsEmpty';
 import { SummaryItemSimple } from 'src/layout/Summary/SummaryItemSimple';
-import { getFieldNameKey } from 'src/utils/formComponentUtils';
 import type { LayoutValidationCtx } from 'src/features/devtools/layoutValidation/types';
 import type { DisplayDataProps } from 'src/features/displayData';
-import type { ComponentValidation, ValidationDataSources } from 'src/features/validation';
+import type { ComponentValidation } from 'src/features/validation';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type { ExprResolver, SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types';
@@ -62,63 +61,8 @@ export class List extends ListDef {
     );
   }
 
-  runEmptyFieldValidation(
-    node: LayoutNode<'List'>,
-    { formDataSelector, invalidDataSelector, nodeDataSelector }: ValidationDataSources,
-  ): ComponentValidation[] {
-    const required = nodeDataSelector(
-      (picker) => {
-        const item = picker(node.id, 'List')?.item;
-        return item && 'required' in item ? item.required : false;
-      },
-      [node.id],
-    );
-    const dataModelBindings = nodeDataSelector(
-      (picker) => picker(node.id, 'List')?.layout.dataModelBindings,
-      [node.id],
-    );
-    if (!required || !dataModelBindings) {
-      return [];
-    }
-
-    const references = Object.values(dataModelBindings);
-    const validations: ComponentValidation[] = [];
-    const textResourceBindings = nodeDataSelector(
-      (picker) => picker(node.id, 'List')?.item?.textResourceBindings,
-      [node.id],
-    );
-
-    let listHasErrors = false;
-    for (const reference of references) {
-      const data = formDataSelector(reference) ?? invalidDataSelector(reference);
-      const dataAsString =
-        typeof data === 'string' || typeof data === 'number' || typeof data === 'boolean' ? String(data) : undefined;
-
-      if (!dataAsString?.length) {
-        listHasErrors = true;
-      }
-    }
-    if (listHasErrors) {
-      const key = textResourceBindings?.requiredValidation
-        ? textResourceBindings?.requiredValidation
-        : 'form_filler.error_required';
-
-      const fieldNameReference = {
-        key: getFieldNameKey(textResourceBindings, undefined),
-        makeLowerCase: true,
-      };
-
-      validations.push({
-        message: {
-          key,
-          params: [fieldNameReference],
-        },
-        severity: 'error',
-        source: FrontendValidationSource.EmptyField,
-        category: ValidationMask.Required,
-      });
-    }
-    return validations;
+  useEmptyFieldValidation(node: LayoutNode<'List'>): ComponentValidation[] {
+    return useValidateListIsEmpty(node);
   }
 
   validateDataModelBindings(ctx: LayoutValidationCtx<'List'>): string[] {

--- a/src/layout/List/useValidateListIsEmpty.ts
+++ b/src/layout/List/useValidateListIsEmpty.ts
@@ -1,29 +1,21 @@
 import { FrontendValidationSource, ValidationMask } from 'src/features/validation';
 import { getFieldNameKey } from 'src/utils/formComponentUtils';
 import { GeneratorData } from 'src/utils/layout/generator/GeneratorDataSources';
+import { NodesInternal } from 'src/utils/layout/NodesContext';
 import type { ComponentValidation } from 'src/features/validation';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export function useValidateListIsEmpty(node: LayoutNode<'List'>): ComponentValidation[] {
-  const { nodeDataSelector, formDataSelector, invalidDataSelector } = GeneratorData.useValidationDataSources();
-  const required = nodeDataSelector(
-    (picker) => {
-      const item = picker(node.id, 'List')?.item;
-      return item && 'required' in item ? item.required : false;
-    },
-    [node.id],
-  );
-  const dataModelBindings = nodeDataSelector((picker) => picker(node.id, 'List')?.layout.dataModelBindings, [node.id]);
+  const required = NodesInternal.useNodeData(node, (d) => (d.item && 'required' in d.item ? d.item.required : false));
+  const dataModelBindings = NodesInternal.useNodeData(node, (d) => d.layout.dataModelBindings);
+  const textResourceBindings = NodesInternal.useNodeData(node, (d) => d.item?.textResourceBindings);
+  const { formDataSelector, invalidDataSelector } = GeneratorData.useValidationDataSources();
   if (!required || !dataModelBindings) {
     return [];
   }
 
   const references = Object.values(dataModelBindings);
   const validations: ComponentValidation[] = [];
-  const textResourceBindings = nodeDataSelector(
-    (picker) => picker(node.id, 'List')?.item?.textResourceBindings,
-    [node.id],
-  );
 
   let listHasErrors = false;
   for (const reference of references) {

--- a/src/layout/List/useValidateListIsEmpty.ts
+++ b/src/layout/List/useValidateListIsEmpty.ts
@@ -1,0 +1,59 @@
+import { FrontendValidationSource, ValidationMask } from 'src/features/validation';
+import { getFieldNameKey } from 'src/utils/formComponentUtils';
+import { GeneratorData } from 'src/utils/layout/generator/GeneratorDataSources';
+import type { ComponentValidation } from 'src/features/validation';
+import type { LayoutNode } from 'src/utils/layout/LayoutNode';
+
+export function useValidateListIsEmpty(node: LayoutNode<'List'>): ComponentValidation[] {
+  const { nodeDataSelector, formDataSelector, invalidDataSelector } = GeneratorData.useValidationDataSources();
+  const required = nodeDataSelector(
+    (picker) => {
+      const item = picker(node.id, 'List')?.item;
+      return item && 'required' in item ? item.required : false;
+    },
+    [node.id],
+  );
+  const dataModelBindings = nodeDataSelector((picker) => picker(node.id, 'List')?.layout.dataModelBindings, [node.id]);
+  if (!required || !dataModelBindings) {
+    return [];
+  }
+
+  const references = Object.values(dataModelBindings);
+  const validations: ComponentValidation[] = [];
+  const textResourceBindings = nodeDataSelector(
+    (picker) => picker(node.id, 'List')?.item?.textResourceBindings,
+    [node.id],
+  );
+
+  let listHasErrors = false;
+  for (const reference of references) {
+    const data = formDataSelector(reference) ?? invalidDataSelector(reference);
+    const dataAsString =
+      typeof data === 'string' || typeof data === 'number' || typeof data === 'boolean' ? String(data) : undefined;
+
+    if (!dataAsString?.length) {
+      listHasErrors = true;
+    }
+  }
+  if (listHasErrors) {
+    const key = textResourceBindings?.requiredValidation
+      ? textResourceBindings?.requiredValidation
+      : 'form_filler.error_required';
+
+    const fieldNameReference = {
+      key: getFieldNameKey(textResourceBindings, undefined),
+      makeLowerCase: true,
+    };
+
+    validations.push({
+      message: {
+        key,
+        params: [fieldNameReference],
+      },
+      severity: 'error',
+      source: FrontendValidationSource.EmptyField,
+      category: ValidationMask.Required,
+    });
+  }
+  return validations;
+}

--- a/src/layout/List/useValidateListIsEmpty.ts
+++ b/src/layout/List/useValidateListIsEmpty.ts
@@ -1,6 +1,6 @@
+import { FD } from 'src/features/formData/FormDataWrite';
 import { FrontendValidationSource, ValidationMask } from 'src/features/validation';
 import { getFieldNameKey } from 'src/utils/formComponentUtils';
-import { GeneratorData } from 'src/utils/layout/generator/GeneratorDataSources';
 import { NodesInternal } from 'src/utils/layout/NodesContext';
 import type { ComponentValidation } from 'src/features/validation';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
@@ -9,7 +9,8 @@ export function useValidateListIsEmpty(node: LayoutNode<'List'>): ComponentValid
   const required = NodesInternal.useNodeData(node, (d) => (d.item && 'required' in d.item ? d.item.required : false));
   const dataModelBindings = NodesInternal.useNodeData(node, (d) => d.layout.dataModelBindings);
   const textResourceBindings = NodesInternal.useNodeData(node, (d) => d.item?.textResourceBindings);
-  const { formDataSelector, invalidDataSelector } = GeneratorData.useValidationDataSources();
+  const formDataSelector = FD.useDebouncedSelector();
+  const invalidDataSelector = FD.useInvalidDebouncedSelector();
   if (!required || !dataModelBindings) {
     return [];
   }

--- a/src/layout/MultipleSelect/index.tsx
+++ b/src/layout/MultipleSelect/index.tsx
@@ -2,14 +2,14 @@ import React, { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { getCommaSeparatedOptionsToText } from 'src/features/options/getCommaSeparatedOptionsToText';
-import { runEmptyFieldValidationOnlySimpleBinding } from 'src/features/validation/nodeValidation/emptyFieldValidation';
+import { useEmptyFieldValidationOnlySimpleBinding } from 'src/features/validation/nodeValidation/emptyFieldValidation';
 import { MultipleChoiceSummary } from 'src/layout/Checkboxes/MultipleChoiceSummary';
 import { MultipleSelectDef } from 'src/layout/MultipleSelect/config.def.generated';
 import { MultipleSelectComponent } from 'src/layout/MultipleSelect/MultipleSelectComponent';
 import { MultipleSelectSummary } from 'src/layout/MultipleSelect/MultipleSelectSummary';
 import type { LayoutValidationCtx } from 'src/features/devtools/layoutValidation/types';
 import type { DisplayDataProps } from 'src/features/displayData';
-import type { ComponentValidation, ValidationDataSources } from 'src/features/validation';
+import type { ComponentValidation } from 'src/features/validation';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types';
@@ -46,11 +46,8 @@ export class MultipleSelect extends MultipleSelectDef {
     );
   }
 
-  runEmptyFieldValidation(
-    node: BaseLayoutNode<'MultipleSelect'>,
-    validationDataSources: ValidationDataSources,
-  ): ComponentValidation[] {
-    return runEmptyFieldValidationOnlySimpleBinding(node, validationDataSources);
+  useEmptyFieldValidation(node: BaseLayoutNode<'MultipleSelect'>): ComponentValidation[] {
+    return useEmptyFieldValidationOnlySimpleBinding(node);
   }
 
   validateDataModelBindings(ctx: LayoutValidationCtx<'MultipleSelect'>): string[] {

--- a/src/layout/RadioButtons/index.tsx
+++ b/src/layout/RadioButtons/index.tsx
@@ -3,14 +3,14 @@ import type { JSX } from 'react';
 
 import { useDisplayData } from 'src/features/displayData/useDisplayData';
 import { getSelectedValueToText } from 'src/features/options/getSelectedValueToText';
-import { runEmptyFieldValidationOnlySimpleBinding } from 'src/features/validation/nodeValidation/emptyFieldValidation';
+import { useEmptyFieldValidationOnlySimpleBinding } from 'src/features/validation/nodeValidation/emptyFieldValidation';
 import { RadioButtonsDef } from 'src/layout/RadioButtons/config.def.generated';
 import { ControlledRadioGroup } from 'src/layout/RadioButtons/ControlledRadioGroup';
 import { RadioButtonsSummary } from 'src/layout/RadioButtons/RadioButtonsSummary';
 import { SummaryItemSimple } from 'src/layout/Summary/SummaryItemSimple';
 import type { LayoutValidationCtx } from 'src/features/devtools/layoutValidation/types';
 import type { DisplayDataProps } from 'src/features/displayData';
-import type { ComponentValidation, ValidationDataSources } from 'src/features/validation';
+import type { ComponentValidation } from 'src/features/validation';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types';
@@ -44,11 +44,8 @@ export class RadioButtons extends RadioButtonsDef {
     );
   }
 
-  runEmptyFieldValidation(
-    node: BaseLayoutNode<'RadioButtons'>,
-    validationDataSources: ValidationDataSources,
-  ): ComponentValidation[] {
-    return runEmptyFieldValidationOnlySimpleBinding(node, validationDataSources);
+  useEmptyFieldValidation(node: BaseLayoutNode<'RadioButtons'>): ComponentValidation[] {
+    return useEmptyFieldValidationOnlySimpleBinding(node);
   }
 
   validateDataModelBindings(ctx: LayoutValidationCtx<'RadioButtons'>): string[] {

--- a/src/layout/RepeatingGroup/index.tsx
+++ b/src/layout/RepeatingGroup/index.tsx
@@ -13,13 +13,13 @@ import { RepeatingGroupSummary } from 'src/layout/RepeatingGroup/Summary2/Repeat
 import { useValidateRepGroupMinCount } from 'src/layout/RepeatingGroup/useValidateRepGroupMinCount';
 import { splitDashedKey } from 'src/utils/splitDashedKey';
 import type { LayoutValidationCtx } from 'src/features/devtools/layoutValidation/types';
+import type { LayoutLookups } from 'src/features/form/layout/makeLayoutLookups';
 import type { BaseValidation, ComponentValidation } from 'src/features/validation';
 import type { ExprResolver, SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { GroupExpressions, RepGroupInternal, RepGroupRowExtras } from 'src/layout/RepeatingGroup/types';
 import type { RepeatingGroupSummaryOverrideProps } from 'src/layout/Summary2/config.generated';
 import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
-import type { NodeDataSelector } from 'src/utils/layout/NodesContext';
 import type { NodeData } from 'src/utils/layout/types';
 
 export class RepeatingGroup extends RepeatingGroupDef implements ValidateComponent<'RepeatingGroup'>, ValidationFilter {
@@ -110,8 +110,9 @@ export class RepeatingGroup extends RepeatingGroupDef implements ValidateCompone
     );
   }
 
-  getValidationFilters(node: LayoutNode<'RepeatingGroup'>, selector: NodeDataSelector): ValidationFilterFunction[] {
-    if (selector((picker) => picker(node.id, 'RepeatingGroup')?.item?.minCount ?? 0, [node.id]) > 0) {
+  getValidationFilters(node: LayoutNode<'RepeatingGroup'>, layoutLookups: LayoutLookups): ValidationFilterFunction[] {
+    const component = layoutLookups.getComponent(node.baseId, 'RepeatingGroup');
+    if (component.minCount && component.minCount > 0) {
       return [this.schemaMinItemsFilter];
     }
     return [];

--- a/src/layout/RepeatingGroup/index.tsx
+++ b/src/layout/RepeatingGroup/index.tsx
@@ -3,16 +3,17 @@ import type { JSX } from 'react';
 
 import type { PropsFromGenericComponent, ValidateComponent, ValidationFilter, ValidationFilterFunction } from '..';
 
-import { FrontendValidationSource, ValidationMask } from 'src/features/validation';
+import { FrontendValidationSource } from 'src/features/validation';
 import { RepeatingGroupDef } from 'src/layout/RepeatingGroup/config.def.generated';
 import { RepeatingGroupContainer } from 'src/layout/RepeatingGroup/Container/RepeatingGroupContainer';
 import { RepeatingGroupProvider } from 'src/layout/RepeatingGroup/Providers/RepeatingGroupContext';
 import { RepeatingGroupsFocusProvider } from 'src/layout/RepeatingGroup/Providers/RepeatingGroupFocusContext';
 import { SummaryRepeatingGroup } from 'src/layout/RepeatingGroup/Summary/SummaryRepeatingGroup';
 import { RepeatingGroupSummary } from 'src/layout/RepeatingGroup/Summary2/RepeatingGroupSummary';
+import { useValidateRepGroupMinCount } from 'src/layout/RepeatingGroup/useValidateRepGroupMinCount';
 import { splitDashedKey } from 'src/utils/splitDashedKey';
 import type { LayoutValidationCtx } from 'src/features/devtools/layoutValidation/types';
-import type { BaseValidation, ComponentValidation, ValidationDataSources } from 'src/features/validation';
+import type { BaseValidation, ComponentValidation } from 'src/features/validation';
 import type { ExprResolver, SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { GroupExpressions, RepGroupInternal, RepGroupRowExtras } from 'src/layout/RepeatingGroup/types';
 import type { RepeatingGroupSummaryOverrideProps } from 'src/layout/Summary2/config.generated';
@@ -96,39 +97,8 @@ export class RepeatingGroup extends RepeatingGroupDef implements ValidateCompone
     return false;
   }
 
-  runComponentValidation(
-    node: LayoutNode<'RepeatingGroup'>,
-    { nodeDataSelector }: ValidationDataSources,
-  ): ComponentValidation[] {
-    const dataModelBindings = nodeDataSelector(
-      (picker) => picker(node.id, 'RepeatingGroup')?.layout.dataModelBindings,
-      [node.id],
-    );
-    if (!dataModelBindings) {
-      return [];
-    }
-
-    const validations: ComponentValidation[] = [];
-    // check if minCount is less than visible rows
-    const minCount = nodeDataSelector((picker) => picker(node.id, 'RepeatingGroup')?.item?.minCount, [node.id]) ?? 0;
-    const visibleRows = nodeDataSelector(
-      (picker) =>
-        picker(node.id, 'RepeatingGroup')?.item?.rows?.filter((row) => row && !row.groupExpressions?.hiddenRow).length,
-      [node.id],
-    );
-
-    // Validate minCount
-    if (visibleRows !== undefined && visibleRows < minCount) {
-      validations.push({
-        message: { key: 'validation_errors.minItems', params: [minCount] },
-        severity: 'error',
-        source: FrontendValidationSource.Component,
-        // Treat visibility of minCount the same as required to prevent showing an error immediately
-        category: ValidationMask.Required,
-      });
-    }
-
-    return validations;
+  useComponentValidation(node: LayoutNode<'RepeatingGroup'>): ComponentValidation[] {
+    return useValidateRepGroupMinCount(node);
   }
 
   /**

--- a/src/layout/RepeatingGroup/useValidateRepGroupMinCount.ts
+++ b/src/layout/RepeatingGroup/useValidateRepGroupMinCount.ts
@@ -1,27 +1,22 @@
 import { FrontendValidationSource, ValidationMask } from 'src/features/validation';
-import { GeneratorData } from 'src/utils/layout/generator/GeneratorDataSources';
+import { NodesInternal } from 'src/utils/layout/NodesContext';
 import type { ComponentValidation } from 'src/features/validation';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export function useValidateRepGroupMinCount(node: LayoutNode<'RepeatingGroup'>): ComponentValidation[] {
-  const { nodeDataSelector } = GeneratorData.useValidationDataSources();
-  const dataModelBindings = nodeDataSelector(
-    (picker) => picker(node.id, 'RepeatingGroup')?.layout.dataModelBindings,
-    [node.id],
+  const dataModelBindings = NodesInternal.useNodeData(node, (d) => d.layout.dataModelBindings);
+  const minCount = NodesInternal.useNodeData(node, (d) => d.layout.minCount) ?? 0;
+  const visibleRows = NodesInternal.useNodeData(
+    node,
+    (d) => d.item?.rows.filter((row) => row && !row.groupExpressions?.hiddenRow).length,
   );
   if (!dataModelBindings) {
     return [];
   }
 
   const validations: ComponentValidation[] = [];
-  // check if minCount is less than visible rows
-  const minCount = nodeDataSelector((picker) => picker(node.id, 'RepeatingGroup')?.item?.minCount, [node.id]) ?? 0;
-  const visibleRows = nodeDataSelector(
-    (picker) =>
-      picker(node.id, 'RepeatingGroup')?.item?.rows?.filter((row) => row && !row.groupExpressions?.hiddenRow).length,
-    [node.id],
-  );
 
+  // check if minCount is less than visible rows
   if (visibleRows !== undefined && visibleRows < minCount) {
     validations.push({
       message: { key: 'validation_errors.minItems', params: [minCount] },

--- a/src/layout/RepeatingGroup/useValidateRepGroupMinCount.ts
+++ b/src/layout/RepeatingGroup/useValidateRepGroupMinCount.ts
@@ -1,0 +1,36 @@
+import { FrontendValidationSource, ValidationMask } from 'src/features/validation';
+import { GeneratorData } from 'src/utils/layout/generator/GeneratorDataSources';
+import type { ComponentValidation } from 'src/features/validation';
+import type { LayoutNode } from 'src/utils/layout/LayoutNode';
+
+export function useValidateRepGroupMinCount(node: LayoutNode<'RepeatingGroup'>): ComponentValidation[] {
+  const { nodeDataSelector } = GeneratorData.useValidationDataSources();
+  const dataModelBindings = nodeDataSelector(
+    (picker) => picker(node.id, 'RepeatingGroup')?.layout.dataModelBindings,
+    [node.id],
+  );
+  if (!dataModelBindings) {
+    return [];
+  }
+
+  const validations: ComponentValidation[] = [];
+  // check if minCount is less than visible rows
+  const minCount = nodeDataSelector((picker) => picker(node.id, 'RepeatingGroup')?.item?.minCount, [node.id]) ?? 0;
+  const visibleRows = nodeDataSelector(
+    (picker) =>
+      picker(node.id, 'RepeatingGroup')?.item?.rows?.filter((row) => row && !row.groupExpressions?.hiddenRow).length,
+    [node.id],
+  );
+
+  if (visibleRows !== undefined && visibleRows < minCount) {
+    validations.push({
+      message: { key: 'validation_errors.minItems', params: [minCount] },
+      severity: 'error',
+      source: FrontendValidationSource.Component,
+      // Treat visibility of minCount the same as required to prevent showing an error immediately
+      category: ValidationMask.Required,
+    });
+  }
+
+  return validations;
+}

--- a/src/layout/Subform/index.tsx
+++ b/src/layout/Subform/index.tsx
@@ -3,13 +3,7 @@ import { Route, Routes } from 'react-router-dom';
 import type { JSX, ReactNode } from 'react';
 
 import { TaskStoreProvider } from 'src/core/contexts/taskStoreContext';
-import {
-  type ComponentValidation,
-  FrontendValidationSource,
-  type SubformValidation,
-  type ValidationDataSources,
-  ValidationMask,
-} from 'src/features/validation';
+import { type ComponentValidation } from 'src/features/validation';
 import { type SummaryRendererProps } from 'src/layout/LayoutComponent';
 import { SubformDef } from 'src/layout/Subform/config.def.generated';
 import { SubformComponent } from 'src/layout/Subform/SubformComponent';
@@ -17,6 +11,7 @@ import { SubformValidator } from 'src/layout/Subform/SubformValidator';
 import { RedirectBackToMainForm, SubformForm, SubformWrapper } from 'src/layout/Subform/SubformWrapper';
 import { SubformSummaryComponent } from 'src/layout/Subform/Summary/SubformSummaryComponent';
 import { SubformSummaryComponent2 } from 'src/layout/Subform/Summary/SubformSummaryComponent2';
+import { useValidateSubform } from 'src/layout/Subform/useValidateSubform';
 import type { PropsFromGenericComponent, SubRouting, ValidateComponent } from 'src/layout';
 import type { NodeValidationProps } from 'src/layout/layout';
 import type { SubformSummaryOverrideProps } from 'src/layout/Summary2/config.generated';
@@ -73,69 +68,7 @@ export class Subform extends SubformDef implements ValidateComponent<'Subform'>,
     );
   }
 
-  runComponentValidation(
-    node: LayoutNode<'Subform'>,
-    {
-      applicationMetadata,
-      dataElementsSelector,
-      nodeDataSelector,
-      layoutSets,
-      dataElementHasErrorsSelector,
-    }: ValidationDataSources,
-  ): ComponentValidation[] {
-    const layoutSetName = nodeDataSelector((picker) => picker(node.id, 'Subform')?.layout.layoutSet, [node]);
-    if (!layoutSetName) {
-      throw new Error(`Layoutset not found for node with id ${node.id}.`);
-    }
-    const targetType = layoutSets.find((set) => set.id === layoutSetName)?.dataType;
-    if (!targetType) {
-      throw new Error(`Data type not found for layout with name ${layoutSetName}`);
-    }
-    const dataTypeDefinition = applicationMetadata.dataTypes.find((x) => x.id === targetType);
-    if (dataTypeDefinition === undefined) {
-      return [];
-    }
-
-    const validations: ComponentValidation[] = [];
-
-    const elements = dataElementsSelector((d) => d.filter((x) => x.dataType === targetType), [targetType]);
-    const numDataElements = Array.isArray(elements) ? elements.length : 0;
-    const { minCount, maxCount } = dataTypeDefinition;
-
-    if (minCount > 0 && numDataElements < minCount) {
-      validations.push({
-        message: { key: 'form_filler.error_min_count_not_reached_subform', params: [minCount, targetType] },
-        severity: 'error',
-        source: FrontendValidationSource.Component,
-        category: ValidationMask.Required,
-      });
-    }
-
-    if (maxCount > 0 && numDataElements > maxCount) {
-      validations.push({
-        message: { key: 'form_filler.error_max_count_reached_subform_local', params: [targetType, maxCount] },
-        severity: 'error',
-        source: FrontendValidationSource.Component,
-        category: ValidationMask.Required,
-      });
-    }
-
-    const subformIdsWithError = Array.isArray(elements)
-      ? elements?.map((dE) => dE.id).filter((id) => dataElementHasErrorsSelector(id))
-      : [];
-    if (subformIdsWithError?.length) {
-      const validation: SubformValidation = {
-        subformDataElementIds: subformIdsWithError,
-        message: { key: 'form_filler.error_validation_inside_subform', params: [targetType] },
-        severity: 'error',
-        source: FrontendValidationSource.Component,
-        category: ValidationMask.Required,
-        noIncrementalUpdates: true, // Validations for subform data is not updated incrementally in the main form
-      };
-
-      validations.push(validation);
-    }
-
-    return validations;
+  useComponentValidation(node: LayoutNode<'Subform'>): ComponentValidation[] {
+    return useValidateSubform(node);
   }
 }

--- a/src/layout/Subform/useValidateSubform.ts
+++ b/src/layout/Subform/useValidateSubform.ts
@@ -1,0 +1,63 @@
+import { FrontendValidationSource, ValidationMask } from 'src/features/validation';
+import { GeneratorData } from 'src/utils/layout/generator/GeneratorDataSources';
+import type { ComponentValidation, SubformValidation } from 'src/features/validation';
+import type { LayoutNode } from 'src/utils/layout/LayoutNode';
+
+export function useValidateSubform(node: LayoutNode<'Subform'>): ComponentValidation[] {
+  const { nodeDataSelector, dataElementsSelector, dataElementHasErrorsSelector, applicationMetadata, layoutSets } =
+    GeneratorData.useValidationDataSources();
+  const layoutSetName = nodeDataSelector((picker) => picker(node.id, 'Subform')?.layout.layoutSet, [node]);
+  if (!layoutSetName) {
+    throw new Error(`Layoutset not found for node with id ${node.id}.`);
+  }
+  const targetType = layoutSets.find((set) => set.id === layoutSetName)?.dataType;
+  if (!targetType) {
+    throw new Error(`Data type not found for layout with name ${layoutSetName}`);
+  }
+  const dataTypeDefinition = applicationMetadata.dataTypes.find((x) => x.id === targetType);
+  if (dataTypeDefinition === undefined) {
+    return [];
+  }
+
+  const validations: ComponentValidation[] = [];
+
+  const elements = dataElementsSelector((d) => d.filter((x) => x.dataType === targetType), [targetType]);
+  const numDataElements = Array.isArray(elements) ? elements.length : 0;
+  const { minCount, maxCount } = dataTypeDefinition;
+
+  if (minCount > 0 && numDataElements < minCount) {
+    validations.push({
+      message: { key: 'form_filler.error_min_count_not_reached_subform', params: [minCount, targetType] },
+      severity: 'error',
+      source: FrontendValidationSource.Component,
+      category: ValidationMask.Required,
+    });
+  }
+
+  if (maxCount > 0 && numDataElements > maxCount) {
+    validations.push({
+      message: { key: 'form_filler.error_max_count_reached_subform_local', params: [targetType, maxCount] },
+      severity: 'error',
+      source: FrontendValidationSource.Component,
+      category: ValidationMask.Required,
+    });
+  }
+
+  const subformIdsWithError = Array.isArray(elements)
+    ? elements?.map((dE) => dE.id).filter((id) => dataElementHasErrorsSelector(id))
+    : [];
+  if (subformIdsWithError?.length) {
+    const validation: SubformValidation = {
+      subformDataElementIds: subformIdsWithError,
+      message: { key: 'form_filler.error_validation_inside_subform', params: [targetType] },
+      severity: 'error',
+      source: FrontendValidationSource.Component,
+      category: ValidationMask.Required,
+      noIncrementalUpdates: true, // Validations for subform data is not updated incrementally in the main form
+    };
+
+    validations.push(validation);
+  }
+
+  return validations;
+}

--- a/src/layout/Subform/useValidateSubform.ts
+++ b/src/layout/Subform/useValidateSubform.ts
@@ -1,12 +1,16 @@
+import { useApplicationMetadata } from 'src/features/applicationMetadata/ApplicationMetadataProvider';
+import { useLayoutSets } from 'src/features/form/layoutSets/LayoutSetsProvider';
 import { FrontendValidationSource, ValidationMask } from 'src/features/validation';
 import { GeneratorData } from 'src/utils/layout/generator/GeneratorDataSources';
+import { NodesInternal } from 'src/utils/layout/NodesContext';
 import type { ComponentValidation, SubformValidation } from 'src/features/validation';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export function useValidateSubform(node: LayoutNode<'Subform'>): ComponentValidation[] {
-  const { nodeDataSelector, dataElementsSelector, dataElementHasErrorsSelector, applicationMetadata, layoutSets } =
-    GeneratorData.useValidationDataSources();
-  const layoutSetName = nodeDataSelector((picker) => picker(node.id, 'Subform')?.layout.layoutSet, [node]);
+  const applicationMetadata = useApplicationMetadata();
+  const layoutSets = useLayoutSets();
+  const layoutSetName = NodesInternal.useNodeData(node, (data) => data.layout.layoutSet);
+  const { dataElementsSelector, dataElementHasErrorsSelector } = GeneratorData.useValidationDataSources();
   if (!layoutSetName) {
     throw new Error(`Layoutset not found for node with id ${node.id}.`);
   }

--- a/src/layout/index.ts
+++ b/src/layout/index.ts
@@ -3,13 +3,13 @@ import type { MutableRefObject, ReactNode } from 'react';
 import { getComponentConfigs } from 'src/layout/components.generated';
 import type { CompBehaviors } from 'src/codegen/Config';
 import type { DisplayData } from 'src/features/displayData';
+import type { LayoutLookups } from 'src/features/form/layout/makeLayoutLookups';
 import type { BaseValidation, ComponentValidation } from 'src/features/validation';
 import type { IDataModelReference } from 'src/layout/common.generated';
 import type { IGenericComponentProps } from 'src/layout/GenericComponent';
 import type { CompInternal, CompTypes } from 'src/layout/layout';
 import type { AnyComponent } from 'src/layout/LayoutComponent';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
-import type { NodeDataSelector } from 'src/utils/layout/NodesContext';
 import type { BaseRow } from 'src/utils/layout/types';
 
 type ComponentConfigs = ReturnType<typeof getComponentConfigs>;
@@ -115,7 +115,7 @@ export type ValidationFilterFunction = (
 ) => boolean;
 
 export interface ValidationFilter {
-  getValidationFilters: (node: LayoutNode, nodeDataSelector: NodeDataSelector) => ValidationFilterFunction[];
+  getValidationFilters: (node: LayoutNode, layoutLookups: LayoutLookups) => ValidationFilterFunction[];
 }
 
 export type FormDataSelector = (reference: IDataModelReference) => unknown;

--- a/src/layout/index.ts
+++ b/src/layout/index.ts
@@ -3,7 +3,7 @@ import type { MutableRefObject, ReactNode } from 'react';
 import { getComponentConfigs } from 'src/layout/components.generated';
 import type { CompBehaviors } from 'src/codegen/Config';
 import type { DisplayData } from 'src/features/displayData';
-import type { BaseValidation, ComponentValidation, ValidationDataSources } from 'src/features/validation';
+import type { BaseValidation, ComponentValidation } from 'src/features/validation';
 import type { IDataModelReference } from 'src/layout/common.generated';
 import type { IGenericComponentProps } from 'src/layout/GenericComponent';
 import type { CompInternal, CompTypes } from 'src/layout/layout';
@@ -81,27 +81,27 @@ type TypeFromDef<Def extends CompDef> = Def extends CompDef<infer T> ? T : CompT
 export function implementsAnyValidation<Def extends CompDef>(
   def: Def,
 ): def is Def & (ValidateEmptyField<TypeFromDef<Def>> | ValidateComponent<TypeFromDef<Def>>) {
-  return 'runEmptyFieldValidation' in def || 'runComponentValidation' in def;
+  return 'useEmptyFieldValidation' in def || 'useComponentValidation' in def;
 }
 
 export interface ValidateEmptyField<Type extends CompTypes> {
-  runEmptyFieldValidation: (node: LayoutNode<Type>, validationContext: ValidationDataSources) => ComponentValidation[];
+  useEmptyFieldValidation: (node: LayoutNode<Type>) => ComponentValidation[];
 }
 
 export function implementsValidateEmptyField<Def extends CompDef>(
   def: Def,
 ): def is Def & ValidateEmptyField<TypeFromDef<Def>> {
-  return 'runEmptyFieldValidation' in def;
+  return 'useEmptyFieldValidation' in def;
 }
 
 export interface ValidateComponent<Type extends CompTypes> {
-  runComponentValidation: (node: LayoutNode<Type>, validationContext: ValidationDataSources) => ComponentValidation[];
+  useComponentValidation: (node: LayoutNode<Type>) => ComponentValidation[];
 }
 
 export function implementsValidateComponent<Def extends CompDef>(
   def: Def,
 ): def is Def & ValidateComponent<TypeFromDef<Def>> {
-  return 'runComponentValidation' in def;
+  return 'useComponentValidation' in def;
 }
 
 export interface SubRouting<Type extends CompTypes> {

--- a/src/utils/layout/generator/GeneratorDataSources.tsx
+++ b/src/utils/layout/generator/GeneratorDataSources.tsx
@@ -12,7 +12,6 @@ import { useLaxProcessData } from 'src/features/instance/ProcessContext';
 import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
 import { useInnerLanguageWithForcedNodeSelector } from 'src/features/language/useLanguage';
 import { useCodeListSelectorProps } from 'src/features/options/CodeListsProvider';
-import { Validation } from 'src/features/validation/validationContext';
 import { useMultipleDelayedSelectors } from 'src/hooks/delayedSelectors';
 import { useShallowMemo } from 'src/hooks/useShallowMemo';
 import { useCurrentDataModelLocation } from 'src/utils/layout/DataModelLocation';
@@ -106,25 +105,13 @@ function useExpressionDataSources(): ExpressionDataSources {
 }
 
 function useValidationDataSources(): ValidationDataSources {
-  const [
-    formDataSelector,
-    invalidDataSelector,
-    attachmentsSelector,
-    dataElementsSelector,
-    dataElementHasErrorsSelector,
-  ] = useMultipleDelayedSelectors(
+  const [formDataSelector, invalidDataSelector] = useMultipleDelayedSelectors(
     FD.useDebouncedSelectorProps(),
     FD.useInvalidDebouncedSelectorProps(),
-    NodesInternal.useAttachmentsSelectorProps(),
-    useLaxDataElementsSelectorProps(),
-    Validation.useDataElementHasErrorsSelectorProps(),
   );
 
   return useShallowMemo({
     formDataSelector,
     invalidDataSelector,
-    attachmentsSelector,
-    dataElementsSelector,
-    dataElementHasErrorsSelector,
   });
 }

--- a/src/utils/layout/generator/GeneratorDataSources.tsx
+++ b/src/utils/layout/generator/GeneratorDataSources.tsx
@@ -5,7 +5,6 @@ import { DataModels } from 'src/features/datamodel/DataModelsProvider';
 import { useDevToolsStore } from 'src/features/devtools/data/DevToolsStore';
 import { useExternalApis } from 'src/features/externalApi/useExternalApi';
 import { useLayoutLookups } from 'src/features/form/layout/LayoutsContext';
-import { useLayoutSets } from 'src/features/form/layoutSets/LayoutSetsProvider';
 import { useCurrentLayoutSet } from 'src/features/form/layoutSets/useCurrentLayoutSet';
 import { FD } from 'src/features/formData/FormDataWrite';
 import { useLaxDataElementsSelectorProps, useLaxInstanceDataSources } from 'src/features/instance/InstanceContext';
@@ -111,31 +110,21 @@ function useValidationDataSources(): ValidationDataSources {
     formDataSelector,
     invalidDataSelector,
     attachmentsSelector,
-    nodeDataSelector,
     dataElementsSelector,
     dataElementHasErrorsSelector,
   ] = useMultipleDelayedSelectors(
     FD.useDebouncedSelectorProps(),
     FD.useInvalidDebouncedSelectorProps(),
     NodesInternal.useAttachmentsSelectorProps(),
-    NodesInternal.useNodeDataSelectorProps(),
     useLaxDataElementsSelectorProps(),
     Validation.useDataElementHasErrorsSelectorProps(),
   );
-
-  const currentLanguage = useCurrentLanguage();
-  const applicationMetadata = useApplicationMetadata();
-  const layoutSets = useLayoutSets();
 
   return useShallowMemo({
     formDataSelector,
     invalidDataSelector,
     attachmentsSelector,
-    nodeDataSelector,
     dataElementsSelector,
     dataElementHasErrorsSelector,
-    currentLanguage,
-    applicationMetadata,
-    layoutSets,
   });
 }

--- a/src/utils/layout/generator/GeneratorDataSources.tsx
+++ b/src/utils/layout/generator/GeneratorDataSources.tsx
@@ -18,7 +18,6 @@ import { useCurrentDataModelLocation } from 'src/utils/layout/DataModelLocation'
 import { useCommitWhenFinished } from 'src/utils/layout/generator/CommitQueue';
 import { Hidden, NodesInternal } from 'src/utils/layout/NodesContext';
 import { useInnerDataModelBindingTranspose } from 'src/utils/layout/useDataModelBindingTranspose';
-import type { ValidationDataSources } from 'src/features/validation';
 import type { ExpressionDataSources } from 'src/utils/layout/useExpressionDataSources';
 
 const { Provider, hooks } = createHookContext({
@@ -35,7 +34,6 @@ const { Provider, hooks } = createHookContext({
 export const GeneratorData = {
   Provider,
   useExpressionDataSources,
-  useValidationDataSources,
   useDefaultDataType: hooks.useDefaultDataType,
   useIsForcedVisibleByDevTools: hooks.useIsForcedVisibleByDevTools,
   useGetDataElementIdForDataType: hooks.useGetDataElementIdForDataType,
@@ -101,17 +99,5 @@ function useExpressionDataSources(): ExpressionDataSources {
     codeListSelector,
     currentDataModelPath,
     layoutLookups,
-  });
-}
-
-function useValidationDataSources(): ValidationDataSources {
-  const [formDataSelector, invalidDataSelector] = useMultipleDelayedSelectors(
-    FD.useDebouncedSelectorProps(),
-    FD.useInvalidDebouncedSelectorProps(),
-  );
-
-  return useShallowMemo({
-    formDataSelector,
-    invalidDataSelector,
   });
 }


### PR DESCRIPTION
## Description

As a step to simplify the framework code and make us independent of `NodeData.item` having resolved expression values, I'm moving component-level validation to use plain hooks (i.e. `useEmptyFieldValidation(node)` instead of `runEmptyFieldValidation(node, validationDataSources)`).

This has a few advantages:
- It should be slightly easier to reason about what every node needs in order to validate, and make changes to that code. No need to extend `ValidationDataSources`, just use a hook to select the data you need from a store.
- In places we now select from `NodesContext` to get parts of `NodeData`, we can probably just resolve the expressions we need values for in the future - it should be better and more performant to evaluate an expression twice than having to store the results of all expressions and evaluate all of them regardless of the need to actually read those values.
- This won't actually break the rule of hooks as long as components don't change types during runtime - and luckily they don't.

The changes in this PR, simply put:
- Adding a utility function `layoutLookups.getComponent(baseId, expectedType)` that lets us get `CompExternal<ExpectedType>`, i.e. the configuration from the layout file.
- Removing `ValidationDataSources`
- Moved component-level validation functions to hooks, and extracted them from the `index.tsx` files
- Rewrote `useNodeValidation()` to use the hooks instead

## Related Issue(s)

- #2490

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
