### PR TITLE
Fixing missing instantiation error(s)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { NavigateToStartUrl, ProcessWrapper } from 'src/components/wrappers/Proc
 import { Entrypoint } from 'src/features/entrypoint/Entrypoint';
 import { InstanceProvider } from 'src/features/instance/InstanceContext';
 import { PartySelection } from 'src/features/instantiate/containers/PartySelection';
+import { InstantiationError } from 'src/features/instantiate/InstantiationError';
 import { InstanceSelectionWrapper } from 'src/features/instantiate/selection/InstanceSelection';
 import { CustomReceipt, DefaultReceipt } from 'src/features/receipt/ReceiptContainer';
 import { TaskKeys } from 'src/hooks/useNavigatePage';
@@ -32,12 +33,14 @@ export const App = () => (
       path='/instance-selection/*'
       element={<InstanceSelectionWrapper />}
     />
-
     <Route
       path='/party-selection/*'
       element={<PartySelection />}
     />
-
+    <Route
+      path='/instantiation/:error'
+      element={<InstantiationError />}
+    />
     <Route
       path='/instance/:instanceOwnerPartyId/:instanceGuid/*'
       element={

--- a/src/features/instantiate/InstantiationError.tsx
+++ b/src/features/instantiate/InstantiationError.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+
+import { InstantiateValidationError } from 'src/features/instantiate/containers/InstantiateValidationError';
+import { MissingRolesError } from 'src/features/instantiate/containers/MissingRolesError';
+import { UnknownError } from 'src/features/instantiate/containers/UnknownError';
+import { useInstantiation } from 'src/features/instantiate/InstantiationContext';
+import { isAxiosError } from 'src/utils/isAxiosError';
+
+export function InstantiationError() {
+  const error = useParams()?.error;
+  const exception = useInstantiation().error;
+
+  if (error === 'forbidden') {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const message = isAxiosError(exception) ? (exception.response?.data as any)?.message : undefined;
+    if (message) {
+      return <InstantiateValidationError message={message} />;
+    }
+
+    return <MissingRolesError />;
+  }
+
+  return <UnknownError />;
+}

--- a/src/features/instantiate/containers/InstantiateContainer.tsx
+++ b/src/features/instantiate/containers/InstantiateContainer.tsx
@@ -1,16 +1,11 @@
 import React, { useEffect } from 'react';
 
 import { Loader } from 'src/core/loading/Loader';
-import { InstantiateValidationError } from 'src/features/instantiate/containers/InstantiateValidationError';
-import { MissingRolesError } from 'src/features/instantiate/containers/MissingRolesError';
-import { UnknownError } from 'src/features/instantiate/containers/UnknownError';
 import { useInstantiation } from 'src/features/instantiate/InstantiationContext';
 import { useCurrentParty } from 'src/features/party/PartiesProvider';
 import { useAsRef } from 'src/hooks/useAsRef';
 import { AltinnPalette } from 'src/theme/altinnAppTheme';
 import { changeBodyBackground } from 'src/utils/bodyStyling';
-import { isAxiosError } from 'src/utils/isAxiosError';
-import { HttpStatusCodes } from 'src/utils/network/networking';
 
 export const InstantiateContainer = () => {
   changeBodyBackground(AltinnPalette.greyLight);
@@ -40,19 +35,6 @@ export const InstantiateContainer = () => {
       instantiationCleanupTimeout = setTimeout(clear, TIMEOUT);
     };
   }, [clearRef]);
-
-  if (isAxiosError(instantiation.error)) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const message = (instantiation.error.response?.data as any)?.message;
-    if (instantiation.error.response?.status === HttpStatusCodes.Forbidden) {
-      if (message) {
-        return <InstantiateValidationError message={message} />;
-      }
-      return <MissingRolesError />;
-    }
-
-    return <UnknownError />;
-  }
 
   return <Loader reason='instantiating' />;
 };

--- a/src/features/instantiate/containers/InstantiateValidationError.tsx
+++ b/src/features/instantiate/containers/InstantiateValidationError.tsx
@@ -7,25 +7,20 @@ import { useLanguage } from 'src/features/language/useLanguage';
 export function InstantiateValidationError(props: { message: string }) {
   const { langAsString } = useLanguage();
 
-  function createErrorContent() {
-    const errorCustomerService = langAsString(
-      'instantiate.authorization_error_instantiate_validation_info_customer_service',
-      [langAsString('general.customer_service_phone_number')],
-    );
-    return (
-      <>
-        <span>{props.message && <Lang id={props.message} />}</span>
-        <br />
-        <br />
-        <span>{errorCustomerService}</span>
-      </>
-    );
-  }
-
   return (
     <InstantiationErrorPage
       title={<Lang id='instantiate.authorization_error_instantiate_validation_title' />}
-      content={createErrorContent()}
+      content={
+        <>
+          {props.message && <Lang id={props.message} />}
+          <br />
+          <br />
+          <Lang
+            id='instantiate.authorization_error_instantiate_validation_info_customer_service'
+            params={[langAsString('general.customer_service_phone_number')]}
+          />
+        </>
+      }
       statusCode={`${langAsString('party_selection.error_caption_prefix')} 403`}
     />
   );

--- a/test/e2e/integration/frontend-test/instantiation.ts
+++ b/test/e2e/integration/frontend-test/instantiation.ts
@@ -1,0 +1,49 @@
+import { AppFrontend } from 'test/e2e/pageobjects/app-frontend';
+import { cyMockResponses } from 'test/e2e/pageobjects/party-mocks';
+
+const appFrontend = new AppFrontend();
+
+describe('Instantiation', () => {
+  // See ttd/frontend-test/App/logic/Instantiation/InstantiationValidator.cs
+  const invalidParty =
+    Cypress.env('type') === 'localtest'
+      ? /950474084/ // Localtest: Oslos Vakreste borettslag
+      : /310732001/; // TT02: Søvnig Impulsiv Tiger AS
+
+  it('should show an error message when going directly to instantiation', () => {
+    cyMockResponses({
+      doNotPromptForParty: false,
+      onEntryShow: 'new-instance',
+    });
+    cy.startAppInstance(appFrontend.apps.frontendTest, { user: 'manager' });
+    cy.findByRole('button', { name: invalidParty }).click();
+    assertErrorMessage();
+  });
+
+  it('should show an error message when starting a new instance from instance-selection', () => {
+    cyMockResponses({
+      doNotPromptForParty: false,
+      onEntryShow: 'select-instance',
+      activeInstances: [
+        { id: 'abc123', lastChanged: '2023-01-01T00:00:00.000Z', lastChangedBy: 'user' },
+        { id: 'def456', lastChanged: '2023-01-02T00:00:00.000Z', lastChangedBy: 'user' },
+      ],
+    });
+    cy.startAppInstance(appFrontend.apps.frontendTest, { user: 'manager' });
+    cy.findByRole('button', { name: invalidParty }).click();
+
+    cy.findByText('Du har allerede startet å fylle ut dette skjemaet.').should('be.visible');
+    cy.findByRole('button', { name: 'Start på nytt' }).click();
+    assertErrorMessage();
+  });
+
+  function assertErrorMessage() {
+    cy.findByText('Du kan ikke starte denne tjenesten').should('be.visible');
+    cy.findByText(
+      /Aktøren du valgte kan ikke opprette en instans av dette skjemaet. Dette er en egendefinert feilmelding for akkurat denne appen./,
+    ).should('be.visible');
+    cy.findByRole('link', { name: 'Vennligst velg en annen aktør' }).click();
+
+    cy.findByRole('button', { name: invalidParty }).should('be.visible');
+  }
+});


### PR DESCRIPTION
## Description

This fixes the missing instantiation error that didn't appear when creating a new instance from the instance selection screen. I added a route for this error, and read the exception to print out the actual error. This also means that you can navigate to that route and just end up with a generic/unknown error.

It also fixes the same when instantiating via a `InstantiationButton` from a stateless app. I wanted to rework this even more for stateless apps, as you might want to use a `IInstantiationValidator` to disallow some prefill values when creating a new instance with prefill (i.e. using the `InstantiationButton` with `mapping`). However, it doesn't seem like that's possible yet in the backend. If we get a feature request for that, we'd probably have to change both the backend and frontend at that point instead. Optimally the error should be displayed inline as a validation error in the stateless form, such that the user can make changes in the stateless form and retry - but right now I can't find a clear way for a change in the stateless form to make a difference in the `IInstantiationValidator`, so I'm scrapping that idea.

## Related Issue(s)

- closes #2578

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->
