### PR TITLE
Sync with azure cdn directly

### DIFF
--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -131,7 +131,7 @@ else
     azcopy sync "$TARGET" "$AZURE_TARGET_URI/toolkits${AZURE_STORAGE_ACCOUNT_TOKEN}" "${AZCOPY_TOOLKITS_OPTS[@]}" "${AZCOPY_ADDITIONAL_OPTS[@]}"
     echo "-------------------------------------"
     if [[ "$SYNC_AZURE_CDN" == "yes" && "$PRE_RELEASE" == "no" ]]; then
-      bash "$PATH_TO_FRONTEND/.github/scripts/purge-frontdoor-cache.sh" --path "/toolkits/altinn-app-frontend/$APP_MAJOR/*" --path "/toolkits/altinn-app-frontend/$APP_MAJOR_MINOR/*"
+      bash ".github/scripts/purge-frontdoor-cache.sh" --path "/toolkits/altinn-app-frontend/$APP_MAJOR/*" --path "/toolkits/altinn-app-frontend/$APP_MAJOR_MINOR/*"
       echo "-------------------------------------"
     fi
   fi

--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -4,27 +4,12 @@ set -e
 set -u
 
 PRE_RELEASE=no
-COMMIT=no
 SYNC_AZURE_CDN=no
 
 while [[ $# -gt 0 ]]; do
   case $1 in
-    --cdn)
-      PATH_TO_CDN=$(realpath "$2")
-      shift # pop option
-      shift # pop value
-      ;;
-    --frontend)
-      PATH_TO_FRONTEND=$(realpath "$2")
-      shift # pop option
-      shift # pop value
-      ;;
     --pre-release)
       PRE_RELEASE=yes
-      shift # pop option
-      ;;
-    --commit)
-      COMMIT=yes
       shift # pop option
       ;;
     --azure-sa-name)
@@ -53,28 +38,18 @@ while [[ $# -gt 0 ]]; do
 done
 
 SOURCE=dist
-TARGET=toolkits/altinn-app-frontend
+TARGET="$RUNNER_TEMP/release-target"
 AZURE_TARGET_URI="https://${AZURE_STORAGE_ACCOUNT_NAME}.blob.core.windows.net/app-frontend"
 
-if ! test -d "$PATH_TO_CDN" || ! test -d "$PATH_TO_CDN/$TARGET"; then
-  echo "Unable to find $PATH_TO_CDN/$TARGET"
-  echo "Make sure path to CDN has been passed with --cdn <path>"
+if ! test -d "$SOURCE"; then
+  echo "Unable to find $SOURCE (did you run yarn build first?)"
   exit 1
 fi
-if ! test -d "$PATH_TO_FRONTEND" || ! test -d "$PATH_TO_FRONTEND/$SOURCE"; then
-  echo "Unable to find $PATH_TO_FRONTEND/$SOURCE (did you run yarn build first?)"
-  echo "Make sure path to CDN has been passed with --frontend <path>"
-  exit 1
-fi
-
-SOURCE="$PATH_TO_FRONTEND/$SOURCE"
-TARGET="$PATH_TO_CDN/$TARGET"
 
 echo "-------------------------------------"
 echo "Source:        $SOURCE"
 echo "Target:        $TARGET"
 echo "Pre-release:   $PRE_RELEASE (toggle with --pre-release)"
-echo "Commit:        $COMMIT (toggle with --commit)"
 echo "-------------------------------------"
 
 CURRENT_VERSION=$(git describe --abbrev=0 --tags 2>/dev/null)
@@ -82,19 +57,11 @@ CURRENT_VERSION_PARTS=(${CURRENT_VERSION//./ })
 APP_FULL=${CURRENT_VERSION:1}
 APP_MAJOR=${CURRENT_VERSION_PARTS[0]:1}
 APP_MAJOR_MINOR=${CURRENT_VERSION_PARTS[0]:1}.${CURRENT_VERSION_PARTS[1]}
-AUTHOR_FULL=$(git log -1 | grep Author | sed 's/^Author: //')
-AUTHOR_NAME="$(echo "$AUTHOR_FULL" | sed -r 's/<.*//')"
-AUTHOR_EMAIL="$(echo "$AUTHOR_FULL" | sed -r 's/^.*?<//' | sed 's/>//')"
-COMMIT_ID=$(git rev-parse HEAD~0)
 
 echo "Git tag:       '$CURRENT_VERSION'"
 echo "Full version:  '$APP_FULL'"
 echo "Major version: '$APP_MAJOR'"
 echo "Major + minor: '$APP_MAJOR_MINOR'"
-echo "Latest author: '$AUTHOR_FULL'"
-echo "Author name:   '$AUTHOR_NAME'"
-echo "Author email:  '$AUTHOR_EMAIL'"
-echo "Commit ID:     '$COMMIT_ID'"
 echo "-------------------------------------"
 
 if ! [[ "$CURRENT_VERSION" =~ ^v ]]; then
@@ -108,17 +75,6 @@ if ! echo "$APP_FULL" | grep --quiet --perl-regexp "$VERSION_REGEX"; then
   exit 1
 fi
 
-COMMIT_FILE=$(mktemp --suffix=-cdn-commit)
-{
-  echo "$AUTHOR_FULL updated altinn-app-frontend to $APP_FULL"
-  echo "based on commit https://github.com/Altinn/app-frontend-react/commit/$COMMIT_ID"
-  git log -1 | grep -Ev "commit|Author|Date"
-} >> "$COMMIT_FILE"
-
-echo "CDN commit message:"
-echo
-cat "$COMMIT_FILE"
-echo "-------------------------------------"
 echo "Files to be copied:"
 echo
 ls -1 $SOURCE/*
@@ -126,16 +82,11 @@ echo "-------------------------------------"
 echo "Log:"
 echo
 
-# Needed in order for git commands to work
-cd "$TARGET"
-
 if [[ "$PRE_RELEASE" == "no" ]]; then
     echo " * Copying Major version"
-    test -e "$TARGET/$APP_MAJOR" && git rm -r "$TARGET/$APP_MAJOR"
     mkdir -p "$TARGET/$APP_MAJOR"
     cp -fr $SOURCE/* "$TARGET/$APP_MAJOR/"
     echo " * Copying Minor version"
-    test -e "$TARGET/$APP_MAJOR_MINOR" && git rm -r "$TARGET/$APP_MAJOR_MINOR"
     mkdir -p "$TARGET/$APP_MAJOR_MINOR"
     cp -fr $SOURCE/* "$TARGET/$APP_MAJOR_MINOR/"
 else
@@ -144,28 +95,8 @@ else
 fi
 
 echo " * Copying Patch version"
-test -e "$TARGET/$APP_FULL" && git rm -r "$TARGET/$APP_FULL"
 mkdir -p "$TARGET/$APP_FULL"
 cp -fr $SOURCE/* "$TARGET/$APP_FULL/"
-
-echo " * Updating index.json"
-ls -1 | \
-  grep --perl-regexp "$VERSION_REGEX" | \
-  sort --version-sort | \
-  jq --raw-input --slurp 'split("\n") | map(select(. != ""))' > index.json
-
-cd ../..
-
-echo " * Staged for commit:"
-git add .
-git status --short
-
-if [[ "$COMMIT" == "yes" ]]; then
-  echo " * Committing changes"
-  git -c user.email="$AUTHOR_EMAIL" -c user.name="$AUTHOR_NAME" commit -F "$COMMIT_FILE"
-else
-    echo " * Skipping commit (toggle with --commit)"
-fi
 
 echo "-------------------------------------"
 if [[ -z "$AZURE_STORAGE_ACCOUNT_NAME" ]]; then
@@ -175,7 +106,7 @@ else
     echo
     echo "azure-sa-name seems to be a local directory. Simulating azcopy sync with rsync to folder"
     echo
-    toolkits_rsync_opts=( -am --include='*/' --include="${APP_FULL}/*" --include="index.json" )
+    toolkits_rsync_opts=( -am --include='*/' --include="${APP_FULL}/*" )
     if [[ "$PRE_RELEASE" == "no" ]]; then
       toolkits_rsync_opts+=( --include="${APP_MAJOR}/*" --include="${APP_MAJOR_MINOR}/*" )
     fi
@@ -185,7 +116,7 @@ else
     set +x
     echo "-------------------------------------"
   else
-    AZCOPY_INCLUDE_REGEX="^index\.json$|^$APP_FULL/*"
+    AZCOPY_INCLUDE_REGEX="^$APP_FULL/*"
     if [[ "$PRE_RELEASE" == "no" ]]; then
       AZCOPY_INCLUDE_REGEX+="|^$APP_MAJOR/.*|^$APP_MAJOR_MINOR/.*"
     fi
@@ -199,13 +130,8 @@ else
     fi
     azcopy sync "$TARGET" "$AZURE_TARGET_URI/toolkits${AZURE_STORAGE_ACCOUNT_TOKEN}" "${AZCOPY_TOOLKITS_OPTS[@]}" "${AZCOPY_ADDITIONAL_OPTS[@]}"
     echo "-------------------------------------"
-    if [[ "$SYNC_AZURE_CDN" != "no" ]]; then
-      AFD_PATH_PREFIX="/toolkits/altinn-app-frontend"
-      AFD_PATHS=( --path "$AFD_PATH_PREFIX/index.json" )
-      if [[ "$PRE_RELEASE" == "no" ]]; then
-        AFD_PATHS+=( --path "$AFD_PATH_PREFIX/$APP_MAJOR/*" --path "$AFD_PATH_PREFIX/$APP_MAJOR_MINOR/*" )
-      fi
-      bash "$PATH_TO_FRONTEND/.github/scripts/purge-frontdoor-cache.sh" "${AFD_PATHS[@]}"
+    if [[ "$SYNC_AZURE_CDN" == "yes" && "$PRE_RELEASE" == "no" ]]; then
+      bash "$PATH_TO_FRONTEND/.github/scripts/purge-frontdoor-cache.sh" --path "/toolkits/altinn-app-frontend/$APP_MAJOR/*" --path "/toolkits/altinn-app-frontend/$APP_MAJOR_MINOR/*"
       echo "-------------------------------------"
     fi
   fi

--- a/.github/scripts/revert.sh
+++ b/.github/scripts/revert.sh
@@ -66,7 +66,7 @@ echo "-------------------------------------"
 if [[ -z "$AZURE_STORAGE_ACCOUNT_NAME" ]]; then
   echo "Skipping publish to azure cdn. As --azure-sa-name flag not defined"
 else
-  AZCOPY_OPTS=( --put-md5 --compare-hash=MD5 --delete-destination=true )
+  AZCOPY_OPTS=( --put-md5 --compare-hash=MD5 --recursive=true --delete-destination=true )
   if [[ "$SYNC_AZURE_CDN" == "no" ]]; then
     echo "Publish to azure cdn will run with --dry-run (toggle with --azure-sync-cdn). No files will actually be synced"
     AZCOPY_OPTS+=( --dry-run )

--- a/.github/scripts/revert.sh
+++ b/.github/scripts/revert.sh
@@ -3,7 +3,6 @@
 set -e
 set -u
 
-COMMIT=no
 SYNC_AZURE_CDN=no
 
 while [[ $# -gt 0 ]]; do
@@ -11,30 +10,6 @@ while [[ $# -gt 0 ]]; do
     --tag)
       REVERT_TAG="$2"
       shift #pop option
-      shift # pop option
-      ;;
-    --actor)
-      GITHUB_ACTOR="$2"
-      shift #pop option
-      shift # pop option
-      ;;
-    --actor_id)
-      GITHUB_ACTOR_ID="$2"
-      shift #pop option
-      shift # pop option
-      ;;
-    --frontend)
-      PATH_TO_FRONTEND=$(realpath "$2")
-      shift # pop option
-      shift # pop value
-      ;;
-    --cdn)
-      PATH_TO_CDN=$(realpath "$2")
-      shift # pop option
-      shift # pop value
-      ;;
-    --commit)
-      COMMIT=yes
       shift # pop option
       ;;
     --azure-sa-name)
@@ -62,21 +37,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-TARGET=toolkits/altinn-app-frontend
 AZURE_TARGET_URI="https://${AZURE_STORAGE_ACCOUNT_NAME}.blob.core.windows.net/app-frontend"
-
-if ! test -d "$PATH_TO_CDN" || ! test -d "$PATH_TO_CDN/$TARGET"; then
-  echo "Unable to find $PATH_TO_CDN/$TARGET"
-  echo "Make sure path to CDN has been passed with --cdn <path>"
-  exit 1
-fi
-
-TARGET="$PATH_TO_CDN/$TARGET"
-
-echo "-------------------------------------"
-echo "Commit:        $COMMIT (toggle with --commit)"
-echo "Version tag:   $REVERT_TAG"
-echo "Actor:         $GITHUB_ACTOR ($GITHUB_ACTOR_ID)"
 
 REVERT_TAG_PARTS=(${REVERT_TAG//./ })
 APP_FULL=${REVERT_TAG:1}
@@ -84,6 +45,7 @@ APP_MAJOR=${REVERT_TAG_PARTS[0]:1}
 APP_MAJOR_MINOR=${REVERT_TAG_PARTS[0]:1}.${REVERT_TAG_PARTS[1]}
 
 echo "-------------------------------------"
+echo "Version tag:   $REVERT_TAG"
 echo "Full version:  $APP_FULL"
 echo "Major version: $APP_MAJOR"
 echo "Major + minor: $APP_MAJOR_MINOR"
@@ -94,80 +56,28 @@ if ! [[ "$REVERT_TAG" =~ ^v ]]; then
   exit 1
 fi
 
-VERSION_REGEX="^[\d\.]+(-[a-z0-9.]+)?$"
+VERSION_REGEX="^[\d\.]+((?:-|.)[a-z0-9.\-]+)?$"
 if ! echo "$APP_FULL" | grep --quiet --perl-regexp "$VERSION_REGEX"; then
   echo "Error: Broken/unexpected version number: $APP_FULL"
   exit 1
-fi
-
-COMMIT_MESSAGE="Revert altinn-app-frontend to $REVERT_TAG"
-
-echo "CDN commit message:"
-echo
-echo "$COMMIT_MESSAGE"
-echo "-------------------------------------"
-echo "Files to be copied:"
-echo
-ls -1 "$TARGET/$APP_FULL"
-echo "-------------------------------------"
-echo "Log:"
-echo
-
-# Needed in order for git commands to work
-cd "$TARGET"
-
-echo " * Copying Major version"
-test -e "$TARGET/$APP_MAJOR" && git rm -r "$TARGET/$APP_MAJOR"
-mkdir -p "$TARGET/$APP_MAJOR"
-cp -fr "$TARGET/$APP_FULL/." "$TARGET/$APP_MAJOR"
-echo " * Copying Minor version"
-test -e "$TARGET/$APP_MAJOR_MINOR" && git rm -r "$TARGET/$APP_MAJOR_MINOR"
-mkdir -p "$TARGET/$APP_MAJOR_MINOR"
-cp -fr "$TARGET/$APP_FULL/." "$TARGET/$APP_MAJOR_MINOR"
-
-cd ../..
-
-echo " * Staged for commit:"
-git add .
-git status --short
-
-if [[ "$COMMIT" == "yes" ]]; then
-  echo " * Committing changes"
-  git -c user.email="$GITHUB_ACTOR_ID+$GITHUB_ACTOR@users.noreply.github.com" -c user.name="$GITHUB_ACTOR" commit -m "$COMMIT_MESSAGE"
-else
-    echo " * Skipping commit (toggle with --commit)"
 fi
 
 echo "-------------------------------------"
 if [[ -z "$AZURE_STORAGE_ACCOUNT_NAME" ]]; then
   echo "Skipping publish to azure cdn. As --azure-sa-name flag not defined"
 else
-  if [[ -d "$AZURE_STORAGE_ACCOUNT_NAME" ]]; then
-    echo
-    echo "azure-sa-name seems to be a local directory. Simulating azcopy sync with rsync to folder"
-    echo
-    toolkits_rsync_opts=( -am --include='*/' --include="${APP_MAJOR}/*" --include="${APP_MAJOR_MINOR}/*" --exclude='*' )
-    set -x
-    rsync "${toolkits_rsync_opts[@]}" $TARGET $AZURE_STORAGE_ACCOUNT_NAME
-    set +x
-    echo "-------------------------------------"
+  AZCOPY_OPTS=( --put-md5 --compare-hash=MD5 --delete-destination=true )
+  if [[ "$SYNC_AZURE_CDN" == "no" ]]; then
+    echo "Publish to azure cdn will run with --dry-run (toggle with --azure-sync-cdn). No files will actually be synced"
+    AZCOPY_OPTS+=( --dry-run )
   else
-    AZCOPY_INCLUDE_REGEX="^$APP_MAJOR/.*|^$APP_MAJOR_MINOR/.*"
-    AZCOPY_TOOLKITS_OPTS=( --include-regex="${AZCOPY_INCLUDE_REGEX}" )
-    AZCOPY_ADDITIONAL_OPTS=( --put-md5 --compare-hash=MD5 --delete-destination=true )
-    if [[ "$SYNC_AZURE_CDN" == "no" ]]; then
-      echo "Publish to azure cdn will run with --dry-run (toggle with --azure-sync-cdn). No files will actually be synced"
-      AZCOPY_ADDITIONAL_OPTS+=( --dry-run )
-    else
-      echo "Publishing files to azure cdn"
-    fi
-    azcopy sync "$TARGET" "$AZURE_TARGET_URI/toolkits${AZURE_STORAGE_ACCOUNT_TOKEN}" "${AZCOPY_TOOLKITS_OPTS[@]}" "${AZCOPY_ADDITIONAL_OPTS[@]}"
+    echo "Publishing files to azure cdn"
+  fi
+  azcopy sync "$AZURE_TARGET_URI/toolkits/$APP_FULL/${AZURE_STORAGE_ACCOUNT_TOKEN}" "$AZURE_TARGET_URI/toolkits/$APP_MAJOR/${AZURE_STORAGE_ACCOUNT_TOKEN}" "${AZCOPY_OPTS[@]}"
+  azcopy sync "$AZURE_TARGET_URI/toolkits/$APP_FULL/${AZURE_STORAGE_ACCOUNT_TOKEN}" "$AZURE_TARGET_URI/toolkits/$APP_MAJOR_MINOR/${AZURE_STORAGE_ACCOUNT_TOKEN}" "${AZCOPY_OPTS[@]}"
+  echo "-------------------------------------"
+  if [[ "$SYNC_AZURE_CDN" != "no" ]]; then
+    bash ".github/scripts/purge-frontdoor-cache.sh" --path "/toolkits/altinn-app-frontend/$APP_MAJOR/*" --path "/toolkits/altinn-app-frontend/$APP_MAJOR_MINOR/*"
     echo "-------------------------------------"
-    if [[ "$SYNC_AZURE_CDN" != "no" ]]; then
-      AFD_PATH_PREFIX="/toolkits/altinn-app-frontend"
-      AFD_PATHS=( --path "$AFD_PATH_PREFIX/$APP_MAJOR/*" --path "$AFD_PATH_PREFIX/$APP_MAJOR_MINOR/*" )
-      bash "$PATH_TO_FRONTEND/.github/scripts/purge-frontdoor-cache.sh" "${AFD_PATHS[@]}"
-      echo "-------------------------------------"
-    fi
   fi
 fi

--- a/.github/scripts/sync-index.sh
+++ b/.github/scripts/sync-index.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+
+SYNC_AZURE_CDN=no
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --azure-sa-name)
+      AZURE_STORAGE_ACCOUNT_NAME="$2"
+      shift # pop option
+      shift # pop option
+      ;;
+    --azure-sa-token)
+      AZURE_STORAGE_ACCOUNT_TOKEN="$2"
+      shift # pop option
+      shift # pop option
+      ;;
+    --azure-sync-cdn )
+      SYNC_AZURE_CDN=yes
+      shift #pop option
+      ;;
+    -*|--*)
+      echo "Unknown option $1"
+      exit 1
+      ;;
+    *)
+      echo "Unknown argument $1"
+      exit 1
+      ;;
+  esac
+done
+
+TARGET="$RUNNER_TEMP/sync-index-target"
+AZURE_TARGET_URI="https://${AZURE_STORAGE_ACCOUNT_NAME}.blob.core.windows.net/app-frontend"
+VERSION_REGEX="^[\d\.]+((?:-|.)[a-z0-9.\-]+)?$"
+
+mkdir -p "$TARGET"
+
+echo "Updating index.json"
+azcopy ls "$AZURE_TARGET_URI/toolkits/${AZURE_STORAGE_ACCOUNT_TOKEN}" | \
+  cut -d/ -f 1 | \
+  grep --perl-regexp "$VERSION_REGEX" | \
+  sort --version-sort | \
+  uniq | \
+  jq --raw-input --slurp 'split("\n") | map(select(. != ""))' > "$TARGET/index.json"
+
+AZCOPY_OPTS=( --put-md5 --compare-hash=MD5 )
+if [[ "$SYNC_AZURE_CDN" == "no" ]]; then
+  echo "Publish to azure cdn will run with --dry-run (toggle with --azure-sync-cdn). No files will actually be synced"
+  AZCOPY_OPTS+=( --dry-run )
+else
+  echo "Publishing index to azure cdn"
+fi
+azcopy sync "$TARGET/index.json" "$AZURE_TARGET_URI/toolkits/index.json${AZURE_STORAGE_ACCOUNT_TOKEN}" "${AZCOPY_OPTS[@]}"
+if [[ "$SYNC_AZURE_CDN" == "yes" ]]; then
+  bash ".github/scripts/purge-frontdoor-cache.sh" --path "/toolkits/altinn-app-frontend/index.json"
+fi

--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -66,14 +66,6 @@ jobs:
         working-directory: app-frontend
         run: yarn build
 
-      - name: Checkout Altinn-CDN repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-        if: '!env.ACT'
-        with:
-          repository: 'Altinn/altinn-cdn'
-          token: ${{secrets.ALTINN_CDN_TOKEN}}
-          path: cdn
-
       - name: Azure login
         uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
         if: '!env.ACT'
@@ -92,18 +84,24 @@ jobs:
           FD_RESOURCEGROUP: ${{ vars.AZURE_RESOURCE_GROUP_FC }}
         run: |
           bash .github/scripts/release.sh \
-            --frontend . \
-            --cdn ../cdn \
-            --commit \
             --pre-release \
             --azure-sync-cdn \
             --azure-sa-name "${{ secrets.PRODUCTION_STORAGEACCOUNT_NAME }}" \
             --azure-sa-token "${{ secrets.PRODUCTION_ALTINN_CDN_SAS_TOKEN }}"
 
-      - name: Push to CDN
-        working-directory: cdn
+      - name: Run sync-index script
+        working-directory: app-frontend
         if: '!env.ACT'
-        run: git push
+        env:
+          FD_DOMAIN: ${{ vars.AZURE_DOMAIN_FC }}
+          FD_ENDPOINT: ${{ vars.AZURE_ENDPOINT_FC }}
+          FD_PROFILE: ${{ vars.AZURE_PROFILE_FC }}
+          FD_RESOURCEGROUP: ${{ vars.AZURE_RESOURCE_GROUP_FC }}
+        run: |
+          bash .github/scripts/sync-index.sh \
+           --azure-sync-cdn \
+           --azure-sa-name "${{ secrets.PRODUCTION_STORAGEACCOUNT_NAME }}" \
+           --azure-sa-token "${{ secrets.PRODUCTION_ALTINN_CDN_SAS_TOKEN }}"
 
       - name: Update PR comment - failure
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,14 +43,6 @@ jobs:
         working-directory: app-frontend
         run: yarn build
 
-      - name: Checkout Altinn-CDN repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-        if: '!env.ACT'
-        with:
-          repository: 'Altinn/altinn-cdn'
-          token: ${{secrets.ALTINN_CDN_TOKEN}}
-          path: cdn
-
       - name: Azure login
         uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
         if: '!env.ACT'
@@ -69,9 +61,6 @@ jobs:
           FD_RESOURCEGROUP: ${{ vars.AZURE_RESOURCE_GROUP_FC }}
         run: |
           bash .github/scripts/release.sh \
-           --frontend . \
-           --cdn ../cdn \
-           --commit \
            --azure-sync-cdn \
            --azure-sa-name "${{ secrets.PRODUCTION_STORAGEACCOUNT_NAME }}" \
            --azure-sa-token "${{ secrets.PRODUCTION_ALTINN_CDN_SAS_TOKEN }}"
@@ -86,15 +75,21 @@ jobs:
           FD_RESOURCEGROUP: ${{ vars.AZURE_RESOURCE_GROUP_FC }}
         run: |
           bash .github/scripts/release.sh \
-            --frontend . \
-            --cdn ../cdn \
-            --commit \
             --pre-release \
             --azure-sync-cdn \
             --azure-sa-name "${{ secrets.PRODUCTION_STORAGEACCOUNT_NAME }}" \
             --azure-sa-token "${{ secrets.PRODUCTION_ALTINN_CDN_SAS_TOKEN }}"
 
-      - name: Push to CDN
-        working-directory: cdn
+      - name: Run sync-index script
+        working-directory: app-frontend
         if: '!env.ACT'
-        run: git push
+        env:
+          FD_DOMAIN: ${{ vars.AZURE_DOMAIN_FC }}
+          FD_ENDPOINT: ${{ vars.AZURE_ENDPOINT_FC }}
+          FD_PROFILE: ${{ vars.AZURE_PROFILE_FC }}
+          FD_RESOURCEGROUP: ${{ vars.AZURE_RESOURCE_GROUP_FC }}
+        run: |
+          bash .github/scripts/sync-index.sh \
+           --azure-sync-cdn \
+           --azure-sa-name "${{ secrets.PRODUCTION_STORAGEACCOUNT_NAME }}" \
+           --azure-sa-token "${{ secrets.PRODUCTION_ALTINN_CDN_SAS_TOKEN }}"

--- a/.github/workflows/revert.yml
+++ b/.github/workflows/revert.yml
@@ -33,13 +33,6 @@ jobs:
           sparse-checkout: |
             .github
 
-      - name: Checkout Altinn-CDN repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-        with:
-          repository: 'Altinn/altinn-cdn'
-          token: ${{secrets.ALTINN_CDN_TOKEN}}
-          path: cdn
-
       - name: Azure login
         uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
         with:
@@ -48,6 +41,7 @@ jobs:
           subscription-id: ${{ secrets.AZURE_CDN_SUBSCRIPTION_ID_FC }}
 
       - name: Run roll back script
+        working-directory: app-frontend
         env:
           FD_DOMAIN: ${{ vars.AZURE_DOMAIN_FC }}
           FD_ENDPOINT: ${{ vars.AZURE_ENDPOINT_FC }}
@@ -56,15 +50,6 @@ jobs:
         run: |
           bash app-frontend/.github/scripts/revert.sh \
            --tag "${{ inputs.tag }}" \
-           --actor "${{ github.actor }}" \
-           --actor_id "${{ github.actor_id }}" \
-           --frontend ./app-frontend \
-           --cdn ./cdn \
-           --commit \
            --azure-sync-cdn \
            --azure-sa-name "${{ secrets.PRODUCTION_STORAGEACCOUNT_NAME }}" \
            --azure-sa-token "${{ secrets.PRODUCTION_ALTINN_CDN_SAS_TOKEN }}"
-
-      - name: Push to CDN
-        working-directory: cdn
-        run: git push

--- a/.github/workflows/revert.yml
+++ b/.github/workflows/revert.yml
@@ -48,7 +48,7 @@ jobs:
           FD_PROFILE: ${{ vars.AZURE_PROFILE_FC }}
           FD_RESOURCEGROUP: ${{ vars.AZURE_RESOURCE_GROUP_FC }}
         run: |
-          bash app-frontend/.github/scripts/revert.sh \
+          bash .github/scripts/revert.sh \
            --tag "${{ inputs.tag }}" \
            --azure-sync-cdn \
            --azure-sa-name "${{ secrets.PRODUCTION_STORAGEACCOUNT_NAME }}" \


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

Remove everything related to syncing with Altinn-CDN repo:
- Removed checkout Altinn-CDN
- Removed commit to Altinn-CDN from release / revert scripts
- Removed push Altinn-CDN
- Revert script now works by directly calling `azcopy sync` between two virtual directories in azure
- Making the `index.json` file was previously done by listing the directories in the Altinn-CDN repo. I considered fetching the existing file and appending to it, but if there are race-conditions (multiple releases at the same time) things will not necessarily be eventually consistent. So I instead optet for moving it into a separate script / workflow step, and using `azcopy ls` to list the versions and generate the index file _after_ we are done with pushing the files. I tested generating the index file this way on my personal azure account.

## Related Issue(s)

- closes #3201 
