### PR TITLE
Fix: '1.00' marked as invalid data in an Input field

### DIFF
--- a/src/features/formData/convertData.ts
+++ b/src/features/formData/convertData.ts
@@ -120,14 +120,20 @@ function asNumber(value: string, type: 'float' | 'int', isValid: (n: number) => 
   if (toStr !== trimmed) {
     // Remove leading zeros and check again (0001 === 1)
     const trimmedNoLeadingZeros = trimmed.replace(/^(-?)0+/, '$1');
-    if (parsedValue.toString() === trimmedNoLeadingZeros) {
+    if (toStr === trimmedNoLeadingZeros) {
       return parsedValue;
     }
     // If the number is a decimal, try to remove trailing zeros (1.2000 === 1.2)
     const trimmedNoTrailingZeros = trimmed.replace(/(\.\d+?)0+$/, '$1');
-    if (parsedValue.toString() === trimmedNoTrailingZeros) {
+    if (toStr === trimmedNoTrailingZeros) {
       return parsedValue;
     }
+    // Special case for numbers like 123.00, which are valid, but the decimal part is redundant.
+    const withoutZeroes = trimmed.replace(/\.0+$/, '');
+    if (toStr === withoutZeroes) {
+      return parsedValue;
+    }
+
     return NaN;
   }
 

--- a/src/features/formData/useDataModelBindings.ts
+++ b/src/features/formData/useDataModelBindings.ts
@@ -4,7 +4,7 @@ import { FD } from 'src/features/formData/FormDataWrite';
 import { DEFAULT_DEBOUNCE_TIMEOUT } from 'src/features/formData/types';
 import { useMemoDeepEqual } from 'src/hooks/useStateDeepEqual';
 import type { FDLeafValue } from 'src/features/formData/FormDataWrite';
-import type { FDNewValue } from 'src/features/formData/FormDataWriteStateMachine';
+import type { FDNewValue, FDSetValueResult } from 'src/features/formData/FormDataWriteStateMachine';
 import type { IDataModelReference, SaveWhileTyping } from 'src/layout/common.generated';
 import type { IDataModelBindings } from 'src/layout/layout';
 
@@ -22,7 +22,11 @@ interface Output<B extends IDataModelBindings | undefined, DA extends DataAs> ex
 }
 
 interface SaveOutput<B extends IDataModelBindings | undefined> {
-  setValue: (key: keyof Exclude<B, undefined>, value: FDLeafValue) => void;
+  setValue: (
+    key: keyof Exclude<B, undefined>,
+    value: FDLeafValue,
+    callback?: (result: FDSetValueResult) => void,
+  ) => void;
   setValues: (values: Partial<{ [key in keyof B]: FDLeafValue }>) => void;
 }
 
@@ -72,10 +76,11 @@ export function useSaveDataModelBindings<B extends IDataModelBindings | undefine
   );
 
   const setValue = useCallback(
-    (key: keyof B, newValue: FDLeafValue) =>
+    (key: keyof B, newValue: FDLeafValue, callback?: (result: FDSetValueResult) => void) =>
       setLeafValue({
         reference: bindings[key] as IDataModelReference,
         newValue,
+        callback,
         ...saveOptions,
       }),
     [bindings, saveOptions, setLeafValue],

--- a/src/features/validation/invalidDataValidation/InvalidDataValidation.tsx
+++ b/src/features/validation/invalidDataValidation/InvalidDataValidation.tsx
@@ -18,26 +18,27 @@ export function InvalidDataValidation({ dataType }: { dataType: string }) {
   const dataElementId = DataModels.useDataElementIdForDataType(dataType) ?? dataType; // stateless does not have dataElementId
 
   useEffect(() => {
-    let validations = {};
+    const validations = {};
 
     if (Object.keys(invalidData).length > 0) {
-      validations = Object.entries(dot.dot(invalidData))
-        .filter(([_, value]) => isScalar(value))
-        .reduce((validations, [field, _]) => {
-          if (!validations[field]) {
-            validations[field] = [];
-          }
+      const flattened = dot.dot(invalidData);
+      for (const [field, value] of Object.entries(flattened)) {
+        if (!isScalar(value)) {
+          continue;
+        }
 
-          validations[field].push({
-            field,
-            source: FrontendValidationSource.InvalidData,
-            message: { key: 'validation_errors.pattern' },
-            severity: 'error',
-            category: ValidationMask.Schema, // Use same visibility as schema validations
-          });
+        if (!validations[field]) {
+          validations[field] = [];
+        }
 
-          return validations;
-        }, {});
+        validations[field].push({
+          field,
+          source: FrontendValidationSource.InvalidData,
+          message: { key: 'validation_errors.pattern' },
+          severity: 'error',
+          category: ValidationMask.Schema, // Use same visibility as schema validations
+        });
+      }
     }
     updateDataModelValidations('invalidData', dataElementId, validations);
   }, [dataElementId, invalidData, updateDataModelValidations]);

--- a/src/layout/Input/InputComponent.test.tsx
+++ b/src/layout/Input/InputComponent.test.tsx
@@ -81,6 +81,7 @@ describe('InputComponent', () => {
     expect(formDataMethods.setLeafValue).toHaveBeenCalledWith({
       reference: { field: 'some.field', dataType: defaultDataTypeMock },
       newValue: finalValuePlainText,
+      callback: expect.any(Function),
     });
   });
 
@@ -163,6 +164,7 @@ describe('InputComponent', () => {
     expect(formDataMethods.setLeafValue).toHaveBeenCalledWith({
       reference: { field: 'some.field', dataType: defaultDataTypeMock },
       newValue: typedValue,
+      callback: expect.any(Function),
     });
     expect(inputComponent).toHaveValue(formattedValue);
   });

--- a/test/e2e/integration/frontend-test/components.ts
+++ b/test/e2e/integration/frontend-test/components.ts
@@ -645,6 +645,7 @@ describe('UI Components', () => {
     withoutLeading?: string; // The number as it should appear in the string-formatted field, if different from the number we typed
     formatted: string; // The number as it should appear in the number-formatted field
     invalidFor: string[]; // Which types the number should be invalid for
+    afterBlur?: string; // The number as it should appear after blurring the field
   }
 
   it('number conversion in regular form fields and number-formatted fields', () => {
@@ -659,6 +660,13 @@ describe('UI Components', () => {
     };
 
     const testNumbers: TestNumber[] = [
+      {
+        number: '123.00',
+        formatted: '123,00',
+        invalidFor: ['int32', 'int16', 'int64'],
+        withoutTrailing: '123',
+        afterBlur: '123', // This is a special case, as redundant zeroes after will be removed on blur
+      },
       { number: '123', formatted: '123', invalidFor: [] },
       { number: '123.456', formatted: '123,456', invalidFor: ['int32', 'int16', 'int64'] },
       { number: '0', formatted: '0', invalidFor: [] },
@@ -706,7 +714,7 @@ describe('UI Components', () => {
     cy.get('#int16AsString').should('have.value', '0');
     cy.get('#int16AsNumber').should('have.value', '0 stikk');
 
-    for (const { number, withoutTrailing, withoutLeading, formatted, invalidFor } of testNumbers) {
+    for (const { number, withoutTrailing, withoutLeading, formatted, invalidFor, afterBlur } of testNumbers) {
       for (const [type, value] of Object.entries(fields)) {
         const { targets, suffix } = value;
         const [asNumber, asString] = targets;
@@ -715,6 +723,8 @@ describe('UI Components', () => {
         // Type into the number-formatted field
         cy.get(asNumber).type(`{selectall}${number}`);
         cy.get(asNumber).should('have.value', formatted + suffix);
+        cy.get(asNumber).blur();
+        cy.get(asNumber).should('have.value', (afterBlur && isValid ? afterBlur : formatted) + suffix);
 
         // Test that the string-formatted field is updated correctly
         if (isValid) {


### PR DESCRIPTION
## Description

When combining number formatting with storing data in a `decimal` field in the data model, we have to convert the typed number to an actual number when storing it. To make sure we don't trick the user into thinking we can store numbers that cannot be stored, we _compare the typed number with the stringified number we stored in the data model_ and mark it as invalid if they aren't equal. This caused some unexpected friction for some use-cases:

- Typing `1` is fine
- Typing `1.` shows up as an error (if you stop typing at that point). We cannot store just the decimal point without any numbers after it.
- Typing `1.0` used to show an error (because we cannot tell a numeric type to store extra zeroes after the comma, this value is essentially equal to `1`). Now it stores the number (`1`) but temporarily stores local state in the input component for the string you're actually typing. When blurring the input field the value will revert to what we stored in the data model (`1`). 
- Typing `1.02` suddenly turn this into something we can store again, so the data model goes from storing `1` to `1.02`. This shows why it's important we show this value until the user blurs the field.

## Related Issue(s)

- closes #2368

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->
