### PR TITLE
Cleanup after recent refactoring

### DIFF
--- a/src/components/wrappers/ProcessWrapper.tsx
+++ b/src/components/wrappers/ProcessWrapper.tsx
@@ -173,7 +173,7 @@ export const ComponentRouting = () => {
   }
 
   function isSubroutingNode(node: LayoutNode): node is LayoutNode<'Subform'> {
-    return node.type === 'Subform' && !!node.def.subRouting;
+    return node.isType('Subform') && !!node.def.subRouting;
   }
 
   if (isSubroutingNode(node)) {

--- a/src/features/devtools/components/NodeInspector/DefaultNodeInspector.tsx
+++ b/src/features/devtools/components/NodeInspector/DefaultNodeInspector.tsx
@@ -23,9 +23,7 @@ export function DefaultNodeInspector({ node, ignoredProperties }: DefaultNodeIns
   const hiddenIsExpression = NodesInternal.useNodeData(node, (s) => Array.isArray(s.layout.hidden));
   const item = hiddenIsExpression ? { ..._item, hidden } : _item;
 
-  const ignoredPropertiesFinal = new Set(
-    ['id', 'type', 'multiPageIndex', 'baseComponentId'].concat(ignoredProperties ?? []),
-  );
+  const ignoredPropertiesFinal = new Set(['id', 'type'].concat(ignoredProperties ?? []));
 
   return (
     <dl className={cn(classes.propertyList, classes.mainPropertyList)}>

--- a/src/features/devtools/components/NodeInspector/NodeInspectorDataField.tsx
+++ b/src/features/devtools/components/NodeInspector/NodeInspectorDataField.tsx
@@ -8,10 +8,9 @@ import { useNodeInspectorContext } from 'src/features/devtools/components/NodeIn
 import { useDevToolsStore } from 'src/features/devtools/data/DevToolsStore';
 import { DevToolsTab } from 'src/features/devtools/data/types';
 import { canBeExpression } from 'src/features/expressions/validation';
-import { BaseLayoutNode } from 'src/utils/layout/LayoutNode';
+import { LayoutNode } from 'src/utils/layout/LayoutNode';
 import { NodesInternal } from 'src/utils/layout/NodesContext';
 import { useNodeItem } from 'src/utils/layout/useNodeItem';
-import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 interface NodeInspectorDataFieldParams {
   path: string[];
@@ -208,7 +207,7 @@ export function NodeInspectorDataField({ path, property, value: inputValue }: No
     );
   }
 
-  if (typeof value === 'object' && value instanceof BaseLayoutNode) {
+  if (typeof value === 'object' && value instanceof LayoutNode) {
     return (
       <OtherNode
         property={property}

--- a/src/features/expressions/shared-functions.test.tsx
+++ b/src/features/expressions/shared-functions.test.tsx
@@ -19,7 +19,7 @@ import { fetchApplicationMetadata, fetchProcessState } from 'src/queries/queries
 import { renderWithNode } from 'src/test/renderWithProviders';
 import { DataModelLocationProvider } from 'src/utils/layout/DataModelLocation';
 import { useEvalExpression } from 'src/utils/layout/generator/useEvalExpression';
-import { BaseLayoutNode } from 'src/utils/layout/LayoutNode';
+import { LayoutNode } from 'src/utils/layout/LayoutNode';
 import { NodesInternal, useNode } from 'src/utils/layout/NodesContext';
 import type {
   ExprPositionalArgs,
@@ -32,7 +32,6 @@ import type { RepeatingComponents } from 'src/features/form/layout/utils/repeati
 import type { IRawOption } from 'src/layout/common.generated';
 import type { ILayoutCollection } from 'src/layout/layout';
 import type { IData, IDataType } from 'src/types/shared';
-import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 import type { LayoutPage } from 'src/utils/layout/LayoutPage';
 
 jest.mock('src/features/externalApi/useExternalApi');
@@ -86,12 +85,12 @@ function DataModelLocationFromNode({ nodeId, children }: PropsWithChildren<{ nod
 
 function getClosestRepeating(node: LayoutNode): [LayoutNode<RepeatingComponents>, number] | [undefined, undefined] {
   let subject: LayoutNode | LayoutPage = node;
-  while (subject.parent instanceof BaseLayoutNode && !isRepeatingComponentType(subject.parent.type)) {
+  while (subject.parent instanceof LayoutNode && !isRepeatingComponentType(subject.parent.type)) {
     subject = subject.parent;
   }
 
   const parent = subject.parent;
-  if (parent instanceof BaseLayoutNode && isRepeatingComponentType(parent.type)) {
+  if (parent instanceof LayoutNode && isRepeatingComponentType(parent.type)) {
     return [parent as LayoutNode<RepeatingComponents>, subject.rowIndex!];
   }
 

--- a/src/features/validation/selectors/bindingValidationsForNode.ts
+++ b/src/features/validation/selectors/bindingValidationsForNode.ts
@@ -6,7 +6,7 @@ import { Validation } from 'src/features/validation/validationContext';
 import { NodesInternal } from 'src/utils/layout/NodesContext';
 import { useNodeItem } from 'src/utils/layout/useNodeItem';
 import type { CompTypes, IDataModelBindings } from 'src/layout/layout';
-import type { BaseLayoutNode, LayoutNode } from 'src/utils/layout/LayoutNode';
+import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 type OutValues = NodeValidation<ComponentValidation | FieldValidation>[];
 
@@ -16,7 +16,7 @@ type OutValues = NodeValidation<ComponentValidation | FieldValidation>[];
  */
 export function useBindingValidationsForNode<
   N extends LayoutNode,
-  T extends CompTypes = N extends BaseLayoutNode<infer T> ? T : never,
+  T extends CompTypes = N extends LayoutNode<infer T> ? T : never,
 >(node: N): { [binding in keyof NonNullable<IDataModelBindings<T>>]: OutValues } | undefined {
   const showAll = Validation.useShowAllBackendErrors();
   const component = NodesInternal.useVisibleValidations(node, showAll);

--- a/src/layout/Cards/CardsPlugin.tsx
+++ b/src/layout/Cards/CardsPlugin.tsx
@@ -118,7 +118,7 @@ export class CardsPlugin<Type extends CompTypes>
     } as DefPluginExtraInItem<Config<Type>>;
   }
 
-  pickDirectChildren(state: DefPluginState<Config<Type>>, restriction?: number | undefined | undefined): string[] {
+  pickDirectChildren(state: DefPluginState<Config<Type>>, restriction?: number | undefined): string[] {
     const out: string[] = [];
     if (restriction !== undefined) {
       return out;

--- a/src/layout/Cards/CardsPlugin.tsx
+++ b/src/layout/Cards/CardsPlugin.tsx
@@ -57,17 +57,18 @@ export class CardsPlugin<Type extends CompTypes>
     return `'${this.component!.type}'`;
   }
 
-  claimChildren({ item, claimChild, getProto }: DefPluginChildClaimerProps<Config<Type>>): void {
+  claimChildren({ item, claimChild, getType, getCapabilities }: DefPluginChildClaimerProps<Config<Type>>): void {
     for (const card of (item.cards || []).values()) {
       if (card.media) {
-        const proto = getProto(card.media);
-        if (!proto) {
+        const type = getType(card.media);
+        if (!type) {
           continue;
         }
-        if (!proto.capabilities.renderInCardsMedia) {
+        const capabilities = getCapabilities(type);
+        if (!capabilities.renderInCardsMedia) {
           window.logWarn(
             `Cards component included a component '${card.media}', which ` +
-              `is a '${proto.type}' and cannot be rendered as Card media.`,
+              `is a '${type}' and cannot be rendered as Card media.`,
           );
           continue;
         }
@@ -75,14 +76,15 @@ export class CardsPlugin<Type extends CompTypes>
       }
 
       for (const child of card.children?.values() ?? []) {
-        const proto = getProto(child);
-        if (!proto) {
+        const type = getType(child);
+        if (!type) {
           continue;
         }
-        if (!proto.capabilities.renderInCards) {
+        const capabilities = getCapabilities(type);
+        if (!capabilities.renderInCards) {
           window.logWarn(
             `Cards component included a component '${child}', which ` +
-              `is a '${proto.type}' and cannot be rendered as a Card child.`,
+              `is a '${type}' and cannot be rendered as a Card child.`,
           );
           continue;
         }

--- a/src/layout/Checkboxes/index.tsx
+++ b/src/layout/Checkboxes/index.tsx
@@ -16,7 +16,7 @@ import type { PropsFromGenericComponent } from 'src/layout';
 import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { CheckboxSummaryOverrideProps } from 'src/layout/Summary2/config.generated';
 import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types';
-import type { BaseLayoutNode } from 'src/utils/layout/LayoutNode';
+import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class Checkboxes extends CheckboxesDef {
   render = forwardRef<HTMLElement, PropsFromGenericComponent<'Checkboxes'>>(
@@ -48,7 +48,7 @@ export class Checkboxes extends CheckboxesDef {
     );
   }
 
-  useEmptyFieldValidation(node: BaseLayoutNode<'Checkboxes'>): ComponentValidation[] {
+  useEmptyFieldValidation(node: LayoutNode<'Checkboxes'>): ComponentValidation[] {
     return useEmptyFieldValidationOnlySimpleBinding(node);
   }
 

--- a/src/layout/Dropdown/index.tsx
+++ b/src/layout/Dropdown/index.tsx
@@ -16,7 +16,7 @@ import type { ComponentValidation } from 'src/features/validation';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types';
-import type { BaseLayoutNode } from 'src/utils/layout/LayoutNode';
+import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class Dropdown extends DropdownDef {
   render = forwardRef<HTMLElement, PropsFromGenericComponent<'Dropdown'>>(
@@ -52,7 +52,7 @@ export class Dropdown extends DropdownDef {
     );
   }
 
-  useEmptyFieldValidation(node: BaseLayoutNode<'Dropdown'>): ComponentValidation[] {
+  useEmptyFieldValidation(node: LayoutNode<'Dropdown'>): ComponentValidation[] {
     return useEmptyFieldValidationOnlySimpleBinding(node);
   }
 

--- a/src/layout/Grid/GridComponent.tsx
+++ b/src/layout/Grid/GridComponent.tsx
@@ -23,7 +23,7 @@ import {
   useNodeIdsFromGrid,
 } from 'src/layout/Grid/tools';
 import { getColumnStyles } from 'src/utils/formComponentUtils';
-import { BaseLayoutNode } from 'src/utils/layout/LayoutNode';
+import { LayoutNode } from 'src/utils/layout/LayoutNode';
 import { LayoutPage } from 'src/utils/layout/LayoutPage';
 import { Hidden, useNode } from 'src/utils/layout/NodesContext';
 import { useLabel } from 'src/utils/layout/useLabel';
@@ -31,7 +31,6 @@ import { useNodeItem } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type { ITableColumnFormatting, ITableColumnProperties } from 'src/layout/common.generated';
 import type { GridRowInternal } from 'src/layout/Grid/types';
-import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export function RenderGrid(props: PropsFromGenericComponent<'Grid'>) {
   const { node } = props;
@@ -40,7 +39,7 @@ export function RenderGrid(props: PropsFromGenericComponent<'Grid'>) {
   const shouldHaveFullWidth = node.parent instanceof LayoutPage;
   const columnSettings: ITableColumnFormatting = {};
   const isMobile = useIsMobile();
-  const isNested = node.parent instanceof BaseLayoutNode;
+  const isNested = node.parent instanceof LayoutNode;
   const { elementAsString } = useLanguage();
   const accessibleTitle = elementAsString(title);
 

--- a/src/layout/Grid/GridRowsPlugin.tsx
+++ b/src/layout/Grid/GridRowsPlugin.tsx
@@ -98,7 +98,7 @@ export class GridRowsPlugin<E extends ExternalConfig>
     component.addProperty(new CG.prop(this.settings.externalProp, prop));
   }
 
-  claimChildren({ item, claimChild, getProto }: DefPluginChildClaimerProps<ToInternal<E>>): void {
+  claimChildren({ item, claimChild, getType, getCapabilities }: DefPluginChildClaimerProps<ToInternal<E>>): void {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const rows = (item as any)[this.settings.externalProp] as GridRows | undefined;
     if (!rows) {
@@ -108,14 +108,15 @@ export class GridRowsPlugin<E extends ExternalConfig>
     for (const row of rows.values()) {
       for (const cell of row.cells.values()) {
         if (cell && 'component' in cell && cell.component) {
-          const proto = getProto(cell.component);
-          if (!proto) {
+          const type = getType(cell.component);
+          if (!type) {
             continue;
           }
-          if (!proto.capabilities.renderInTable) {
+          const capabilities = getCapabilities(type);
+          if (!capabilities.renderInTable) {
             window.logWarn(
               `Grid-like component included a component '${cell.component}', which ` +
-                `is a '${proto.type}' and cannot be rendered in a table.`,
+                `is a '${type}' and cannot be rendered in a table.`,
             );
             continue;
           }

--- a/src/layout/Grid/GridRowsPlugin.tsx
+++ b/src/layout/Grid/GridRowsPlugin.tsx
@@ -168,7 +168,7 @@ export class GridRowsPlugin<E extends ExternalConfig>
     } as DefPluginExtraInItem<ToInternal<E>>;
   }
 
-  pickDirectChildren(state: DefPluginState<ToInternal<E>>, restriction?: number | undefined | undefined): string[] {
+  pickDirectChildren(state: DefPluginState<ToInternal<E>>, restriction?: number | undefined): string[] {
     const out: string[] = [];
     if (restriction !== undefined) {
       return out;

--- a/src/layout/Grid/GridSummary.tsx
+++ b/src/layout/Grid/GridSummary.tsx
@@ -416,19 +416,18 @@ function CellWithText({ children, columnStyleOptions, isHeader = false, headerTi
 }
 
 function CellWithLabel({ cell, columnStyleOptions, isHeader = false, headerTitle, isSmall }: CellWithLabelProps) {
-  const referenceComponent = useNode(cell.labelFrom);
-  const refItem = useNodeItem(referenceComponent);
+  const referenceNode = useNode(cell.labelFrom);
+  const refItem = useNodeItem(referenceNode);
   const columnStyles = columnStyleOptions && getColumnStyles(columnStyleOptions);
   const trb = (refItem && 'textResourceBindings' in refItem ? refItem.textResourceBindings : {}) as
     | ITextResourceBindings
     | undefined;
   const title = trb && 'title' in trb ? trb.title : undefined;
-  const required = (referenceComponent && refItem && 'required' in refItem && refItem.required) ?? false;
-  const componentId = refItem?.id ?? refItem?.baseComponentId;
+  const required = (referenceNode && refItem && 'required' in refItem && refItem.required) ?? false;
 
   const CellComponent = isHeader ? Table.HeaderCell : Table.Cell;
 
-  if (!componentId) {
+  if (!referenceNode) {
     return <CellComponent />;
   }
 
@@ -438,9 +437,9 @@ function CellWithLabel({ cell, columnStyleOptions, isHeader = false, headerTitle
       style={columnStyles}
       data-header-title={isSmall ? headerTitle : ''}
     >
-      {componentId && (
+      {referenceNode && (
         <LabelContent
-          componentId={componentId}
+          componentId={referenceNode.id}
           label={title}
           required={required}
         />

--- a/src/layout/Group/GroupComponent.tsx
+++ b/src/layout/Group/GroupComponent.tsx
@@ -89,10 +89,10 @@ export function GroupComponent({
           }
         >
           <div
-            data-componentid={container.id}
-            data-componentbaseid={container.baseComponentId || container.id}
+            data-componentid={groupNode.id}
+            data-componentbaseid={groupNode.baseId}
             ref={containerDivRef}
-            id={id ?? container.id}
+            id={id ?? groupNode.id}
             data-testid='display-group-container'
             className={cn(classes.groupContainer, {
               [classes.indented]: isIndented && !isNested,

--- a/src/layout/Group/GroupComponent.tsx
+++ b/src/layout/Group/GroupComponent.tsx
@@ -10,11 +10,10 @@ import { ConditionalWrapper } from 'src/components/ConditionalWrapper';
 import { FullWidthWrapper } from 'src/components/form/FullWidthWrapper';
 import { Lang } from 'src/features/language/Lang';
 import classes from 'src/layout/Group/GroupComponent.module.css';
-import { BaseLayoutNode } from 'src/utils/layout/LayoutNode';
+import { LayoutNode } from 'src/utils/layout/LayoutNode';
 import { Hidden, NodesInternal } from 'src/utils/layout/NodesContext';
 import { useNodeDirectChildren, useNodeItem } from 'src/utils/layout/useNodeItem';
 import type { HeadingLevel } from 'src/layout/common.generated';
-import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export interface IGroupComponent {
   groupNode: LayoutNode<'Group'>;
@@ -52,7 +51,7 @@ export function GroupComponent({
     return null;
   }
 
-  const isNested = groupNode.parent instanceof BaseLayoutNode;
+  const isNested = groupNode.parent instanceof LayoutNode;
   const isPanel = container.groupingIndicator === 'panel';
   const isIndented = container.groupingIndicator === 'indented';
   const headingLevel = container.headingLevel ?? (Math.min(Math.max(depth + 1, 2), 6) as HeadingLevel);

--- a/src/layout/LayoutComponent.tsx
+++ b/src/layout/LayoutComponent.tsx
@@ -355,15 +355,11 @@ export abstract class FormComponent<Type extends CompTypes>
   }
 }
 
-export interface ComponentProto {
-  type: CompTypes;
-  capabilities: CompCapabilities;
-}
-
 export interface ChildClaimerProps<Type extends CompTypes> {
   item: CompExternal<Type>;
   claimChild: (pluginKey: string, id: string) => void;
-  getProto: (id: string) => ComponentProto | undefined;
+  getType: (id: string) => CompTypes | undefined;
+  getCapabilities: (type: CompTypes) => CompCapabilities;
 }
 
 export abstract class ContainerComponent<Type extends CompTypes> extends _FormComponent<Type> {

--- a/src/layout/Likert/Generator/LikertRowsPlugin.tsx
+++ b/src/layout/Likert/Generator/LikertRowsPlugin.tsx
@@ -68,7 +68,7 @@ export class LikertRowsPlugin extends NodeDefPlugin<Config> implements NodeDefCh
 
   claimChildren(_props: DefPluginChildClaimerProps<Config>) {}
 
-  pickDirectChildren(state: DefPluginState<Config>, restriction?: number | undefined | undefined): string[] {
+  pickDirectChildren(state: DefPluginState<Config>, restriction?: number | undefined): string[] {
     if (restriction !== undefined) {
       const nodeId = state.item?.rows[restriction]?.itemNodeId;
       return nodeId ? [nodeId] : [];

--- a/src/layout/Likert/Summary/LargeLikertSummaryContainer.tsx
+++ b/src/layout/Likert/Summary/LargeLikertSummaryContainer.tsx
@@ -61,8 +61,8 @@ export function LargeLikertSummaryContainer({
         )
       }
       className={classes.summary}
-      data-componentid={container.id}
-      data-componentbaseid={container.baseComponentId || container.id}
+      data-componentid={groupNode.id}
+      data-componentbaseid={groupNode.baseId}
     >
       <div
         ref={divRef}

--- a/src/layout/LikertItem/LikertItemComponent.tsx
+++ b/src/layout/LikertItem/LikertItemComponent.tsx
@@ -12,7 +12,7 @@ import { LayoutStyle } from 'src/layout/common.generated';
 import classes from 'src/layout/LikertItem/LikertItemComponent.module.css';
 import { ControlledRadioGroup } from 'src/layout/RadioButtons/ControlledRadioGroup';
 import { useRadioButtons } from 'src/layout/RadioButtons/radioButtonsUtils';
-import { BaseLayoutNode } from 'src/utils/layout/LayoutNode';
+import { LayoutNode } from 'src/utils/layout/LayoutNode';
 import { useNodeItem } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 
@@ -42,8 +42,7 @@ const RadioGroupTableRow = forwardRef<HTMLTableRowElement, PropsFromGenericCompo
   const validations = useUnifiedValidationsForNode(node);
 
   const { id, readOnly, textResourceBindings, required } = useNodeItem(node);
-  const groupContainer =
-    node.parent instanceof BaseLayoutNode && node.parent.isType('Likert') ? node.parent : undefined;
+  const groupContainer = node.parent instanceof LayoutNode && node.parent.isType('Likert') ? node.parent : undefined;
 
   const columns = useNodeItem(props.node, (i) => i.columns);
 

--- a/src/layout/LikertItem/index.tsx
+++ b/src/layout/LikertItem/index.tsx
@@ -9,7 +9,7 @@ import { useEmptyFieldValidationOnlySimpleBinding } from 'src/features/validatio
 import { LikertItemDef } from 'src/layout/LikertItem/config.def.generated';
 import { LikertItemComponent } from 'src/layout/LikertItem/LikertItemComponent';
 import { SummaryItemSimple } from 'src/layout/Summary/SummaryItemSimple';
-import { BaseLayoutNode } from 'src/utils/layout/LayoutNode';
+import { LayoutNode } from 'src/utils/layout/LayoutNode';
 import { useNodeFormDataWhenType } from 'src/utils/layout/useNodeItem';
 import type { LayoutValidationCtx } from 'src/features/devtools/layoutValidation/types';
 import type { ComponentValidation } from 'src/features/validation';
@@ -45,7 +45,7 @@ export class LikertItem extends LikertItemDef {
     return <SummaryItemSimple formDataAsString={displayData} />;
   }
 
-  useEmptyFieldValidation(node: BaseLayoutNode<'LikertItem'>): ComponentValidation[] {
+  useEmptyFieldValidation(node: LayoutNode<'LikertItem'>): ComponentValidation[] {
     return useEmptyFieldValidationOnlySimpleBinding(node);
   }
 
@@ -53,7 +53,7 @@ export class LikertItem extends LikertItemDef {
     const [answerErr] = this.validateDataModelBindingsAny(ctx, 'simpleBinding', ['string', 'number', 'boolean']);
     const errors: string[] = [...(answerErr ?? [])];
 
-    if (!(ctx.node.parent instanceof BaseLayoutNode) || !ctx.node.parent.isType('Likert')) {
+    if (!(ctx.node.parent instanceof LayoutNode) || !ctx.node.parent.isType('Likert')) {
       throw new Error('LikertItem must have a parent of type "Likert"');
     }
     const parentId = ctx.node.parent.id;

--- a/src/layout/MultipleSelect/index.tsx
+++ b/src/layout/MultipleSelect/index.tsx
@@ -15,7 +15,7 @@ import type { ComponentValidation } from 'src/features/validation';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types';
-import type { BaseLayoutNode } from 'src/utils/layout/LayoutNode';
+import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class MultipleSelect extends MultipleSelectDef {
   render = forwardRef<HTMLElement, PropsFromGenericComponent<'MultipleSelect'>>(
@@ -47,7 +47,7 @@ export class MultipleSelect extends MultipleSelectDef {
     );
   }
 
-  useEmptyFieldValidation(node: BaseLayoutNode<'MultipleSelect'>): ComponentValidation[] {
+  useEmptyFieldValidation(node: LayoutNode<'MultipleSelect'>): ComponentValidation[] {
     return useEmptyFieldValidationOnlySimpleBinding(node);
   }
 

--- a/src/layout/RadioButtons/ControlledRadioGroup.tsx
+++ b/src/layout/RadioButtons/ControlledRadioGroup.tsx
@@ -11,7 +11,7 @@ import { useIsValid } from 'src/features/validation/selectors/isValid';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
 import { useRadioButtons } from 'src/layout/RadioButtons/radioButtonsUtils';
 import { shouldUseRowLayout } from 'src/utils/layout';
-import { BaseLayoutNode } from 'src/utils/layout/LayoutNode';
+import { LayoutNode } from 'src/utils/layout/LayoutNode';
 import { useNodeItem } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 
@@ -21,7 +21,7 @@ export const ControlledRadioGroup = (props: IControlledRadioGroupProps) => {
   const { node, overrideDisplay } = props;
   const isValid = useIsValid(node);
   const item = useNodeItem(node);
-  const parentItem = useNodeItem(node.parent instanceof BaseLayoutNode ? node.parent : undefined);
+  const parentItem = useNodeItem(node.parent instanceof LayoutNode ? node.parent : undefined);
   const { id, layout, readOnly, textResourceBindings, required, showLabelsInTable } = item;
   const showAsCard = 'showAsCard' in item ? item.showAsCard : false;
   const { selectedValues, handleChange, fetchingOptions, calculatedOptions } = useRadioButtons(props);

--- a/src/layout/RadioButtons/index.tsx
+++ b/src/layout/RadioButtons/index.tsx
@@ -16,7 +16,7 @@ import type { ComponentValidation } from 'src/features/validation';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types';
-import type { BaseLayoutNode } from 'src/utils/layout/LayoutNode';
+import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export class RadioButtons extends RadioButtonsDef {
   render = forwardRef<HTMLElement, PropsFromGenericComponent<'RadioButtons'>>(
@@ -48,7 +48,7 @@ export class RadioButtons extends RadioButtonsDef {
     );
   }
 
-  useEmptyFieldValidation(node: BaseLayoutNode<'RadioButtons'>): ComponentValidation[] {
+  useEmptyFieldValidation(node: LayoutNode<'RadioButtons'>): ComponentValidation[] {
     return useEmptyFieldValidationOnlySimpleBinding(node);
   }
 

--- a/src/layout/RepeatingGroup/Container/RepeatingGroupContainer.tsx
+++ b/src/layout/RepeatingGroup/Container/RepeatingGroupContainer.tsx
@@ -20,7 +20,7 @@ import {
 } from 'src/layout/RepeatingGroup/Providers/RepeatingGroupContext';
 import { useRepeatingGroupsFocusContext } from 'src/layout/RepeatingGroup/Providers/RepeatingGroupFocusContext';
 import { RepeatingGroupTable } from 'src/layout/RepeatingGroup/Table/RepeatingGroupTable';
-import { BaseLayoutNode } from 'src/utils/layout/LayoutNode';
+import { LayoutNode } from 'src/utils/layout/LayoutNode';
 import { Hidden } from 'src/utils/layout/NodesContext';
 import { useLabel } from 'src/utils/layout/useLabel';
 import { useNodeItem } from 'src/utils/layout/useNodeItem';
@@ -71,7 +71,7 @@ function ModeOnlyTable() {
 
 function ModeOnlyEdit({ editingId }: { editingId: string }) {
   const { node } = useRepeatingGroup();
-  const isNested = node.parent instanceof BaseLayoutNode;
+  const isNested = node.parent instanceof LayoutNode;
 
   const { grid } = useNodeItem(node);
   const { labelText, getDescriptionComponent, getHelpTextComponent } = useLabel({ node, overrideDisplay: undefined });
@@ -97,7 +97,7 @@ function ModeOnlyEdit({ editingId }: { editingId: string }) {
 
 function ModeShowAll() {
   const { node } = useRepeatingGroup();
-  const isNested = node.parent instanceof BaseLayoutNode;
+  const isNested = node.parent instanceof LayoutNode;
 
   const { rowsToDisplay } = useRepeatingGroupPagination();
   const numRows = rowsToDisplay.length;

--- a/src/layout/RepeatingGroup/EditContainer/RepeatingGroupEditContext.tsx
+++ b/src/layout/RepeatingGroup/EditContainer/RepeatingGroupEditContext.tsx
@@ -4,10 +4,9 @@ import type { PropsWithChildren } from 'react';
 import { createContext } from 'src/core/contexts/context';
 import { useRegisterNodeNavigationHandler } from 'src/features/form/layout/NavigateToNode';
 import { useRepeatingGroup } from 'src/layout/RepeatingGroup/Providers/RepeatingGroupContext';
-import { BaseLayoutNode } from 'src/utils/layout/LayoutNode';
+import { LayoutNode } from 'src/utils/layout/LayoutNode';
 import { LayoutPage } from 'src/utils/layout/LayoutPage';
 import { useNodeItem } from 'src/utils/layout/useNodeItem';
-import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 interface RepeatingGroupEditRowContext {
   multiPageEnabled: boolean;
@@ -61,7 +60,7 @@ export function RepeatingGroupEditRowProvider({ children }: PropsWithChildren) {
     }
     let isOurChildRecursively = false;
     let subject: LayoutNode | LayoutPage | undefined = targetNode;
-    while (subject instanceof BaseLayoutNode) {
+    while (subject instanceof LayoutNode) {
       if (subject.parent === node) {
         isOurChildRecursively = true;
         break;

--- a/src/layout/RepeatingGroup/EditContainer/RepeatingGroupsEditContainer.tsx
+++ b/src/layout/RepeatingGroup/EditContainer/RepeatingGroupsEditContainer.tsx
@@ -19,6 +19,7 @@ import {
 } from 'src/layout/RepeatingGroup/Providers/RepeatingGroupContext';
 import { useRepeatingGroupsFocusContext } from 'src/layout/RepeatingGroup/Providers/RepeatingGroupFocusContext';
 import classes from 'src/layout/RepeatingGroup/RepeatingGroup.module.css';
+import { LayoutNode } from 'src/utils/layout/LayoutNode';
 import { useNode } from 'src/utils/layout/NodesContext';
 import { useNodeItem } from 'src/utils/layout/useNodeItem';
 import type { CompInternal } from 'src/layout/layout';
@@ -87,7 +88,7 @@ function RepeatingGroupsEditContainerInternal({
   const freshUuid = FD.useFreshRowUuid(group.dataModelBindings?.group, row?.index);
   const isFresh = freshUuid === editId;
 
-  const isNested = typeof group.baseComponentId === 'string';
+  const isNested = node.parent instanceof LayoutNode;
   let saveButtonVisible =
     !forceHideSaveButton &&
     (editForRow?.saveButton !== false || (editForRow.saveAndNextButton === true && !moreVisibleRowsAfterEditIndex));

--- a/src/layout/RepeatingGroup/Providers/RepeatingGroupFocusContext.tsx
+++ b/src/layout/RepeatingGroup/Providers/RepeatingGroupFocusContext.tsx
@@ -4,9 +4,8 @@ import type { PropsWithChildren } from 'react';
 import { createContext } from 'src/core/contexts/context';
 import { useRegisterNodeNavigationHandler } from 'src/features/form/layout/NavigateToNode';
 import { useRepeatingGroup } from 'src/layout/RepeatingGroup/Providers/RepeatingGroupContext';
-import { BaseLayoutNode } from 'src/utils/layout/LayoutNode';
+import { LayoutNode } from 'src/utils/layout/LayoutNode';
 import { NodesInternal } from 'src/utils/layout/NodesContext';
-import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 import type { LayoutPage } from 'src/utils/layout/LayoutPage';
 
 type FocusableHTMLElement =
@@ -48,7 +47,7 @@ export function RepeatingGroupsFocusProvider({ children }: PropsWithChildren) {
     let subject: LayoutNode | LayoutPage | undefined = targetNode;
 
     while (subject) {
-      if (!(subject instanceof BaseLayoutNode)) {
+      if (!(subject instanceof LayoutNode)) {
         break;
       }
       if (subject.parent === node) {

--- a/src/layout/RepeatingGroup/Summary/LargeGroupSummaryContainer.tsx
+++ b/src/layout/RepeatingGroup/Summary/LargeGroupSummaryContainer.tsx
@@ -7,11 +7,10 @@ import cn from 'classnames';
 import { Lang } from 'src/features/language/Lang';
 import classes from 'src/layout/RepeatingGroup/Summary/LargeGroupSummaryContainer.module.css';
 import { pageBreakStyles } from 'src/utils/formComponentUtils';
-import { BaseLayoutNode } from 'src/utils/layout/LayoutNode';
+import { LayoutNode } from 'src/utils/layout/LayoutNode';
 import { Hidden, NodesInternal } from 'src/utils/layout/NodesContext';
 import { useNodeDirectChildren, useNodeItem } from 'src/utils/layout/useNodeItem';
 import type { HeadingLevel } from 'src/layout/common.generated';
-import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export interface IDisplayRepAsLargeGroup {
   groupNode: LayoutNode<'RepeatingGroup'>;
@@ -38,7 +37,7 @@ export function LargeGroupSummaryContainer({ groupNode, id, restriction, renderL
   }
   const { title, summaryTitle } = item.textResourceBindings || {};
 
-  const isNested = groupNode.parent instanceof BaseLayoutNode;
+  const isNested = groupNode.parent instanceof LayoutNode;
   const headingLevel = Math.min(Math.max(depth + 1, 2), 6) as HeadingLevel;
   const headingSize = headingSizes[headingLevel];
   const legend = summaryTitle ?? title;

--- a/src/layout/RepeatingGroup/Summary2/RepeatingGroupSummary.tsx
+++ b/src/layout/RepeatingGroup/Summary2/RepeatingGroupSummary.tsx
@@ -14,7 +14,7 @@ import { RepeatingGroupTableSummary } from 'src/layout/RepeatingGroup/Summary2/R
 import { SingleValueSummary } from 'src/layout/Summary2/CommonSummaryComponents/SingleValueSummary';
 import { ComponentSummaryById } from 'src/layout/Summary2/SummaryComponent2/ComponentSummary';
 import { DataModelLocationProvider } from 'src/utils/layout/DataModelLocation';
-import { BaseLayoutNode } from 'src/utils/layout/LayoutNode';
+import { LayoutNode } from 'src/utils/layout/LayoutNode';
 import { useNodeItem } from 'src/utils/layout/useNodeItem';
 
 export const RepeatingGroupSummary = ({
@@ -23,7 +23,7 @@ export const RepeatingGroupSummary = ({
   display,
   emptyFieldText,
 }: {
-  componentNode: BaseLayoutNode<'RepeatingGroup'>;
+  componentNode: LayoutNode<'RepeatingGroup'>;
   isCompact?: boolean;
   display?: 'table' | 'full';
   emptyFieldText?: string;
@@ -35,7 +35,7 @@ export const RepeatingGroupSummary = ({
   const errors = validationsOfSeverity(validations, 'error');
   const title = useNodeItem(componentNode, (i) => i.textResourceBindings?.title);
   const dataModelBindings = useNodeItem(componentNode, (i) => i.dataModelBindings);
-  const isNested = componentNode.parent instanceof BaseLayoutNode;
+  const isNested = componentNode.parent instanceof LayoutNode;
 
   if (rows.length === 0) {
     return (

--- a/src/layout/RepeatingGroup/Summary2/RepeatingGroupTableSummary/RepeatingGroupTableSummary.tsx
+++ b/src/layout/RepeatingGroup/Summary2/RepeatingGroupTableSummary/RepeatingGroupTableSummary.tsx
@@ -29,14 +29,14 @@ import { useNode } from 'src/utils/layout/NodesContext';
 import { useNodeItem } from 'src/utils/layout/useNodeItem';
 import type { ITableColumnFormatting } from 'src/layout/common.generated';
 import type { RepGroupRow } from 'src/layout/RepeatingGroup/types';
-import type { BaseLayoutNode } from 'src/utils/layout/LayoutNode';
+import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export const RepeatingGroupTableSummary = ({
   componentNode,
   isCompact,
   emptyFieldText,
 }: {
-  componentNode: BaseLayoutNode<'RepeatingGroup'>;
+  componentNode: LayoutNode<'RepeatingGroup'>;
   isCompact?: boolean;
   emptyFieldText?: string;
 }) => {
@@ -145,7 +145,7 @@ function HeaderCell({ nodeId, columnSettings }: { nodeId: string; columnSettings
 
 type DataRowProps = {
   row: RepGroupRow | undefined;
-  node: BaseLayoutNode<'RepeatingGroup'>;
+  node: LayoutNode<'RepeatingGroup'>;
   pdfModeActive: boolean;
   columnSettings: ITableColumnFormatting;
 };

--- a/src/layout/RepeatingGroup/Table/RepeatingGroupTable.tsx
+++ b/src/layout/RepeatingGroup/Table/RepeatingGroupTable.tsx
@@ -42,7 +42,6 @@ export function RepeatingGroupTable(): React.JSX.Element | null {
     stickyHeader,
     tableColumns,
     rows,
-    baseComponentId,
     dataModelBindings,
   } = useNodeItem(node);
   const required = !!minCount && minCount > 0;
@@ -70,7 +69,7 @@ export function RepeatingGroupTable(): React.JSX.Element | null {
     displayEditColumn = false;
   }
 
-  const isNested = typeof baseComponentId === 'string';
+  const isNested = node.parent instanceof LayoutNode;
   const extraCells = [...(displayEditColumn ? [null] : []), ...(displayDeleteColumn ? [null] : [])];
 
   return (

--- a/src/layout/RepeatingGroup/Table/RepeatingGroupTable.tsx
+++ b/src/layout/RepeatingGroup/Table/RepeatingGroupTable.tsx
@@ -23,7 +23,7 @@ import { RepeatingGroupTableTitle } from 'src/layout/RepeatingGroup/Table/Repeat
 import { useTableComponentIds } from 'src/layout/RepeatingGroup/useTableComponentIds';
 import { useColumnStylesRepeatingGroups } from 'src/utils/formComponentUtils';
 import { DataModelLocationProvider, useDataModelLocationForRow } from 'src/utils/layout/DataModelLocation';
-import { BaseLayoutNode } from 'src/utils/layout/LayoutNode';
+import { LayoutNode } from 'src/utils/layout/LayoutNode';
 import { useNode } from 'src/utils/layout/NodesContext';
 import { useNodeItem } from 'src/utils/layout/useNodeItem';
 import type { ITableColumnFormatting } from 'src/layout/common.generated';
@@ -207,7 +207,7 @@ function ExtraRows({ where, extraCells, columnSettings }: ExtraRowsProps) {
   const { visibleRows } = useRepeatingGroupRowState();
   const isEmpty = visibleRows.length === 0;
   const item = useNodeItem(node);
-  const isNested = node.parent instanceof BaseLayoutNode;
+  const isNested = node.parent instanceof LayoutNode;
 
   const rows = where === 'Before' ? item.rowsBeforeInternal : item.rowsAfterInternal;
   const mobileNodeIds = useNodeIdsFromGridRows(rows, mobileView);

--- a/src/layout/Summary2/SummaryComponent2/ComponentSummary.tsx
+++ b/src/layout/Summary2/SummaryComponent2/ComponentSummary.tsx
@@ -4,15 +4,17 @@ import cn from 'classnames';
 
 import { Flex } from 'src/app-components/Flex/Flex';
 import { useDataModelBindings } from 'src/features/formData/useDataModelBindings';
+import { getComponentDef } from 'src/layout';
 import classes from 'src/layout/Summary2/SummaryComponent2/SummaryComponent2.module.css';
 import { useSummary2Store } from 'src/layout/Summary2/summaryStoreContext';
 import { pageBreakStyles } from 'src/utils/formComponentUtils';
 import { Hidden, useNode } from 'src/utils/layout/NodesContext';
 import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import type { CompTypes } from 'src/layout/layout';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
-interface ComponentSummaryProps {
-  componentNode: LayoutNode;
+interface ComponentSummaryProps<T extends CompTypes = CompTypes> {
+  componentNode: LayoutNode<T>;
   isCompact?: boolean;
 }
 
@@ -33,23 +35,19 @@ export function ComponentSummaryById({
   );
 }
 
-export function ComponentSummary({ componentNode }: ComponentSummaryProps) {
+export function ComponentSummary<T extends CompTypes>({ componentNode }: ComponentSummaryProps<T>) {
   const summaryNodeItem = useSummary2Store((state) => state.summaryItem);
   const componentNodeItem = useNodeItem(componentNode);
-
   const override = summaryNodeItem?.overrides?.find((override) => override.componentId === componentNode.id);
-
   const isRequired = 'required' in componentNodeItem && componentNodeItem['required'] === true;
-
   const { formData } = useDataModelBindings(componentNodeItem.dataModelBindings);
-
   const isHidden = Hidden.useIsHidden(componentNode);
-
   const noUserInput = Object.values(formData).every((value) => value?.length < 1);
+  const def = getComponentDef(componentNode.type);
 
-  const renderedComponent = componentNode.def.renderSummary2
-    ? componentNode.def.renderSummary2({
-        target: componentNode as LayoutNode<never>,
+  const renderedComponent = def.renderSummary2
+    ? def.renderSummary2({
+        target: componentNode as never,
         override,
         isCompact: summaryNodeItem.isCompact,
       })

--- a/src/layout/Tabs/Tabs.tsx
+++ b/src/layout/Tabs/Tabs.tsx
@@ -9,11 +9,10 @@ import { useLanguage } from 'src/features/language/useLanguage';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
 import { GenericComponentById } from 'src/layout/GenericComponent';
 import classes from 'src/layout/Tabs/Tabs.module.css';
-import { BaseLayoutNode } from 'src/utils/layout/LayoutNode';
+import { LayoutNode } from 'src/utils/layout/LayoutNode';
 import { useNodeItem } from 'src/utils/layout/useNodeItem';
 import { typedBoolean } from 'src/utils/typing';
 import type { PropsFromGenericComponent } from 'src/layout';
-import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export const Tabs = ({ node }: PropsFromGenericComponent<'Tabs'>) => {
   const size = useNodeItem(node, (i) => i.size);
@@ -130,7 +129,7 @@ function parentNodes(node: LayoutNode): LayoutNode[] {
   const parents: LayoutNode[] = [];
   let parent = node.parent;
   while (parent) {
-    if (!(parent instanceof BaseLayoutNode)) {
+    if (!(parent instanceof LayoutNode)) {
       break;
     }
     parents.push(parent);

--- a/src/layout/Tabs/TabsPlugin.tsx
+++ b/src/layout/Tabs/TabsPlugin.tsx
@@ -100,7 +100,7 @@ export class TabsPlugin<Type extends CompTypes>
     } as DefPluginExtraInItem<Config<Type>>;
   }
 
-  pickDirectChildren(state: DefPluginState<Config<Type>>, restriction?: number | undefined | undefined): string[] {
+  pickDirectChildren(state: DefPluginState<Config<Type>>, restriction?: number | undefined): string[] {
     const out: string[] = [];
     if (restriction !== undefined) {
       return out;

--- a/src/layout/Tabs/TabsPlugin.tsx
+++ b/src/layout/Tabs/TabsPlugin.tsx
@@ -56,17 +56,18 @@ export class TabsPlugin<Type extends CompTypes>
     return 'TabsPlugin';
   }
 
-  claimChildren({ item, claimChild, getProto }: DefPluginChildClaimerProps<Config<Type>>): void {
+  claimChildren({ item, claimChild, getType, getCapabilities }: DefPluginChildClaimerProps<Config<Type>>): void {
     for (const tab of (item.tabs || []).values()) {
       for (const child of tab.children.values()) {
-        const proto = getProto(child);
-        if (!proto) {
+        const type = getType(child);
+        if (!type) {
           continue;
         }
-        if (proto.capabilities.renderInTabs === false) {
+        const capabilities = getCapabilities(type);
+        if (!capabilities.renderInTabs) {
           window.logWarn(
             `Tabs component included a component '${child}', which ` +
-              `is a '${proto.type}' and cannot be rendered as a Tabs child.`,
+              `is a '${type}' and cannot be rendered as a Tabs child.`,
           );
           continue;
         }

--- a/src/layout/Tabs/TabsSummary.tsx
+++ b/src/layout/Tabs/TabsSummary.tsx
@@ -8,10 +8,10 @@ import { ComponentSummaryById } from 'src/layout/Summary2/SummaryComponent2/Comp
 import classes from 'src/layout/Tabs/TabsSummary.module.css';
 import { useNodeItem } from 'src/utils/layout/useNodeItem';
 import { typedBoolean } from 'src/utils/typing';
-import type { BaseLayoutNode } from 'src/utils/layout/LayoutNode';
+import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 type TabsSummaryProps = {
-  componentNode: BaseLayoutNode<'Tabs'>;
+  componentNode: LayoutNode<'Tabs'>;
 };
 
 export const TabsSummary = ({ componentNode }: TabsSummaryProps) => {

--- a/src/layout/layout.ts
+++ b/src/layout/layout.ts
@@ -50,11 +50,11 @@ export type CompExternalExact<Type extends CompTypes> = ComponentTypeConfigs[Typ
 
 /**
  * When running hierarchy generation, an intermediate type is used. This will contain the same properties as
- * CompExternal, but also the hierarchy extensions (as applied when running hierarchy mutations). At this point
- * the ID property will be set to `<baseId>-<rowIndex>` as expected for repeating groups, etc.
+ * CompExternal. At this point the ID property will be set to `<baseId>-<rowIndex>` as expected for
+ * repeating groups, etc.
  */
-export type CompIntermediate<Type extends CompTypes = CompTypes> = CompExternal<Type> & HierarchyExtensions;
-export type CompIntermediateExact<Type extends CompTypes> = CompExternalExact<Type> & HierarchyExtensions;
+export type CompIntermediate<Type extends CompTypes = CompTypes> = CompExternal<Type>;
+export type CompIntermediateExact<Type extends CompTypes> = CompExternalExact<Type>;
 
 /**
  * This is the type you should use when referencing a specific component type, and will give
@@ -73,21 +73,10 @@ export type ITextResourceBindings<T extends CompTypes = CompTypes> = CompInterna
 export type ILayout = CompExternal[];
 
 /**
- * These keys are not defined anywhere in the actual form layout files, but are added by the hierarchy.
+ * The result of evaluating expressions for a component. This 'internal' item is what the layout configuration will
+ * look like once every expression within it has been evaluated.
  */
-interface HierarchyExtensions {
-  // These will be set if the component is inside a repeating group
-  baseComponentId?: string;
-  multiPageIndex?: number;
-}
-
-/**
- * Any item inside a hierarchy. Note that a LayoutNode _contains_ an item. The LayoutNode itself is an instance of the
- * LayoutNode class, while _an item_ is the object inside it that is somewhat similar to layout objects.
- */
-type NodeItem<T extends CompTypes> = ReturnType<ComponentConfigs[T]['def']['evalExpressions']>;
-
-export type CompInternal<T extends CompTypes = CompTypes> = NodeItem<T> & HierarchyExtensions;
+export type CompInternal<T extends CompTypes = CompTypes> = ReturnType<ComponentConfigs[T]['def']['evalExpressions']>;
 
 /**
  * Any parent object of a LayoutNode (with for example repeating groups, the parent can be the group node, but above

--- a/src/layout/layout.ts
+++ b/src/layout/layout.ts
@@ -11,7 +11,7 @@ import type {
   FormComponent,
   PresentationComponent,
 } from 'src/layout/LayoutComponent';
-import type { BaseLayoutNode, LayoutNode } from 'src/utils/layout/LayoutNode';
+import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 import type { LayoutPage } from 'src/utils/layout/LayoutPage';
 
 export interface ILayouts {
@@ -39,7 +39,7 @@ type AllComponents = ComponentTypeConfigs[CompTypes]['layout'];
  *  const myImageComponent:CompExternal<'Image'> = ...
  *
  * @see CompInternal
- * @see LayoutNode
+ * @see REMOVELayoutNode
  */
 export type CompExternal<Type extends CompTypes = CompTypes> = Extract<AllComponents, { type: Type }>;
 
@@ -103,7 +103,7 @@ export type TypeFromConfig<T extends CompInternal | CompExternal> = T extends { 
 
 export type TypeFromNode<N extends LayoutNode | undefined> = N extends undefined
   ? never
-  : N extends BaseLayoutNode<infer Type>
+  : N extends LayoutNode<infer Type>
     ? Type
     : CompTypes;
 

--- a/src/layout/layout.ts
+++ b/src/layout/layout.ts
@@ -39,7 +39,6 @@ type AllComponents = ComponentTypeConfigs[CompTypes]['layout'];
  *  const myImageComponent:CompExternal<'Image'> = ...
  *
  * @see CompInternal
- * @see REMOVELayoutNode
  */
 export type CompExternal<Type extends CompTypes = CompTypes> = Extract<AllComponents, { type: Type }>;
 

--- a/src/utils/layout/LayoutNode.ts
+++ b/src/utils/layout/LayoutNode.ts
@@ -2,37 +2,37 @@ import { getComponentDef } from 'src/layout';
 import { LayoutPage } from 'src/utils/layout/LayoutPage';
 import type { CompClassMap } from 'src/layout';
 import type { CompCategory } from 'src/layout/common';
-import type { CompIntermediate, CompTypes, LayoutNodeFromCategory, ParentNode } from 'src/layout/layout';
+import type { CompTypes, LayoutNodeFromCategory, ParentNode } from 'src/layout/layout';
 
 export interface LayoutNodeProps<Type extends CompTypes> {
-  item: CompIntermediate<Type>;
+  id: string;
+  baseId: string;
+  type: Type;
   parent: ParentNode;
-  rowIndex?: number;
+  rowIndex: number | undefined;
+  multiPageIndex: number | undefined;
 }
 
 /**
- * A LayoutNode wraps a component with information about its parent, allowing you to traverse a component (or an
- * instance of a component inside a repeating group), finding other components near it.
+ * A LayoutNode is a pointer to an instance of a component in the layout. Some components will appear only once, but
+ * others (like those inside repeating groups) will appear multiple times.
  */
 export class LayoutNode<Type extends CompTypes = CompTypes> {
   public readonly parent: ParentNode;
   public readonly rowIndex?: number;
   public readonly page: LayoutPage;
   public readonly def: CompClassMap[Type];
+  public readonly id: string;
+  public readonly baseId: string;
+  public readonly multiPageIndex: number | undefined;
+  public readonly pageKey: string;
+  public readonly type: Type;
 
-  // These may be overwritten if the state in NodesContext changes. They are only kept
-  // updated here for convenience.
-  public id: string;
-  public baseId: string;
-  public multiPageIndex: number | undefined;
-  public pageKey: string;
-  public type: Type;
-
-  public constructor({ item, parent, rowIndex }: LayoutNodeProps<Type>) {
-    this.id = item.id;
-    this.baseId = item.baseComponentId ?? item.id;
-    this.type = item.type as Type;
-    this.multiPageIndex = item.multiPageIndex;
+  public constructor({ id, type, baseId, parent, rowIndex, multiPageIndex }: LayoutNodeProps<Type>) {
+    this.id = id;
+    this.baseId = baseId;
+    this.type = type;
+    this.multiPageIndex = multiPageIndex;
     this.page = parent instanceof LayoutPage ? parent : parent.page;
     this.pageKey = this.page.pageKey;
     this.def = getComponentDef(this.type);

--- a/src/utils/layout/LayoutNode.ts
+++ b/src/utils/layout/LayoutNode.ts
@@ -2,7 +2,6 @@ import { getComponentDef } from 'src/layout';
 import { LayoutPage } from 'src/utils/layout/LayoutPage';
 import type { CompClassMap } from 'src/layout';
 import type { CompCategory } from 'src/layout/common';
-import type { ComponentTypeConfigs } from 'src/layout/components.generated';
 import type { CompIntermediate, CompTypes, LayoutNodeFromCategory, ParentNode } from 'src/layout/layout';
 
 export interface LayoutNodeProps<Type extends CompTypes> {
@@ -15,7 +14,7 @@ export interface LayoutNodeProps<Type extends CompTypes> {
  * A LayoutNode wraps a component with information about its parent, allowing you to traverse a component (or an
  * instance of a component inside a repeating group), finding other components near it.
  */
-export class BaseLayoutNode<Type extends CompTypes = CompTypes> {
+export class LayoutNode<Type extends CompTypes = CompTypes> {
   public readonly parent: ParentNode;
   public readonly rowIndex?: number;
   public readonly page: LayoutPage;
@@ -50,7 +49,3 @@ export class BaseLayoutNode<Type extends CompTypes = CompTypes> {
     return this.def.category === category;
   }
 }
-
-export type LayoutNode<Type extends CompTypes = CompTypes> = Type extends CompTypes
-  ? ComponentTypeConfigs[Type]['nodeObj']
-  : BaseLayoutNode;

--- a/src/utils/layout/NodesContext.tsx
+++ b/src/utils/layout/NodesContext.tsx
@@ -41,7 +41,7 @@ import {
 } from 'src/utils/layout/generator/GeneratorStages';
 import { LayoutSetGenerator } from 'src/utils/layout/generator/LayoutSetGenerator';
 import { GeneratorValidationProvider } from 'src/utils/layout/generator/validation/GenerationValidationContext';
-import { BaseLayoutNode } from 'src/utils/layout/LayoutNode';
+import { LayoutNode } from 'src/utils/layout/LayoutNode';
 import { LayoutPage } from 'src/utils/layout/LayoutPage';
 import { LayoutPages } from 'src/utils/layout/LayoutPages';
 import { RepeatingChildrenStorePlugin } from 'src/utils/layout/plugins/RepeatingChildrenStorePlugin';
@@ -54,7 +54,6 @@ import type { WaitForState } from 'src/hooks/useWaitForState';
 import type { CompTypes, ILayouts } from 'src/layout/layout';
 import type { LayoutComponent } from 'src/layout/LayoutComponent';
 import type { GeneratorStagesContext, Registry } from 'src/utils/layout/generator/GeneratorStages';
-import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 import type { NodeDataPlugin } from 'src/utils/layout/plugins/NodeDataPlugin';
 import type { RepeatingChildrenStorePluginConfig } from 'src/utils/layout/plugins/RepeatingChildrenStorePlugin';
 import type { GeneratorErrors, NodeData, NodeDataFromNode } from 'src/utils/layout/types';
@@ -731,7 +730,7 @@ export function useNode<T extends string | undefined | LayoutNode>(id: T): Layou
       return lastValue.current;
     }
 
-    const node = id instanceof BaseLayoutNode ? id : nodes.findById(id);
+    const node = id instanceof LayoutNode ? id : nodes.findById(id);
     lastValue.current = node;
     return node;
   });

--- a/src/utils/layout/NodesContext.tsx
+++ b/src/utils/layout/NodesContext.tsx
@@ -51,7 +51,7 @@ import type { ValidationsProcessedLast } from 'src/features/validation';
 import type { ValidationStorePluginConfig } from 'src/features/validation/ValidationStorePlugin';
 import type { ObjectOrArray } from 'src/hooks/useShallowMemo';
 import type { WaitForState } from 'src/hooks/useWaitForState';
-import type { CompExternal, CompTypes, ILayouts } from 'src/layout/layout';
+import type { CompTypes, ILayouts } from 'src/layout/layout';
 import type { LayoutComponent } from 'src/layout/LayoutComponent';
 import type { GeneratorStagesContext, Registry } from 'src/utils/layout/generator/GeneratorStages';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
@@ -510,20 +510,6 @@ function ProvideGlobalContext({ children, registry }: PropsWithChildren<{ regist
     }
   }, [latestLayouts, layouts, markNotReady, reset, getProcessedLast]);
 
-  const layoutMap = useMemo(() => {
-    const out: { [id: string]: CompExternal } = {};
-    for (const page of Object.values(latestLayouts)) {
-      if (!page) {
-        continue;
-      }
-      for (const component of page) {
-        out[component.id] = component;
-      }
-    }
-
-    return out;
-  }, [latestLayouts]);
-
   if (layouts !== latestLayouts) {
     // You changed the layouts, possibly by using devtools. Hold on while we re-generate!
     return <NodesLoader />;
@@ -533,7 +519,6 @@ function ProvideGlobalContext({ children, registry }: PropsWithChildren<{ regist
     <ProvideLayoutPages value={pagesRef.current}>
       <GeneratorGlobalProvider
         layouts={layouts}
-        layoutMap={layoutMap}
         registry={registry}
       >
         {children}

--- a/src/utils/layout/generator/GeneratorContext.tsx
+++ b/src/utils/layout/generator/GeneratorContext.tsx
@@ -81,6 +81,7 @@ export function GeneratorNodeProvider({ children, parent, item }: PropsWithChild
       ...parentCtx,
       parent,
       item,
+      multiPageMapping: undefined,
 
       // Direct mutators and rows are not meant to be inherited, and regular non-repeating nodes do not pass them.
       directMutators: emptyArray,
@@ -126,6 +127,7 @@ export function GeneratorRowProvider({
   groupBinding,
   idMutators,
   recursiveMutators,
+  multiPageMapping,
 }: PropsWithChildren<RowGeneratorProps>) {
   const parent = useCtx();
   const value: GeneratorContext = useMemo(
@@ -137,12 +139,13 @@ export function GeneratorRowProvider({
         binding: groupBinding,
       },
 
+      multiPageMapping,
       idMutators: parent.idMutators ? [...parent.idMutators, ...(idMutators ?? [])] : idMutators,
       recursiveMutators: parent.recursiveMutators
         ? [...parent.recursiveMutators, ...(recursiveMutators ?? [])]
         : recursiveMutators,
     }),
-    [parent, rowIndex, groupBinding, idMutators, recursiveMutators],
+    [parent, rowIndex, groupBinding, multiPageMapping, idMutators, recursiveMutators],
   );
   return <Provider value={value}>{children}</Provider>;
 }
@@ -153,6 +156,7 @@ export function GeneratorGlobalProvider({ children, ...rest }: PropsWithChildren
       item: undefined,
       row: undefined,
       depth: 0,
+      multiPageIndex: undefined,
       childrenMap: undefined,
       parent: undefined,
       page: undefined,

--- a/src/utils/layout/generator/GeneratorContext.tsx
+++ b/src/utils/layout/generator/GeneratorContext.tsx
@@ -3,7 +3,7 @@ import type { MutableRefObject, PropsWithChildren } from 'react';
 
 import { ContextNotProvided, createContext } from 'src/core/contexts/context';
 import type { IDataModelReference } from 'src/layout/common.generated';
-import type { CompExternal, CompIntermediate, CompIntermediateExact, CompTypes, ILayouts } from 'src/layout/layout';
+import type { CompIntermediate, CompIntermediateExact, CompTypes, ILayouts } from 'src/layout/layout';
 import type { Registry } from 'src/utils/layout/generator/GeneratorStages';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 import type { LayoutPage } from 'src/utils/layout/LayoutPage';
@@ -23,7 +23,7 @@ export interface ChildClaimsMap {
   [parentId: string]: ChildClaims;
 }
 
-type GlobalProviderProps = Pick<GeneratorContext, 'layouts' | 'layoutMap' | 'registry'>;
+type GlobalProviderProps = Pick<GeneratorContext, 'layouts' | 'registry'>;
 
 type PageProviderProps = Pick<GeneratorContext, 'isValid'> & {
   parent: LayoutPage;
@@ -45,7 +45,6 @@ interface GeneratorContext {
   directMutators?: ChildMutator[];
   recursiveMutators?: ChildMutator[];
   layouts: ILayouts;
-  layoutMap: Record<string, CompExternal>;
   page: LayoutPage | undefined;
   parent: LayoutNode | LayoutPage | undefined;
   item: CompIntermediateExact<CompTypes> | undefined;
@@ -181,10 +180,8 @@ export const GeneratorInternal = {
   useRecursiveMutators: () => useCtx().recursiveMutators ?? emptyArray,
   useDepth: () => useCtx().depth,
   useLayouts: () => useCtx().layouts,
-  // useLayoutMap: () => useCtx().layoutMap,
   useParent: () => useCtx().parent,
   usePage: () => useCtx().page,
-  useRowBinding: () => useCtx().row?.binding,
   useRowIndex: () => useCtx().row?.index,
   useIntermediateItem: () => useCtx().item,
   useIsValid: () => useCtx().isValid ?? true,

--- a/src/utils/layout/generator/GeneratorContext.tsx
+++ b/src/utils/layout/generator/GeneratorContext.tsx
@@ -25,7 +25,7 @@ export interface ChildClaimsMap {
 
 type GlobalProviderProps = Pick<GeneratorContext, 'layouts' | 'layoutMap' | 'registry'>;
 
-type PageProviderProps = Pick<GeneratorContext, 'childrenMap' | 'isValid'> & {
+type PageProviderProps = Pick<GeneratorContext, 'isValid'> & {
   parent: LayoutPage;
 };
 
@@ -46,7 +46,6 @@ interface GeneratorContext {
   recursiveMutators?: ChildMutator[];
   layouts: ILayouts;
   layoutMap: Record<string, CompExternal>;
-  childrenMap: ChildClaimsMap | undefined;
   page: LayoutPage | undefined;
   parent: LayoutNode | LayoutPage | undefined;
   item: CompIntermediateExact<CompTypes> | undefined;
@@ -182,8 +181,7 @@ export const GeneratorInternal = {
   useRecursiveMutators: () => useCtx().recursiveMutators ?? emptyArray,
   useDepth: () => useCtx().depth,
   useLayouts: () => useCtx().layouts,
-  useLayoutMap: () => useCtx().layoutMap,
-  useChildrenMap: () => useCtx().childrenMap,
+  // useLayoutMap: () => useCtx().layoutMap,
   useParent: () => useCtx().parent,
   usePage: () => useCtx().page,
   useRowBinding: () => useCtx().row?.binding,

--- a/src/utils/layout/generator/GeneratorContext.tsx
+++ b/src/utils/layout/generator/GeneratorContext.tsx
@@ -29,7 +29,7 @@ type PageProviderProps = Pick<GeneratorContext, 'isValid'> & {
   parent: LayoutPage;
 };
 
-type NodeGeneratorProps = Pick<GeneratorContext, 'idMutators' | 'directMutators' | 'recursiveMutators'> & {
+type NodeGeneratorProps = {
   item: CompIntermediateExact<CompTypes>;
   parent: LayoutNode;
 };
@@ -72,26 +72,22 @@ const emptyArray: never[] = [];
  *
  * This provider is meant to be used for nodes, i.e. the lowest level components in the hierarchy.
  */
-export function GeneratorNodeProvider({ children, ...rest }: PropsWithChildren<NodeGeneratorProps>) {
-  const parent = useCtx();
+export function GeneratorNodeProvider({ children, parent, item }: PropsWithChildren<NodeGeneratorProps>) {
+  const parentCtx = useCtx();
   const value: GeneratorContext = useMemo(
     () => ({
       // Inherit all values from the parent, overwrite with our own if they are passed
-      ...parent,
-      ...rest,
+      ...parentCtx,
+      parent,
+      item,
 
-      // Direct mutators and rows are not meant to be inherited, if none are passed to us directly we'll reset
-      directMutators: rest.directMutators ?? emptyArray,
-      row: parent.row ?? undefined,
+      // Direct mutators and rows are not meant to be inherited, and regular non-repeating nodes do not pass them.
+      directMutators: emptyArray,
+      row: undefined,
 
-      idMutators: parent.idMutators ? [...parent.idMutators, ...(rest.idMutators ?? [])] : rest.idMutators,
-      recursiveMutators: parent.recursiveMutators
-        ? [...parent.recursiveMutators, ...(rest.recursiveMutators ?? [])]
-        : rest.recursiveMutators,
-
-      depth: parent.depth + 1,
+      depth: parentCtx.depth + 1,
     }),
-    [parent, rest],
+    [parentCtx, parent, item],
   );
 
   return <Provider value={value}>{children}</Provider>;

--- a/src/utils/layout/generator/GeneratorErrorBoundary.tsx
+++ b/src/utils/layout/generator/GeneratorErrorBoundary.tsx
@@ -1,10 +1,9 @@
 import React, { Component, useEffect } from 'react';
 import type { MutableRefObject, PropsWithChildren } from 'react';
 
-import { BaseLayoutNode } from 'src/utils/layout/LayoutNode';
+import { LayoutNode } from 'src/utils/layout/LayoutNode';
 import { LayoutPage } from 'src/utils/layout/LayoutPage';
 import { NodesInternal } from 'src/utils/layout/NodesContext';
-import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 interface IErrorBoundary {
   lastError?: Error;
@@ -73,5 +72,5 @@ function isPage(node: LayoutPage | LayoutNode | undefined): node is LayoutPage {
 }
 
 function isNode(node: LayoutPage | LayoutNode | undefined): node is LayoutNode {
-  return node !== undefined && node instanceof BaseLayoutNode;
+  return node !== undefined && node instanceof LayoutNode;
 }

--- a/src/utils/layout/generator/GeneratorStages.tsx
+++ b/src/utils/layout/generator/GeneratorStages.tsx
@@ -4,7 +4,7 @@ import type { MutableRefObject, PropsWithChildren } from 'react';
 import { SetWaitForCommits, useCommit } from 'src/utils/layout/generator/CommitQueue';
 import { GeneratorDebug, generatorLog } from 'src/utils/layout/generator/debug';
 import { GeneratorInternal } from 'src/utils/layout/generator/GeneratorContext';
-import { BaseLayoutNode } from 'src/utils/layout/LayoutNode';
+import { LayoutNode } from 'src/utils/layout/LayoutNode';
 import { NodesInternal, NodesReadiness, NodesStore } from 'src/utils/layout/NodesContext';
 import type { ValidationsProcessedLast } from 'src/features/validation';
 import type { RegistryCommitQueues } from 'src/utils/layout/generator/CommitQueue';
@@ -509,7 +509,7 @@ function WhenParentAdded({ id, stage, registryRef, children }: WhenProps) {
   const ready = NodesInternal.useIsAdded(parent);
   useMarkFinished(id, stage, ready);
   registryRef.current.conditions =
-    parent instanceof BaseLayoutNode ? `node ${parent.id} must be added` : `page ${parent?.pageKey} must be added`;
+    parent instanceof LayoutNode ? `node ${parent.id} must be added` : `page ${parent?.pageKey} must be added`;
 
   return ready ? children : null;
 }
@@ -521,7 +521,7 @@ function WhenAllAdded({ id, stage, registryRef, children }: WhenProps) {
   const ready = allAdded && parentAdded;
   useMarkFinished(id, stage, ready);
   registryRef.current.conditions =
-    parent instanceof BaseLayoutNode
+    parent instanceof LayoutNode
       ? `node ${parent.id} and all others are added`
       : `page ${parent?.pageKey} and all others are added`;
 

--- a/src/utils/layout/generator/LayoutSetGenerator.tsx
+++ b/src/utils/layout/generator/LayoutSetGenerator.tsx
@@ -86,29 +86,22 @@ interface PageProps {
   layoutSet: LayoutPages;
 }
 
-const emptyMap: Record<string, never> = {};
 function PageGenerator({ layout, name, layoutSet }: PageProps) {
   const page = useMemo(() => new LayoutPage(), []);
   useGeneratorErrorBoundaryNodeRef().current = page;
-  const map = useLayoutLookups().childClaims[name] ?? emptyMap;
-
+  const layoutLookups = useLayoutLookups();
+  const topLevel = layoutLookups.topLevelComponents[name];
   const pageOrder = useRawPageOrder();
   const pdfPage = usePdfLayoutName();
   const isValid = pageOrder.includes(name) || name === pdfPage;
 
   const topLevelIdsAsClaims = useMemo(() => {
-    const claimedChildren = new Set(
-      Object.values(map)
-        .map((claims) => Object.keys(claims))
-        .flat(),
-    );
-    const ids = layout.filter((component) => !claimedChildren.has(component.id)).map((component) => component.id);
     const claims: ChildClaims = {};
-    for (const id of ids) {
+    for (const id of topLevel || []) {
       claims[id] = {};
     }
     return claims;
-  }, [map, layout]);
+  }, [topLevel]);
 
   if (layout.length === 0) {
     return null;
@@ -258,7 +251,7 @@ function GenerateNodeChildrenInternal({ claims, layoutMap }: NodeChildrenInterna
             <GenerateComponent
               layout={layout}
               claim={claims[id]}
-              childClaims={map?.[id]}
+              childClaims={map[id]}
             />
           </GeneratorErrorBoundary>
         );

--- a/src/utils/layout/generator/LayoutSetGenerator.tsx
+++ b/src/utils/layout/generator/LayoutSetGenerator.tsx
@@ -1,10 +1,9 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo } from 'react';
 
 import { ExprVal } from 'src/features/expressions/types';
-import { useHiddenLayoutsExpressions } from 'src/features/form/layout/LayoutsContext';
+import { useHiddenLayoutsExpressions, useLayoutLookups } from 'src/features/form/layout/LayoutsContext';
 import { usePdfLayoutName, useRawPageOrder } from 'src/features/form/layoutSettings/LayoutSettingsContext';
-import { getComponentCapabilities, getComponentDef } from 'src/layout';
-import { ContainerComponent } from 'src/layout/LayoutComponent';
+import { getComponentDef } from 'src/layout';
 import { NodesStateQueue } from 'src/utils/layout/generator/CommitQueue';
 import { GeneratorDebug } from 'src/utils/layout/generator/debug';
 import { GeneratorInternal, GeneratorPageProvider } from 'src/utils/layout/generator/GeneratorContext';
@@ -18,8 +17,8 @@ import { LayoutPage } from 'src/utils/layout/LayoutPage';
 import { Hidden, NodesInternal, NodesStore, useNodes } from 'src/utils/layout/NodesContext';
 import type { LayoutReference } from 'src/features/expressions/types';
 import type { CompExternal, CompExternalExact, CompTypes, ILayout } from 'src/layout/layout';
-import type { ChildClaimerProps, ComponentProto, NodeGeneratorProps } from 'src/layout/LayoutComponent';
-import type { ChildClaim, ChildClaims, ChildClaimsMap } from 'src/utils/layout/generator/GeneratorContext';
+import type { NodeGeneratorProps } from 'src/layout/LayoutComponent';
+import type { ChildClaim, ChildClaims } from 'src/utils/layout/generator/GeneratorContext';
 import type { LayoutPages } from 'src/utils/layout/LayoutPages';
 
 const style: React.CSSProperties = GeneratorDebug.displayState
@@ -37,11 +36,6 @@ const style: React.CSSProperties = GeneratorDebug.displayState
       overflow: 'auto',
     }
   : { display: 'none' };
-
-interface ChildrenState {
-  forLayout: ILayout;
-  map: ChildClaimsMap | undefined;
-}
 
 export function LayoutSetGenerator() {
   const layouts = GeneratorInternal.useLayouts();
@@ -86,100 +80,23 @@ function ExportStores() {
   return null;
 }
 
-function useChildClaims(layout: ILayout, getProto: (id: string) => ComponentProto | undefined) {
-  const mapRef = useRef<ChildClaimsMap>({});
-  const [children, setChildren] = useState<ChildrenState>({ forLayout: layout, map: undefined });
-
-  useEffect(() => {
-    if (children.forLayout !== layout) {
-      // Force a new first pass if the layout changes
-      setChildren({ forLayout: layout, map: undefined });
-      mapRef.current = {};
-    }
-    if (children.map === undefined) {
-      // We always run this in a useEffect, so that even if nobody calls setChildren() via addClaim(), the
-      // first pass still finishes. This is needed to support layouts without any child-bearing components.
-      setChildren((prev) => ({ ...prev, map: prev.map ?? {} }));
-    }
-  }, [children, layout]);
-
-  const getClaimedBy = useCallback((childId: string) => {
-    if (mapRef.current === undefined) {
-      return [];
-    }
-
-    const out: string[] = [];
-    for (const parentId in mapRef.current) {
-      if (mapRef.current[parentId]?.[childId]) {
-        out.push(parentId);
-      }
-    }
-
-    return out;
-  }, []);
-
-  const addClaim = useCallback(
-    (parentId: string, childId: string, pluginKey: string) => {
-      if (getProto(childId) === undefined) {
-        window.logError(`Component '${childId}' (as referenced by '${parentId}') does not exist`);
-        return;
-      }
-      const otherClaims = getClaimedBy(childId);
-      if (otherClaims.length > 0) {
-        const claimsStr = otherClaims.join(', ');
-        window.logError(`Component '${childId}' (as referenced by '${parentId}') is already claimed by '${claimsStr}'`);
-        return;
-      }
-
-      // We keep both the ref and the state in sync, so that getClaimedBy() can work immediately during a render (and not
-      // have to wait for the next render to get the updated state).
-      mapRef.current[parentId] = {
-        ...mapRef.current[parentId],
-        [childId]: { pluginKey },
-      };
-      setChildren((prev) => ({ ...prev, map: mapRef.current }));
-    },
-    [getProto, getClaimedBy],
-  );
-
-  return { map: children.map, addClaim };
-}
-
 interface PageProps {
   layout: ILayout;
   name: string;
   layoutSet: LayoutPages;
 }
 
+const emptyMap: Record<string, never> = {};
 function PageGenerator({ layout, name, layoutSet }: PageProps) {
   const page = useMemo(() => new LayoutPage(), []);
   useGeneratorErrorBoundaryNodeRef().current = page;
+  const map = useLayoutLookups().childClaims[name] ?? emptyMap;
 
   const pageOrder = useRawPageOrder();
   const pdfPage = usePdfLayoutName();
   const isValid = pageOrder.includes(name) || name === pdfPage;
 
-  const getProto = useMemo(() => {
-    const proto: { [id: string]: ComponentProto } = {};
-
-    for (const component of layout) {
-      proto[component.id] = {
-        type: component.type,
-        capabilities: getComponentCapabilities(component.type),
-      };
-    }
-
-    return (id: string) => proto[id];
-  }, [layout]);
-
-  const claims = useChildClaims(layout, getProto);
-  const map = claims.map;
-
   const topLevelIdsAsClaims = useMemo(() => {
-    if (!map) {
-      return {};
-    }
-
     const claimedChildren = new Set(
       Object.values(map)
         .map((claims) => Object.keys(claims))
@@ -210,28 +127,16 @@ function PageGenerator({ layout, name, layoutSet }: PageProps) {
           name={name}
         />
       </GeneratorCondition>
-      {map === undefined &&
-        layout.map((component) => (
-          <ComponentClaimChildren
-            key={component.id}
-            component={component}
-            claims={claims}
-            getProto={getProto}
-          />
-        ))}
       {GeneratorDebug.displayState && <h2>Page: {name}</h2>}
-      {map !== undefined && (
-        <GeneratorPageProvider
-          parent={page}
-          childrenMap={map}
-          isValid={isValid}
-        >
-          <GenerateNodeChildren
-            claims={topLevelIdsAsClaims}
-            pluginKey={undefined}
-          />
-        </GeneratorPageProvider>
-      )}
+      <GeneratorPageProvider
+        parent={page}
+        isValid={isValid}
+      >
+        <GenerateNodeChildren
+          claims={topLevelIdsAsClaims}
+          pluginKey={undefined}
+        />
+      </GeneratorPageProvider>
     </>
   );
 }
@@ -290,7 +195,7 @@ interface NodeChildrenProps {
 }
 
 export function GenerateNodeChildren({ claims, pluginKey }: NodeChildrenProps) {
-  const layoutMap = GeneratorInternal.useLayoutMap();
+  const layoutMap = useLayoutLookups().allComponents;
   const filteredClaims = useFilteredClaims(claims, pluginKey);
 
   return (
@@ -334,23 +239,30 @@ export function GenerateNodeChildrenWithStaticLayout({
 
 interface NodeChildrenInternalProps {
   claims: ChildClaims;
-  layoutMap: Record<string, CompExternal>;
+  layoutMap: Record<string, CompExternal | undefined>;
 }
 
 function GenerateNodeChildrenInternal({ claims, layoutMap }: NodeChildrenInternalProps) {
-  const map = GeneratorInternal.useChildrenMap();
+  const map = useLayoutLookups().childClaims;
 
   return (
     <>
-      {Object.keys(claims).map((id) => (
-        <GeneratorErrorBoundary key={id}>
-          <GenerateComponent
-            layout={layoutMap[id]}
-            claim={claims[id]}
-            childClaims={map?.[id]}
-          />
-        </GeneratorErrorBoundary>
-      ))}
+      {Object.keys(claims).map((id) => {
+        const layout = layoutMap[id];
+        if (!layout) {
+          return null;
+        }
+
+        return (
+          <GeneratorErrorBoundary key={id}>
+            <GenerateComponent
+              layout={layout}
+              claim={claims[id]}
+              childClaims={map?.[id]}
+            />
+          </GeneratorErrorBoundary>
+        );
+      })}
     </>
   );
 }
@@ -359,52 +271,6 @@ function useIsHiddenPage(page: LayoutPage): boolean {
   const hiddenExpr = useHiddenLayoutsExpressions();
   const reference: LayoutReference = useMemo(() => ({ type: 'page', id: page.pageKey }), [page.pageKey]);
   return useEvalExpressionInGenerator(ExprVal.Boolean, reference, hiddenExpr[page.pageKey], false) ?? false;
-}
-
-interface ComponentClaimChildrenProps {
-  component: CompExternal;
-  claims: ReturnType<typeof useChildClaims>;
-  getProto: (id: string) => ComponentProto | undefined;
-}
-
-function ComponentClaimChildren({ component, claims, getProto }: ComponentClaimChildrenProps) {
-  const def = getComponentDef(component.type);
-  const { addClaim } = claims;
-
-  // The first render will be used to determine which components will be claimed as children by others (which will
-  // prevent them from rendering on the top-level on the next render pass). We must always set a state here,
-  // otherwise the page will not know if the first pass is done.
-  useEffect(() => {
-    if (def instanceof ContainerComponent) {
-      const props: ChildClaimerProps<CompTypes> = {
-        item: component,
-        claimChild: (pluginKey, childId) => {
-          addClaim(component.id, childId, pluginKey);
-        },
-        getProto: (id) => {
-          const proto = getProto(id);
-          if (proto === undefined) {
-            window.logError(`Component '${id}' (as referenced by '${component.id}') does not exist`);
-          }
-          return proto;
-        },
-      };
-
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      def.claimChildren(props as any);
-    }
-  }, [def, component, getProto, addClaim]);
-
-  return (
-    <>
-      {GeneratorDebug.displayState && (
-        <h3>
-          {component.id} ({component.type})
-        </h3>
-      )}
-      {GeneratorDebug.displayState && <span>(first pass render)</span>}
-    </>
-  );
 }
 
 interface ComponentProps {

--- a/src/utils/layout/generator/NodeGenerator.tsx
+++ b/src/utils/layout/generator/NodeGenerator.tsx
@@ -6,6 +6,7 @@ import deepEqual from 'fast-deep-equal';
 import { evalExpr } from 'src/features/expressions';
 import { ExprVal } from 'src/features/expressions/types';
 import { ExprValidation } from 'src/features/expressions/validation';
+import { useLayoutLookups } from 'src/features/form/layout/LayoutsContext';
 import { useAsRef } from 'src/hooks/useAsRef';
 import { getComponentCapabilities, getComponentDef, getNodeConstructor } from 'src/layout';
 import { NodesStateQueue } from 'src/utils/layout/generator/CommitQueue';
@@ -122,7 +123,7 @@ function AddRemoveNode<T extends CompTypes>({ node, intermediateItem }: CommonPr
   const rowIndex = GeneratorInternal.useRowIndex();
   const pageKey = GeneratorInternal.usePage()?.pageKey ?? '';
   const idMutators = GeneratorInternal.useIdMutators() ?? [];
-  const layoutMap = GeneratorInternal.useLayoutMap();
+  const layoutMap = useLayoutLookups().allComponents;
   const isValid = GeneratorInternal.useIsValid();
   const getCapabilities = (type: CompTypes) => getComponentCapabilities(type);
   const stateFactoryProps = {

--- a/src/utils/layout/generator/NodeGenerator.tsx
+++ b/src/utils/layout/generator/NodeGenerator.tsx
@@ -22,7 +22,7 @@ import {
 } from 'src/utils/layout/generator/GeneratorStages';
 import { useEvalExpressionInGenerator } from 'src/utils/layout/generator/useEvalExpression';
 import { NodePropertiesValidation } from 'src/utils/layout/generator/validation/NodePropertiesValidation';
-import { BaseLayoutNode } from 'src/utils/layout/LayoutNode';
+import { LayoutNode } from 'src/utils/layout/LayoutNode';
 import { NodesInternal } from 'src/utils/layout/NodesContext';
 import { useExpressionDataSources } from 'src/utils/layout/useExpressionDataSources';
 import type { SimpleEval } from 'src/features/expressions';
@@ -45,7 +45,7 @@ import type {
   ITextResourceBindings,
 } from 'src/layout/layout';
 import type { ExprResolver, NodeGeneratorProps } from 'src/layout/LayoutComponent';
-import type { LayoutNode, LayoutNodeProps } from 'src/utils/layout/LayoutNode';
+import type { LayoutNodeProps } from 'src/utils/layout/LayoutNode';
 import type { StateFactoryProps } from 'src/utils/layout/types';
 import type { ExpressionDataSources } from 'src/utils/layout/useExpressionDataSources';
 
@@ -129,7 +129,7 @@ function AddRemoveNode<T extends CompTypes>({ node, intermediateItem }: CommonPr
   const stateFactoryProps = {
     item: intermediateItem,
     parent,
-    parentId: parent instanceof BaseLayoutNode ? parent.id : undefined,
+    parentId: parent instanceof LayoutNode ? parent.id : undefined,
     depth,
     rowIndex,
     pageKey,

--- a/src/utils/layout/generator/NodeRepeatingChildren.tsx
+++ b/src/utils/layout/generator/NodeRepeatingChildren.tsx
@@ -97,7 +97,6 @@ const GenerateRow = React.memo(function GenerateRow({
 }: GenerateRowProps) {
   const node = GeneratorInternal.useParent() as LayoutNode;
   const depth = GeneratorInternal.useDepth();
-  const directMutators = useMemo(() => [mutateMultiPageIndex(multiPageMapping)], [multiPageMapping]);
 
   const recursiveMutators = useMemo(
     () => [
@@ -117,8 +116,8 @@ const GenerateRow = React.memo(function GenerateRow({
     >
       <GeneratorRowProvider
         rowIndex={rowIndex}
+        multiPageMapping={multiPageMapping}
         groupBinding={groupBinding}
-        directMutators={directMutators}
         idMutators={[mutateComponentIdPlain(rowIndex)]}
         recursiveMutators={recursiveMutators}
       >
@@ -205,7 +204,7 @@ function MaintainRowUuid({
   return null;
 }
 
-interface MultiPageMapping {
+export interface MultiPageMapping {
   [childId: string]: number;
 }
 
@@ -218,27 +217,12 @@ function makeMultiPageMapping(children: string[] | undefined): MultiPageMapping 
   return mapping;
 }
 
-function mutateMultiPageIndex(multiPageMapping: MultiPageMapping | undefined): ChildMutator {
-  return (item) => {
-    if (!multiPageMapping) {
-      return;
-    }
-
-    const id = item.baseComponentId ?? item.id;
-    const multiPageIndex = multiPageMapping[id];
-    if (multiPageIndex !== undefined) {
-      item['multiPageIndex'] = multiPageIndex;
-    }
-  };
-}
-
 export function mutateComponentIdPlain(rowIndex: number): ChildIdMutator {
   return (id) => `${id}-${rowIndex}`;
 }
 
 export function mutateComponentId(rowIndex: number): ChildMutator {
   return (item) => {
-    item.baseComponentId = item.baseComponentId || item.id;
     item.id += `-${rowIndex}`;
   };
 }

--- a/src/utils/layout/plugins/NonRepeatingChildrenPlugin.tsx
+++ b/src/utils/layout/plugins/NonRepeatingChildrenPlugin.tsx
@@ -129,17 +129,18 @@ export class NonRepeatingChildrenPlugin<E extends ExternalConfig>
     } as DefPluginExtraInItem<ToInternal<E>>;
   }
 
-  claimChildren({ item, claimChild, getProto }: DefPluginChildClaimerProps<ToInternal<E>>): void {
+  claimChildren({ item, claimChild, getType, getCapabilities }: DefPluginChildClaimerProps<ToInternal<E>>): void {
     for (const id of item[this.settings.externalProp].values()) {
       if (this.settings.onlyWithCapability) {
-        const proto = getProto(id);
-        if (!proto) {
+        const type = getType(id);
+        if (!type) {
           continue;
         }
-        if (!proto.capabilities[this.settings.onlyWithCapability]) {
+        const capabilities = getCapabilities(type);
+        if (!capabilities[this.settings.onlyWithCapability]) {
           window.logWarn(
             `${this.settings.componentType} component included a component '${id}', which ` +
-              `is a '${proto.type}' and cannot be rendered in an ${this.settings.componentType}.`,
+              `is a '${type}' and cannot be rendered in an ${this.settings.componentType}.`,
           );
           continue;
         }

--- a/src/utils/layout/types.ts
+++ b/src/utils/layout/types.ts
@@ -31,7 +31,7 @@ export interface StateFactoryProps<Type extends CompTypes> {
   depth: number;
   rowIndex: number | undefined;
   idMutators: ChildIdMutator[];
-  layoutMap: Record<string, CompExternal>;
+  layoutMap: Record<string, CompExternal | undefined>;
   getCapabilities: (type: CompTypes) => CompCapabilities;
   isValid: boolean;
 }

--- a/src/utils/layout/useDataModelBindingTranspose.ts
+++ b/src/utils/layout/useDataModelBindingTranspose.ts
@@ -2,10 +2,9 @@ import { useCallback } from 'react';
 
 import { ContextNotProvided } from 'src/core/contexts/context';
 import { transposeDataBinding } from 'src/utils/databindings/DataBinding';
-import { BaseLayoutNode } from 'src/utils/layout/LayoutNode';
+import { LayoutNode } from 'src/utils/layout/LayoutNode';
 import { NodesInternal } from 'src/utils/layout/NodesContext';
 import type { IDataModelReference } from 'src/layout/common.generated';
-import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 import type { LaxNodeDataSelector } from 'src/utils/layout/NodesContext';
 
 export type DataModelTransposeSelector = ReturnType<typeof useDataModelBindingTranspose>;
@@ -60,7 +59,7 @@ function firstDataModelBinding(
 } {
   const data = nodeDataSelector(
     (picker) => {
-      const nodeData = picker(node instanceof BaseLayoutNode ? node.id : node);
+      const nodeData = picker(node instanceof LayoutNode ? node.id : node);
       if (!nodeData) {
         return undefined;
       }

--- a/test/e2e/integration/frontend-test/mobile.ts
+++ b/test/e2e/integration/frontend-test/mobile.ts
@@ -127,7 +127,7 @@ function testConfirm() {
   cy.get(appFrontend.confirm.sendIn).click();
   cy.get(appFrontend.confirm.sendIn).should('not.exist');
   cy.get(appFrontend.receipt.container).should('be.visible');
-  cy.get(appFrontend.receipt.linkToArchive).should('be.visible');
+  cy.findByRole('link', { name: 'Kopi av din kvittering er sendt til ditt arkiv' }).should('be.visible');
 }
 
 function sendIn() {

--- a/test/e2e/pageobjects/app-frontend.ts
+++ b/test/e2e/pageobjects/app-frontend.ts
@@ -112,7 +112,6 @@ export class AppFrontend {
   //Receipt
   public receipt = {
     container: '#ReceiptContainer',
-    linkToArchive: 'a[href$="/ui/messagebox/archive"]',
     pdf: '#attachment-list-pdf',
     uploadedAttachments: '[data-testid=attachment-list]',
   };


### PR DESCRIPTION
## Description

Taking the time to clean up some dangling parts and things that could be optimized:

- Fixing duplicate `| undefined | undefined` after I inlined the traversal restriction type
- Skipping the first render in LayoutSetGenerator now that children have already been claimed as soon as we fetched layouts. Also removing the 'ComponentProto' stuff and just making functions for fetching the component type and capabilities.
- Using `layoutLookups` directly when figuring out the top-level components in `Form.tsx`.
- Removing selection from `NodesContext` when figuring out how many rows there are in repeating groups in the legacy dynamics engine.
- Removing the layout map provided by `GeneratorContext`, we can get the same from `layoutLookups` now.
- Simplifying the props passed to `GeneratorGlobalProvider`/`GeneratorPageProvider`/`GeneratorNodeProvider`/`GeneratorRowProvider`. A node cannot pass mutators, there was never a use-case for that.
- Renaming `BaseLayoutNode` to just `LayoutNode`. We had functionality for extending the `BaseLayoutNode` and adding functionality for some node types, but no components have been using this. As a result, lots of code have been confusing the two types and using them interchangeably. Now it's just one. :partying_face:
- Removing the need for the `HierarchyExtensions` type. We no longer add the `baseComponentId` to `node.item`. This will make it easier to rewrite this to just resolve expressions (without having to add the two extra properties after resolving expressions). 

## Related Issue(s)

- #2490

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [x] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
