### PR TITLE
Fixing broken form data when going back via signing rejection

### DIFF
--- a/src/features/formData/useFormDataQuery.tsx
+++ b/src/features/formData/useFormDataQuery.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 
 import { skipToken, useQuery } from '@tanstack/react-query';
+import type { QueryClient } from '@tanstack/react-query';
 import type { AxiosRequestConfig } from 'axios';
 
 import { useAppQueries } from 'src/core/contexts/AppQueriesProvider';
@@ -42,6 +43,10 @@ export function useFormDataQueryKey(url: string | undefined) {
 
 export function getFormDataQueryKey(url: string | undefined) {
   return ['fetchFormData', getFormDataCacheKeyUrl(url)];
+}
+
+export async function invalidateFormDataQueries(queryClient: QueryClient) {
+  await queryClient.invalidateQueries({ queryKey: ['fetchFormData'] });
 }
 
 export function useFormDataQueryOptions() {

--- a/src/features/formData/useFormDataQuery.tsx
+++ b/src/features/formData/useFormDataQuery.tsx
@@ -41,12 +41,17 @@ export function useFormDataQueryKey(url: string | undefined) {
   return useMemoDeepEqual(() => getFormDataQueryKey(url), [url]);
 }
 
+const formDataQueryKeys = {
+  all: ['fetchFormData'] as const,
+  withUrl: (url: string | undefined) => [...formDataQueryKeys.all, url ? getFormDataCacheKeyUrl(url) : url] as const,
+};
+
 export function getFormDataQueryKey(url: string | undefined) {
-  return ['fetchFormData', getFormDataCacheKeyUrl(url)];
+  return formDataQueryKeys.withUrl(url);
 }
 
 export async function invalidateFormDataQueries(queryClient: QueryClient) {
-  await queryClient.invalidateQueries({ queryKey: ['fetchFormData'] });
+  await queryClient.invalidateQueries({ queryKey: formDataQueryKeys.all });
 }
 
 export function useFormDataQueryOptions() {
@@ -63,7 +68,7 @@ export function useFormDataQueryOptions() {
 
 // We dont want to include the current language in the cacheKey url, but for stateless we still need to keep
 // the 'dataType' query parameter in the cacheKey url to avoid caching issues.
-export function getFormDataCacheKeyUrl(url: string | undefined) {
+function getFormDataCacheKeyUrl(url: string | undefined) {
   if (!url) {
     return undefined;
   }

--- a/src/features/instance/ProcessContext.tsx
+++ b/src/features/instance/ProcessContext.tsx
@@ -9,7 +9,7 @@ import { Loader } from 'src/core/loading/Loader';
 import { useApplicationMetadata } from 'src/features/applicationMetadata/ApplicationMetadataProvider';
 import { useLayoutSets } from 'src/features/form/layoutSets/LayoutSetsProvider';
 import { useNavigationParam } from 'src/features/routing/AppRoutingContext';
-import { TaskKeys, useNavigateToTask } from 'src/hooks/useNavigatePage';
+import { TaskKeys } from 'src/hooks/useNavigatePage';
 import { fetchProcessState } from 'src/queries/queries';
 import { isProcessTaskType, ProcessTaskType } from 'src/types';
 import { behavesLikeDataTask } from 'src/utils/formLayout';
@@ -34,26 +34,8 @@ export function ProcessProvider({ children }: PropsWithChildren) {
   const instanceOwnerPartyId = useNavigationParam('instanceOwnerPartyId');
   const instanceGuid = useNavigationParam('instanceGuid');
   const instanceId = `${instanceOwnerPartyId}/${instanceGuid}`;
-  const taskId = useNavigationParam('taskId');
-  const layoutSets = useLayoutSets();
-  const navigateToTask = useNavigateToTask();
 
   const { isLoading, data, error, refetch } = useQuery<IProcess, HttpClientError>(getProcessQueryDef(instanceId));
-
-  useEffect(() => {
-    const elementId = data?.currentTask?.elementId;
-    if (data?.ended) {
-      const hasCustomReceipt = behavesLikeDataTask(TaskKeys.CustomReceipt, layoutSets);
-      if (hasCustomReceipt) {
-        navigateToTask(TaskKeys.CustomReceipt);
-      } else {
-        navigateToTask(TaskKeys.ProcessEnd);
-      }
-    } else if (elementId && elementId !== taskId) {
-      navigateToTask(elementId, { replace: true, runEffect: taskId !== undefined });
-    }
-    //eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data]);
 
   useEffect(() => {
     error && window.logError('Fetching process state failed:\n', error);

--- a/src/features/instance/useProcessNext.tsx
+++ b/src/features/instance/useProcessNext.tsx
@@ -17,7 +17,7 @@ import { appSupportsIncrementalValidationFeatures } from 'src/features/validatio
 import { useOnFormSubmitValidation } from 'src/features/validation/callbacks/onFormSubmitValidation';
 import { Validation } from 'src/features/validation/validationContext';
 import { useEffectEvent } from 'src/hooks/useEffectEvent';
-import { useNavigateToTask } from 'src/hooks/useNavigatePage';
+import { TaskKeys, useNavigateToTask } from 'src/hooks/useNavigatePage';
 import { isAtLeastVersion } from 'src/utils/versionCompare';
 import type { ApplicationMetadata } from 'src/features/applicationMetadata/types';
 import type { BackendValidationIssue } from 'src/features/validation';
@@ -72,7 +72,9 @@ export function useProcessNext() {
         await reFetchInstanceData();
         await refetchProcessData?.();
         await invalidateFormDataQueries(queryClient);
-        navigateToTask(processData?.currentTask?.elementId);
+        navigateToTask(
+          processData.ended || !processData.currentTask ? TaskKeys.ProcessEnd : processData.currentTask.elementId,
+        );
       } else if (validationIssues) {
         // Set initial validation to validation issues from process/next and make all errors visible
         updateInitialValidations(validationIssues, !appSupportsIncrementalValidationFeatures(applicationMetadata));

--- a/src/features/instance/useProcessNext.tsx
+++ b/src/features/instance/useProcessNext.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { toast } from 'react-toastify';
 
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { useAppMutations } from 'src/core/contexts/AppQueriesProvider';
 import { ContextNotProvided } from 'src/core/contexts/context';
 import { useDisplayError } from 'src/core/errorHandling/DisplayErrorProvider';
 import { useApplicationMetadata } from 'src/features/applicationMetadata/ApplicationMetadataProvider';
+import { invalidateFormDataQueries } from 'src/features/formData/useFormDataQuery';
 import { useLaxInstanceId, useStrictInstanceRefetch } from 'src/features/instance/InstanceContext';
 import { useReFetchProcessData } from 'src/features/instance/ProcessContext';
 import { Lang } from 'src/features/language/Lang';
@@ -40,6 +41,7 @@ export function useProcessNext() {
   const onSubmitFormValidation = useOnFormSubmitValidation();
   const applicationMetadata = useApplicationMetadata();
   const displayError = useDisplayError();
+  const queryClient = useQueryClient();
 
   const { mutateAsync } = useMutation({
     mutationFn: async ({ action }: ProcessNextProps = {}) => {
@@ -69,6 +71,7 @@ export function useProcessNext() {
       if (processData) {
         await reFetchInstanceData();
         await refetchProcessData?.();
+        await invalidateFormDataQueries(queryClient);
         navigateToTask(processData?.currentTask?.elementId);
       } else if (validationIssues) {
         // Set initial validation to validation issues from process/next and make all errors visible

--- a/test/e2e/integration/signing-test/double-signing.ts
+++ b/test/e2e/integration/signing-test/double-signing.ts
@@ -1,72 +1,7 @@
 import { AppFrontend } from 'test/e2e/pageobjects/app-frontend';
-import type { CyUser } from 'test/e2e/support/auth';
-
-import type { IParty } from 'src/types/shared';
+import { signingTestLogin } from 'test/e2e/support/apps/signing-test/signing-login';
 
 const appFrontend = new AppFrontend();
-
-function login(user: CyUser) {
-  cy.url().then((url) => {
-    const instanceSuffix = new URL(url).hash;
-    const partyId = Cypress.env('signingPartyId');
-
-    if (partyId) {
-      // Intercepting party list to only return the party we want to use. This will be automatically used by
-      // app-frontend when it starts.
-      let correctParty: IParty | undefined = undefined;
-
-      // The /parties request and /current request happen in parallel, so we need
-      // to await the first request in order to use its value in the second intercept.
-      let resolveParties: () => void;
-      const partiesPromise = new Promise<void>((res) => {
-        resolveParties = res;
-      });
-
-      cy.intercept(
-        {
-          method: 'GET',
-          url: `**/api/v1/parties?allowedtoinstantiatefilter=true`,
-          times: 1,
-        },
-        (req) => {
-          req.on('response', (res) => {
-            const parties = res.body as IParty[];
-            correctParty = parties.find((party: IParty) => party.partyId == partyId);
-            if (!correctParty) {
-              throw new Error(`Could not find party with id ${partyId}`);
-            }
-            res.send([correctParty]);
-            resolveParties();
-          });
-        },
-      );
-      cy.intercept(
-        {
-          method: 'GET',
-          url: `**/api/authorization/parties/current?returnPartyObject=true`,
-          times: 1,
-        },
-        (req) => {
-          req.on('response', async (res) => {
-            await partiesPromise;
-            if (!correctParty) {
-              throw new Error(`Could not find party with id ${partyId}`);
-            }
-            res.send(correctParty);
-          });
-        },
-      );
-    }
-
-    cy.startAppInstance(appFrontend.apps.signingTest, { user, urlSuffix: instanceSuffix });
-
-    // We need to reload after re-logging in when we already had a session, because the startAppInstance command
-    // will not reload the page if we already are visiting the correct URL.
-    instanceSuffix && cy.reloadAndWait();
-
-    cy.assertUser(user);
-  });
-}
 
 describe('Double signing', () => {
   beforeEach(() => {
@@ -75,7 +10,7 @@ describe('Double signing', () => {
   });
 
   it('accountant -> manager -> auditor', () => {
-    login('accountant');
+    signingTestLogin('accountant');
 
     cy.get(appFrontend.signingTest.incomeField).type('4567');
 
@@ -84,7 +19,7 @@ describe('Double signing', () => {
 
     cy.snapshot('signing:accountant');
 
-    login('manager');
+    signingTestLogin('manager');
     cy.get(appFrontend.signingTest.managerConfirmPanel).should('exist').and('be.visible');
     cy.get(appFrontend.signingTest.incomeSummary).should('contain.text', '4 567 000 NOK');
 
@@ -93,7 +28,7 @@ describe('Double signing', () => {
 
     cy.snapshot('signing:manager');
 
-    login('auditor');
+    signingTestLogin('auditor');
     cy.get(appFrontend.signingTest.auditorConfirmPanel).should('exist').and('be.visible');
     cy.get(appFrontend.signingTest.incomeSummary).should('contain.text', '4 567 000 NOK');
     cy.get(appFrontend.signingTest.signingButton).should('not.be.disabled').click();
@@ -103,7 +38,7 @@ describe('Double signing', () => {
   });
 
   it('manager -> manager -> auditor', () => {
-    login('manager');
+    signingTestLogin('manager');
 
     cy.get(appFrontend.signingTest.incomeField).type('4567');
 
@@ -114,7 +49,7 @@ describe('Double signing', () => {
     cy.get(appFrontend.signingTest.signingButton).should('not.be.disabled').click();
     cy.get(appFrontend.signingTest.sentToAuditor).should('exist').and('be.visible');
 
-    login('auditor');
+    signingTestLogin('auditor');
     cy.get(appFrontend.signingTest.auditorConfirmPanel).should('exist').and('be.visible');
     cy.get(appFrontend.signingTest.incomeSummary).should('contain.text', '4 567 000 NOK');
     cy.get(appFrontend.signingTest.signingButton).should('not.be.disabled').click();

--- a/test/e2e/integration/signing-test/reject.ts
+++ b/test/e2e/integration/signing-test/reject.ts
@@ -1,0 +1,36 @@
+import { AppFrontend } from 'test/e2e/pageobjects/app-frontend';
+import { signingTestLogin } from 'test/e2e/support/apps/signing-test/signing-login';
+
+const appFrontend = new AppFrontend();
+
+describe('Rejecting a signing task', () => {
+  it('rejection should work, also when changing a repeating group row after', () => {
+    cy.intercept('**/active', []).as('noActiveInstances');
+    signingTestLogin('accountant');
+
+    cy.get(appFrontend.signingTest.incomeField).type('84567');
+    cy.findByRole('button', { name: 'Legg til ny' }).click();
+    cy.dsSelect('#sourceType-0', 'Kryptosvindel');
+    cy.findAllByRole('button', { name: 'Lagre og lukk' }).first().click();
+    cy.findByRole('button', { name: 'Legg til ny' }).click();
+    cy.dsSelect('#sourceType-1', 'Varesalg');
+    cy.findAllByRole('button', { name: 'Lagre og lukk' }).first().click();
+
+    cy.get(appFrontend.signingTest.submitButton).click();
+    cy.get(appFrontend.signingTest.noAccessPanel).should('be.visible');
+
+    signingTestLogin('manager');
+
+    cy.get(appFrontend.signingTest.managerConfirmPanel).should('be.visible');
+    cy.get(appFrontend.signingTest.incomeSummary).should('contain.text', '84 567 000 NOK');
+    cy.findAllByTestId('summary-repeating-row').should('have.length', 2);
+    cy.findAllByTestId('summary-repeating-row').first().should('contain.text', 'Kryptosvindel');
+    cy.findAllByTestId('summary-repeating-row').last().should('contain.text', 'Varesalg');
+
+    cy.get(appFrontend.signingTest.rejectButton).click();
+    cy.get(appFrontend.signingTest.incomeField).should('be.visible');
+
+    cy.get('tbody tr').should('have.length', 2);
+    cy.findByRole('button', { name: /slett-varesalg/i }).click();
+  });
+});

--- a/test/e2e/integration/signing-test/reject.ts
+++ b/test/e2e/integration/signing-test/reject.ts
@@ -30,7 +30,15 @@ describe('Rejecting a signing task', () => {
     cy.get(appFrontend.signingTest.rejectButton).click();
     cy.get(appFrontend.signingTest.incomeField).should('be.visible');
 
+    // Deleting a repeating group row failed before: https://github.com/Altinn/app-frontend-react/issues/3245
     cy.get('tbody tr').should('have.length', 2);
     cy.findByRole('button', { name: /slett-varesalg/i }).click();
+    cy.get('tbody tr').should('have.length', 1);
+    cy.get(appFrontend.signingTest.submitButton).click();
+
+    cy.get(appFrontend.signingTest.managerConfirmPanel).should('be.visible');
+    cy.get(appFrontend.signingTest.incomeSummary).should('contain.text', '84 567 000 NOK');
+    cy.findByTestId('summary-repeating-row').should('have.length', 1);
+    cy.findByTestId('summary-repeating-row').should('contain.text', 'Kryptosvindel');
   });
 });

--- a/test/e2e/pageobjects/app-frontend.ts
+++ b/test/e2e/pageobjects/app-frontend.ts
@@ -332,6 +332,7 @@ export class AppFrontend {
     incomeField: '#Input-income',
     incomeSummary: '[data-testid="summary-Input-income"]',
     submitButton: '#Button-submit',
+    rejectButton: '#action-button-RejectButton',
     signingButton: '#action-button-SigningButton',
     managerConfirmPanel: '#form-content-Panel-confirm1',
     auditorConfirmPanel: '#form-content-Panel-confirm2',

--- a/test/e2e/support/apps/signing-test/signing-login.ts
+++ b/test/e2e/support/apps/signing-test/signing-login.ts
@@ -1,0 +1,69 @@
+import { AppFrontend } from 'test/e2e/pageobjects/app-frontend';
+import type { CyUser } from 'test/e2e/support/auth';
+
+import type { IParty } from 'src/types/shared';
+
+export function signingTestLogin(user: CyUser) {
+  const appFrontend = new AppFrontend();
+  cy.waitUntilSaved();
+  cy.url().then((url) => {
+    const instanceSuffix = new URL(url).hash;
+    const partyId = Cypress.env('signingPartyId');
+
+    if (partyId) {
+      // Intercepting party list to only return the party we want to use. This will be automatically used by
+      // app-frontend when it starts.
+      let correctParty: IParty | undefined = undefined;
+
+      // The /parties request and /current request happen in parallel, so we need
+      // to await the first request in order to use its value in the second intercept.
+      let resolveParties: () => void;
+      const partiesPromise = new Promise<void>((res) => {
+        resolveParties = res;
+      });
+
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `**/api/v1/parties?allowedtoinstantiatefilter=true`,
+          times: 1,
+        },
+        (req) => {
+          req.on('response', (res) => {
+            const parties = res.body as IParty[];
+            correctParty = parties.find((party: IParty) => party.partyId == partyId);
+            if (!correctParty) {
+              throw new Error(`Could not find party with id ${partyId}`);
+            }
+            res.send([correctParty]);
+            resolveParties();
+          });
+        },
+      );
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `**/api/authorization/parties/current?returnPartyObject=true`,
+          times: 1,
+        },
+        (req) => {
+          req.on('response', async (res) => {
+            await partiesPromise;
+            if (!correctParty) {
+              throw new Error(`Could not find party with id ${partyId}`);
+            }
+            res.send(correctParty);
+          });
+        },
+      );
+    }
+
+    cy.startAppInstance(appFrontend.apps.signingTest, { user, urlSuffix: instanceSuffix });
+
+    // We need to reload after re-logging in when we already had a session, because the startAppInstance command
+    // will not reload the page if we already are visiting the correct URL.
+    instanceSuffix && cy.reloadAndWait();
+
+    cy.assertUser(user);
+  });
+}


### PR DESCRIPTION
## Description

As described in #3245, when rejecting and going back to the previous task, repeating group form data could be stale in a way that doesn't let you delete a row (that would cause a `409 conflict` as the data model on the backend had cleaned its `altinnRowId` fields). Invalidating the query cache when moving between process steps solves the issue.

## Related Issue(s)

- closes #3245

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->
