### PR TITLE
Fixing rare broken row-removal in PATCH

### DIFF
--- a/test/e2e/integration/component-library/checkboxes.ts
+++ b/test/e2e/integration/component-library/checkboxes.ts
@@ -94,22 +94,20 @@ describe('Checkboxes component', () => {
 
     //Check options in checkboxes component
     cy.get(checkboxes).contains('label', checkboxText1).prev('input[type="checkbox"]').click();
+    cy.get(checkboxes).contains('label', checkboxText1).prev('input[type="checkbox"]').should('be.checked');
     cy.get(checkboxes).contains('label', checkboxText2).prev('input[type="checkbox"]').click();
+    cy.get(checkboxes).contains('label', checkboxText2).prev('input[type="checkbox"]').should('be.checked');
     cy.get(checkboxes).contains('label', checkboxText3).prev('input[type="checkbox"]').click();
+    cy.get(checkboxes).contains('label', checkboxText3).prev('input[type="checkbox"]').should('be.checked');
     cy.get(checkboxes).contains('label', checkboxText4).prev('input[type="checkbox"]').click();
+    cy.get(checkboxes).contains('label', checkboxText4).prev('input[type="checkbox"]').should('be.checked');
     cy.get(checkboxes).contains('label', checkboxText5).prev('input[type="checkbox"]').click();
+    cy.get(checkboxes).contains('label', checkboxText5).prev('input[type="checkbox"]').should('be.checked');
 
     //Uncheck
-    cy.get(checkboxes).contains('label', checkboxText4).prev('input[type="checkbox"]').should('be.checked');
-    cy.get(checkboxes).contains('label', checkboxText5).prev('input[type="checkbox"]').should('be.checked');
     cy.get(checkboxes).contains('label', checkboxText4).prev('input[type="checkbox"]').click();
-    cy.get(checkboxes).contains('label', checkboxText5).prev('input[type="checkbox"]').click();
-
-    //Check that checkboxes is correct
-    cy.get(checkboxes).contains('label', checkboxText1).prev('input[type="checkbox"]').should('be.checked');
-    cy.get(checkboxes).contains('label', checkboxText2).prev('input[type="checkbox"]').should('be.checked');
-    cy.get(checkboxes).contains('label', checkboxText3).prev('input[type="checkbox"]').should('be.checked');
     cy.get(checkboxes).contains('label', checkboxText4).prev('input[type="checkbox"]').should('not.be.checked');
+    cy.get(checkboxes).contains('label', checkboxText5).prev('input[type="checkbox"]').click();
     cy.get(checkboxes).contains('label', checkboxText5).prev('input[type="checkbox"]').should('not.be.checked');
 
     //Validate that the corresponding options in checkboxes is available in RepeatingGroup
@@ -127,7 +125,7 @@ describe('Checkboxes component', () => {
 
     // Unchecking from Checkboxes should remove from RepeatingGroup (observe that data is preserved)
     cy.get(checkboxes).contains('label', checkboxText2).prev('input[type="checkbox"]').should('be.checked');
-    cy.get(repGroup).findAllByRole('row').should('have.length', 3); // Header + 2 row
+    cy.get(repGroup).findAllByRole('row').should('have.length', 3); // Header + 2 rows
     cy.get(repGroup)
       .findAllByRole('button', { name: /^Rediger/ })
       .first()

--- a/test/e2e/integration/component-library/multiple-select.ts
+++ b/test/e2e/integration/component-library/multiple-select.ts
@@ -119,7 +119,6 @@ describe('Multiple select component', () => {
 
     //Uncheck
     cy.get(multiselectList).contains('span', checkboxText4).click();
-
     cy.get(multiselect).contains('span', checkboxText4).should('not.exist');
     cy.get(multiselectList).contains('span', checkboxText5).click();
     cy.get(multiselect).contains('span', checkboxText5).should('not.exist');
@@ -135,7 +134,7 @@ describe('Multiple select component', () => {
     cy.get(repGroup).findByRole('cell', { name: checkboxText5 }).should('not.exist');
 
     // Removing from RepeatingGroup should deselect from List
-    cy.get(repGroup).findAllByRole('row').should('have.length', 4); // Header + 1 row
+    cy.get(repGroup).findAllByRole('row').should('have.length', 4); // Header + 3 rows
     cy.get(repGroup)
       .findAllByRole('button', { name: /^Slett/ })
       .first()
@@ -144,7 +143,7 @@ describe('Multiple select component', () => {
 
     // Unchecking from Checkboxes should remove from RepeatingGroup (observe that data is preserved)
     cy.get(multiselect).contains('span', checkboxText2).should('exist');
-    cy.get(repGroup).findAllByRole('row').should('have.length', 3); // Header + 2 row
+    cy.get(repGroup).findAllByRole('row').should('have.length', 3); // Header + 2 rows
     cy.get(repGroup)
       .findAllByRole('button', { name: /^Rediger/ })
       .first()


### PR DESCRIPTION
## Description

I noticed in a test-run that the new group-binding tests for `Checkboxes` and `MultipleSelect` does something we haven't seen much of before; multiple rows are removed (and potentially added) in the same PATCH request. When doing so, it turns out our `createPatch()` function can end up removing indexes that doesn't exist in the data model.

As we can see in [this Cypress run](https://cloud.cypress.io/projects/y2jhp6/runs/8966/overview/998c0da3-6ce7-4f4b-9cc1-e0ef22352c2e/replay?att=2&pc=1895.609__network-calls&roarHideRunsWithDiffGroupsAndTags=1&ts=1747898874378.273), the patch is broken:

```json
[
  {
    "op": "test",
    "path": "/MultiselectGroupExample",
    "value": [
      {
        "altinnRowId": "49e1ac48-a940-4b9c-9c55-44e78cc0430a",
        "age": null,
        "profession": null,
        "surname": null,
        "Internal": null,
        "Name": {
          "firstname": "Karoline",
          "id": null
        }
      },
      {
        "altinnRowId": "1d46705d-4312-4ab1-b6ac-2dd0e8b4a822",
        "age": null,
        "profession": null,
        "surname": null,
        "Internal": null,
        "Name": {
          "firstname": "Kåre",
          "id": null
        }
      },
      {
        "altinnRowId": "8096239f-aa26-43a2-9807-d13acdda3ae2",
        "age": null,
        "profession": null,
        "surname": null,
        "Internal": null,
        "Name": {
          "firstname": "Johanne",
          "id": null
        }
      },
      {
        "altinnRowId": "6c10387b-06e3-4374-ae7e-5aacfe546504",
        "age": null,
        "profession": null,
        "surname": null,
        "Internal": null,
        "Name": {
          "firstname": "Petter",
          "id": null
        }
      }
    ]
  },
  {
    "op": "remove",
    "path": "/MultiselectGroupExample/0"
  },
  {
    "op": "remove",
    "path": "/MultiselectGroupExample/3"
  },
  {
    "op": "test",
    "path": "/MultiselectGroupExample/2",
    "value": {
      "altinnRowId": "6c10387b-06e3-4374-ae7e-5aacfe546504",
      "age": null,
      "profession": null,
      "surname": null,
      "Internal": null,
      "Name": {
        "firstname": "Petter",
        "id": null
      }
    }
  },
  {
    "op": "remove",
    "path": "/MultiselectGroupExample/2"
  }
]
```

So then this happens:
1. It starts off with 4 rows (indexes 0-3)
2. Index 0 is removed (we now have 0-2)
3. Index 3 is removed (but that doesn't exist - we meant to remove index 2, which used to be index 3 before the first removal).
4. Backend crashes with a 422 `Target path `/MultiselectGroupExample/3` could not be reached`

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [x] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->
