### PR TITLE
Refetch instance data on task change by adding task id to query key

### DIFF
--- a/src/features/instance/InstanceContext.tsx
+++ b/src/features/instance/InstanceContext.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import { useParams } from 'react-router-dom';
 import type { PropsWithChildren } from 'react';
 
 import { skipToken, useQuery } from '@tanstack/react-query';
@@ -101,22 +102,32 @@ const {
     })),
 });
 
+const instanceQueryKeys = {
+  instanceData: (
+    instanceOwnerPartyId: string | undefined,
+    instanceGuid: string | undefined,
+    taskId: string | undefined,
+  ) => ['instanceData', instanceOwnerPartyId, instanceGuid, taskId],
+};
+
 // Also used for prefetching @see appPrefetcher.ts
 export function useInstanceDataQueryDef(
   hasResultFromInstantiation: boolean,
-  partyId?: string,
-  instanceGuid?: string,
+  partyId: string | undefined,
+  instanceGuid: string | undefined,
+  taskId: string | undefined,
 ): QueryDefinition<IInstance> {
   const { fetchInstanceData } = useAppQueries();
   return {
-    queryKey: ['fetchInstanceData', partyId, instanceGuid],
+    queryKey: instanceQueryKeys.instanceData(partyId, instanceGuid, taskId),
     queryFn: partyId && instanceGuid ? () => fetchInstanceData(partyId, instanceGuid) : skipToken,
     enabled: !!partyId && !!instanceGuid && !hasResultFromInstantiation,
   };
 }
 
 function useGetInstanceDataQuery(hasResultFromInstantiation: boolean, partyId: string, instanceGuid: string) {
-  const utils = useQuery(useInstanceDataQueryDef(hasResultFromInstantiation, partyId, instanceGuid));
+  const { taskId } = useParams();
+  const utils = useQuery(useInstanceDataQueryDef(hasResultFromInstantiation, partyId, instanceGuid, taskId));
 
   useEffect(() => {
     utils.error && window.logError('Fetching instance data failed:\n', utils.error);

--- a/src/queries/appPrefetcher.ts
+++ b/src/queries/appPrefetcher.ts
@@ -18,6 +18,12 @@ import { useProfileQueryDef } from 'src/features/profile/ProfileProvider';
 export function AppPrefetcher() {
   const { instanceOwnerPartyId, instanceGuid } =
     matchPath({ path: '/instance/:instanceOwnerPartyId/:instanceGuid/*' }, window.location.hash.slice(1))?.params ?? {};
+
+  const taskId = matchPath(
+    { path: '/instance/:instanceOwnerPartyId/:instanceGuid/:taskId/*' },
+    window.location.hash.slice(1),
+  )?.params?.taskId;
+
   const instanceId = instanceOwnerPartyId && instanceGuid ? `${instanceOwnerPartyId}/${instanceGuid}` : undefined;
 
   usePrefetchQuery(getApplicationMetadataQueryDef(instanceGuid));
@@ -28,7 +34,7 @@ export function AppPrefetcher() {
   usePrefetchQuery(usePartiesQueryDef(true), Boolean(instanceOwnerPartyId));
   usePrefetchQuery(useCurrentPartyQueryDef(true), Boolean(instanceOwnerPartyId));
 
-  usePrefetchQuery(useInstanceDataQueryDef(false, instanceOwnerPartyId, instanceGuid));
+  usePrefetchQuery(useInstanceDataQueryDef(false, instanceOwnerPartyId, instanceGuid, taskId));
   usePrefetchQuery(getProcessQueryDef(instanceId));
 
   return null;


### PR DESCRIPTION
## Description
Instance data is not necessarily updated on task change. Added task id to query key to make sure it is being refetched. 

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels

  - [ ] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->
