### PR TITLE
Treating null as empty string in `stringReplace`

### DIFF
--- a/src/features/expressions/expression-functions.ts
+++ b/src/features/expressions/expression-functions.ts
@@ -685,10 +685,12 @@ export const ExprFunctionImplementations: { [K in ExprFunctionName]: Implementat
     }
     return string.startsWith(stringToMatch);
   },
-  stringReplace(string, search, replace) {
-    if (!string || !search || replace === null) {
+  stringReplace(string, search, _replace) {
+    if (!string || !search) {
       return null;
     }
+
+    const replace = _replace === null ? '' : _replace;
     return string.replace(new RegExp(escapeStringRegexp(search), 'g'), replace);
   },
   stringLength: (string) => (string === null ? 0 : string.length),

--- a/src/features/expressions/shared-tests/functions/stringReplace/replace-with-null.json
+++ b/src/features/expressions/shared-tests/functions/stringReplace/replace-with-null.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should allow replacing with null (as empty string)",
+  "expression": ["stringReplace", "Hello, {0}!", "{0}", null],
+  "expects": "Hello, !"
+}


### PR DESCRIPTION
## Description

This should have been the behaviour when this was released, but that was not the case. [When searching](https://altinn.studio/repos/explore/code?q=replace&l=JSON&fuzzy=false), it seems this expression is still only used in the app developed by Ronny (who reported the issue).

## Related Issue(s)

- closes #3151
- https://github.com/Altinn/app-lib-dotnet/pull/1214

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
