### PR TITLE
Validate when entering subform

### DIFF
--- a/src/features/navigation/components/SubformsForPage.tsx
+++ b/src/features/navigation/components/SubformsForPage.tsx
@@ -9,9 +9,9 @@ import { useDataTypeFromLayoutSet } from 'src/features/form/layout/LayoutsContex
 import { useStrictDataElements } from 'src/features/instance/InstanceContext';
 import { Lang } from 'src/features/language/Lang';
 import classes from 'src/features/navigation/components/SubformsForPage.module.css';
-import { useNavigate, useNavigationParams } from 'src/features/routing/AppRoutingContext';
 import { isSubformValidation } from 'src/features/validation';
 import { useComponentValidationsForNode } from 'src/features/validation/selectors/componentValidationsForNode';
+import { useNavigatePage } from 'src/hooks/useNavigatePage';
 import {
   getSubformEntryDisplayName,
   useExpressionDataSourcesForSubform,
@@ -116,8 +116,7 @@ function SubformLink({
   hasErrors: boolean;
 }) {
   const { isAnyProcessing: disabled } = useIsProcessing();
-  const { instanceOwnerPartyId, instanceGuid, taskId } = useNavigationParams();
-  const navigate = useNavigate();
+  const { enterSubform } = useNavigatePage();
   const { isSubformDataFetching, subformData, subformDataError } = useSubformFormData(dataElement.id);
   const subformDataSources = useExpressionDataSourcesForSubform(dataElement.dataType, subformData, entryDisplayName);
 
@@ -130,14 +129,12 @@ function SubformLink({
     return null;
   }
 
-  const url = `/instance/${instanceOwnerPartyId}/${instanceGuid}/${taskId}/${page}/${nodeId}/${dataElement.id}${hasErrors ? '?validate=true' : ''}`;
-
   return (
     <li>
       <button
         disabled={disabled}
         className={cn(classes.subformLink, 'fds-focus')}
-        onClick={() => navigate(url)}
+        onClick={() => enterSubform({ nodeId, dataElementId: dataElement.id, page, validate: hasErrors })}
       >
         <span className={classes.subformLinkName}>{subformEntryName}</span>
       </button>

--- a/src/hooks/useNavigatePage.ts
+++ b/src/hooks/useNavigatePage.ts
@@ -370,6 +370,29 @@ export function useNavigatePage() {
     });
   };
 
+  const enterSubform = async ({
+    nodeId,
+    dataElementId,
+    page,
+    validate,
+  }: {
+    nodeId: string;
+    dataElementId: string;
+    page?: string;
+    validate?: boolean;
+  }) => {
+    if (page && !orderRef.current.includes(page)) {
+      window.logWarn('enterSubform called with invalid page:', `"${page}"`);
+      return;
+    }
+    const { instanceOwnerPartyId, instanceGuid, taskId, pageKey } = navParams.current;
+    const url = `/instance/${instanceOwnerPartyId}/${instanceGuid}/${taskId}/${page ?? pageKey}/${nodeId}/${dataElementId}${validate ? '?validate=true' : ''}`;
+
+    await maybeSaveOnPageChange();
+    await refetchInitialValidations();
+    return navigate(url, undefined, undefined, () => focusMainContent());
+  };
+
   return {
     navigateToPage,
     isValidPageId,
@@ -378,6 +401,7 @@ export function useNavigatePage() {
     navigateToPreviousPage,
     maybeSaveOnPageChange,
     exitSubform,
+    enterSubform,
   };
 }
 

--- a/src/hooks/useNavigatePage.ts
+++ b/src/hooks/useNavigatePage.ts
@@ -389,7 +389,7 @@ export function useNavigatePage() {
     const url = `/instance/${instanceOwnerPartyId}/${instanceGuid}/${taskId}/${page ?? pageKey}/${nodeId}/${dataElementId}${validate ? '?validate=true' : ''}`;
 
     await maybeSaveOnPageChange();
-    await refetchInitialValidations();
+    refetchInitialValidations();
     return navigate(url, undefined, undefined, () => focusMainContent());
   };
 

--- a/src/layout/Subform/SubformComponent.tsx
+++ b/src/layout/Subform/SubformComponent.tsx
@@ -13,10 +13,11 @@ import { FD } from 'src/features/formData/FormDataWrite';
 import { useStrictDataElements } from 'src/features/instance/InstanceContext';
 import { Lang } from 'src/features/language/Lang';
 import { useLanguage } from 'src/features/language/useLanguage';
-import { useIsSubformPage, useNavigate } from 'src/features/routing/AppRoutingContext';
+import { useIsSubformPage } from 'src/features/routing/AppRoutingContext';
 import { useAddEntryMutation, useDeleteEntryMutation } from 'src/features/subformData/useSubformMutations';
 import { isSubformValidation } from 'src/features/validation';
 import { useComponentValidationsForNode } from 'src/features/validation/selectors/componentValidationsForNode';
+import { useNavigatePage } from 'src/hooks/useNavigatePage';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
 import { SubformCellContent } from 'src/layout/Subform/SubformCellContent';
 import classes from 'src/layout/Subform/SubformComponent.module.css';
@@ -52,7 +53,7 @@ export function SubformComponent({ node }: PropsFromGenericComponent<'Subform'>)
   const { langAsString } = useLanguage();
   const addEntryMutation = useAddEntryMutation(dataType);
   const dataElements = useStrictDataElements(dataType);
-  const navigate = useNavigate();
+  const { enterSubform } = useNavigatePage();
   const lock = FD.useLocking(id);
   const { performProcess, isAnyProcessing: isAddingDisabled, isThisProcessing: isAdding } = useIsProcessing();
   const [subformEntries, updateSubformEntries] = useState(dataElements);
@@ -64,7 +65,7 @@ export function SubformComponent({ node }: PropsFromGenericComponent<'Subform'>)
       const currentLock = await lock();
       try {
         const result = await addEntryMutation.mutateAsync({});
-        navigate(`${node.id}/${result.id}`);
+        enterSubform({ nodeId: node.id, dataElementId: result.id });
       } catch {
         // NOTE: Handled by useAddEntryMutation
       } finally {
@@ -194,7 +195,7 @@ function SubformTableRow({
   const { isSubformDataFetching, subformData, subformDataError } = useSubformFormData(dataElement.id);
   const subformDataSources = useExpressionDataSourcesForSubform(dataElement.dataType, subformData, tableColumns);
   const { langAsString } = useLanguage();
-  const navigate = useNavigate();
+  const { enterSubform } = useNavigatePage();
   const [isDeleting, setIsDeleting] = useState(false);
 
   const deleteEntryMutation = useDeleteEntryMutation(id);
@@ -259,7 +260,7 @@ function SubformTableRow({
             disabled={isDeleting}
             variant='tertiary'
             color='second'
-            onClick={async () => navigate(`${node.id}/${id}${hasErrors ? '?validate=true' : ''}`)}
+            onClick={async () => enterSubform({ nodeId: node.id, dataElementId: id, validate: hasErrors })}
             aria-label={editButtonText}
             className={classes.tableButton}
           >


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

I will try to describe the issue. When entering a subform, the subform gets its own formcontext including validation state, this is initially populated by the initialValidations from tanstack. When making changes in the main form, we update the validation state with the partial validations from the patch responses. When you then enter a subform, and a new validation context gets created all of the incremental changes to the validation state are "lost" as it only gets the initial validations from the tanstack cache. Validation state is kind of global (as opposed to formdatawrite), we don't techincally need to have a separate state between subforms and the main form besides that our current architecture kind of forces us to.

This is a quick fix, as I was told this was important to fix. We already revalidate the entire form when exiting the subform (so that the main form knows about validation changes made in the subform), so now I also revalidate the whole thing when entering a subform as well to make sure the subform context gets up-to-date initial validations.

## Related Issue(s)

- closes #3339

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->
