### PR TITLE
Renaming new binding in `List` from `saveToList` to `group`

### DIFF
--- a/src/layout/List/ListComponent.tsx
+++ b/src/layout/List/ListComponent.tsx
@@ -80,14 +80,13 @@ export const ListComponent = ({ node }: IListProps) => {
   }
 
   function isRowSelected(row: Row): boolean {
+    if (groupBinding) {
+      const rows = (formData?.group as Row[] | undefined) ?? [];
+      return rows.some((selectedRow) =>
+        Object.keys(row).every((key) => Object.hasOwn(selectedRow, key) && row[key] === selectedRow[key]),
+      );
+    }
     return JSON.stringify(selectedRow) === JSON.stringify(row);
-  }
-
-  function isRowChecked(row: Row): boolean {
-    const rows = (formData?.group as Row[] | undefined) ?? [];
-    return rows.some((selectedRow) =>
-      Object.keys(row).every((key) => Object.hasOwn(selectedRow, key) && row[key] === selectedRow[key]),
-    );
   }
 
   const title = item.textResourceBindings?.title;
@@ -105,7 +104,7 @@ export const ListComponent = ({ node }: IListProps) => {
     if (!groupBinding) {
       return;
     }
-    if (isRowChecked(row)) {
+    if (isRowSelected(row)) {
       const index = (formData?.group as Row[]).findIndex((selectedRow) => {
         const { altinnRowId: _ } = selectedRow;
         return Object.keys(row).every((key) => Object.hasOwn(selectedRow, key) && row[key] === selectedRow[key]);
@@ -160,7 +159,7 @@ export const ListComponent = ({ node }: IListProps) => {
           onClick={() => handleRowClick(row)}
           value={JSON.stringify(row)}
           className={cn(classes.mobile)}
-          checked={isRowChecked(row)}
+          checked={isRowSelected(row)}
         >
           {renderListItems(row, tableHeaders)}
         </Checkbox>
@@ -271,7 +270,7 @@ export const ListComponent = ({ node }: IListProps) => {
                     aria-label={JSON.stringify(row)}
                     onChange={() => {}}
                     value={JSON.stringify(row)}
-                    checked={isRowChecked(row)}
+                    checked={isRowSelected(row)}
                     name={node.id}
                   />
                 ) : (

--- a/src/layout/List/ListComponent.tsx
+++ b/src/layout/List/ListComponent.tsx
@@ -58,7 +58,7 @@ export const ListComponent = ({ node }: IListProps) => {
   const bindings = item.dataModelBindings ?? ({} as IDataModelBindingsForList);
 
   const { formData, setValues } = useDataModelBindings(bindings, DEFAULT_DEBOUNCE_TIMEOUT, 'raw');
-  const saveToList = item.dataModelBindings?.saveToList;
+  const groupBinding = item.dataModelBindings?.group;
 
   const appendToList = FD.useAppendToList();
   const removeFromList = FD.useRemoveIndexFromList();
@@ -67,7 +67,7 @@ export const ListComponent = ({ node }: IListProps) => {
     (key) => !tableHeadersMobile || tableHeadersMobile.includes(key),
   );
 
-  const selectedRow = !saveToList
+  const selectedRow = !groupBinding
     ? (data?.listItems.find((row) => Object.keys(formData).every((key) => row[key] === formData[key])) ?? '')
     : '';
 
@@ -84,7 +84,7 @@ export const ListComponent = ({ node }: IListProps) => {
   }
 
   function isRowChecked(row: Row): boolean {
-    const rows = (formData?.saveToList as Row[] | undefined) ?? [];
+    const rows = (formData?.group as Row[] | undefined) ?? [];
     return rows.some((selectedRow) =>
       Object.keys(row).every((key) => Object.hasOwn(selectedRow, key) && row[key] === selectedRow[key]),
     );
@@ -94,7 +94,7 @@ export const ListComponent = ({ node }: IListProps) => {
   const description = item.textResourceBindings?.description;
 
   const handleRowClick = (row: Row) => {
-    if (saveToList) {
+    if (groupBinding) {
       handleSelectedCheckboxRow(row);
     } else {
       handleSelectedRadioRow({ selectedValue: row });
@@ -102,17 +102,17 @@ export const ListComponent = ({ node }: IListProps) => {
   };
 
   const handleSelectedCheckboxRow = (row: Row) => {
-    if (!saveToList) {
+    if (!groupBinding) {
       return;
     }
     if (isRowChecked(row)) {
-      const index = (formData?.saveToList as Row[]).findIndex((selectedRow) => {
+      const index = (formData?.group as Row[]).findIndex((selectedRow) => {
         const { altinnRowId: _ } = selectedRow;
         return Object.keys(row).every((key) => Object.hasOwn(selectedRow, key) && row[key] === selectedRow[key]);
       });
       if (index >= 0) {
         removeFromList({
-          reference: saveToList,
+          reference: groupBinding,
           index,
         });
       }
@@ -120,12 +120,12 @@ export const ListComponent = ({ node }: IListProps) => {
       const uuid = uuidv4();
       const next: Row = { [ALTINN_ROW_ID]: uuid };
       for (const binding of Object.keys(bindings)) {
-        if (binding !== 'saveToList') {
+        if (binding !== 'group') {
           next[binding] = row[binding];
         }
       }
       appendToList({
-        reference: saveToList,
+        reference: groupBinding,
         newValue: { ...next },
       });
     }
@@ -141,7 +141,7 @@ export const ListComponent = ({ node }: IListProps) => {
       </div>
     ));
 
-  const options = saveToList ? (
+  const options = groupBinding ? (
     <Checkbox.Group
       legend={
         <Heading
@@ -265,7 +265,7 @@ export const ListComponent = ({ node }: IListProps) => {
                   [classes.selectedRowCell]: isRowSelected(row),
                 })}
               >
-                {saveToList ? (
+                {groupBinding ? (
                   <Checkbox
                     className={classes.toggleControl}
                     aria-label={JSON.stringify(row)}

--- a/src/layout/List/ListSummary.tsx
+++ b/src/layout/List/ListSummary.tsx
@@ -33,7 +33,7 @@ export const ListSummary = ({ componentNode, isCompact, emptyFieldText }: ListCo
   const { tableHeaders, dataModelBindings } = useNodeItem(componentNode);
   const { formData } = useDataModelBindings(dataModelBindings, DEFAULT_DEBOUNCE_TIMEOUT, 'raw');
 
-  const displayRows = (formData?.saveToList as Row[])?.map((row: Row) => {
+  const displayRows = (formData?.group as Row[])?.map((row: Row) => {
     const { altinnRowId: _, ...rest } = row;
     return rest;
   });

--- a/src/layout/List/config.ts
+++ b/src/layout/List/config.ts
@@ -26,20 +26,20 @@ export const Config = new CG.component({
   .extends(CG.common('LabeledComponentProps'))
   .extendTextResources(CG.common('TRBLabel'))
   .addDataModelBinding(
-    new CG.obj().optional().additionalProperties(new CG.dataModelBinding()).exportAs('IDataModelBindingsForList'),
-  )
-  .addDataModelBinding(
     new CG.obj(
       new CG.prop(
-        'saveToList',
+        'group',
         new CG.dataModelBinding()
-          .setTitle('SaveToList')
+          .setTitle('group binding')
           .setDescription(
             'Dot notation location for a repeating structure (array of objects), where you want to save the content of checked checkboxes',
           )
           .optional(),
       ),
-    ).exportAs('IDataModelBindingsForSaveTolist'),
+    )
+      .optional()
+      .additionalProperties(new CG.dataModelBinding().optional())
+      .exportAs('IDataModelBindingsForList'),
   )
   .addProperty(
     new CG.prop(

--- a/src/layout/List/index.tsx
+++ b/src/layout/List/index.tsx
@@ -40,7 +40,7 @@ export class List extends ListDef {
       return formData?.[summaryBinding] ?? '';
     } else if (legacySummaryBinding && dmBindings) {
       for (const [key, binding] of Object.entries(dmBindings)) {
-        if (binding.field === legacySummaryBinding) {
+        if (binding?.field === legacySummaryBinding) {
           return formData?.[key] ?? '';
         }
       }
@@ -74,21 +74,21 @@ export class List extends ListDef {
 
     const dataModelBindings = ctx.item.dataModelBindings ?? {};
 
-    if (!dataModelBindings?.saveToList) {
+    if (!dataModelBindings?.group) {
       for (const [binding] of Object.entries(dataModelBindings ?? {})) {
         const [newErrors] = this.validateDataModelBindingsAny(ctx, binding, allowedTypes, false);
         errors.push(...(newErrors || []));
       }
     }
 
-    const [newErrors] = this.validateDataModelBindingsAny(ctx, 'saveToList', ['array'], false);
+    const [newErrors] = this.validateDataModelBindingsAny(ctx, 'group', ['array'], false);
     if (newErrors) {
       errors.push(...(newErrors || []));
     }
 
-    if (dataModelBindings?.saveToList) {
-      const saveToListBinding = ctx.lookupBinding(dataModelBindings?.saveToList);
-      const items = saveToListBinding[0]?.items;
+    if (dataModelBindings?.group) {
+      const groupBinding = ctx.lookupBinding(dataModelBindings.group);
+      const items = groupBinding[0]?.items;
       const properties =
         items && !Array.isArray(items) && typeof items === 'object' && 'properties' in items
           ? items.properties
@@ -97,15 +97,16 @@ export class List extends ListDef {
       for (const [binding] of Object.entries(dataModelBindings ?? {})) {
         let selectedBinding: JSONSchema7Definition | undefined;
         if (properties) {
+          // TODO: Fix this, it doesn't properly handle nested properties
           selectedBinding = properties[binding];
         }
-        if (binding !== 'saveToList' && items && typeof items === 'object' && 'properties' in items) {
+        if (binding !== 'group' && items && typeof items === 'object' && 'properties' in items) {
           if (!selectedBinding) {
-            errors.push(`saveToList must contain a field with the same name as the field ${binding}`);
+            errors.push(`group must contain a field with the same name as the field ${binding}`);
           } else if (typeof selectedBinding !== 'object' || typeof selectedBinding.type !== 'string') {
-            errors.push(`Field ${binding} in saveToList must be one of types ${allowedTypes.join(', ')}`);
+            errors.push(`Field ${binding} in group must be one of types ${allowedTypes.join(', ')}`);
           } else if (!allowedTypes.includes(selectedBinding.type)) {
-            errors.push(`Field ${binding} in saveToList must be one of types ${allowedTypes.join(', ')}`);
+            errors.push(`Field ${binding} in group must be one of types ${allowedTypes.join(', ')}`);
           }
         }
       }

--- a/src/layout/List/index.tsx
+++ b/src/layout/List/index.tsx
@@ -1,8 +1,9 @@
 import React, { forwardRef } from 'react';
 import type { JSX } from 'react';
 
-import type { JSONSchema7Definition } from 'json-schema';
+import dot from 'dot-object';
 
+import { lookupErrorAsText } from 'src/features/datamodel/lookupErrorAsText';
 import { useDisplayData } from 'src/features/displayData/useDisplayData';
 import { evalQueryParameters } from 'src/features/options/evalQueryParameters';
 import { ListDef } from 'src/layout/List/config.def.generated';
@@ -15,6 +16,7 @@ import { useNodeFormDataWhenType } from 'src/utils/layout/useNodeItem';
 import type { LayoutValidationCtx } from 'src/features/devtools/layoutValidation/types';
 import type { ComponentValidation } from 'src/features/validation';
 import type { PropsFromGenericComponent } from 'src/layout';
+import type { IDataModelReference } from 'src/layout/common.generated';
 import type { ExprResolver, SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
@@ -28,6 +30,7 @@ export class List extends ListDef {
 
   useDisplayData(nodeId: string): string {
     const dmBindings = NodesInternal.useNodeDataWhenType(nodeId, 'List', (data) => data.layout.dataModelBindings);
+    const groupBinding = dmBindings?.group;
     const summaryBinding = NodesInternal.useNodeDataWhenType(nodeId, 'List', (data) => data.item?.summaryBinding);
     const legacySummaryBinding = NodesInternal.useNodeDataWhenType(
       nodeId,
@@ -35,6 +38,27 @@ export class List extends ListDef {
       (data) => data.item?.bindingToShowInSummary,
     );
     const formData = useNodeFormDataWhenType(nodeId, 'List');
+
+    if (groupBinding) {
+      // When the data model binding is a group binding, all the data is now in formData.group, and all the other
+      // values are undefined. This is because useNodeFormDataWhenType doesn't know the intricacies of the group
+      // binding and how it works in the List component. We need to find the values inside the rows ourselves.
+      const rows = (formData?.group as unknown[] | undefined) ?? [];
+      if (summaryBinding && dmBindings) {
+        const summaryReference = dmBindings[summaryBinding];
+        const rowData = rows.map((row) => (summaryReference ? findDataInRow(row, summaryReference, groupBinding) : ''));
+        return Object.values(rowData).join(', ');
+      }
+
+      if (legacySummaryBinding && dmBindings) {
+        window.logError(
+          `Node ${nodeId}: BindingToShowInSummary is deprecated and does not work ` +
+            `along with a group binding, use summaryBinding instead`,
+        );
+      }
+
+      return '';
+    }
 
     if (summaryBinding && dmBindings) {
       return formData?.[summaryBinding] ?? '';
@@ -70,45 +94,44 @@ export class List extends ListDef {
 
   validateDataModelBindings(ctx: LayoutValidationCtx<'List'>): string[] {
     const errors: string[] = [];
-    const allowedTypes = ['string', 'boolean', 'number', 'integer'];
-
+    const allowedLeafTypes = ['string', 'boolean', 'number', 'integer'];
     const dataModelBindings = ctx.item.dataModelBindings ?? {};
 
-    if (!dataModelBindings?.group) {
-      for (const [binding] of Object.entries(dataModelBindings ?? {})) {
-        const [newErrors] = this.validateDataModelBindingsAny(ctx, binding, allowedTypes, false);
-        errors.push(...(newErrors || []));
+    const groupBinding = dataModelBindings?.group;
+    if (groupBinding) {
+      const [groupErrors] = this.validateDataModelBindingsAny(ctx, 'group', ['array'], false);
+      if (groupErrors) {
+        errors.push(...(groupErrors || []));
       }
-    }
 
-    const [newErrors] = this.validateDataModelBindingsAny(ctx, 'group', ['array'], false);
-    if (newErrors) {
-      errors.push(...(newErrors || []));
-    }
-
-    if (dataModelBindings?.group) {
-      const groupBinding = ctx.lookupBinding(dataModelBindings.group);
-      const items = groupBinding[0]?.items;
-      const properties =
-        items && !Array.isArray(items) && typeof items === 'object' && 'properties' in items
-          ? items.properties
-          : undefined;
-
+      for (const key of Object.keys(dataModelBindings)) {
+        const binding = dataModelBindings[key];
+        if (key === 'group' || !binding) {
+          continue;
+        }
+        if (binding.dataType !== groupBinding.dataType) {
+          errors.push(`Field ${key} must have the same data type as the group binding`);
+          continue;
+        }
+        if (!binding.field.startsWith(`${groupBinding.field}.`)) {
+          errors.push(
+            `Field ${key} must start with the group binding field (must point to a property inside the group)`,
+          );
+          continue;
+        }
+        const fieldWithoutGroup = binding.field.replace(`${groupBinding.field}.`, '');
+        const fieldWithIndex = `${groupBinding.field}[0].${fieldWithoutGroup}`;
+        const [schema, err] = ctx.lookupBinding({ field: fieldWithIndex, dataType: binding.dataType });
+        if (err || !schema) {
+          errors.push(lookupErrorAsText(err));
+        } else if (!schema || typeof schema.type !== 'string' || !allowedLeafTypes.includes(schema.type)) {
+          errors.push(`Field ${binding} in group must be one of types ${allowedLeafTypes.join(', ')}`);
+        }
+      }
+    } else {
       for (const [binding] of Object.entries(dataModelBindings ?? {})) {
-        let selectedBinding: JSONSchema7Definition | undefined;
-        if (properties) {
-          // TODO: Fix this, it doesn't properly handle nested properties
-          selectedBinding = properties[binding];
-        }
-        if (binding !== 'group' && items && typeof items === 'object' && 'properties' in items) {
-          if (!selectedBinding) {
-            errors.push(`group must contain a field with the same name as the field ${binding}`);
-          } else if (typeof selectedBinding !== 'object' || typeof selectedBinding.type !== 'string') {
-            errors.push(`Field ${binding} in group must be one of types ${allowedTypes.join(', ')}`);
-          } else if (!allowedTypes.includes(selectedBinding.type)) {
-            errors.push(`Field ${binding} in group must be one of types ${allowedTypes.join(', ')}`);
-          }
-        }
+        const [newErrors] = this.validateDataModelBindingsAny(ctx, binding, allowedLeafTypes, false);
+        errors.push(...(newErrors || []));
       }
     }
 
@@ -121,4 +144,10 @@ export class List extends ListDef {
       queryParameters: evalQueryParameters(props),
     };
   }
+}
+
+function findDataInRow(row: unknown, binding: IDataModelReference, groupBinding: IDataModelReference): unknown {
+  // Remove the first part of the binding.field that overlaps with the group binding
+  const field = binding.field.replace(`${groupBinding.field}.`, '');
+  return dot.pick(field, row);
 }

--- a/src/layout/List/index.tsx
+++ b/src/layout/List/index.tsx
@@ -100,9 +100,7 @@ export class List extends ListDef {
     const groupBinding = dataModelBindings?.group;
     if (groupBinding) {
       const [groupErrors] = this.validateDataModelBindingsAny(ctx, 'group', ['array'], false);
-      if (groupErrors) {
-        errors.push(...(groupErrors || []));
-      }
+      groupErrors && errors.push(...groupErrors);
 
       for (const key of Object.keys(dataModelBindings)) {
         const binding = dataModelBindings[key];
@@ -122,9 +120,9 @@ export class List extends ListDef {
         const fieldWithoutGroup = binding.field.replace(`${groupBinding.field}.`, '');
         const fieldWithIndex = `${groupBinding.field}[0].${fieldWithoutGroup}`;
         const [schema, err] = ctx.lookupBinding({ field: fieldWithIndex, dataType: binding.dataType });
-        if (err || !schema) {
+        if (err) {
           errors.push(lookupErrorAsText(err));
-        } else if (!schema || typeof schema.type !== 'string' || !allowedLeafTypes.includes(schema.type)) {
+        } else if (typeof schema?.type !== 'string' || !allowedLeafTypes.includes(schema.type)) {
           errors.push(`Field ${binding} in group must be one of types ${allowedLeafTypes.join(', ')}`);
         }
       }

--- a/src/layout/List/useValidateListIsEmpty.ts
+++ b/src/layout/List/useValidateListIsEmpty.ts
@@ -2,6 +2,7 @@ import { FD } from 'src/features/formData/FormDataWrite';
 import { FrontendValidationSource, ValidationMask } from 'src/features/validation';
 import { getFieldNameKey } from 'src/utils/formComponentUtils';
 import { NodesInternal } from 'src/utils/layout/NodesContext';
+import { useNodeFormDataWhenType } from 'src/utils/layout/useNodeItem';
 import type { ComponentValidation } from 'src/features/validation';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
@@ -9,7 +10,7 @@ export function useValidateListIsEmpty(node: LayoutNode<'List'>): ComponentValid
   const required = NodesInternal.useNodeData(node, (d) => (d.item && 'required' in d.item ? d.item.required : false));
   const dataModelBindings = NodesInternal.useNodeData(node, (d) => d.layout.dataModelBindings);
   const textResourceBindings = NodesInternal.useNodeData(node, (d) => d.item?.textResourceBindings);
-  const formDataSelector = FD.useDebouncedSelector();
+  const formData = useNodeFormDataWhenType(node.id, 'List');
   const invalidDataSelector = FD.useInvalidDebouncedSelector();
   if (!required || !dataModelBindings) {
     return [];
@@ -18,23 +19,24 @@ export function useValidateListIsEmpty(node: LayoutNode<'List'>): ComponentValid
   const validations: ComponentValidation[] = [];
 
   let listHasErrors = false;
-  for (const key of Object.keys(dataModelBindings)) {
-    const reference = dataModelBindings[key];
-    if (!reference) {
-      continue;
-    }
-    if (key === 'group') {
-      // TODO: Fix, it should validate properly when using a group binding as well
-    }
+  if (dataModelBindings.group) {
+    const numRows = (formData?.group as unknown[] | undefined) ?? [];
+    listHasErrors = numRows.length === 0;
+  } else {
+    for (const key of Object.keys(dataModelBindings)) {
+      const reference = dataModelBindings[key];
+      if (reference) {
+        const data = formData?.[key] ?? invalidDataSelector(reference);
+        const dataAsString =
+          typeof data === 'string' || typeof data === 'number' || typeof data === 'boolean' ? String(data) : undefined;
 
-    const data = formDataSelector(reference) ?? invalidDataSelector(reference);
-    const dataAsString =
-      typeof data === 'string' || typeof data === 'number' || typeof data === 'boolean' ? String(data) : undefined;
-
-    if (!dataAsString?.length) {
-      listHasErrors = true;
+        if (!dataAsString?.length) {
+          listHasErrors = true;
+        }
+      }
     }
   }
+
   if (listHasErrors) {
     const key = textResourceBindings?.requiredValidation
       ? textResourceBindings?.requiredValidation

--- a/src/layout/List/useValidateListIsEmpty.ts
+++ b/src/layout/List/useValidateListIsEmpty.ts
@@ -15,11 +15,18 @@ export function useValidateListIsEmpty(node: LayoutNode<'List'>): ComponentValid
     return [];
   }
 
-  const references = Object.values(dataModelBindings);
   const validations: ComponentValidation[] = [];
 
   let listHasErrors = false;
-  for (const reference of references) {
+  for (const key of Object.keys(dataModelBindings)) {
+    const reference = dataModelBindings[key];
+    if (!reference) {
+      continue;
+    }
+    if (key === 'group') {
+      // TODO: Fix, it should validate properly when using a group binding as well
+    }
+
     const data = formDataSelector(reference) ?? invalidDataSelector(reference);
     const dataAsString =
       typeof data === 'string' || typeof data === 'number' || typeof data === 'boolean' ? String(data) : undefined;

--- a/test/e2e/integration/component-library/list.ts
+++ b/test/e2e/integration/component-library/list.ts
@@ -9,48 +9,61 @@ describe('List component', () => {
     cy.startAppInstance(appFrontend.apps.componentLibrary, { authenticationLevel: '2' });
     cy.gotoNavPage('Liste (tabell)');
   });
+
   it('Should be possible to select multiple rows', () => {
-    cy.findAllByRole('cell', { name: 'Johanne' }).last().parent().click(); /*[1].parent().click();*/
-    cy.findAllByRole('cell', { name: 'Kari' }).last().parent().click();
-    cy.findAllByRole('cell', { name: 'Johanne' }).last().parent().findByRole('checkbox').should('be.checked');
-    cy.findAllByRole('cell', { name: 'Kari' }).last().parent().findByRole('checkbox').should('be.checked');
-  });
+    const list = '[data-componentid=ListPage-ListWithCheckboxesComponent]';
+    const repGroup = '[data-componentid=RepeatingGroupListWithCheckboxes]';
+    const summary1 = '[data-componentid=ListPage-Summary-Component2]';
 
-  it('Should be possible to deselect rows', () => {
-    cy.findAllByRole('cell', { name: 'Johanne' }).last().parent().click();
-    cy.findAllByRole('cell', { name: 'Kari' }).last().parent().click();
-    cy.findAllByRole('cell', { name: 'Johanne' }).last().parent().click();
-    cy.findAllByRole('cell', { name: 'Kari' }).last().parent().findByRole('checkbox').should('be.checked');
-    cy.findAllByRole('cell', { name: 'Johanne' }).last().parent().findByRole('checkbox').should('not.be.checked');
-  });
+    cy.get(list).findByRole('cell', { name: 'Johanne' }).parent().click();
+    cy.get(list).findByRole('cell', { name: 'Kari' }).parent().click();
+    cy.get(list).findByRole('cell', { name: 'Johanne' }).parent().findByRole('checkbox').should('be.checked');
+    cy.get(list).findByRole('cell', { name: 'Kari' }).parent().findByRole('checkbox').should('be.checked');
 
-  it('Selections in list should apply to RepeatingGroup', () => {
-    cy.findAllByRole('cell', { name: 'Johanne' }).last().parent().click();
-    cy.findAllByRole('cell', { name: 'Kari' }).last().parent().click();
-    cy.findAllByRole('cell', { name: 'Johanne' }).last().parent().click();
+    // Unchecking
+    cy.get(list).findByRole('cell', { name: 'Johanne' }).parent().click();
+    cy.get(list).findByRole('cell', { name: 'Kari' }).parent().findByRole('checkbox').should('be.checked');
+    cy.get(list).findByRole('cell', { name: 'Johanne' }).parent().findByRole('checkbox').should('not.be.checked');
 
-    cy.findAllByRole('cell', { name: 'Kari' }).last().should('exist');
-  });
+    // Should be visible in RepeatingGroup
+    cy.get(repGroup).findByRole('cell', { name: 'Kari' }).should('exist');
 
-  it('Removing from RepeatingGroup should deselect from List', () => {
-    cy.findAllByRole('cell', { name: 'Kari' }).last().parent().click();
-    cy.findAllByRole('cell', { name: 'Kari' }).last().parent().findByRole('checkbox').should('be.checked');
+    // Removing from RepeatingGroup should deselect from List
+    cy.get(repGroup).findAllByRole('row').should('have.length', 2); // Header + 1 row
+    cy.get(repGroup)
+      .findByRole('button', { name: /^Slett/ })
+      .click();
+    cy.get(list).findByRole('cell', { name: 'Kari' }).parent().findByRole('checkbox').should('not.be.checked');
 
-    cy.findAllByRole('cell', { name: 'Kari' }).last().parent().contains('td', 'Slett').findByRole('button').click();
-
-    cy.findAllByRole('cell', { name: 'Kari' }).last().parent().findByRole('checkbox').should('not.be.checked');
-  });
-
-  it('Deselecting in List should remove from RepeatingGroup', () => {
-    cy.findAllByRole('cell', { name: 'Kari' }).last().parent().click();
-    cy.findAllByRole('cell', { name: 'Kari' }).last().parent().findByRole('checkbox').should('be.checked');
-    cy.findAllByRole('cell', { name: 'Kari' }).last().parent().contains('td', 'Rediger').findByRole('button').click();
+    // Deleting from List should remove from RepeatingGroup (observe that data is lost)
+    cy.get(list).findByRole('cell', { name: 'Kari' }).parent().click();
+    cy.get(list).findByRole('cell', { name: 'Kari' }).parent().findByRole('checkbox').should('be.checked');
+    cy.get(repGroup).findAllByRole('row').should('have.length', 2); // Header + 1 row
+    cy.get(repGroup)
+      .findByRole('button', { name: /^Rediger/ })
+      .click();
     cy.findByRole('textbox', { name: /Surname/ }).type('Olsen');
     cy.findAllByRole('button', { name: /Lagre og lukk/ })
-      .first()
+      .last()
       .click();
-    cy.findAllByRole('cell', { name: 'Kari' }).last().parent().contains('td', 'Olsen');
-    cy.findAllByRole('cell', { name: 'Kari' }).last().parent().click();
-    cy.get('div[data-componentid*="group-RepeatingGroupListWithCheckboxes"]').should('not.exist');
+    cy.get(repGroup).findByRole('cell', { name: 'Kari' }).parent().contains('td', 'Olsen');
+    cy.get(list).findByRole('cell', { name: 'Kari' }).parent().click();
+
+    cy.get(repGroup).findAllByRole('row').should('have.length', 0);
+
+    // Checking 'Kari' again does not bring back the surname
+    cy.get(list).findByRole('cell', { name: 'Kari' }).parent().click();
+    cy.get(repGroup).findAllByRole('row').should('have.length', 2); // Header + 1 row
+    cy.get(repGroup).findByRole('cell', { name: 'Kari' }).should('exist');
+    cy.get(repGroup).findAllByRole('cell', { name: 'Olsen' }).should('not.exist');
+
+    // Testing summaries
+    cy.get(list).findByRole('cell', { name: 'Johanne' }).parent().click();
+    cy.get(repGroup).findAllByRole('row').should('have.length', 3); // Header + 2 rows
+    cy.get(summary1).should('contain.text', 'Kari, Johanne');
+
+    // Summary2 is a bit more tricky to find
+    cy.get('table').last().should('have.not.have.attr', 'id');
+    cy.get('table').last().findAllByRole('row').should('have.length', 3); // Header + 2 row
   });
 });


### PR DESCRIPTION
## Description

With this change, the data model binding in `List` matches that used for `object[]` types in `RepeatingGroup` (which also adds/removes rows). This should make the setting less confusing when we port this over to `Checkboxes` and `MultipleSelect` later, which hopefully should also get a `list` binding in the future (ref #273). Having both `list` and `saveToList` at that point would be confusing, so we should fix this before releasing #3007.

Also fixing a few minor issues I found:
- `useDisplayData()` for the `List` component now works with the `group` binding (it returns comma-separated strings, using `summaryBinding` when set).
- Data model binding validation didn't account for deeply nested properties in the data model, and also assumed the binding key was the same as the property name in the model (which is not always the case).
- Empty field validation didn't work properly with the `group` binding.

## Related Issue(s)

- #3007

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [x] I will do that later/have created an issue
    - https://github.com/Altinn/altinn-studio-docs/pull/2030
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
