### PR TITLE
Fixing repeated instantiation bug

### DIFF
--- a/src/features/instantiate/containers/InstantiateContainer.tsx
+++ b/src/features/instantiate/containers/InstantiateContainer.tsx
@@ -4,7 +4,7 @@ import { Loader } from 'src/core/loading/Loader';
 import { InstantiateValidationError } from 'src/features/instantiate/containers/InstantiateValidationError';
 import { MissingRolesError } from 'src/features/instantiate/containers/MissingRolesError';
 import { UnknownError } from 'src/features/instantiate/containers/UnknownError';
-import { useClearInstantiation, useInstantiation } from 'src/features/instantiate/InstantiationContext';
+import { useInstantiation } from 'src/features/instantiate/InstantiationContext';
 import { useCurrentParty } from 'src/features/party/PartiesProvider';
 import { AltinnPalette } from 'src/theme/altinnAppTheme';
 import { changeBodyBackground } from 'src/utils/bodyStyling';
@@ -15,8 +15,6 @@ export const InstantiateContainer = () => {
   changeBodyBackground(AltinnPalette.greyLight);
   const party = useCurrentParty();
   const instantiation = useInstantiation();
-
-  useClearInstantiation(true);
 
   useEffect(() => {
     const shouldCreateInstance = !!party;

--- a/src/features/instantiate/selection/InstanceSelection.tsx
+++ b/src/features/instantiate/selection/InstanceSelection.tsx
@@ -14,7 +14,7 @@ import { useIsProcessing } from 'src/core/contexts/processingContext';
 import { TaskStoreProvider } from 'src/core/contexts/taskStoreContext';
 import { useAppName, useAppOwner } from 'src/core/texts/appTexts';
 import { useApplicationMetadata } from 'src/features/applicationMetadata/ApplicationMetadataProvider';
-import { useClearInstantiation, useInstantiation } from 'src/features/instantiate/InstantiationContext';
+import { useInstantiation } from 'src/features/instantiate/InstantiationContext';
 import {
   ActiveInstancesProvider,
   useActiveInstances,
@@ -82,8 +82,6 @@ function InstanceSelection() {
 
   const instances = instanceSelectionOptions?.sortDirection === 'desc' ? [..._instances].reverse() : _instances;
   const paginatedInstances = instances.slice(currentPage * rowsPerPage, (currentPage + 1) * rowsPerPage);
-
-  useClearInstantiation();
 
   function handleRowsPerPageChanged(newRowsPerPage: number) {
     setRowsPerPage(newRowsPerPage);
@@ -282,7 +280,7 @@ function InstanceSelection() {
                 performProcess(async () => {
                   if (currentParty) {
                     storeCallback(focusMainContent);
-                    await instantiation.instantiate(currentParty.partyId);
+                    await instantiation.instantiate(currentParty.partyId, true);
                   }
                 })
               }

--- a/src/layout/InstantiationButton/InstantiationButton.tsx
+++ b/src/layout/InstantiationButton/InstantiationButton.tsx
@@ -28,12 +28,15 @@ export const InstantiationButton = ({ children, ...props }: Props) => {
         id={props.node.id}
         onClick={() =>
           performProcess(() =>
-            instantiation.instantiateWithPrefill({
-              prefill,
-              instanceOwner: {
-                partyId: party?.partyId.toString(),
+            instantiation.instantiateWithPrefill(
+              {
+                prefill,
+                instanceOwner: {
+                  partyId: party?.partyId.toString(),
+                },
               },
-            }),
+              true,
+            ),
           )
         }
         disabled={isAnyProcessing}


### PR DESCRIPTION
## Description

When running the cypress tests in the signing branch (specifically `frontend-test/message.ts`), sometimes the instantiation would be cleared early, and thus a later render of `InstantiateContainer` would trigger another instantiation before the first one had a chance to finish. The result would be that the user got two instances, and frontend crashed when it noticed the mismatch.

This should fix the issue by removing the timing part of this effect. The instantiation is only cleared when the URL changes (i.e. when the user navigates away).

## Related Issue(s)

- #3259 (bug presumably introduced here)
- https://digdir.slack.com/archives/C076GU2QHCG/p1746781299912699

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->
