### PR TITLE
Use the same date format in instance information as in receipt

### DIFF
--- a/src/app-components/Datepicker/utils/dateHelpers.ts
+++ b/src/app-components/Datepicker/utils/dateHelpers.ts
@@ -9,7 +9,7 @@ import { DateFlags } from 'src/types';
 export const DatepickerMinDateDefault = '1900-01-01T00:00:00Z';
 export const DatepickerMaxDateDefault = '2100-01-01T23:59:59Z';
 export const DatepickerFormatDefault = 'dd.MM.yyyy';
-export const PrettyDateAndTime = 'dd.MM.yyyy HH.mm.ss';
+export const PrettyDateAndTime = 'dd.MM.yyyy / HH:mm';
 
 /**
  * Moment used a non-standard format for dates, this is a work-around to prevent breaking changes

--- a/src/features/receipt/ReceiptContainer.tsx
+++ b/src/features/receipt/ReceiptContainer.tsx
@@ -4,6 +4,7 @@ import { Route, Routes } from 'react-router-dom';
 
 import { formatDate } from 'date-fns';
 
+import { PrettyDateAndTime } from 'src/app-components/Datepicker/utils/dateHelpers';
 import { AltinnContentIconReceipt } from 'src/components/atoms/AltinnContentIconReceipt';
 import { Form } from 'src/components/form/Form';
 import { AltinnContentLoader } from 'src/components/molecules/AltinnContentLoader';
@@ -161,7 +162,7 @@ export const ReceiptContainer = () => {
   const { langAsString } = useLanguage();
   const lastChangedDateTime = useMemo(() => {
     if (lastChanged) {
-      return formatDate(lastChanged, 'dd.MM.yyyy / HH:mm');
+      return formatDate(lastChanged, PrettyDateAndTime);
     }
     return undefined;
   }, [lastChanged]);

--- a/src/layout/InstanceInformation/InstanceInformationComponent.tsx
+++ b/src/layout/InstanceInformation/InstanceInformationComponent.tsx
@@ -5,12 +5,11 @@ import { formatDate, formatISO } from 'date-fns';
 
 import type { PropsFromGenericComponent } from '..';
 
-import { getDateFormat, PrettyDateAndTime } from 'src/app-components/Datepicker/utils/dateHelpers';
+import { PrettyDateAndTime } from 'src/app-components/Datepicker/utils/dateHelpers';
 import { Fieldset } from 'src/app-components/Label/Fieldset';
 import { AltinnSummaryTable } from 'src/components/table/AltinnSummaryTable';
 import { useAppReceiver } from 'src/core/texts/appTexts';
 import { useLaxInstanceData, useLaxInstanceId } from 'src/features/instance/InstanceContext';
-import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
 import { useLanguage } from 'src/features/language/useLanguage';
 import { useInstanceOwnerParty } from 'src/features/party/PartiesProvider';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
@@ -65,7 +64,6 @@ export function InstanceInformation({ elements }: Pick<CompInternal<'InstanceInf
   const { dateSent, sender, receiver, referenceNumber } = elements || {};
 
   const langTools = useLanguage();
-  const selectedLanguage = useCurrentLanguage();
 
   const lastChanged = useLaxInstanceData((data) => data.lastChanged);
   const instanceId = useLaxInstanceId();
@@ -76,10 +74,7 @@ export function InstanceInformation({ elements }: Pick<CompInternal<'InstanceInf
   const instanceDateSent =
     lastChanged &&
     dateSent !== false &&
-    formatDate(
-      new TZDate(new Date(formatISO(lastChanged)), 'Europe/Oslo'),
-      getDateFormat(PrettyDateAndTime, selectedLanguage),
-    );
+    formatDate(new TZDate(new Date(formatISO(lastChanged)), 'Europe/Oslo'), PrettyDateAndTime);
 
   const instanceSender =
     sender !== false &&


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

I don't think showing the exact second is necessary in PDF, I think its more important to use the same format as in the receipt. We also don't need to use the `getDateFormat` function here, that is only intended for use on the DatePicker component's `format`-property, which is nullable. Using the function with a constant has no effect.

## Related Issue(s)

- closes #2476

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->
