### PR TITLE
added size, textAlign and fullWidth to button components

### DIFF
--- a/src/app-components/Button/Button.tsx
+++ b/src/app-components/Button/Button.tsx
@@ -8,6 +8,7 @@ import { useLanguage } from 'src/features/language/useLanguage';
 
 export type ButtonVariant = 'primary' | 'secondary' | 'tertiary' | undefined;
 export type ButtonColor = 'first' | 'second' | 'success' | 'danger' | undefined;
+export type TextAlign = 'left' | 'center' | 'right';
 
 export type ButtonProps = {
   variant?: ButtonVariant;
@@ -15,6 +16,7 @@ export type ButtonProps = {
   isLoading?: boolean;
   size?: 'sm' | 'md' | 'lg';
   className?: string;
+  textAlign?: TextAlign;
 } & Pick<
   DesignSystemButtonProps,
   | 'id'
@@ -56,6 +58,7 @@ export const Button = forwardRef<HTMLButtonElement, PropsWithChildren<ButtonProp
     onMouseDown,
     onKeyUp,
     asChild,
+    textAlign,
     'aria-label': ariaLabel,
     'aria-busy': ariaBusy,
     'aria-controls': ariaControls,
@@ -67,6 +70,7 @@ export const Button = forwardRef<HTMLButtonElement, PropsWithChildren<ButtonProp
   ref,
 ) {
   const { langAsString } = useLanguage();
+  const expandedStyle = { ...style, justifyContent: textAlign ? textAlign : undefined };
   return (
     <DesignSystemButton
       id={id}
@@ -80,7 +84,7 @@ export const Button = forwardRef<HTMLButtonElement, PropsWithChildren<ButtonProp
       icon={icon}
       fullWidth={fullWidth}
       onClick={onClick}
-      style={style}
+      style={expandedStyle}
       tabIndex={tabIndex}
       onMouseDown={onMouseDown}
       onKeyUp={onKeyUp}

--- a/src/layout/Button/ButtonComponent.tsx
+++ b/src/layout/Button/ButtonComponent.tsx
@@ -12,7 +12,6 @@ import { useIsSubformPage } from 'src/features/routing/AppRoutingContext';
 import { getComponentFromMode } from 'src/layout/Button/getComponentFromMode';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
 import { ProcessTaskType } from 'src/types';
-import { LayoutPage } from 'src/utils/layout/LayoutPage';
 import { useNodeItem } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type { CompInternal } from 'src/layout/layout';
@@ -45,8 +44,6 @@ export const ButtonComponent = ({ node, ...componentProps }: IButtonReceivedProp
     (currentTaskType === ProcessTaskType.Data && !write) ||
     (currentTaskType === ProcessTaskType.Confirm && !actions?.confirm);
 
-  const parentIsPage = node.parent instanceof LayoutPage;
-
   if (mode && !(mode === 'save' || mode === 'submit')) {
     const GenericButton = getComponentFromMode(mode);
     if (!GenericButton) {
@@ -54,11 +51,9 @@ export const ButtonComponent = ({ node, ...componentProps }: IButtonReceivedProp
     }
 
     return (
-      <div style={{ marginTop: parentIsPage ? 'var(--button-margin-top)' : undefined }}>
-        <GenericButton {...props}>
-          <Lang id={item.textResourceBindings?.title} />
-        </GenericButton>
-      </div>
+      <GenericButton {...props}>
+        <Lang id={item.textResourceBindings?.title} />
+      </GenericButton>
     );
   }
 
@@ -74,20 +69,21 @@ export const ButtonComponent = ({ node, ...componentProps }: IButtonReceivedProp
 
   return (
     <ComponentStructureWrapper node={node}>
-      <div style={{ marginTop: parentIsPage ? 'var(--button-margin-top)' : undefined }}>
-        <Button
-          id={node.id}
-          onClick={submitTask}
-          isLoading={isThisProcessing}
-          disabled={disabled}
-          color='success'
-        >
-          <Lang id={item.textResourceBindings?.title} />
-        </Button>
-        {attachmentsPending && (
-          <span style={{ position: 'absolute' }}>{langAsString('general.wait_for_attachments')}</span>
-        )}
-      </div>
+      <Button
+        textAlign={item.textAlign}
+        size={item.size}
+        fullWidth={item.fullWidth}
+        id={node.id}
+        onClick={submitTask}
+        isLoading={isThisProcessing}
+        disabled={disabled}
+        color='success'
+      >
+        <Lang id={item.textResourceBindings?.title} />
+      </Button>
+      {attachmentsPending && (
+        <span style={{ position: 'absolute' }}>{langAsString('general.wait_for_attachments')}</span>
+      )}
     </ComponentStructureWrapper>
   );
 };

--- a/src/layout/Button/config.ts
+++ b/src/layout/Button/config.ts
@@ -33,4 +33,29 @@ export const Config = new CG.component({
         .exportAs('ButtonMode'),
     ),
   )
+  .addProperty(
+    new CG.prop(
+      'textAlign',
+      new CG.enum('left', 'center', 'right')
+        .optional({ default: 'center' })
+        .setTitle('Text Align')
+        .exportAs('ButtonTextAlign'),
+    ),
+  )
+  .addProperty(
+    new CG.prop(
+      'size',
+      new CG.enum('sm', 'md', 'lg')
+        .optional({ default: 'md' })
+        .setTitle('Size')
+        .setDescription('The size of the button')
+        .exportAs('Size'),
+    ),
+  )
+  .addProperty(
+    new CG.prop(
+      'fullWidth',
+      new CG.bool().optional().setTitle('Full width').setDescription('Whether the button should expand to full width'),
+    ),
+  )
   .addProperty(new CG.prop('mapping', CG.common('IMapping').optional()));

--- a/src/layout/Link/LinkComponent.tsx
+++ b/src/layout/Link/LinkComponent.tsx
@@ -6,7 +6,6 @@ import { Button, type ButtonColor, type ButtonVariant } from 'src/app-components
 import { Lang } from 'src/features/language/Lang';
 import { useLanguage } from 'src/features/language/useLanguage';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
-import { LayoutPage } from 'src/utils/layout/LayoutPage';
 import { useNodeItem } from 'src/utils/layout/useNodeItem';
 import type { LinkStyle } from 'src/layout/Link/config.generated';
 
@@ -20,14 +19,21 @@ export const buttonStyles: {
 export type ILinkComponent = PropsFromGenericComponent<'Link'>;
 
 export function LinkComponent({ node }: ILinkComponent) {
-  const { id, style: linkStyle, openInNewTab, textResourceBindings } = useNodeItem(node);
+  const {
+    id,
+    style: linkStyle,
+    openInNewTab,
+    textResourceBindings,
+    size,
+    fullWidth,
+    linkButtonTextAlign,
+  } = useNodeItem(node);
   const { langAsString } = useLanguage();
-  const parentIsPage = node.parent instanceof LayoutPage;
-  const style = { marginTop: parentIsPage ? 'var(--button-margin-top)' : undefined };
+
   const downloadName = textResourceBindings?.download;
 
   const Link = () => (
-    <div style={style}>
+    <div>
       <a
         id={`link-${id}`}
         download={downloadName !== undefined ? (downloadName === '' ? true : langAsString(downloadName)) : undefined}
@@ -42,11 +48,13 @@ export function LinkComponent({ node }: ILinkComponent) {
 
   const LinkButton = () => (
     <Button
+      textAlign={linkButtonTextAlign}
       id={`link-${id}`}
-      style={style}
       color={buttonStyles[linkStyle].color}
       variant={buttonStyles[linkStyle].variant}
       onClick={LinkButtonOnClick()}
+      size={size}
+      fullWidth={fullWidth}
     >
       <Lang id={textResourceBindings?.title} />
     </Button>

--- a/src/layout/Link/config.ts
+++ b/src/layout/Link/config.ts
@@ -49,6 +49,35 @@ export const Config = new CG.component({
   )
   .addProperty(
     new CG.prop(
+      'size',
+      new CG.enum('sm', 'md', 'lg')
+        .optional({ default: 'md' })
+        .setTitle('Size')
+        .setDescription('The size of the button. Only effective using style of primary or secondary')
+        .exportAs('LinkButtonSize'),
+    ),
+  )
+  .addProperty(
+    new CG.prop(
+      'linkButtonTextAlign',
+      new CG.enum('left', 'center', 'right')
+        .optional({ default: 'center' })
+        .setTitle('Text Align')
+        .setDescription('Text align when using style of primary or secondary.')
+        .exportAs('LinkButtonTextAlign'),
+    ),
+  )
+  .addProperty(
+    new CG.prop(
+      'fullWidth',
+      new CG.bool()
+        .optional()
+        .setTitle('Full width')
+        .setDescription('Whether a link button should expand to full width'),
+    ),
+  )
+  .addProperty(
+    new CG.prop(
       'openInNewTab',
       new CG.bool().optional().setTitle('Open in new tab').setDescription('Open the link in a new tab'),
     ),

--- a/src/layout/NavigationButtons/NavigationButtonsComponent.module.css
+++ b/src/layout/NavigationButtons/NavigationButtonsComponent.module.css
@@ -3,4 +3,5 @@
   flex-direction: row-reverse;
   justify-content: flex-end;
   gap: var(--button-gap);
+  margin-top: var(--button-margin-top);
 }

--- a/src/layout/NavigationButtons/NavigationButtonsComponent.module.css
+++ b/src/layout/NavigationButtons/NavigationButtonsComponent.module.css
@@ -3,5 +3,4 @@
   flex-direction: row-reverse;
   justify-content: flex-end;
   gap: var(--button-gap);
-  margin-top: var(--button-margin-top);
 }

--- a/src/layout/NavigationButtons/NavigationButtonsComponent.tsx
+++ b/src/layout/NavigationButtons/NavigationButtonsComponent.tsx
@@ -9,7 +9,6 @@ import { useOnPageNavigationValidation } from 'src/features/validation/callbacks
 import { useNavigatePage, useNextPageKey, usePreviousPageKey } from 'src/hooks/useNavigatePage';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
 import classes from 'src/layout/NavigationButtons/NavigationButtonsComponent.module.css';
-import { LayoutPage } from 'src/utils/layout/LayoutPage';
 import { useNodeItem } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 export type INavigationButtons = PropsFromGenericComponent<'NavigationButtons'>;
@@ -22,7 +21,6 @@ export function NavigationButtonsComponent({ node }: INavigationButtons) {
   const returnToView = useReturnToView();
   const summaryItem = useNodeItem(useSummaryNodeOfOrigin());
   const { performProcess, isAnyProcessing, process } = useIsProcessing<'next' | 'previous' | 'backToSummary'>();
-  const parentIsPage = node.parent instanceof LayoutPage;
 
   const nextTextKey = textResourceBindings?.next || 'next';
   const backTextKey = textResourceBindings?.back || 'back';
@@ -96,7 +94,6 @@ export function NavigationButtonsComponent({ node }: INavigationButtons) {
       <div
         data-testid='NavigationButtons'
         className={classes.container}
-        style={{ marginTop: parentIsPage ? 'var(--button-margin-top)' : undefined }}
       >
         {showBackToSummaryButton && (
           <Button

--- a/src/layout/PrintButton/PrintButtonComponent.tsx
+++ b/src/layout/PrintButton/PrintButtonComponent.tsx
@@ -5,17 +5,14 @@ import type { PropsFromGenericComponent } from '..';
 import { Button } from 'src/app-components/Button/Button';
 import { Lang } from 'src/features/language/Lang';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
-import { LayoutPage } from 'src/utils/layout/LayoutPage';
 import { useNodeItem } from 'src/utils/layout/useNodeItem';
 
 export const PrintButtonComponent = ({ node }: PropsFromGenericComponent<'PrintButton'>) => {
   const { textResourceBindings } = useNodeItem(node);
-  const parentIsPage = node.parent instanceof LayoutPage;
 
   return (
     <ComponentStructureWrapper node={node}>
       <Button
-        style={{ marginTop: parentIsPage ? 'var(--button-margin-top)' : undefined }}
         variant='secondary'
         color='first'
         onClick={window.print}

--- a/test/e2e/integration/component-library/button.ts
+++ b/test/e2e/integration/component-library/button.ts
@@ -1,0 +1,12 @@
+import { AppFrontend } from 'test/e2e/pageobjects/app-frontend';
+
+const appFrontend = new AppFrontend();
+
+describe('Button component', () => {
+  it('Renders the different options for button correctly', () => {
+    cy.startAppInstance(appFrontend.apps.componentLibrary, { authenticationLevel: '2' });
+    cy.gotoNavPage('Knapp');
+
+    cy.snapshot('button');
+  });
+});

--- a/test/e2e/integration/component-library/link.ts
+++ b/test/e2e/integration/component-library/link.ts
@@ -1,0 +1,12 @@
+import { AppFrontend } from 'test/e2e/pageobjects/app-frontend';
+
+const appFrontend = new AppFrontend();
+
+describe('Link component', () => {
+  it('Renders the different options for link correctly', () => {
+    cy.startAppInstance(appFrontend.apps.componentLibrary, { authenticationLevel: '2' });
+    cy.gotoNavPage('Link');
+
+    cy.snapshot('link');
+  });
+});


### PR DESCRIPTION
## Description

Buttons now support:

- Expanding to full width:
- Size: small, medium and large
- Text align: left, center and right

![Screenshot 2025-04-09 at 13 16 50](https://github.com/user-attachments/assets/e17a7cfc-c6e8-4512-ac59-3f4a62c81cc9)


## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [x] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels

  - [ ] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->
