### PR TITLE
Remove autocomplete from dropdown and multiselect

### DIFF
--- a/src/layout/Dropdown/DropdownComponent.test.tsx
+++ b/src/layout/Dropdown/DropdownComponent.test.tsx
@@ -335,17 +335,4 @@ describe('DropdownComponent', () => {
     expect(screen.getAllByRole('listitem')).toHaveLength(1);
     expect(screen.getByRole('listitem')).toHaveTextContent('Du må fylle ut land');
   });
-
-  it('should render autocomplete prop if provided', async () => {
-    await render({
-      component: {
-        optionsId: 'countries',
-        autocomplete: 'name',
-      },
-      options: countries,
-    });
-
-    const inputComponent = screen.getByRole('combobox') as HTMLInputElement;
-    expect(inputComponent).toHaveAttribute('autocomplete', 'name');
-  });
 });

--- a/src/layout/Dropdown/DropdownComponent.tsx
+++ b/src/layout/Dropdown/DropdownComponent.tsx
@@ -24,7 +24,7 @@ export type IDropdownProps = PropsFromGenericComponent<'Dropdown'>;
 export function DropdownComponent({ node, overrideDisplay }: IDropdownProps) {
   const item = useNodeItem(node);
   const isValid = useIsValid(node);
-  const { id, readOnly, textResourceBindings, alertOnChange, grid, required, autocomplete } = item;
+  const { id, readOnly, textResourceBindings, alertOnChange, grid, required } = item;
   const { langAsString, lang } = useLanguage(node);
 
   const { labelText, getRequiredComponent, getOptionalComponent, getHelpTextComponent, getDescriptionComponent } =
@@ -96,7 +96,6 @@ export function DropdownComponent({ node, overrideDisplay }: IDropdownProps) {
             label={overrideDisplay?.renderedInTable ? langAsString(textResourceBindings?.title) : undefined}
             aria-label={overrideDisplay?.renderedInTable ? langAsString(textResourceBindings?.title) : undefined}
             className={comboboxClasses.container}
-            autoComplete={autocomplete}
             style={{ width: '100%' }}
           >
             <Combobox.Empty>

--- a/src/layout/Dropdown/config.ts
+++ b/src/layout/Dropdown/config.ts
@@ -1,4 +1,3 @@
-import { INPUT_AUTO_COMPLETE } from 'src/app-components/Input/constants';
 import { CG } from 'src/codegen/CG';
 import { AlertOnChangePlugin } from 'src/features/alertOnChange/AlertOnChangePlugin';
 import { OptionsPlugin } from 'src/features/options/OptionsPlugin';
@@ -33,17 +32,6 @@ export const Config = new CG.component({
       title: 'Alert on change',
       description: 'Boolean value indicating if the component should alert on change',
     }),
-  )
-  .addProperty(
-    new CG.prop(
-      'autocomplete',
-      new CG.enum(...INPUT_AUTO_COMPLETE)
-        .optional()
-        .setTitle('Autocomplete')
-        .setDescription(
-          'The HTML autocomplete attribute helps browsers suggest or autofill input values based on the expected type of data.',
-        ),
-    ),
   )
   .addDataModelBinding(CG.common('IDataModelBindingsOptionsSimple'))
   .extends(CG.common('LabeledComponentProps'))

--- a/src/layout/MultipleSelect/MultipleSelectComponent.test.tsx
+++ b/src/layout/MultipleSelect/MultipleSelectComponent.test.tsx
@@ -84,23 +84,4 @@ describe('MultipleSelect', () => {
     expect(screen.getAllByRole('listitem')).toHaveLength(1);
     expect(screen.getByRole('listitem')).toHaveTextContent('Du må fylle ut velg');
   });
-
-  it('should render autocomplete prop if provided', async () => {
-    await render({
-      component: {
-        autocomplete: 'name',
-        dataModelBindings: {
-          simpleBinding: { dataType: defaultDataTypeMock, field: 'value' },
-          label: { dataType: defaultDataTypeMock, field: 'label' },
-          metadata: { dataType: defaultDataTypeMock, field: 'metadata' },
-        },
-      },
-      queries: {
-        fetchFormData: () => Promise.resolve({ simpleBinding: '', label: '', metadata: '' }),
-      },
-    });
-
-    const inputComponent = screen.getByRole('combobox') as HTMLInputElement;
-    expect(inputComponent).toHaveAttribute('autocomplete', 'name');
-  });
 });

--- a/src/layout/MultipleSelect/MultipleSelectComponent.tsx
+++ b/src/layout/MultipleSelect/MultipleSelectComponent.tsx
@@ -24,7 +24,7 @@ export type IMultipleSelectProps = PropsFromGenericComponent<'MultipleSelect'>;
 export function MultipleSelectComponent({ node, overrideDisplay }: IMultipleSelectProps) {
   const item = useNodeItem(node);
   const isValid = useIsValid(node);
-  const { id, readOnly, textResourceBindings, alertOnChange, grid, required, autocomplete } = item;
+  const { id, readOnly, textResourceBindings, alertOnChange, grid, required } = item;
   const { options, isFetching, selectedValues, setData } = useGetOptions(node, 'multi');
   const debounce = FD.useDebounceImmediately();
   const { langAsString, lang } = useLanguage(node);
@@ -104,7 +104,6 @@ export function MultipleSelectComponent({ node, overrideDisplay }: IMultipleSele
                 ? getDescriptionId(id)
                 : undefined
             }
-            autoComplete={autocomplete}
             style={{ width: '100%' }}
           >
             <Combobox.Empty>

--- a/src/layout/MultipleSelect/config.ts
+++ b/src/layout/MultipleSelect/config.ts
@@ -1,4 +1,3 @@
-import { INPUT_AUTO_COMPLETE } from 'src/app-components/Input/constants';
 import { CG } from 'src/codegen/CG';
 import { AlertOnChangePlugin } from 'src/features/alertOnChange/AlertOnChangePlugin';
 import { OptionsPlugin } from 'src/features/options/OptionsPlugin';
@@ -41,17 +40,6 @@ export const Config = new CG.component({
       title: 'Alert on change',
       description: 'Boolean value indicating if the component should alert on change',
     }),
-  )
-  .addProperty(
-    new CG.prop(
-      'autocomplete',
-      new CG.enum(...INPUT_AUTO_COMPLETE)
-        .optional()
-        .setTitle('Autocomplete')
-        .setDescription(
-          'The HTML autocomplete attribute helps browsers suggest or autofill input values based on the expected type of data.',
-        ),
-    ),
   )
   .addDataModelBinding(CG.common('IDataModelBindingsOptionsSimple'))
   .extends(CG.common('LabeledComponentProps'))


### PR DESCRIPTION
## Description

It is not recommended by the Designsystem to use autocomplete with select and multi-select type components, as the autocomplete list will interfere with the option list. 

Also it might not make sense to use autocomplete with these components because the value saved in the browser for a given autocomplete category might not exist within the possible options.

Currently only one deployed app (in TT02) is using the autocomplete property for dropdown, setting it to `"off"`.
No deployed apps are using the autocomplete property with the mulitpleselect component.

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [x] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [x] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release
  --->
