### PR TITLE
Fix release include-regex

### DIFF
--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -116,7 +116,7 @@ else
     set +x
     echo "-------------------------------------"
   else
-    AZCOPY_INCLUDE_REGEX="^$APP_FULL/*"
+    AZCOPY_INCLUDE_REGEX="^$APP_FULL/.*"
     if [[ "$PRE_RELEASE" == "no" ]]; then
       AZCOPY_INCLUDE_REGEX+="|^$APP_MAJOR/.*|^$APP_MAJOR_MINOR/.*"
     fi


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

Preview version were matched by `azcopy sync` regex when releasing a new prod version. I highly suspect that this is due to a missing `.` in the regex. The regex has been like this for a long time. But previously, we pulled the whole altinn-cdn repo, so even if some more versions matched, sync would find the files and not delete them. But now we don't do this any more, so when sync matches these versions and they don't appear locally, they are deleted.

To demonstrate:

https://github.com/user-attachments/assets/af7b1cc5-950c-4a27-8f46-4ae7a902ab67

## Related Issue(s)

- https://digdir.slack.com/archives/C076GU2QHCG/p1747226866975369
- #3201