### PR TITLE
Script to run all test apps and cypress tests locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -403,6 +403,8 @@ layout.schema.v1.json
 layout-sets.schema.v1.json
 layoutSettings.schema.v1.json
 
+/test/run-all-artifacts
+
 eslint-results.html
 
 runner-results

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "exports": "./src/index.tsx",
   "scripts": {
     "postinstall": "husky",
+    "cy:all": "node -r ts-node/register/transpile-only -r tsconfig-paths/register scripts/cypress-run-all.ts",
     "gen": "node -r ts-node/register/transpile-only -r tsconfig-paths/register src/codegen/run.ts",
     "copy-schemas": "node -r ts-node/register/transpile-only -r tsconfig-paths/register scripts/copy-schemas.ts",
     "start": "yarn gen && cross-env NODE_ENV=development webpack-dev-server --config webpack.config.development.js --mode development --progress",

--- a/scripts/cypress-run-all.ts
+++ b/scripts/cypress-run-all.ts
@@ -1,0 +1,141 @@
+/* eslint-disable no-console */
+// Script to run all Cypress tests for all apps. This will start one app, run all tests for that app until completion,
+// then start the next app and run all tests for that app until completion, and so on.
+
+import { spawn } from 'child_process';
+import dotenv from 'dotenv';
+import { existsSync, mkdirSync, readdirSync, renameSync } from 'fs';
+
+const apps = readdirSync('./test/e2e/integration');
+const env = dotenv.config().parsed || {};
+let artifactsDir = './test/run-all-artifacts';
+let environment: string | undefined;
+
+const allArgs = process.argv.slice(2);
+
+// Figure out if the user passed --artifacts-dir and set the artifacts directory accordingly
+if (allArgs.includes('--artifacts-dir')) {
+  const index = allArgs.indexOf('--artifacts-dir');
+  artifactsDir = allArgs[index + 1];
+  allArgs.splice(index, 2);
+}
+
+// Inform the user to provide som arguments for cypress
+if (allArgs.length === 0) {
+  console.log(`Please provide arguments for Cypress. For example: --env environment=podman --config retries=1`);
+  process.exit(1);
+}
+
+// Figure out which environment to run the tests in (passed via -e or --env, with the
+// argument being comma-separated key-value pairs)
+const envIndex = allArgs.findIndex((arg) => arg === '-e' || arg === '--env');
+if (envIndex !== -1) {
+  const envArg = allArgs[envIndex + 1];
+  environment = envArg
+    .split(',')
+    .find((arg) => arg.startsWith('environment='))
+    ?.split('=')[1];
+}
+
+if (!environment) {
+  console.log(`Please provide an environment using --env environment=<value>`);
+  process.exit(1);
+}
+
+// Valid environment values correspond to the files in test/e2e/config/*.json
+if (environment && !existsSync(`./test/e2e/config/${environment}.json`)) {
+  console.log(`Invalid environment: ${environment}`);
+  process.exit(1);
+}
+
+if (environment !== 'tt02' && !env.CYPRESS_APPS_DIR) {
+  console.log(`Please set CYPRESS_APPS_DIR in your .env file to the directory where the apps are located.`);
+  process.exit(1);
+}
+
+const appsDir = env.CYPRESS_APPS_DIR;
+
+if (environment !== 'tt02') {
+  // Make sure every found test directory has a matching app
+  const appDirs = readdirSync(appsDir);
+  const appDirsSet = new Set(appDirs);
+  const missingApps = apps.filter((app) => !appDirsSet.has(app));
+  if (missingApps.length > 0) {
+    console.log(`The following apps are missing from '${appsDir}': ${missingApps.join(', ')}`);
+    process.exit(1);
+  }
+}
+
+const startTime = new Date().toISOString().replace(/:/g, '-');
+
+console.log('Cypress arguments:', ...allArgs);
+console.log(`Artifacts will be stored in: ${artifactsDir}/${startTime}-<app-name> (use --artifacts-dir to change)`);
+console.log('Preparing to run Cypress tests for the following apps:');
+for (const app of apps) {
+  console.log(`- ${app}`);
+}
+
+console.log(``);
+async function runAll() {
+  for (const app of apps) {
+    if (environment === 'tt02') {
+      await runCypressTests(app);
+      continue;
+    }
+
+    console.log(`Starting app: ${app}`);
+    const proc = spawn('dotnet', ['run'], { cwd: `${appsDir}/${app}/App` });
+    let successful = false;
+
+    // Connect to the output and wait until we find the line `Now listening on: http://[::]:5005`
+    proc.stdout.on('data', async (data) => {
+      const line = data.toString().trim();
+      if (line.includes('Now listening on: http://[::]:5005')) {
+        console.log(`App started successfully, running test suite`);
+        successful = true;
+        await runCypressTests(app);
+        proc.kill();
+      }
+    });
+
+    proc.on('close', (code) => {
+      if (!successful) {
+        console.error(`App failed to start, code ${code}`);
+      }
+    });
+
+    await new Promise((resolve) => proc.on('close', resolve));
+  }
+}
+
+async function runCypressTests(app: string) {
+  const proc = spawn('npx', ['cypress', 'run', ...allArgs, '-s', `test/e2e/integration/${app}/*.ts`], {
+    stdio: 'inherit',
+  });
+
+  await new Promise((resolve) => proc.on('close', resolve));
+
+  // When the tests are done, there may be screenshots, videos, etc in the main test dir. We'll clean those up
+  // and move them to the artifacts dir, in sub-folders for each test app (and the timestamp when our tests started)
+  const artifactsAppDir = `${artifactsDir}/${startTime}-${app}`;
+  const sourceArtifacts = [
+    './test/screenshots',
+    './test/videos',
+    './test/reports',
+    './test/redux-history',
+    './test/logs',
+  ];
+
+  mkdirSync(artifactsAppDir, { recursive: true });
+  for (const source of sourceArtifacts) {
+    if (!existsSync(source)) {
+      continue;
+    }
+    renameSync(source, `${artifactsAppDir}/${source.split('/').pop()}`);
+  }
+}
+
+runAll().then(() => {
+  console.log('All apps have been started and all tests have been run');
+  process.exit(0);
+});

--- a/template.env
+++ b/template.env
@@ -25,6 +25,9 @@ JEST_PREVIEW_AUTO=false
 ## ------------------------
 ## Cypress settings
 
+## Directory that contains apps to use for testing (see `cypress-run-all.ts`)
+#CYPRESS_APPS_DIR=C:/Code/altinn/apps
+
 ## Enable this to record videos of Cypress failures
 CYPRESS_RECORD_VIDEO=false
 


### PR DESCRIPTION
## Description

I reviewed old issues and came across #214. Then I remembed I had this script laying around somewhere, so I dug it out. Opening a PR for it here if more people want it.

I usually run it something like this:

```sh
yarn cy:all --env environment=docker,host=localhost:8080 --config retries=1
```

## Related Issue(s)

- closes #214

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [x] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
