### PR TITLE
Adding current data model path to expression validation

### DIFF
--- a/src/features/validation/expressionValidation/ExpressionValidation.tsx
+++ b/src/features/validation/expressionValidation/ExpressionValidation.tsx
@@ -59,12 +59,6 @@ function IndividualExpressionValidation({ dataType }: { dataType: string }) {
       const validations = {};
 
       for (const { nodeReference, dmb } of allBindings) {
-        // Modify the hierarchy data sources to make the current dataModel the default one when running expression validations
-        const modifiedDataSources: ExpressionDataSources = {
-          ...dataSources,
-          defaultDataType: dataType,
-        };
-
         for (const reference of Object.values(dmb as Record<string, IDataModelReference>)) {
           if (reference.dataType !== dataType) {
             continue;
@@ -87,6 +81,11 @@ function IndividualExpressionValidation({ dataType }: { dataType: string }) {
 
           for (const validationDef of validationDefs) {
             const valueArguments: ExprValueArgs<{ field: string }> = { data: { field }, defaultKey: 'field' };
+            const modifiedDataSources: ExpressionDataSources = {
+              ...dataSources,
+              defaultDataType: dataType,
+              currentDataModelPath: reference,
+            };
             const isInvalid = evalExpr(validationDef.condition as Expression, nodeReference, modifiedDataSources, {
               positionalArguments: [field],
               valueArguments,


### PR DESCRIPTION
## Description

When looking up relative paths in the data model in expression validation, this no longer worked now that the node data is no longer being used to resolve that relative path. This did not fail any tests because the `ttd/expression-validation-test` app used `["argv", 0]` for looking up in the data model, but it was also possible to use the full path manually (which I broke in the latest release).

Updating the test app to look these up with a full path when this fix has been merged, so that we get regression test coverage. 

## Related Issue(s)

- closes #3165
- reverts #3077 (at least the bug that was introduced there)

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
