### PR TITLE
Test external-api in pdf

### DIFF
--- a/test/e2e/integration/component-library/pdf.ts
+++ b/test/e2e/integration/component-library/pdf.ts
@@ -3,7 +3,7 @@ import { AppFrontend } from 'test/e2e/pageobjects/app-frontend';
 const appFrontend = new AppFrontend();
 
 describe('PDF', () => {
-  it('Custom logo is rendered in PDF', () => {
+  it('Custom logo and externalApi works in PDF', () => {
     cy.startAppInstance(appFrontend.apps.componentLibrary, { authenticationLevel: '2' });
     cy.waitForLoad();
 
@@ -12,6 +12,7 @@ describe('PDF', () => {
       enableResponseFuzzing: true,
       callback: () => {
         cy.get('[data-testid="pdf-logo"]').should('be.visible');
+        cy.getSummary('Eksternt api').should('contain.text', 'firstDetail');
       },
     });
   });


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

#3223 added a check in `ReadyForPrint` for pending queries. This seems to have solved the issue at least for external api. I tried adding this test-case before this change and it would fail frequently, but it now seems to work consistently so we can include this test now.

## Related Issue(s)

- closes #3158
