### PR TITLE
Update renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,15 +1,14 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["local>Altinn/renovate-config"],
-  "labels": ["kind/dependencies"],
+  "labels": ["kind/dependencies", "backport-ignore"],
   "baseBranches": ["main"],
   "packageRules": [
     {
       "matchPackageNames": [
         "@digdir/designsystemet-react",
         "@digdir/designsystemet-css",
-        "@digdir/designsystemet-theme",
-        "@digdir/design-system-react"
+        "@digdir/designsystemet-theme"
       ],
       "groupName": "Digdir design system",
       "schedule": ["* 0-7 * * 1-5"],


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

Renovate PRs fail the new backport label check, adding `backport-ignore` to list of labels. Also removed `@digdir/design-system-react` from the design system group as this package is deprecated and will be removed shortly.