### PR TITLE
Fixing flakyness in MultipleSelect test

### DIFF
--- a/test/e2e/integration/component-library/multiple-select.ts
+++ b/test/e2e/integration/component-library/multiple-select.ts
@@ -39,26 +39,26 @@ describe('Multiple select component', () => {
 
     //Check options in checkboxes component
     cy.get(multiselectList).contains('span', checkboxText1).click();
+    cy.get(multiselect).contains('span', checkboxText1).should('exist');
     cy.get(multiselectList).contains('span', checkboxText2).click();
+    cy.get(multiselect).contains('span', checkboxText2).should('exist');
     cy.get(multiselectList).contains('span', checkboxText3).click();
+    cy.get(multiselect).contains('span', checkboxText3).should('exist');
     cy.get(multiselectList).contains('span', checkboxText4).click();
+    cy.get(multiselect).contains('span', checkboxText4).should('exist');
     cy.get(multiselectList).contains('span', checkboxText5).click();
+    cy.get(multiselect).contains('span', checkboxText5).should('exist');
 
     //Uncheck
     cy.get(multiselectList).contains('span', checkboxText4).click();
-    cy.get(multiselectList).contains('span', checkboxText5).click();
-
-    //Check that checkboxes is correct
-    cy.get(multiselect).contains('span', checkboxText1).should('exist');
-    cy.get(multiselect).contains('span', checkboxText2).should('exist');
-    cy.get(multiselect).contains('span', checkboxText3).should('exist');
     cy.get(multiselect).contains('span', checkboxText4).should('not.exist');
+    cy.get(multiselectList).contains('span', checkboxText5).click();
     cy.get(multiselect).contains('span', checkboxText5).should('not.exist');
 
     //Clicking on the repeating group to close the popover from the multiselect
     cy.get(repGroup).click({ force: true });
 
-    //Validate that the corresponding options in checkboxes is avaliable in repeating group
+    //Validate that the corresponding options in checkboxes is available in RepeatingGroup
     cy.get(repGroup).findByRole('cell', { name: checkboxText1 }).should('exist');
     cy.get(repGroup).findByRole('cell', { name: checkboxText2 }).should('exist');
     cy.get(repGroup).findByRole('cell', { name: checkboxText3 }).should('exist');


### PR DESCRIPTION
## Description

This test failed for me locally sometimes, and I suspect it's the same reason for why it failed in #3336 ([cypress cloud link](https://cloud.cypress.io/projects/y2jhp6/runs/8948/overview/4b9ed01f-7845-47aa-92ae-896440401708?roarHideRunsWithDiffGroupsAndTags=1)). Checking these values earlier makes Cypress wait until the value has been selected before proceeding.

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->
