### PR TITLE
Fixing CSV uploads in Firefox on Windows

### DIFF
--- a/src/layout/FileUpload/DropZone/DropzoneComponent.tsx
+++ b/src/layout/FileUpload/DropZone/DropzoneComponent.tsx
@@ -80,7 +80,7 @@ export function DropzoneComponent({
         disabled={readOnly}
         accept={
           hasCustomFileEndings && validFileEndings !== undefined
-            ? mapExtensionToAcceptMime({ extensionList: validFileEndings })
+            ? mapExtensionToAcceptMime(validFileEndings)
             : undefined
         }
       >

--- a/src/layout/FileUpload/DropZone/mapExtensionToAcceptMime.test.ts
+++ b/src/layout/FileUpload/DropZone/mapExtensionToAcceptMime.test.ts
@@ -1,46 +1,37 @@
-import { mapExtensionToAcceptMime, mapExtToMimeObject } from 'src/layout/FileUpload/DropZone/mapExtensionToAcceptMime';
+import { mapExtensionToAcceptMime } from 'src/layout/FileUpload/DropZone/mapExtensionToAcceptMime';
 
 describe('mapExtensionToAcceptMime', () => {
   it('should map a single file extension as string to mime object', () => {
-    const result = mapExtensionToAcceptMime({ extensionList: '.png' });
-    expect(result).toEqual({
-      'image/png': ['.png'],
-    });
-  });
-
-  it('should map a single file extension as an array to mime object', () => {
-    const result = mapExtensionToAcceptMime({ extensionList: ['.png'] });
-    expect(result).toEqual({
+    expect(mapExtensionToAcceptMime('.png')).toEqual({
       'image/png': ['.png'],
     });
   });
 
   it('should map multiple file extensions as an array to mime object', () => {
-    const result = mapExtensionToAcceptMime({
-      extensionList: ['.png', '.jpg'],
-    });
-    expect(result).toEqual({
+    expect(mapExtensionToAcceptMime(['.png', '.jpg'])).toEqual({
       'image/png': ['.png'],
       'image/jpeg': ['.jpg'],
     });
   });
 
   it('should map multiple file extensions as a comma separated list to mime object', () => {
-    const result = mapExtensionToAcceptMime({
-      extensionList: '.png, .jpg',
-    });
-    expect(result).toEqual({
+    expect(mapExtensionToAcceptMime('.png, .jpg')).toEqual({
       'image/png': ['.png'],
       'image/jpeg': ['.jpg'],
     });
   });
-});
 
-describe('mapExtToMimeObject', () => {
-  it('should map file extension to mime object', () => {
-    const result = mapExtToMimeObject('.png');
-    expect(result).toEqual({
-      'image/png': ['.png'],
+  it('should map unknown file extensions to application/octet-stream, and ignore the dot', () => {
+    expect(mapExtensionToAcceptMime(['.unknown1', 'unknown2'])).toEqual({
+      'application/octet-stream': ['.unknown1', '.unknown2'],
+    });
+  });
+
+  it('should properly extend .csv mime types', () => {
+    expect(mapExtensionToAcceptMime('.csv')).toEqual({
+      'application/csv': ['.csv'],
+      'application/vnd.ms-excel': ['.csv'],
+      'text/csv': ['.csv'],
     });
   });
 });

--- a/src/layout/FileUpload/Error/FailedAttachments.tsx
+++ b/src/layout/FileUpload/Error/FailedAttachments.tsx
@@ -141,6 +141,12 @@ function ErrorDetails({ attachment: { data, error } }: { attachment: IFailedAtta
   }
 
   if (isRejectedFileError(error)) {
+    const { file, errors } = error.data.rejection;
+    window.logWarn(`Failed to upload attachment "${file.name}" of type "${file.type}":`);
+    for (const error of errors) {
+      window.logWarn(`- ${error.message}`);
+    }
+
     if (error.data.rejection.file.size > error.data.maxFileSizeInMB * bytesInOneMB) {
       return (
         <Lang

--- a/src/layout/FileUpload/FileUploadComponent.test.tsx
+++ b/src/layout/FileUpload/FileUploadComponent.test.tsx
@@ -29,428 +29,409 @@ function getDataElements(props: GetDataProps): IData[] {
   return getAttachmentsMock(rest).map((a) => ({ ...a.data, dataType, contentType: 'image/png' }));
 }
 
-describe('FileUploadComponent', () => {
-  it('should show add attachment button and file counter when number of attachments is less than max', async () => {
-    await render({
-      component: { maxNumberOfAttachments: 3 },
-      attachments: (dataType) => getDataElements({ count: 2, dataType }),
-    });
-
-    expect(
-      screen.getByRole('button', {
-        name: 'Legg til flere vedlegg',
-      }),
-    ).toBeInTheDocument();
-    expect(screen.getByText(/Antall filer 2\/3\./i)).toBeInTheDocument();
-  });
-
-  it('should not show add attachment button, and should show file counter when number of attachments is same as max', async () => {
-    await render({
-      component: { maxNumberOfAttachments: 3 },
-      attachments: (dataType) => getDataElements({ count: 3, dataType }),
-    });
-
-    expect(
-      screen.queryByRole('button', {
-        name: 'Legg til flere vedlegg',
-      }),
-    ).not.toBeInTheDocument();
-    expect(screen.getByText(/Antall filer 3\/3\./i)).toBeInTheDocument();
-  });
-
-  describe('file status', () => {
-    it('should show loading when file uploaded=false', async () => {
-      const { mutations, id } = await render({ attachments: () => [] });
-      const attachment = getDataElements({ count: 1, dataType: id })[0];
-      expect(mutations.doAttachmentUploadOld.mock).not.toHaveBeenCalled();
-
-      const file = new File(['(⌐□_□)'], attachment?.filename || '', { type: attachment.contentType });
-
-      const fileInput = screen
-        .getByRole('presentation', { name: /attachment-title/i })
-        .querySelector('input') as HTMLInputElement;
-      await userEvent.upload(fileInput, file);
-
-      await waitFor(() => {
-        expect(screen.getByText('Laster innhold')).toBeInTheDocument();
-      });
-
-      mutations.doAttachmentUploadOld.resolve(attachment);
-
-      await waitFor(() => {
-        expect(screen.queryByText('Laster innhold')).not.toBeInTheDocument();
-      });
-
-      expect(mutations.doAttachmentUploadOld.mock).toHaveBeenCalledTimes(1);
-    });
-
-    it('should not show loading when file uploaded=true', async () => {
-      await render({ attachments: (dataType) => getDataElements({ count: 1, dataType }) });
-
-      expect(screen.queryByText('Laster innhold')).not.toBeInTheDocument();
-    });
-
-    it('should show loading when file deleting=true', async () => {
-      const { mutations } = await render({
-        attachments: (dataType) => getDataElements({ count: 1, dataType }),
-      });
-
-      await waitFor(() => {
-        expect(screen.getByRole('button', { name: 'Slett vedlegg' })).toBeInTheDocument();
-      });
-
-      await deleteAttachment();
-
-      await waitFor(() => {
-        expect(screen.getByText('Laster innhold')).toBeInTheDocument();
-      });
-
-      mutations.doAttachmentRemove.resolve();
-
-      await waitFor(() => {
-        expect(screen.queryByText('Laster innhold')).not.toBeInTheDocument();
-      });
-
-      expect(mutations.doAttachmentRemove.mock).toHaveBeenCalledTimes(1);
-      expect(screen.queryByRole('button', { name: 'Slett vedlegg' })).not.toBeInTheDocument();
-    });
-  });
-
-  describe('displayMode', () => {
-    it('should not display drop area when displayMode is simple', async () => {
+describe('File uploading components', () => {
+  describe('FileUploadComponent', () => {
+    it('should show add attachment button and file counter when number of attachments is less than max', async () => {
       await render({
-        component: { displayMode: 'simple' },
-        attachments: (dataType) => getDataElements({ count: 3, dataType }),
-      });
-
-      expect(screen.queryByRole('presentation', { name: /attachment-title/i })).not.toBeInTheDocument();
-    });
-
-    it('should display drop area when displayMode is not simple', async () => {
-      await render({
-        component: { displayMode: 'list', maxNumberOfAttachments: 5 },
-        attachments: (dataType) => getDataElements({ count: 3, dataType }),
-      });
-
-      expect(screen.getByRole('presentation', { name: /attachment-title/i })).toBeInTheDocument();
-    });
-
-    it('should not display drop area when displayMode is not simple and max attachments is reached', async () => {
-      await render({
-        component: { displayMode: 'list', maxNumberOfAttachments: 3 },
-        attachments: (dataType) => getDataElements({ count: 3, dataType }),
-      });
-
-      expect(screen.queryByRole('presentation', { name: /attachment-title/i })).not.toBeInTheDocument();
-    });
-  });
-
-  it('an error should be displayed if two components are configured with the same binding', async () => {
-    jest
-      .spyOn(window, 'logError')
-      .mockImplementation(() => {})
-      .mockName('window.logError');
-    jest
-      .spyOn(window, 'logErrorOnce')
-      .mockImplementation(() => {})
-      .mockName('window.logErrorOnce');
-    await renderWithInstanceAndLayout({
-      renderer: () => <GenericComponentById id='FileUpload1' />,
-      queries: {
-        fetchLayouts: async (): Promise<ILayoutCollection> => ({
-          page1: {
-            data: {
-              layout: [
-                {
-                  id: 'FileUpload1',
-                  type: 'FileUpload',
-                  dataModelBindings: { list: { dataType: defaultDataTypeMock, field: 'test' } },
-                  minNumberOfAttachments: 1,
-                  maxNumberOfAttachments: 5,
-                  maxFileSizeInMB: 2,
-                  displayMode: 'list',
-                },
-                {
-                  id: 'FileUpload2',
-                  type: 'FileUpload',
-                  dataModelBindings: { list: { dataType: defaultDataTypeMock, field: 'test' } },
-                  minNumberOfAttachments: 1,
-                  maxNumberOfAttachments: 5,
-                  maxFileSizeInMB: 2,
-                  displayMode: 'list',
-                },
-              ],
-            },
-          },
-        }),
-      },
-    });
-
-    expect(
-      screen.getByText(
-        'Det er flere filopplastingskomponenter med samme datamodell-binding. Hver komponent må ha en unik binding. ' +
-          "Andre komponenter med samme binding: 'FileUpload2'",
-      ),
-    ).toBeInTheDocument();
-    jest.restoreAllMocks();
-  });
-});
-
-async function openEdit() {
-  await userEvent.click(screen.getByRole('button', { name: 'Rediger' }));
-}
-
-async function deleteAttachment() {
-  await userEvent.click(screen.getByRole('button', { name: 'Slett vedlegg' }));
-}
-
-async function selectTag(tagName: string = 'Tag 1') {
-  await openEdit();
-  await userEvent.click(screen.getByRole('combobox'));
-  await userEvent.click(screen.getByText(tagName));
-  const saveButton = await waitFor(() => screen.findByRole('button', { name: 'Lagre' }));
-  await userEvent.click(saveButton);
-}
-
-describe('FileUploadWithTagComponent', () => {
-  describe('uploaded', () => {
-    it('should show spinner when file status has uploaded=false', async () => {
-      await renderWithTag({
-        attachments: (dataType) => getDataElements({ count: 0, dataType }),
-      });
-
-      const file = new File(['(⌐□_□)'], 'chucknorris.png', { type: 'image/png' });
-
-      const dropZone = screen
-        .getByRole('presentation', { name: /attachment-title/i })
-        .querySelector('input') as HTMLInputElement;
-      await userEvent.upload(dropZone, file);
-
-      await screen.findByText('Laster innhold');
-    });
-
-    it('should not show spinner when file status has uploaded=true', async () => {
-      await renderWithTag({ attachments: (dataType) => getDataElements({ count: 1, dataType }) });
-      expect(screen.queryByText('Laster innhold')).not.toBeInTheDocument();
-    });
-  });
-
-  describe('updating', () => {
-    it('should show spinner in edit mode when file status has updating=true', async () => {
-      const { mutations } = await renderWithTag({ attachments: (dataType) => getDataElements({ count: 1, dataType }) });
-      await selectTag();
-
-      expect(mutations.doAttachmentAddTag.mock).toHaveBeenCalledTimes(1);
-      expect(screen.getByText('Laster innhold')).toBeInTheDocument();
-      mutations.doAttachmentAddTag.resolve();
-
-      await waitFor(() => expect(mutations.doAttachmentRemoveTag.mock).toHaveBeenCalledTimes(1));
-      mutations.doAttachmentRemoveTag.resolve();
-
-      await waitFor(() => {
-        expect(screen.queryByText('Laster innhold')).not.toBeInTheDocument();
-      });
-    });
-
-    it('should not show spinner in edit mode when file status has updating=false', async () => {
-      await renderWithTag({ attachments: (dataType) => getDataElements({ count: 1, dataType }) });
-      await openEdit();
-
-      expect(screen.queryByText('Laster innhold')).not.toBeInTheDocument();
-    });
-  });
-
-  describe('editing', () => {
-    it('should hide dropdown when updating', async () => {
-      const { mutations } = await renderWithTag({ attachments: (dataType) => getDataElements({ count: 1, dataType }) });
-      await selectTag();
-
-      expect(mutations.doAttachmentAddTag.mock).toHaveBeenCalledTimes(1);
-      expect(screen.getByText('Laster innhold')).toBeInTheDocument();
-      expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
-    });
-
-    it('should not disable dropdown in edit mode when not updating', async () => {
-      await renderWithTag({ attachments: (dataType) => getDataElements({ count: 1, dataType }) });
-      await openEdit();
-
-      expect(screen.getByRole('combobox')).not.toBeDisabled();
-    });
-
-    it('should not disable save button', async () => {
-      await renderWithTag({ attachments: (dataType) => getDataElements({ count: 1, dataType }) });
-      await openEdit();
-
-      expect(
-        screen.getByRole('button', {
-          name: 'Lagre',
-        }),
-      ).not.toBeDisabled();
-    });
-
-    it('should not allow opening for editing when readOnly=true', async () => {
-      await renderWithTag({
-        component: { readOnly: true },
-        attachments: (dataType) => getDataElements({ count: 1, dataType }),
-      });
-      expect(screen.queryByRole('button', { name: 'Rediger' })).not.toBeInTheDocument();
-    });
-
-    it('should not show save button when attachment.uploaded=false', async () => {
-      const { mutations } = await renderWithTag({ attachments: () => [] });
-
-      const file = new File(['(⌐□_□)'], 'chucknorris.png', { type: 'image/png' });
-
-      const dropZone = screen
-        .getByRole('presentation', { name: /attachment-title/i })
-        .querySelector('input') as HTMLInputElement;
-      await userEvent.upload(dropZone, file);
-
-      await waitFor(() => expect(mutations.doAttachmentUploadOld.mock).toHaveBeenCalledTimes(1));
-      expect(screen.getByText('Laster innhold')).toBeInTheDocument();
-      expect(screen.queryByRole('button', { name: 'Lagre' })).not.toBeInTheDocument();
-    });
-
-    it('should not show save button when attachment.updating=true', async () => {
-      const { mutations } = await renderWithTag({ attachments: (dataType) => getDataElements({ count: 1, dataType }) });
-      await selectTag();
-
-      expect(mutations.doAttachmentAddTag.mock).toHaveBeenCalledTimes(1);
-      expect(
-        screen.queryByRole('button', {
-          name: 'Lagre',
-        }),
-      ).not.toBeInTheDocument();
-    });
-
-    it('should automatically show attachments in edit mode for attachments without tags', async () => {
-      await renderWithTag({
-        attachments: (dataType) => {
-          const out = getDataElements({ count: 1, dataType });
-          out[0].tags = [];
-          return out;
-        },
-      });
-
-      expect(
-        screen.getByRole('button', {
-          name: 'Lagre',
-        }),
-      ).toBeInTheDocument();
-    });
-
-    it('should not automatically show attachments in edit mode for attachments with tags', async () => {
-      await renderWithTag({
-        attachments: (dataType) => {
-          const out = getDataElements({ count: 1, dataType });
-          out[0].tags = ['tag1'];
-          return out;
-        },
-      });
-      expect(
-        screen.queryByRole('button', {
-          name: 'Lagre',
-        }),
-      ).not.toBeInTheDocument();
-    });
-  });
-
-  describe('files', () => {
-    it('should display drop area when max attachments is not reached', async () => {
-      await renderWithTag({
         component: { maxNumberOfAttachments: 3 },
         attachments: (dataType) => getDataElements({ count: 2, dataType }),
       });
 
-      expect(screen.getByRole('presentation', { name: /attachment-title/i }).textContent).toMatch(
-        'Dra og slipp eller let etter filTillatte filformater er: alle',
-      );
+      expect(screen.getByRole('button', { name: 'Legg til flere vedlegg' })).toBeInTheDocument();
+      expect(screen.getByText(/Antall filer 2\/3\./i)).toBeInTheDocument();
     });
 
-    it('should not display drop area when max attachments is reached', async () => {
-      await renderWithTag({
+    it('should not show add attachment button, and should show file counter when number of attachments is same as max', async () => {
+      await render({
         component: { maxNumberOfAttachments: 3 },
         attachments: (dataType) => getDataElements({ count: 3, dataType }),
       });
 
+      expect(screen.queryByRole('button', { name: 'Legg til flere vedlegg' })).not.toBeInTheDocument();
+      expect(screen.getByText(/Antall filer 3\/3\./i)).toBeInTheDocument();
+    });
+
+    describe('file status', () => {
+      it('should show loading when file uploaded=false', async () => {
+        const { mutations, id } = await render({ attachments: () => [] });
+        const attachment = getDataElements({ count: 1, dataType: id })[0];
+        expect(mutations.doAttachmentUploadOld.mock).not.toHaveBeenCalled();
+
+        const file = new File(['(⌐□_□)'], attachment?.filename || '', { type: attachment.contentType });
+
+        const fileInput = screen
+          .getByRole('presentation', { name: /attachment-title/i })
+          .querySelector('input') as HTMLInputElement;
+        await userEvent.upload(fileInput, file);
+
+        await waitFor(() => {
+          expect(screen.getByText('Laster innhold')).toBeInTheDocument();
+        });
+
+        mutations.doAttachmentUploadOld.resolve(attachment);
+
+        await waitFor(() => {
+          expect(screen.queryByText('Laster innhold')).not.toBeInTheDocument();
+        });
+
+        expect(mutations.doAttachmentUploadOld.mock).toHaveBeenCalledTimes(1);
+      });
+
+      it('should not show loading when file uploaded=true', async () => {
+        await render({ attachments: (dataType) => getDataElements({ count: 1, dataType }) });
+
+        expect(screen.queryByText('Laster innhold')).not.toBeInTheDocument();
+      });
+
+      it('should show loading when file deleting=true', async () => {
+        const { mutations } = await render({
+          attachments: (dataType) => getDataElements({ count: 1, dataType }),
+        });
+
+        await waitFor(() => {
+          expect(screen.getByRole('button', { name: 'Slett vedlegg' })).toBeInTheDocument();
+        });
+
+        await deleteAttachment();
+
+        await waitFor(() => {
+          expect(screen.getByText('Laster innhold')).toBeInTheDocument();
+        });
+
+        mutations.doAttachmentRemove.resolve();
+
+        await waitFor(() => {
+          expect(screen.queryByText('Laster innhold')).not.toBeInTheDocument();
+        });
+
+        expect(mutations.doAttachmentRemove.mock).toHaveBeenCalledTimes(1);
+        expect(screen.queryByRole('button', { name: 'Slett vedlegg' })).not.toBeInTheDocument();
+      });
+    });
+
+    describe('displayMode', () => {
+      it('should not display drop area when displayMode is simple', async () => {
+        await render({
+          component: { displayMode: 'simple' },
+          attachments: (dataType) => getDataElements({ count: 3, dataType }),
+        });
+
+        expect(screen.queryByRole('presentation', { name: /attachment-title/i })).not.toBeInTheDocument();
+      });
+
+      it('should display drop area when displayMode is not simple', async () => {
+        await render({
+          component: { displayMode: 'list', maxNumberOfAttachments: 5 },
+          attachments: (dataType) => getDataElements({ count: 3, dataType }),
+        });
+
+        expect(screen.getByRole('presentation', { name: /attachment-title/i })).toBeInTheDocument();
+      });
+
+      it('should not display drop area when displayMode is not simple and max attachments is reached', async () => {
+        await render({
+          component: { displayMode: 'list', maxNumberOfAttachments: 3 },
+          attachments: (dataType) => getDataElements({ count: 3, dataType }),
+        });
+
+        expect(screen.queryByRole('presentation', { name: /attachment-title/i })).not.toBeInTheDocument();
+      });
+    });
+
+    it('an error should be displayed if two components are configured with the same binding', async () => {
+      jest
+        .spyOn(window, 'logError')
+        .mockImplementation(() => {})
+        .mockName('window.logError');
+      jest
+        .spyOn(window, 'logErrorOnce')
+        .mockImplementation(() => {})
+        .mockName('window.logErrorOnce');
+      await renderWithInstanceAndLayout({
+        renderer: () => <GenericComponentById id='FileUpload1' />,
+        queries: {
+          fetchLayouts: async (): Promise<ILayoutCollection> => ({
+            page1: {
+              data: {
+                layout: [
+                  {
+                    id: 'FileUpload1',
+                    type: 'FileUpload',
+                    dataModelBindings: { list: { dataType: defaultDataTypeMock, field: 'test' } },
+                    minNumberOfAttachments: 1,
+                    maxNumberOfAttachments: 5,
+                    maxFileSizeInMB: 2,
+                    displayMode: 'list',
+                  },
+                  {
+                    id: 'FileUpload2',
+                    type: 'FileUpload',
+                    dataModelBindings: { list: { dataType: defaultDataTypeMock, field: 'test' } },
+                    minNumberOfAttachments: 1,
+                    maxNumberOfAttachments: 5,
+                    maxFileSizeInMB: 2,
+                    displayMode: 'list',
+                  },
+                ],
+              },
+            },
+          }),
+        },
+      });
+
       expect(
-        screen.queryByRole('presentation', {
-          name: /attachment-title/i,
-        }),
-      ).not.toBeInTheDocument();
+        screen.getByText(
+          'Det er flere filopplastingskomponenter med samme datamodell-binding. Hver komponent må ha en unik binding. ' +
+            "Andre komponenter med samme binding: 'FileUpload2'",
+        ),
+      ).toBeInTheDocument();
+      jest.restoreAllMocks();
     });
   });
-});
 
-type Types = 'FileUpload' | 'FileUploadWithTag';
-interface Props<T extends Types> extends Partial<RenderGenericComponentTestProps<T>> {
-  type: T;
-  attachments?: (dataType: string) => IData[];
-}
+  async function openEdit() {
+    await userEvent.click(screen.getByRole('button', { name: 'Rediger' }));
+  }
 
-async function renderAbstract<T extends Types>({
-  type,
-  component,
-  attachments: attachmentsGenerator = (dataType) => getDataElements({ dataType }),
-}: Props<T>) {
-  jest.mocked(fetchApplicationMetadata).mockImplementationOnce(async () =>
-    getIncomingApplicationMetadataMock((a) => {
-      a.dataTypes.push({
-        id,
-        allowedContentTypes: ['image/png'],
-        maxCount: 4,
-        minCount: 1,
+  async function deleteAttachment() {
+    await userEvent.click(screen.getByRole('button', { name: 'Slett vedlegg' }));
+  }
+
+  async function selectTag(tagName: string = 'Tag 1') {
+    await openEdit();
+    await userEvent.click(screen.getByRole('combobox'));
+    await userEvent.click(screen.getByText(tagName));
+    const saveButton = await waitFor(() => screen.findByRole('button', { name: 'Lagre' }));
+    await userEvent.click(saveButton);
+  }
+
+  describe('FileUploadWithTagComponent', () => {
+    describe('uploaded', () => {
+      it('should show spinner when file status has uploaded=false', async () => {
+        await renderWithTag({
+          attachments: (dataType) => getDataElements({ count: 0, dataType }),
+        });
+
+        const file = new File(['(⌐□_□)'], 'chucknorris.png', { type: 'image/png' });
+
+        const dropZone = screen
+          .getByRole('presentation', { name: /attachment-title/i })
+          .querySelector('input') as HTMLInputElement;
+        await userEvent.upload(dropZone, file);
+
+        await screen.findByText('Laster innhold');
       });
-    }),
-  );
-  const id = uuidv4();
-  const attachments = attachmentsGenerator(id);
 
-  const textResourceBindings = {
-    title: 'attachment-title',
-    description: 'attachment-description',
-  };
+      it('should not show spinner when file status has uploaded=true', async () => {
+        await renderWithTag({ attachments: (dataType) => getDataElements({ count: 1, dataType }) });
+        expect(screen.queryByText('Laster innhold')).not.toBeInTheDocument();
+      });
+    });
 
-  const utils = await renderGenericComponentTest<T>({
-    type,
-    renderer: (props) => <FileUploadComponent {...props} />,
-    component: {
-      id,
-      displayMode: type === 'FileUpload' ? 'simple' : 'list',
-      maxFileSizeInMB: 2,
-      maxNumberOfAttachments: type === 'FileUpload' ? 3 : 7,
-      minNumberOfAttachments: 1,
-      readOnly: false,
-      textResourceBindings,
-      ...(type === 'FileUploadWithTag' && {
-        optionsId: 'test-options-id',
-        textResourceBindings: {
-          ...textResourceBindings,
-          tagTitle: 'attachment-tag-title',
-        },
-      }),
-      ...component,
-    } as CompExternalExact<T>,
-    queries: {
-      fetchInstanceData: async () =>
-        getInstanceDataMock((i) => {
-          i.data.push(...attachments);
-        }),
-      fetchOptions: () =>
-        Promise.resolve({
-          data: [
-            { value: 'tag1', label: 'Tag 1' },
-            { value: 'tag2', label: 'Tag 2' },
-            { value: 'tag3', label: 'Tag 3' },
-          ],
-          headers: {},
-        } as AxiosResponse<IRawOption[], unknown>),
-    },
+    describe('updating', () => {
+      it('should show spinner in edit mode when file status has updating=true', async () => {
+        const { mutations } = await renderWithTag({
+          attachments: (dataType) => getDataElements({ count: 1, dataType }),
+        });
+        await selectTag();
+
+        expect(mutations.doAttachmentAddTag.mock).toHaveBeenCalledTimes(1);
+        expect(screen.getByText('Laster innhold')).toBeInTheDocument();
+        mutations.doAttachmentAddTag.resolve();
+
+        await waitFor(() => expect(mutations.doAttachmentRemoveTag.mock).toHaveBeenCalledTimes(1));
+        mutations.doAttachmentRemoveTag.resolve();
+
+        await waitFor(() => {
+          expect(screen.queryByText('Laster innhold')).not.toBeInTheDocument();
+        });
+      });
+
+      it('should not show spinner in edit mode when file status has updating=false', async () => {
+        await renderWithTag({ attachments: (dataType) => getDataElements({ count: 1, dataType }) });
+        await openEdit();
+
+        expect(screen.queryByText('Laster innhold')).not.toBeInTheDocument();
+      });
+    });
+
+    describe('editing', () => {
+      it('should hide dropdown when updating', async () => {
+        const { mutations } = await renderWithTag({
+          attachments: (dataType) => getDataElements({ count: 1, dataType }),
+        });
+        await selectTag();
+
+        expect(mutations.doAttachmentAddTag.mock).toHaveBeenCalledTimes(1);
+        expect(screen.getByText('Laster innhold')).toBeInTheDocument();
+        expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+      });
+
+      it('should not disable dropdown in edit mode when not updating', async () => {
+        await renderWithTag({ attachments: (dataType) => getDataElements({ count: 1, dataType }) });
+        await openEdit();
+
+        expect(screen.getByRole('combobox')).not.toBeDisabled();
+      });
+
+      it('should not disable save button', async () => {
+        await renderWithTag({ attachments: (dataType) => getDataElements({ count: 1, dataType }) });
+        await openEdit();
+
+        expect(screen.getByRole('button', { name: 'Lagre' })).not.toBeDisabled();
+      });
+
+      it('should not allow opening for editing when readOnly=true', async () => {
+        await renderWithTag({
+          component: { readOnly: true },
+          attachments: (dataType) => getDataElements({ count: 1, dataType }),
+        });
+        expect(screen.queryByRole('button', { name: 'Rediger' })).not.toBeInTheDocument();
+      });
+
+      it('should not show save button when attachment.uploaded=false', async () => {
+        const { mutations } = await renderWithTag({ attachments: () => [] });
+
+        const file = new File(['(⌐□_□)'], 'chucknorris.png', { type: 'image/png' });
+
+        const dropZone = screen
+          .getByRole('presentation', { name: /attachment-title/i })
+          .querySelector('input') as HTMLInputElement;
+        await userEvent.upload(dropZone, file);
+
+        await waitFor(() => expect(mutations.doAttachmentUploadOld.mock).toHaveBeenCalledTimes(1));
+        expect(screen.getByText('Laster innhold')).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Lagre' })).not.toBeInTheDocument();
+      });
+
+      it('should not show save button when attachment.updating=true', async () => {
+        const { mutations } = await renderWithTag({
+          attachments: (dataType) => getDataElements({ count: 1, dataType }),
+        });
+        await selectTag();
+
+        expect(mutations.doAttachmentAddTag.mock).toHaveBeenCalledTimes(1);
+        expect(screen.queryByRole('button', { name: 'Lagre' })).not.toBeInTheDocument();
+      });
+
+      it('should automatically show attachments in edit mode for attachments without tags', async () => {
+        await renderWithTag({
+          attachments: (dataType) => {
+            const out = getDataElements({ count: 1, dataType });
+            out[0].tags = [];
+            return out;
+          },
+        });
+
+        expect(screen.getByRole('button', { name: 'Lagre' })).toBeInTheDocument();
+      });
+
+      it('should not automatically show attachments in edit mode for attachments with tags', async () => {
+        await renderWithTag({
+          attachments: (dataType) => {
+            const out = getDataElements({ count: 1, dataType });
+            out[0].tags = ['tag1'];
+            return out;
+          },
+        });
+        expect(screen.queryByRole('button', { name: 'Lagre' })).not.toBeInTheDocument();
+      });
+    });
+
+    describe('files', () => {
+      it('should display drop area when max attachments is not reached', async () => {
+        await renderWithTag({
+          component: { maxNumberOfAttachments: 3 },
+          attachments: (dataType) => getDataElements({ count: 2, dataType }),
+        });
+
+        expect(screen.getByRole('presentation', { name: /attachment-title/i }).textContent).toMatch(
+          'Dra og slipp eller let etter filTillatte filformater er: alle',
+        );
+      });
+
+      it('should not display drop area when max attachments is reached', async () => {
+        await renderWithTag({
+          component: { maxNumberOfAttachments: 3 },
+          attachments: (dataType) => getDataElements({ count: 3, dataType }),
+        });
+
+        expect(screen.queryByRole('presentation', { name: /attachment-title/i })).not.toBeInTheDocument();
+      });
+    });
   });
 
-  return { ...utils, id, attachments };
-}
+  type Types = 'FileUpload' | 'FileUploadWithTag';
 
-const render = (props: Omit<Props<'FileUpload'>, 'type'> = {}) => renderAbstract({ type: 'FileUpload', ...props });
-const renderWithTag = (props: Omit<Props<'FileUploadWithTag'>, 'type'> = {}) =>
-  renderAbstract({ type: 'FileUploadWithTag', ...props });
+  interface Props<T extends Types> extends Partial<RenderGenericComponentTestProps<T>> {
+    type: T;
+    attachments?: (dataType: string) => IData[];
+  }
+
+  async function renderAbstract<T extends Types>({
+    type,
+    component,
+    attachments: attachmentsGenerator = (dataType) => getDataElements({ dataType }),
+  }: Props<T>) {
+    jest.mocked(fetchApplicationMetadata).mockImplementationOnce(async () =>
+      getIncomingApplicationMetadataMock((a) => {
+        a.dataTypes.push({
+          id,
+          allowedContentTypes: ['image/png'],
+          maxCount: 4,
+          minCount: 1,
+        });
+      }),
+    );
+    const id = uuidv4();
+    const attachments = attachmentsGenerator(id);
+
+    const textResourceBindings = {
+      title: 'attachment-title',
+      description: 'attachment-description',
+    };
+
+    const utils = await renderGenericComponentTest<T>({
+      type,
+      renderer: (props) => <FileUploadComponent {...props} />,
+      component: {
+        id,
+        displayMode: type === 'FileUpload' ? 'simple' : 'list',
+        maxFileSizeInMB: 2,
+        maxNumberOfAttachments: type === 'FileUpload' ? 3 : 7,
+        minNumberOfAttachments: 1,
+        readOnly: false,
+        textResourceBindings,
+        ...(type === 'FileUploadWithTag' && {
+          optionsId: 'test-options-id',
+          textResourceBindings: {
+            ...textResourceBindings,
+            tagTitle: 'attachment-tag-title',
+          },
+        }),
+        ...component,
+      } as CompExternalExact<T>,
+      queries: {
+        fetchInstanceData: async () =>
+          getInstanceDataMock((i) => {
+            i.data.push(...attachments);
+          }),
+        fetchOptions: () =>
+          Promise.resolve({
+            data: [
+              { value: 'tag1', label: 'Tag 1' },
+              { value: 'tag2', label: 'Tag 2' },
+              { value: 'tag3', label: 'Tag 3' },
+            ],
+            headers: {},
+          } as AxiosResponse<IRawOption[], unknown>),
+      },
+    });
+
+    return { ...utils, id, attachments };
+  }
+
+  const render = (props: Omit<Props<'FileUpload'>, 'type'> = {}) => renderAbstract({ type: 'FileUpload', ...props });
+  const renderWithTag = (props: Omit<Props<'FileUploadWithTag'>, 'type'> = {}) =>
+    renderAbstract({ type: 'FileUploadWithTag', ...props });
+});


### PR DESCRIPTION
## Description

When uploading a `.csv` in Firefox on Windows, the file will be recognized as `application/vnd.ms-excel` and rejected by the uploader. In Chrome, either the file is recognized automatically as `text/csv`, or it just accepted as a csv, so this issue is only relevant for Firefox on Windows (Mac and Linux correctly recognizes the file as `text/csv`).

This should fix the issue (verified by manual testing). I failed to write a unit-test for this, as `jest-dom` simply accepts the file I construct with the `application/vnd.ms-excel` mime-type. I don't know if that's because it is lazy and doesn't check, or because it uses Chrome-logic. I also wrote a Cypress test for this, but it always succeeded...because I was running that test in Chrome. :shrug: So, uhh, trust me, this works. :+1: 

## Related Issue(s)

- closes #2934

## Verification/QA

- Manual functionality testing
  - [X] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [X] No automatic testing works here at all! :scream: 
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
