### PR TITLE
Aria role=button on FileUpload dropzone

### DIFF
--- a/src/layout/FileUpload/DropZone/DropzoneComponent.tsx
+++ b/src/layout/FileUpload/DropZone/DropzoneComponent.tsx
@@ -95,14 +95,18 @@ export function DropzoneComponent({
             ? `${descriptionId} ${maxSizeLabelId} ${dragLabelId} ${formatLabelId}`
             : `${maxSizeLabelId} ${dragLabelId} ${formatLabelId}`;
 
+          // Remove the role supplied from rootProps for our own role override
+          // to work (the user can click it, so it's a button)
+          const rootProps = getRootProps({ onClick }) as ReturnType<typeof getRootProps> & { role?: string };
+          delete rootProps.role;
+
           return (
             <div
-              {...getRootProps({
-                onClick,
-              })}
+              {...rootProps}
               style={styles}
               id={`altinn-drop-zone-${id}`}
               className={`${classes.fileUpload}${hasValidationMessages ? classes.fileUploadInvalid : ''}`}
+              role='button'
               aria-labelledby={labelId}
               aria-describedby={ariaDescribedBy}
             >

--- a/src/layout/FileUpload/DropZone/DropzoneComponent.tsx
+++ b/src/layout/FileUpload/DropZone/DropzoneComponent.tsx
@@ -95,18 +95,12 @@ export function DropzoneComponent({
             ? `${descriptionId} ${maxSizeLabelId} ${dragLabelId} ${formatLabelId}`
             : `${maxSizeLabelId} ${dragLabelId} ${formatLabelId}`;
 
-          // Remove the role supplied from rootProps for our own role override
-          // to work (the user can click it, so it's a button)
-          const rootProps = getRootProps({ onClick }) as ReturnType<typeof getRootProps> & { role?: string };
-          delete rootProps.role;
-
           return (
             <div
-              {...rootProps}
+              {...getRootProps({ onClick, role: 'button' })}
               style={styles}
               id={`altinn-drop-zone-${id}`}
               className={`${classes.fileUpload}${hasValidationMessages ? classes.fileUploadInvalid : ''}`}
-              role='button'
               aria-labelledby={labelId}
               aria-describedby={ariaDescribedBy}
             >


### PR DESCRIPTION
## Description

I wanted to reproduce the referenced issue, but I didn't find the same set of problems in ARC - however, it complained about the aria role being 'presentation' while the element was getting a `tabIndex`. The correct role should be a 'button', because you can click it (or press enter when it's focussed).

## Related Issue(s)

- closes #2542
- https://github.com/react-dropzone/react-dropzone/issues/1085

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [x] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
