### PR TITLE
Checking for backport labels

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -40,7 +40,8 @@
   - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
   - [ ] I don't have permissions to do that, please help me out
 - Labels
-  - [ ] I have added a `kind/*` label to this PR for proper release notes grouping
+
+  - [ ] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
   - [ ] I don't have permissions to add labels, please help me out
   <!---
     Breaking changes:       kind/breaking-change
@@ -49,4 +50,7 @@
     Dependencies:             kind/dependencies
     Other changes:            kind/other
     Not in release notes:  ignore-for-release
+
+    Backport (to patch release): backport
+    Do not backport:                   backport-ignore
   --->

--- a/.github/workflows/check-label-added.yml
+++ b/.github/workflows/check-label-added.yml
@@ -12,8 +12,11 @@ jobs:
         with:
           script: |
             const labels = context.payload.pull_request.labels;
-            const required_labels = ['kind/breaking-change', 'kind/product-feature', 'kind/bug', 'kind/other', 'kind/dependencies', 'ignore-for-release'];
-            const hasMatchingLabel = labels.some((label) => required_labels.includes(label.name));
-            if (!hasMatchingLabel) {
-              core.setFailed('The PR must have one of the following labels:\n- ' + required_labels.join('\n- '));
+            const releaseLabels = ['kind/breaking-change', 'kind/product-feature', 'kind/bug', 'kind/other', 'kind/dependencies', 'ignore-for-release'];
+            if(!releaseLabels.some(r=>labels.some(l=>l.name == r))){
+                core.setFailed(`The PR must have at least one of these labels: ${releaseLabels}`)
+            }
+            const backportLabels = ["backport", "backport-ignore"];
+            if(!backportLabels.some(r=>labels.some(l=>l.name == r))){
+                core.setFailed(`The PR must have at least one of these labels: ${backportLabels}`)
             }


### PR DESCRIPTION
## Description

This should make github check for backporting labels, just like in `app-lib-dotnet`.

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->
