### PR TITLE
Feature/signing-bugfix

### DIFF
--- a/src/layout/SigningActions/utils.test.ts
+++ b/src/layout/SigningActions/utils.test.ts
@@ -174,6 +174,13 @@ describe('getCurrentUserStatus', () => {
         currentUserPartyId: 123,
         userSignees: [signedSignee, signedOrgSignee],
         canSign: true,
+        expected: 'signed',
+      },
+      {
+        description: 'No matching signee current user person is not in the list',
+        currentUserPartyId: 123,
+        userSignees: [],
+        canSign: true,
         expected: 'awaitingSignature',
       },
       {

--- a/src/layout/SigningActions/utils.ts
+++ b/src/layout/SigningActions/utils.ts
@@ -23,10 +23,8 @@ export function getCurrentUserStatus(
     return 'awaitingSignature';
   }
 
-  // If the current user is not listed as a person signee, but they have sign permission, they should still be able to sign
-  const currentUserIsInList = userSignees.some(
-    (signee) => signee.partyId === currentUserPartyId && !signee.organization,
-  );
+  // If the current user is not listed as a signee, but they have sign permission, they should still be able to sign
+  const currentUserIsInList = userSignees.some((signee) => signee.partyId === currentUserPartyId);
 
   if (!currentUserIsInList) {
     return 'awaitingSignature';


### PR DESCRIPTION
## Description

Bug: When signing on behlaf of an org as a user delegated signee, you would retain the SignAction in the "sign" mode, rather than the "NoActionRequired" mode, because the component would only match you with a non-behalf-of-org signature.

With the proposed changes this would not happen.

You can still sign on behalf of multiple organization if you have a key role in more than one providedSignee org, and sign as user delegated yourself after signing as user delegated on behalf of.

What you can no longer do is sign on behalf of an org and then sign for yourself (if you have a key role in the provided signee org AND role based access to sign through the XACML)

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->
