### PR TITLE
Fixes for organization logo

### DIFF
--- a/src/components/presentation/Header.tsx
+++ b/src/components/presentation/Header.tsx
@@ -7,7 +7,6 @@ import cn from 'classnames';
 import { Flex } from 'src/app-components/Flex/Flex';
 import classes from 'src/components/presentation/Header.module.css';
 import { useAppName, useAppOwner, useHasAppTextsYet } from 'src/core/texts/appTexts';
-import { useDisplayAppOwnerNameInHeader } from 'src/hooks/useAppLogo';
 
 export interface IHeaderProps extends PropsWithChildren {
   header: string | React.ReactNode;
@@ -60,13 +59,11 @@ export function Header({ children, ...props }: IHeaderProps) {
 function HeaderWithTexts({ header, children }: IHeaderProps) {
   const appOwner = useAppOwner();
   const appName = useAppName();
-  const ownerInHeader = useDisplayAppOwnerNameInHeader();
-  const aboveHeader = ownerInHeader ? appOwner : undefined;
 
   return (
     <InnerHeader
       header={header || appName}
-      aboveHeader={aboveHeader}
+      aboveHeader={appOwner}
     >
       {children}
     </InnerHeader>

--- a/src/components/presentation/OrganisationLogo/OrganisationLogo.module.css
+++ b/src/components/presentation/OrganisationLogo/OrganisationLogo.module.css
@@ -10,15 +10,21 @@
 }
 
 .medium {
-  height: 50px;
+  height: 56px;
 }
 
 .large {
-  height: 50px;
+  height: 72px;
 }
 
 @media only screen and (min-width: 576px) {
   .large {
-    height: 123px;
+    height: 120px;
+  }
+}
+
+@media print {
+  .large {
+    height: 104px;
   }
 }

--- a/src/features/pdf/PDFView.module.css
+++ b/src/features/pdf/PDFView.module.css
@@ -23,15 +23,9 @@
   margin-bottom: var(--fds-spacing-4);
 }
 
-.paymentTitleContainer {
+.pdf-logo-container {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--fds-spacing-6);
-  margin-bottom: var(--fds-spacing-3);
-  h1 {
-    margin-bottom: 0;
-  }
+  margin-bottom: var(--fds-spacing-12);
 }
 
 @media print {

--- a/src/features/pdf/PdfView2.tsx
+++ b/src/features/pdf/PdfView2.tsx
@@ -4,7 +4,6 @@ import type { PropsWithChildren } from 'react';
 import { Heading } from '@digdir/designsystemet-react';
 
 import { Flex } from 'src/app-components/Flex/Flex';
-import { ConditionalWrapper } from 'src/components/ConditionalWrapper';
 import { OrganisationLogo } from 'src/components/presentation/OrganisationLogo/OrganisationLogo';
 import { DummyPresentation } from 'src/components/presentation/Presentation';
 import { ReadyForPrint } from 'src/components/ReadyForPrint';
@@ -157,7 +156,7 @@ function DataLoaderStoreInitWorker({
 }
 
 function PdfWrapping({ children }: PropsWithChildren) {
-  const enableOrgLogo = Boolean(useApplicationMetadata().logoOptions);
+  const orgLogoEnabled = Boolean(useApplicationMetadata().logoOptions);
   const appOwner = useAppOwner();
   const appName = useAppName();
   const { langAsString } = useLanguage();
@@ -168,26 +167,21 @@ function PdfWrapping({ children }: PropsWithChildren) {
       id='pdfView'
       className={classes.pdfWrapper}
     >
-      {appOwner && <span role='doc-subtitle'>{appOwner}</span>}
-
-      <ConditionalWrapper
-        condition={enableOrgLogo}
-        wrapper={(children) => (
-          <div
-            className={classes.paymentTitleContainer}
-            data-testid='pdf-logo'
-          >
-            {children} <OrganisationLogo />
-          </div>
-        )}
-      >
-        <Heading
-          level={1}
-          size='lg'
+      {orgLogoEnabled && (
+        <div
+          className={classes.pdfLogoContainer}
+          data-testid='pdf-logo'
         >
-          {isPayment ? `${appName} - ${langAsString('payment.receipt.title')}` : appName}
-        </Heading>
-      </ConditionalWrapper>
+          <OrganisationLogo />
+        </div>
+      )}
+      {appOwner && <span role='doc-subtitle'>{appOwner}</span>}
+      <Heading
+        level={1}
+        size='lg'
+      >
+        {isPayment ? `${appName} - ${langAsString('payment.receipt.title')}` : appName}
+      </Heading>
       {children}
       <ReadyForPrint type='print' />
     </div>

--- a/src/hooks/useAppLogo.ts
+++ b/src/hooks/useAppLogo.ts
@@ -16,7 +16,7 @@ export function useAppLogoUrl() {
 
 export function useDisplayAppOwnerNameInHeader() {
   const application = useApplicationMetadata();
-  return application.logoOptions?.displayAppOwnerNameInHeader ?? true;
+  return application.logoOptions?.displayAppOwnerNameInHeader === true;
 }
 
 export function useAppLogoSize() {

--- a/test/e2e/integration/component-library/pdf.ts
+++ b/test/e2e/integration/component-library/pdf.ts
@@ -2,15 +2,17 @@ import { AppFrontend } from 'test/e2e/pageobjects/app-frontend';
 
 const appFrontend = new AppFrontend();
 
-describe('PDF rendering', () => {
-  it('Make sure the pdf logo is displayed when rendering in PDF mode only', () => {
+describe('PDF', () => {
+  it('Custom logo is rendered in PDF', () => {
     cy.startAppInstance(appFrontend.apps.componentLibrary, { authenticationLevel: '2' });
-    cy.get('ul#navigation-menu > li').last().click();
-    cy.get('[data-testid="pdf-logo"]').should('not.exist');
-    cy.url().then((currentUrl) => {
-      const newUrl = `${currentUrl}?pdf=1`;
-      cy.visit(newUrl);
-      cy.get('[data-testid="pdf-logo"]').should('exist');
+    cy.waitForLoad();
+
+    cy.testPdf({
+      snapshotName: 'custom-logo',
+      enableResponseFuzzing: true,
+      callback: () => {
+        cy.get('[data-testid="pdf-logo"]').should('be.visible');
+      },
     });
   });
 });


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

- After talking with @Edavda , we decided on some minor tweaks to the sizing of organization logo, as well as increasing the size of `large` in PDF, which previously defaulted to the same size as `medium`, since the breakpoint only applied to `screen` and not to `print`.
- We also decided to move the default position of the logo in PDF to be above the app title and org, as this will be in line with the rules for the norwegian coat of arms, as well as several other requests for moving the logo in PDF. If a need for more custom positioning comes up, we can consider that in a new issue.
- Finally, `displayAppOwnerNameInHeader` no longer affects whether or not the org name is shown above the app title. Now this is always shown instead of being shown only when you also show the org name next to the logo. This seems more correct according to the description in the schema.
- Also changed the PDF test in component-library to use the `testPDF` command with a new snapshot.

## Related Issue(s)

- closes https://github.com/Altinn/app-frontend-react/issues/2945
- closes https://github.com/Altinn/app-frontend-react/issues/2610
- closes https://github.com/Altinn/app-frontend-react/issues/2149
- closes https://github.com/Altinn/app-frontend-react/issues/1706

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
