### PR TITLE
Fix layoutset summary loading in PDF

### DIFF
--- a/src/components/PDFGeneratorPreview/PDFGeneratorPreview.tsx
+++ b/src/components/PDFGeneratorPreview/PDFGeneratorPreview.tsx
@@ -31,7 +31,8 @@ export function PDFGeneratorPreview({
   const instanceId = useLaxInstanceId();
   const language = useCurrentLanguage();
 
-  const disabled = taskType !== ProcessTaskType.Data || !instanceId || !isLocalOrStaging();
+  const disabled =
+    (taskType !== ProcessTaskType.Data && taskType !== ProcessTaskType.Signing) || !instanceId || !isLocalOrStaging();
 
   const { langAsString } = useLanguage();
 

--- a/src/components/ReadyContext.tsx
+++ b/src/components/ReadyContext.tsx
@@ -141,8 +141,9 @@ export function useAllMarkedReady() {
         topState = topStore.getState();
       }
 
-      return topStore.subscribe((state) => {
-        setIsReady(state.ready && Object.values(state.children).every((ready) => ready));
+      setIsReady(topState.ready && Object.values(topState.children).every((ready) => ready));
+      return topStore.subscribe((topState) => {
+        setIsReady(topState.ready && Object.values(topState.children).every((ready) => ready));
       });
     }
   }, [store]);

--- a/src/components/ReadyContext.tsx
+++ b/src/components/ReadyContext.tsx
@@ -1,0 +1,149 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import type { ForwardedRef, PropsWithChildren, PropsWithoutRef } from 'react';
+
+import { v4 as uuid } from 'uuid';
+import { createStore } from 'zustand';
+import type { StoreApi } from 'zustand';
+
+import { ContextNotProvided } from 'src/core/contexts/context';
+import { createZustandContext } from 'src/core/contexts/zustandContext';
+
+type ReadyState = {
+  parent: StoreApi<ReadyState> | null;
+  id: string;
+  ready: boolean;
+  children: { [id: string]: boolean };
+
+  setReady: (ready: boolean) => void;
+  registerChild: (id: string) => void;
+  unRegisterChild: (id: string) => void;
+  setChildReady: (id: string, ready: boolean) => void;
+};
+
+const { Provider, useStore, useLaxStore } = createZustandContext({
+  name: 'ReadyContext',
+  required: true,
+  initialCreateStore: ({ parent }: { parent: StoreApi<ReadyState> | null }) =>
+    createStore<ReadyState>((set) => ({
+      parent,
+      id: uuid(),
+      ready: false,
+      children: {},
+
+      setReady: (ready) => set({ ready }),
+      registerChild: (id) => set((state) => ({ children: { ...state.children, [id]: false } })),
+      unRegisterChild: (id) =>
+        set((state) => ({
+          children: Object.fromEntries(Object.entries(state.children).filter(([_id]) => _id !== id)),
+        })),
+      setChildReady: (id, ready) => set((state) => ({ children: { ...state.children, [id]: ready } })),
+    })),
+});
+
+function InnerReadyProvider({ children }: PropsWithChildren) {
+  const store = useStore();
+
+  useEffect(() => {
+    const { id, parent } = store.getState();
+    if (parent) {
+      parent.getState().registerChild(id);
+      return () => {
+        parent.getState().unRegisterChild(id);
+      };
+    }
+  }, [store]);
+
+  useEffect(() => {
+    const { id, parent } = store.getState();
+    if (parent) {
+      return store.subscribe((state) => {
+        const isReady = state.ready && Object.values(state.children).every((ready) => ready);
+        const parentState = parent.getState();
+        if (parentState.children[id] !== isReady) {
+          parentState.setChildReady(id, isReady);
+        }
+      });
+    }
+  }, [store]);
+
+  return children;
+}
+
+function ReadyProvider({ children }: PropsWithChildren) {
+  const parent = useLaxStore();
+  return (
+    <Provider parent={parent !== ContextNotProvided ? parent : null}>
+      <InnerReadyProvider>{children}</InnerReadyProvider>
+    </Provider>
+  );
+}
+
+/**
+ * Wrap a component with conditional rendering logic and render the MarkReady component in the branch where the component is ready.
+ */
+export function withReadyState<P, R>(Component: React.ComponentType<PropsWithoutRef<P> & { MarkReady: React.FC }>) {
+  function WrappedComponent({ props, ref }: { props: PropsWithoutRef<P>; ref: ForwardedRef<R> }) {
+    const store = useStore();
+    const MarkReady = useMemo(() => makeReady(store), [store]);
+    return (
+      <Component
+        {...props}
+        ref={ref}
+        MarkReady={MarkReady}
+      />
+    );
+  }
+  function forwardRef(props: PropsWithoutRef<P>, ref: ForwardedRef<R>) {
+    return (
+      <ReadyProvider>
+        <WrappedComponent
+          props={props}
+          ref={ref}
+        />
+      </ReadyProvider>
+    );
+  }
+  const name = Component.displayName || Component.name;
+  forwardRef.displayName = `withReadyState(${name})`;
+
+  return React.forwardRef(forwardRef);
+}
+
+function makeReady(store: StoreApi<ReadyState>) {
+  return function MarkReady() {
+    useEffect(() => {
+      const state = store.getState();
+      if (state.ready === false) {
+        state.setReady(true);
+      }
+
+      return () => {
+        const state = store.getState();
+        if (state.ready === true) {
+          state.setReady(false);
+        }
+      };
+    }, []);
+    return null;
+  };
+}
+
+export function useAllMarkedReady() {
+  const store = useStore();
+  const [isReady, setIsReady] = useState(false);
+
+  useEffect(() => {
+    let topStore = store;
+    let topState = topStore.getState();
+    while (topState.parent !== null) {
+      topStore = topState.parent;
+      topState = topStore.getState();
+    }
+
+    return topStore.subscribe((state) => {
+      setIsReady(state.ready && Object.values(state.children).every((ready) => ready));
+    });
+  }, [store]);
+
+  return isReady;
+}

--- a/src/components/ReadyContext.tsx
+++ b/src/components/ReadyContext.tsx
@@ -129,21 +129,23 @@ function makeReady(store: StoreApi<ReadyState>) {
 }
 
 export function useAllMarkedReady() {
-  const store = useStore();
+  const store = useLaxStore();
   const [isReady, setIsReady] = useState(false);
 
   useEffect(() => {
-    let topStore = store;
-    let topState = topStore.getState();
-    while (topState.parent !== null) {
-      topStore = topState.parent;
-      topState = topStore.getState();
-    }
+    if (store !== ContextNotProvided) {
+      let topStore = store;
+      let topState = topStore.getState();
+      while (topState.parent !== null) {
+        topStore = topState.parent;
+        topState = topStore.getState();
+      }
 
-    return topStore.subscribe((state) => {
-      setIsReady(state.ready && Object.values(state.children).every((ready) => ready));
-    });
+      return topStore.subscribe((state) => {
+        setIsReady(state.ready && Object.values(state.children).every((ready) => ready));
+      });
+    }
   }, [store]);
 
-  return isReady;
+  return store != ContextNotProvided ? isReady : ContextNotProvided;
 }

--- a/src/components/ReadyForPrint.tsx
+++ b/src/components/ReadyForPrint.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { useAllMarkedReady } from 'src/components/ReadyContext';
+import { useReadyState } from 'src/components/ReadyContext';
 import { useDataLoadingStore } from 'src/core/contexts/dataLoadingContext';
 import { waitForAnimationFrames } from 'src/utils/waitForAnimationFrames';
 import type { DataLoading } from 'src/core/contexts/dataLoadingContext';
@@ -20,7 +20,7 @@ const readyId: Record<ReadyType, string> = {
 export function ReadyForPrint({ type }: { type: ReadyType }) {
   const [assetsLoaded, setAssetsLoaded] = React.useState(false);
   const dataLoadingIsDone = useDataLoadingStore((state) => state.isDone);
-  const isAllMarkedReady = useAllMarkedReady();
+  const isComponentsReady = useReadyState();
 
   React.useLayoutEffect(() => {
     if (assetsLoaded) {
@@ -36,7 +36,7 @@ export function ReadyForPrint({ type }: { type: ReadyType }) {
     });
   }, [assetsLoaded, dataLoadingIsDone]);
 
-  if (!assetsLoaded || isAllMarkedReady === false) {
+  if (!assetsLoaded || isComponentsReady === false) {
     return null;
   }
 

--- a/src/components/ReadyForPrint.tsx
+++ b/src/components/ReadyForPrint.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { useAllMarkedReady } from 'src/components/ReadyContext';
 import { useDataLoadingStore } from 'src/core/contexts/dataLoadingContext';
 import { waitForAnimationFrames } from 'src/utils/waitForAnimationFrames';
 import type { DataLoading } from 'src/core/contexts/dataLoadingContext';
@@ -19,6 +20,7 @@ const readyId: Record<ReadyType, string> = {
 export function ReadyForPrint({ type }: { type: ReadyType }) {
   const [assetsLoaded, setAssetsLoaded] = React.useState(false);
   const dataLoadingIsDone = useDataLoadingStore((state) => state.isDone);
+  const isAllMarkedReady = useAllMarkedReady();
 
   React.useLayoutEffect(() => {
     if (assetsLoaded) {
@@ -34,7 +36,7 @@ export function ReadyForPrint({ type }: { type: ReadyType }) {
     });
   }, [assetsLoaded, dataLoadingIsDone]);
 
-  if (!assetsLoaded) {
+  if (!assetsLoaded || !isAllMarkedReady) {
     return null;
   }
 

--- a/src/components/ReadyForPrint.tsx
+++ b/src/components/ReadyForPrint.tsx
@@ -36,7 +36,7 @@ export function ReadyForPrint({ type }: { type: ReadyType }) {
     });
   }, [assetsLoaded, dataLoadingIsDone]);
 
-  if (!assetsLoaded || !isAllMarkedReady) {
+  if (!assetsLoaded || isAllMarkedReady === false) {
     return null;
   }
 

--- a/src/core/contexts/zustandContext.tsx
+++ b/src/core/contexts/zustandContext.tsx
@@ -48,6 +48,11 @@ export function createZustandContext<Store extends StoreApi<Type>, Type = Extrac
    */
   const useStaticSelector: SelectorFunc<Type> = (selector) => selector(useCtx().getState());
 
+  const useLaxStaticSelector: SelectorFuncLax<Type> = (selector) => {
+    const ctx = useLaxCtx();
+    return ctx !== ContextNotProvided ? selector(ctx.getState()) : ContextNotProvided;
+  };
+
   const useSelectorAsRef: SelectorRefFunc<Type> = (selector) => {
     const store = useCtx();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -227,5 +232,6 @@ export function createZustandContext<Store extends StoreApi<Type>, Type = Extrac
     useStore: useCtx,
     useLaxStore: useLaxCtx,
     useStaticSelector,
+    useLaxStaticSelector,
   };
 }

--- a/src/features/devtools/components/PDFPreviewButton/PDFPreviewButton.tsx
+++ b/src/features/devtools/components/PDFPreviewButton/PDFPreviewButton.tsx
@@ -31,7 +31,7 @@ export const PDFPreviewButton = () => {
     >
       <Button
         onClick={() => setPdfPreview(true)}
-        disabled={taskType !== ProcessTaskType.Data}
+        disabled={taskType !== ProcessTaskType.Data && taskType !== ProcessTaskType.Signing}
         color='second'
       >
         <FilePdfIcon

--- a/src/features/form/FormContext.tsx
+++ b/src/features/form/FormContext.tsx
@@ -1,7 +1,5 @@
 import React, { useRef } from 'react';
-import type { FC, PropsWithChildren } from 'react';
 
-import { withReadyState } from 'src/components/ReadyContext';
 import { ContextNotProvided, createContext } from 'src/core/contexts/context';
 import { BlockUntilAllLoaded, LoadingRegistryProvider } from 'src/core/loading/LoadingRegistry';
 import { DataModelsProvider } from 'src/features/datamodel/DataModelsProvider';
@@ -33,7 +31,7 @@ export function useIsInFormContext() {
 /**
  * This helper-context provider is used to provide all the contexts needed for forms to work
  */
-export const FormProvider: FC<PropsWithChildren> = withReadyState(({ children, MarkReady }) => {
+export function FormProvider({ children }: React.PropsWithChildren) {
   const hasProcess = useHasProcessProvider();
   const renderCount = useRef(0);
   renderCount.current += 1;
@@ -49,20 +47,14 @@ export const FormProvider: FC<PropsWithChildren> = withReadyState(({ children, M
     <Outer>
       {hasProcess ? (
         <PaymentProvider>
-          <Inner>
-            {children}
-            <MarkReady />
-          </Inner>
+          <Inner>{children}</Inner>
         </PaymentProvider>
       ) : (
-        <Inner>
-          {children}
-          <MarkReady />
-        </Inner>
+        <Inner>{children}</Inner>
       )}
     </Outer>
   );
-});
+}
 
 function Outer({ children }: React.PropsWithChildren) {
   return (

--- a/src/features/form/FormContext.tsx
+++ b/src/features/form/FormContext.tsx
@@ -1,5 +1,7 @@
 import React, { useRef } from 'react';
+import type { FC, PropsWithChildren } from 'react';
 
+import { withReadyState } from 'src/components/ReadyContext';
 import { ContextNotProvided, createContext } from 'src/core/contexts/context';
 import { BlockUntilAllLoaded, LoadingRegistryProvider } from 'src/core/loading/LoadingRegistry';
 import { DataModelsProvider } from 'src/features/datamodel/DataModelsProvider';
@@ -31,7 +33,7 @@ export function useIsInFormContext() {
 /**
  * This helper-context provider is used to provide all the contexts needed for forms to work
  */
-export function FormProvider({ children }: React.PropsWithChildren) {
+export const FormProvider: FC<PropsWithChildren> = withReadyState(({ children, MarkReady }) => {
   const hasProcess = useHasProcessProvider();
   const renderCount = useRef(0);
   renderCount.current += 1;
@@ -47,14 +49,20 @@ export function FormProvider({ children }: React.PropsWithChildren) {
     <Outer>
       {hasProcess ? (
         <PaymentProvider>
-          <Inner>{children}</Inner>
+          <Inner>
+            {children}
+            <MarkReady />
+          </Inner>
         </PaymentProvider>
       ) : (
-        <Inner>{children}</Inner>
+        <Inner>
+          {children}
+          <MarkReady />
+        </Inner>
       )}
     </Outer>
   );
-}
+});
 
 function Outer({ children }: React.PropsWithChildren) {
   return (

--- a/src/features/pdf/PdfView2.tsx
+++ b/src/features/pdf/PdfView2.tsx
@@ -1,11 +1,12 @@
 import React, { useEffect } from 'react';
-import type { PropsWithChildren } from 'react';
+import type { FC, PropsWithChildren } from 'react';
 
 import { Heading } from '@digdir/designsystemet-react';
 
 import { Flex } from 'src/app-components/Flex/Flex';
 import { OrganisationLogo } from 'src/components/presentation/OrganisationLogo/OrganisationLogo';
 import { DummyPresentation } from 'src/components/presentation/Presentation';
+import { withReadyState } from 'src/components/ReadyContext';
 import { ReadyForPrint } from 'src/components/ReadyForPrint';
 import { DataLoadingState, useDataLoadingStore } from 'src/core/contexts/dataLoadingContext';
 import { useAppName, useAppOwner } from 'src/core/texts/appTexts';
@@ -155,7 +156,7 @@ function DataLoaderStoreInitWorker({
   return null;
 }
 
-function PdfWrapping({ children }: PropsWithChildren) {
+const PdfWrapping: FC<PropsWithChildren> = withReadyState(({ children, MarkReady }) => {
   const orgLogoEnabled = Boolean(useApplicationMetadata().logoOptions);
   const appOwner = useAppOwner();
   const appName = useAppName();
@@ -184,9 +185,10 @@ function PdfWrapping({ children }: PropsWithChildren) {
       </Heading>
       {children}
       <ReadyForPrint type='print' />
+      <MarkReady />
     </div>
   );
-}
+});
 
 function PlainPage({ pageKey }: { pageKey: string }) {
   const pageExists = NodesInternal.useSelector((state) =>

--- a/src/features/pdf/PdfView2.tsx
+++ b/src/features/pdf/PdfView2.tsx
@@ -1,12 +1,12 @@
 import React, { useEffect } from 'react';
-import type { FC, PropsWithChildren } from 'react';
+import type { PropsWithChildren } from 'react';
 
 import { Heading } from '@digdir/designsystemet-react';
 
 import { Flex } from 'src/app-components/Flex/Flex';
 import { OrganisationLogo } from 'src/components/presentation/OrganisationLogo/OrganisationLogo';
 import { DummyPresentation } from 'src/components/presentation/Presentation';
-import { withReadyState } from 'src/components/ReadyContext';
+import { MarkRootReady, RootReadyProvider } from 'src/components/ReadyContext';
 import { ReadyForPrint } from 'src/components/ReadyForPrint';
 import { DataLoadingState, useDataLoadingStore } from 'src/core/contexts/dataLoadingContext';
 import { useAppName, useAppOwner } from 'src/core/texts/appTexts';
@@ -156,7 +156,7 @@ function DataLoaderStoreInitWorker({
   return null;
 }
 
-const PdfWrapping: FC<PropsWithChildren> = withReadyState(({ children, MarkReady }) => {
+function PdfWrapping({ children }: PropsWithChildren) {
   const orgLogoEnabled = Boolean(useApplicationMetadata().logoOptions);
   const appOwner = useAppOwner();
   const appName = useAppName();
@@ -164,31 +164,33 @@ const PdfWrapping: FC<PropsWithChildren> = withReadyState(({ children, MarkReady
   const isPayment = useIsPayment();
 
   return (
-    <div
-      id='pdfView'
-      className={classes.pdfWrapper}
-    >
-      {orgLogoEnabled && (
-        <div
-          className={classes.pdfLogoContainer}
-          data-testid='pdf-logo'
-        >
-          <OrganisationLogo />
-        </div>
-      )}
-      {appOwner && <span role='doc-subtitle'>{appOwner}</span>}
-      <Heading
-        level={1}
-        size='lg'
+    <RootReadyProvider>
+      <div
+        id='pdfView'
+        className={classes.pdfWrapper}
       >
-        {isPayment ? `${appName} - ${langAsString('payment.receipt.title')}` : appName}
-      </Heading>
-      {children}
-      <ReadyForPrint type='print' />
-      <MarkReady />
-    </div>
+        {orgLogoEnabled && (
+          <div
+            className={classes.pdfLogoContainer}
+            data-testid='pdf-logo'
+          >
+            <OrganisationLogo />
+          </div>
+        )}
+        {appOwner && <span role='doc-subtitle'>{appOwner}</span>}
+        <Heading
+          level={1}
+          size='lg'
+        >
+          {isPayment ? `${appName} - ${langAsString('payment.receipt.title')}` : appName}
+        </Heading>
+        {children}
+        <ReadyForPrint type='print' />
+      </div>
+      <MarkRootReady />
+    </RootReadyProvider>
   );
-});
+}
 
 function PlainPage({ pageKey }: { pageKey: string }) {
   const pageExists = NodesInternal.useSelector((state) =>

--- a/src/layout/Subform/Summary/SubformSummaryComponent2.tsx
+++ b/src/layout/Subform/Summary/SubformSummaryComponent2.tsx
@@ -1,9 +1,10 @@
-import React, { type PropsWithChildren } from 'react';
+import React, { type FC, type PropsWithChildren } from 'react';
 
 import { Heading, Paragraph } from '@digdir/designsystemet-react';
 
 import { Flex } from 'src/app-components/Flex/Flex';
 import { Label } from 'src/components/label/Label';
+import { withReadyState } from 'src/components/ReadyContext';
 import { TaskStoreProvider } from 'src/core/contexts/taskStoreContext';
 import { FormProvider } from 'src/features/form/FormContext';
 import { useDataTypeFromLayoutSet } from 'src/features/form/layout/LayoutsContext';
@@ -67,19 +68,15 @@ export const SummarySubformWrapper = ({ nodeId }: PropsWithChildren<{ nodeId: st
   );
 };
 
-const DoSummaryWrapper = ({
-  dataElement,
-  layoutSet,
-  entryDisplayName,
-  title,
-  node,
-}: React.PropsWithChildren<{
-  dataElement: IData;
-  layoutSet: string;
-  entryDisplayName?: ExprValToActualOrExpr<ExprVal.String>;
-  title: string | undefined;
-  node: LayoutNode<'Subform'>;
-}>) => {
+const DoSummaryWrapper: FC<
+  PropsWithChildren<{
+    dataElement: IData;
+    layoutSet: string;
+    entryDisplayName?: ExprValToActualOrExpr<ExprVal.String>;
+    title: string | undefined;
+    node: LayoutNode<'Subform'>;
+  }>
+> = withReadyState(({ dataElement, layoutSet, entryDisplayName, title, node, MarkReady }) => {
   const isDone = useDoOverrideSummary(dataElement.id, layoutSet, dataElement.dataType);
 
   const { isSubformDataFetching, subformData, subformDataError } = useSubformFormData(dataElement.id);
@@ -124,11 +121,12 @@ const DoSummaryWrapper = ({
             </div>
           </Flex>
           <LayoutSetSummary />
+          <MarkReady />
         </Flex>
       </FormProvider>
     </div>
   );
-};
+});
 
 export function SubformSummaryComponent2({
   displayType,

--- a/src/layout/Subform/Summary/SubformSummaryTable.tsx
+++ b/src/layout/Subform/Summary/SubformSummaryTable.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import type { FC } from 'react';
 
 import { Paragraph, Spinner, Table } from '@digdir/designsystemet-react';
 import classNames from 'classnames';
@@ -6,6 +7,7 @@ import classNames from 'classnames';
 import { Flex } from 'src/app-components/Flex/Flex';
 import { Caption } from 'src/components/form/caption/Caption';
 import { Label } from 'src/components/label/Label';
+import { withReadyState } from 'src/components/ReadyContext';
 import { useDataTypeFromLayoutSet } from 'src/features/form/layout/LayoutsContext';
 import { useStrictDataElements } from 'src/features/instance/InstanceContext';
 import { Lang } from 'src/features/language/Lang';
@@ -25,19 +27,13 @@ import type { ISubformSummaryComponent } from 'src/layout/Subform/Summary/Subfor
 import type { IData } from 'src/types/shared';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
-function SubformTableRow({
-  dataElement,
-  targetNode,
-  hasErrors,
-  rowNumber,
-  pdfModeActive,
-}: {
+const SubformTableRow: FC<{
   dataElement: IData;
   targetNode: LayoutNode<'Subform'>;
   hasErrors: boolean;
   rowNumber: number;
   pdfModeActive: boolean;
-}) {
+}> = withReadyState(({ dataElement, targetNode, hasErrors, rowNumber, pdfModeActive, MarkReady }) => {
   const id = dataElement.id;
   const { tableColumns } = useNodeItem(targetNode);
   const { instanceOwnerPartyId, instanceGuid, taskId } = useNavigationParams();
@@ -99,9 +95,10 @@ function SubformTableRow({
           />
         </Table.Cell>
       )}
+      <MarkReady />
     </Table.Row>
   );
-}
+});
 
 export function SubformSummaryTable({ targetNode }: ISubformSummaryComponent): React.JSX.Element | null {
   const { id, layoutSet, textResourceBindings, tableColumns = [] } = useNodeItem(targetNode);

--- a/src/layout/Summary2/SummaryComponent2/LayoutSetSummary.tsx
+++ b/src/layout/Summary2/SummaryComponent2/LayoutSetSummary.tsx
@@ -14,12 +14,7 @@ export function LayoutSetSummary({ pageKey }: LayoutSetSummaryProps) {
 
   const summaryItem = useSummary2Store((state) => state.summaryItem);
 
-  const filteredPages = pageOrder.filter((layoutId) => {
-    if (!pageKey) {
-      return layoutId;
-    }
-    return layoutId === pageKey;
-  });
+  const filteredPages = pageOrder.filter((layoutId) => !pageKey || layoutId === pageKey);
 
   if (summaryItem?.showPageInAccordion) {
     return <LayoutSetSummaryAccordion filteredPages={filteredPages} />;

--- a/src/layout/Summary2/SummaryComponent2/SummaryComponent2.tsx
+++ b/src/layout/Summary2/SummaryComponent2/SummaryComponent2.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+import type { FC } from 'react';
 
+import { withReadyState } from 'src/components/ReadyContext';
 import { TaskStoreProvider } from 'src/core/contexts/taskStoreContext';
 import { ComponentSummaryById } from 'src/layout/Summary2/SummaryComponent2/ComponentSummary';
 import { LayoutSetSummary } from 'src/layout/Summary2/SummaryComponent2/LayoutSetSummary';
@@ -34,7 +36,7 @@ function SummaryBody({ target }: SummaryBodyProps) {
   return <ComponentSummaryById componentId={target.id} />;
 }
 
-export function SummaryComponent2({ summaryNode }: ISummaryComponent2) {
+export const SummaryComponent2: FC<ISummaryComponent2> = withReadyState(({ summaryNode, MarkReady }) => {
   const item = useNodeItem(summaryNode);
 
   return (
@@ -45,8 +47,9 @@ export function SummaryComponent2({ summaryNode }: ISummaryComponent2) {
       >
         <TaskSummaryWrapper taskId={item?.target?.taskId}>
           <SummaryBody target={item?.target} />
+          <MarkReady />
         </TaskSummaryWrapper>
       </Summary2StoreProvider>
     </TaskStoreProvider>
   );
-}
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -29,6 +29,7 @@ export interface IExpandedWidthLayoutsExternal {
 export enum ProcessTaskType {
   Unknown = 'unknown',
   Data = 'data',
+  Signing = 'signing',
   Archived = 'ended',
   Confirm = 'confirmation',
   Feedback = 'feedback',


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

This works using a `ReadyContext` in the `PdfWrapping`. Components can be wrapped with the `withReadyState`-wrapper, which will run an effect before it renders to register with the provider so we know to wait for it before we are ready. The component gets an additional prop `MarkReady`, which needs to be rendered out in the branch / inside nested providers where the content gets shown on screen. Essentially, if you have some loading state that conditionally causes a spinner to render, or providers that block with loading until ready, you place the `MarkReady` where the content is rendered.

The new hook in ReadyForPrint checks if the root context is ready (has finished rendering) and that all registered children are also ready. The trick with checking that the root context has finished rendering is that the children wrapped with `withReadyState` should now have had an opportunity to be registered.

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels

  - [ ] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->
