### PR TITLE
Preventing mutation of language object

### DIFF
--- a/src/layout/Custom/CustomWebComponent.tsx
+++ b/src/layout/Custom/CustomWebComponent.tsx
@@ -133,5 +133,5 @@ function getTextsForComponent(textResourceBindings: ITextResourceBindings<'Custo
 
 export function useLegacyNestedTexts() {
   const { language } = useLanguage();
-  return useMemo(() => dot.object(language), [language]);
+  return useMemo(() => dot.object(structuredClone(language)), [language]);
 }


### PR DESCRIPTION
## Description

After #3323 (luckily not released yet, apart from an rc release and some previews), if you used a Custom component in a form, it would mutate the list of language keys built-into app-frontend. This would break all future texts referencing our own text keys.

## Related Issue(s)

- https://github.com/Altinn/app-frontend-react/pull/3323
- https://altinn.slack.com/archives/C02EJ9HKQA3/p1747210682318179
- https://digdir.slack.com/archives/C076GU2QHCG/p1747210540206959

## Verification/QA

- Manual functionality testing
  - [X] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
    - We don't currently have any test mechanisms for Custom components :cry: 
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->
