### PR TITLE
Fixing missing codelists for `optionLabel` function

### DIFF
--- a/src/features/options/CodeListsProvider.tsx
+++ b/src/features/options/CodeListsProvider.tsx
@@ -132,6 +132,14 @@ function getAllReferencedCodeLists(
           queryParameters: component.queryParameters,
           secure: component.secure,
         });
+        if (urls.has(url)) {
+          // If the same URL is already in the list, we don't need to add it again. This is especially important
+          // if this optionsId is needed both in static and dynamic contexts (i.e. both referenced in a component and
+          // in an expression). The expression engine can only read from the store, so we need to make sure that we
+          // don't overwrite with 'storeInZustand: false'. The recursive function below will always overwrite, and
+          // thus take precedence.
+          continue;
+        }
         urls.set(url, { optionsId: component.optionsId, storeInZustand: false });
       }
       addCodeListsFromExpressionsRecursive(component, language, instanceId, urls);

--- a/test/e2e/integration/frontend-test/attachments-in-group.ts
+++ b/test/e2e/integration/frontend-test/attachments-in-group.ts
@@ -185,6 +185,11 @@ describe('Repeating group attachments', () => {
       },
     ];
 
+    cy.get(appFrontend.group.row(0).uploadSingle.fileUploader).should(
+      'contain.text',
+      'Last opp alle vedlegg med kilde Altinn her:',
+    );
+
     uploadFile({
       item: appFrontend.group.row(0).uploadSingle,
       idx: 0,


### PR DESCRIPTION
## Description

I was trying to reproduce and find a solution for #2117 when I stumbled upon a bug with the `CodeListsProvider` I made for the `optionLabel` expression function, and to at the same time replace the former option prefetcher. The problem here was that a component used the same option list without a mapping, and would come in later to overwrite the entry in `CodeListsProvider` with a `storeInZustand: false` flag, making sure the option list was not available to the `optionLabel` function after all. 

## Related Issue(s)

- #2117

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [X] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
