### PR TITLE
Setting inputMode for Input components when autocomplete or variant h…

### DIFF
--- a/src/app-components/Datepicker/DatePickerInput.tsx
+++ b/src/app-components/Datepicker/DatePickerInput.tsx
@@ -10,7 +10,7 @@ import {
   strictParseFormat,
   strictParseISO,
 } from 'src/app-components/Datepicker/utils/dateHelpers';
-import { getFormatPattern } from 'src/utils/dateUtils';
+import { dateFormatCanBeNumericInReactPatternFormat, getFormatAsPatternFormat } from 'src/utils/dateUtils';
 
 export interface DatePickerInputProps {
   id: string;
@@ -31,10 +31,10 @@ export function DatePickerInput({
   readOnly,
   autoComplete,
 }: DatePickerInputProps) {
-  const formatPattern = getFormatPattern(datepickerFormat);
   const dateValue = strictParseISO(value);
   const formattedDateValue = dateValue ? format(dateValue, datepickerFormat) : value;
   const [inputValue, setInputValue] = useState(formattedDateValue ?? '');
+  const numericMode = dateFormatCanBeNumericInReactPatternFormat(datepickerFormat);
 
   useEffect(() => {
     setInputValue(formattedDateValue ?? '');
@@ -58,7 +58,7 @@ export function DatePickerInput({
 
   return (
     <PatternFormat
-      format={formatPattern}
+      format={getFormatAsPatternFormat(datepickerFormat)}
       customInput={Textfield}
       mask='_'
       className={styles.calendarInput}
@@ -71,6 +71,9 @@ export function DatePickerInput({
       readOnly={readOnly}
       aria-readonly={readOnly}
       autoComplete={autoComplete}
+      // May force a numerical input mode in mobile browsers
+      inputMode={numericMode ? 'numeric' : 'text'}
+      pattern={numericMode ? '[0-9]*' : undefined}
     />
   );
 }

--- a/src/app-components/Datepicker/DatePickerInput.tsx
+++ b/src/app-components/Datepicker/DatePickerInput.tsx
@@ -19,6 +19,7 @@ export interface DatePickerInputProps {
   value?: string;
   onValueChange?: (value: string) => void;
   readOnly?: boolean;
+  autoComplete?: 'bday';
 }
 
 export function DatePickerInput({
@@ -28,6 +29,7 @@ export function DatePickerInput({
   timeStamp,
   onValueChange,
   readOnly,
+  autoComplete,
 }: DatePickerInputProps) {
   const formatPattern = getFormatPattern(datepickerFormat);
   const dateValue = strictParseISO(value);
@@ -68,6 +70,7 @@ export function DatePickerInput({
       onBlur={saveValue}
       readOnly={readOnly}
       aria-readonly={readOnly}
+      autoComplete={autoComplete}
     />
   );
 }

--- a/src/app-components/Datepicker/Datepicker.tsx
+++ b/src/app-components/Datepicker/Datepicker.tsx
@@ -27,6 +27,7 @@ export type DatePickerControlProps = {
   DropdownCaption: typeof MonthCaption;
   buttonAriaLabel: string;
   calendarIconTitle: string;
+  autoComplete?: 'bday';
 };
 
 export const DatePickerControl: React.FC<DatePickerControlProps> = ({
@@ -44,6 +45,7 @@ export const DatePickerControl: React.FC<DatePickerControlProps> = ({
   buttonAriaLabel,
   DropdownCaption,
   calendarIconTitle,
+  autoComplete,
 }) => {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const dateValue = new Date(value);
@@ -73,6 +75,7 @@ export const DatePickerControl: React.FC<DatePickerControlProps> = ({
           timeStamp={timeStamp}
           onValueChange={onValueChange}
           readOnly={readOnly}
+          autoComplete={autoComplete}
         />
         <DatePickerDialog
           isDialogOpen={isDialogOpen}

--- a/src/app-components/Input/Input.tsx
+++ b/src/app-components/Input/Input.tsx
@@ -31,6 +31,7 @@ export type InputProps = {
   | 'placeholder'
   | 'inputMode'
   | 'style'
+  | 'pattern'
 >;
 
 export function Input(props: InputProps) {

--- a/src/layout/Datepicker/DatepickerComponent.tsx
+++ b/src/layout/Datepicker/DatepickerComponent.tsx
@@ -32,6 +32,7 @@ export function DatepickerComponent({ node, overrideDisplay }: IDatepickerProps)
     id,
     dataModelBindings,
     grid,
+    autocomplete,
   } = useNodeItem(node);
 
   const calculatedMinDate = getDateConstraint(minDate, 'min');
@@ -81,6 +82,7 @@ export function DatepickerComponent({ node, overrideDisplay }: IDatepickerProps)
             DropdownCaption={DropdownCaption}
             buttonAriaLabel={langAsString('date_picker.aria_label_icon')}
             calendarIconTitle={langAsString('date_picker.aria_label_icon')}
+            autoComplete={autocomplete}
           />
         </Flex>
       </ComponentStructureWrapper>

--- a/src/layout/Datepicker/config.ts
+++ b/src/layout/Datepicker/config.ts
@@ -17,6 +17,7 @@ export const Config = new CG.component({
   },
 })
   .addDataModelBinding(CG.common('IDataModelBindingsSimple'))
+  .addProperty(new CG.prop('autocomplete', new CG.const('bday').optional()))
   .addProperty(
     new CG.prop(
       'minDate',

--- a/src/layout/Input/InputComponent.tsx
+++ b/src/layout/Input/InputComponent.tsx
@@ -19,6 +19,7 @@ import { useNodeItem } from 'src/utils/layout/useNodeItem';
 import type { InputProps } from 'src/app-components/Input/Input';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type {
+  HTMLAutoCompleteValues,
   NumberFormatProps as NumberFormatPropsCG,
   PatternFormatProps as PatternFormatPropsCG,
 } from 'src/layout/common.generated';
@@ -58,6 +59,50 @@ function getVariantWithFormat(
 
 export type IInputProps = PropsFromGenericComponent<'Input'>;
 
+function getMobileKeyboardProps(
+  variant: Variant,
+  autocomplete: HTMLAutoCompleteValues | undefined,
+): Pick<InputProps, 'inputMode' | 'pattern'> {
+  if (variant.type === 'search') {
+    return { inputMode: 'search', pattern: undefined };
+  }
+
+  if (autocomplete === 'email') {
+    return { inputMode: 'email', pattern: undefined };
+  }
+
+  if (autocomplete === 'url' || autocomplete === 'photo') {
+    return { inputMode: 'url', pattern: undefined };
+  }
+
+  if (autocomplete === 'tel') {
+    return { inputMode: 'tel', pattern: '[-+()0-9]*' };
+  }
+
+  if (variant.type === 'pattern') {
+    // Pattern inputs are simple. They fill out spaces or separators for you automatically, so the user can focus on
+    // typing the numbers.
+    return { inputMode: 'numeric', pattern: undefined };
+  }
+
+  if (variant.type === 'number') {
+    if (variant.format.allowNegative === false) {
+      return { inputMode: 'decimal', pattern: `[0-9,.]*` };
+    }
+
+    if (navigator?.platform && /iPhone|iPad/.test(navigator.platform)) {
+      // Decimal on iOS does not allow negative numbers, so we have to fall back to text
+      // when negatives are allowed. For more details, see the issue:
+      // https://github.com/s-yadav/react-number-format/issues/189#issuecomment-623267349
+      return { inputMode: 'text', pattern: `-?[0-9,.]*` };
+    }
+
+    return { inputMode: 'decimal', pattern: `-?[0-9,.]*` };
+  }
+
+  return { inputMode: 'text', pattern: undefined };
+}
+
 export const InputVariant = ({ node, overrideDisplay }: Pick<IInputProps, 'node' | 'overrideDisplay'>) => {
   const {
     id,
@@ -80,6 +125,9 @@ export const InputVariant = ({ node, overrideDisplay }: Pick<IInputProps, 'node'
 
   const [localValue, setLocalValue] = React.useState<string | undefined>(undefined);
   const formValue = localValue ?? realFormValue;
+  const reactNumberFormatConfig = useMapToReactNumberConfig(formatting, formValue);
+  const variant = getVariantWithFormat(inputVariant, reactNumberFormatConfig?.number);
+  const { inputMode, pattern } = getMobileKeyboardProps(variant, autocomplete);
 
   const inputProps: InputProps = {
     id,
@@ -97,10 +145,10 @@ export const InputVariant = ({ node, overrideDisplay }: Pick<IInputProps, 'node'
     suffix: textResourceBindings?.suffix ? langAsString(textResourceBindings.suffix) : undefined,
     characterLimit: !readOnly ? characterLimit : undefined,
     style: { width: '100%' },
+    inputMode,
+    pattern,
   };
 
-  const reactNumberFormatConfig = useMapToReactNumberConfig(formatting, formValue);
-  const variant = getVariantWithFormat(inputVariant, reactNumberFormatConfig?.number);
   switch (variant.type) {
     case 'search':
     case 'text':
@@ -109,15 +157,6 @@ export const InputVariant = ({ node, overrideDisplay }: Pick<IInputProps, 'node'
           {...inputProps}
           value={formValue}
           type={variant.type}
-          inputMode={
-            variant.type === 'search'
-              ? 'search'
-              : autocomplete === 'email'
-                ? 'email'
-                : autocomplete === 'url' || autocomplete === 'photo'
-                  ? 'url'
-                  : undefined
-          }
           onChange={(event) => {
             setValue('simpleBinding', event.target.value);
           }}

--- a/src/layout/Input/InputComponent.tsx
+++ b/src/layout/Input/InputComponent.tsx
@@ -109,6 +109,15 @@ export const InputVariant = ({ node, overrideDisplay }: Pick<IInputProps, 'node'
           {...inputProps}
           value={formValue}
           type={variant.type}
+          inputMode={
+            variant.type === 'search'
+              ? 'search'
+              : autocomplete === 'email'
+                ? 'email'
+                : autocomplete === 'url' || autocomplete === 'photo'
+                  ? 'url'
+                  : undefined
+          }
           onChange={(event) => {
             setValue('simpleBinding', event.target.value);
           }}

--- a/src/layout/OrganisationLookup/OrganisationLookupComponent.tsx
+++ b/src/layout/OrganisationLookup/OrganisationLookupComponent.tsx
@@ -166,6 +166,8 @@ export function OrganisationLookupComponent({
             }}
             onBlur={(e) => handleValidateOrgnr(e.target.value)}
             allowLeadingZeros
+            inputMode='numeric'
+            pattern='[0-9]{9}'
           />
           <div className={classes.submit}>
             {!hasSuccessfullyFetched ? (

--- a/src/layout/PersonLookup/PersonLookupComponent.tsx
+++ b/src/layout/PersonLookup/PersonLookupComponent.tsx
@@ -192,6 +192,9 @@ export function PersonLookupComponent({ node, overrideDisplay }: PropsFromGeneri
             }}
             onBlur={(e) => handleValidateSsn(e.target.value)}
             allowLeadingZeros
+            inputMode='numeric'
+            pattern='[0-9]{11}'
+            autoComplete='off'
           />
           <div className={classes.nameLabel}>
             <Label
@@ -227,6 +230,7 @@ export function PersonLookupComponent({ node, overrideDisplay }: PropsFromGeneri
               setTempName(e.target.value);
             }}
             onBlur={(e) => handleValidateName(e.target.value)}
+            autoComplete='family-name'
           />
 
           <div className={classes.submit}>

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -4,85 +4,52 @@ import { getLanguageFromCode } from 'src/language/languages';
 import type { FixedLanguageList } from 'src/language/languages';
 
 const UNICODE_TOKENS = /[^a-zA-Z0-9]+/g;
-export type Token =
-  | 'G'
-  | 'GG'
-  | 'GGG'
-  | 'GGGG'
-  | 'GGGGG'
-  | 'y'
-  | 'yy'
-  | 'yyy'
-  | 'yyyy'
-  | 'u'
-  | 'uu'
-  | 'uuu'
-  | 'uuuu'
-  | 'M'
-  | 'MM'
-  | 'MMM'
-  | 'MMMM'
-  | 'MMMMM'
-  | 'd'
-  | 'dd'
-  | 'a'
-  | 'E'
-  | 'EE'
-  | 'EEE'
-  | 'EEEE'
-  | 'EEEEE'
-  | 'h'
-  | 'hh'
-  | 'H'
-  | 'HH'
-  | 'm'
-  | 'mm'
-  | 's'
-  | 'ss'
-  | 'S'
-  | 'SS'
-  | 'SSS';
 type Separator = string | undefined;
+export type Token = keyof typeof tokenOptions;
 
-const tokenMappings: Record<Token, Intl.DateTimeFormatOptions> = {
-  G: { era: 'short' },
-  GG: { era: 'short' },
-  GGG: { era: 'short' },
-  GGGG: { era: 'long' },
-  GGGGG: { era: 'narrow' },
-  y: { year: 'numeric' },
-  yy: { year: '2-digit' },
-  yyy: { year: 'numeric' },
-  yyyy: { year: 'numeric' },
-  u: { year: 'numeric' },
-  uu: { year: 'numeric' },
-  uuu: { year: 'numeric' },
-  uuuu: { year: 'numeric' },
-  M: { month: 'numeric' },
-  MM: { month: '2-digit' },
-  MMM: { month: 'short' },
-  MMMM: { month: 'long' },
-  MMMMM: { month: 'narrow' },
-  d: { day: 'numeric' },
-  dd: { day: '2-digit' },
-  E: { weekday: 'short' },
-  EE: { weekday: 'short' },
-  EEE: { weekday: 'short' },
-  EEEE: { weekday: 'long' },
-  EEEEE: { weekday: 'narrow' },
-  a: { hour12: true, hour: '2-digit' },
-  h: { hour: 'numeric', hourCycle: 'h12' },
-  hh: { hour: '2-digit', hourCycle: 'h12' },
-  H: { hour: 'numeric', hourCycle: 'h23' },
-  HH: { hour: '2-digit', hourCycle: 'h23' },
-  m: { minute: 'numeric' },
-  mm: { minute: '2-digit' },
-  s: { second: 'numeric' },
-  ss: { second: '2-digit' },
-  S: { fractionalSecondDigits: 1 },
-  SS: { fractionalSecondDigits: 2 },
-  SSS: { fractionalSecondDigits: 3 },
-};
+interface ExtraOptions {
+  numeric: boolean;
+}
+
+const tokenOptions = {
+  G: { era: 'short', numeric: false },
+  GG: { era: 'short', numeric: false },
+  GGG: { era: 'short', numeric: false },
+  GGGG: { era: 'long', numeric: false },
+  GGGGG: { era: 'narrow', numeric: false },
+  y: { year: 'numeric', numeric: true },
+  yy: { year: '2-digit', numeric: true },
+  yyy: { year: 'numeric', numeric: true },
+  yyyy: { year: 'numeric', numeric: true },
+  u: { year: 'numeric', numeric: true },
+  uu: { year: 'numeric', numeric: true },
+  uuu: { year: 'numeric', numeric: true },
+  uuuu: { year: 'numeric', numeric: true },
+  M: { month: 'numeric', numeric: true },
+  MM: { month: '2-digit', numeric: true },
+  MMM: { month: 'short', numeric: false },
+  MMMM: { month: 'long', numeric: false },
+  MMMMM: { month: 'narrow', numeric: false },
+  d: { day: 'numeric', numeric: true },
+  dd: { day: '2-digit', numeric: true },
+  E: { weekday: 'short', numeric: false },
+  EE: { weekday: 'short', numeric: false },
+  EEE: { weekday: 'short', numeric: false },
+  EEEE: { weekday: 'long', numeric: false },
+  EEEEE: { weekday: 'narrow', numeric: false },
+  a: { hour12: true, hour: '2-digit', numeric: false },
+  h: { hour: 'numeric', hourCycle: 'h12', numeric: true },
+  hh: { hour: '2-digit', hourCycle: 'h12', numeric: true },
+  H: { hour: 'numeric', hourCycle: 'h23', numeric: true },
+  HH: { hour: '2-digit', hourCycle: 'h23', numeric: true },
+  m: { minute: 'numeric', numeric: true },
+  mm: { minute: '2-digit', numeric: true },
+  s: { second: 'numeric', numeric: true },
+  ss: { second: '2-digit', numeric: true },
+  S: { fractionalSecondDigits: 1, numeric: true },
+  SS: { fractionalSecondDigits: 2, numeric: true },
+  SSS: { fractionalSecondDigits: 3, numeric: true },
+} satisfies Record<string, Intl.DateTimeFormatOptions & ExtraOptions>;
 
 export function formatDateLocale(localeStr: string, date: Date, unicodeFormat?: string) {
   if (!unicodeFormat) {
@@ -95,7 +62,7 @@ export function formatDateLocale(localeStr: string, date: Date, unicodeFormat?: 
   let output = '';
   for (let i = 0; i < tokens.length; i++) {
     const token = tokens[i];
-    const options = tokenMappings[token];
+    const options = tokenOptions[token];
     const separator = separators[i] ?? '';
     if (!options) {
       // TODO: Throw an error instead?
@@ -132,7 +99,10 @@ export function getDatepickerFormat(unicodeFormat: string): string {
   }, '');
 }
 
-export function getFormatPattern(datePickerFormat: string): string {
+/**
+ * Convert the date picker format to a react-number-format pattern format
+ */
+export function getFormatAsPatternFormat(datePickerFormat: string): string {
   return datePickerFormat.replaceAll(/[dmy]/gi, '#');
 }
 
@@ -207,4 +177,25 @@ function lookup(lang: FixedLanguageList, key: keyof FixedLanguageList) {
  */
 export function toTimeZonedDate(date: string | Date, zone: string = 'Europe/Oslo') {
   return new TZDate(new Date(date), zone);
+}
+
+/**
+ * This will accept a Unicode date format and figure out if 'inputMode: numeric' can be used for an input field when
+ * combined with a pattern format in react-number-format. When the numeric mode is set, the mobile OS will show a
+ * strictly numeric keyboard (with no punctuation possible, at least on iOS). Since react-number-format fills in the
+ * separators for you automatically, there is no need for the user to actually type them, so we can give the user
+ * a better keyboard for these inputs.
+ *
+ * @see https://github.com/s-yadav/react-number-format/issues/189
+ * @see getFormatAsPatternFormat
+ */
+export function dateFormatCanBeNumericInReactPatternFormat(format: string): boolean {
+  const tokens = format.split(UNICODE_TOKENS) as Token[];
+  for (const token of tokens) {
+    if (!tokenOptions[token] || !tokenOptions[token].numeric) {
+      return false;
+    }
+  }
+
+  return true;
 }


### PR DESCRIPTION
## Description

I checked all components to figure out if we could do better with regards to hinting what kind of input-data each component expects. There are a few props that are useful here:

- [autocomplete](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/autocomplete) allows us to hint at which source the browser can use to look up autocompletion values for the user. This is already configurable for `Input` components, and we never really know this in app-frontend unless the app developer configures it explicitly.
- [inputmode](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/inputmode) hints at mobile browsers which keyboard variant the user should be shown when typing some data.
- [pattern](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/pattern) is often useful together with inputmode. It seems like iOS only displays the correct keyboard if both inputmode and pattern is set correctly.

With this in mind, I changed:

- The `PersonLookup` component
  - Making the SSN field use a numerical keyboard on mobile, with a pattern specifying an 11 digit number is expected. I did not test this manually as I don't have a recent iOS device to test with.
  - The last name text field now correctly indicates `autocomplete: family-name`.
- The `OrganisationLookup` component
  - The organisation number input field now use a numerical keyboard on mobile, with a pattern expecting 9 digits.
- The `Input` component
  - Correctly sets `inputMode: search` when using the search variant of the Input field (often overrides the keyboard return button to be a magnifying glass or a 'search' button).
  - Automatically sets a relevant `inputMode` for getting the appropriate keyboard layout if using:
    - `autocomplete: email` (makes the keyboard show a dedicated '@' button)
    - `autocomplete: url` or `autocomplete: photo` (makes the keyboard show a dedicated '/' symbol)
    - `autocomplete: tel` (makes the keyboard show a button for `+*#`)
  - Automatically use a numerical/decimal keyboard layout if using pattern or number formatting (except on iOS when negative numbers are allowed, because there is no keyboard variant there that supports the minus symbol).
- The `Datepicker` component
  - You can now configure this with `autocomplete: bday` if the date is supposed to be a birthday.
  - It will parse the provided format and figure out if a numerical keyboard can be used for simplified input on mobile.

## Related Issue(s)

- closes #2374

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->
