### PR TITLE
Accessibility fixes for Datepicker

### DIFF
--- a/src/app-components/Datepicker/DatePickerCalendar.tsx
+++ b/src/app-components/Datepicker/DatePickerCalendar.tsx
@@ -14,7 +14,6 @@ export interface CalendarDialogProps {
   minDate?: Date;
   locale?: string;
   required?: boolean;
-  autoFocus?: boolean;
   onBlur?: () => void;
   DropdownCaption: typeof MonthCaption;
 }
@@ -26,7 +25,6 @@ export const DatePickerCalendar = ({
   maxDate,
   locale,
   required,
-  autoFocus,
   DropdownCaption,
 }: CalendarDialogProps) => {
   const currentLocale = getLocale(locale ?? 'nb');
@@ -70,7 +68,7 @@ export const DatePickerCalendar = ({
         }
       }}
       components={{ MonthCaption: DropdownCaption }}
-      autoFocus={autoFocus}
+      autoFocus={true}
       style={{ minHeight: '405px', maxWidth: '100%' }}
     />
   );

--- a/src/app-components/Datepicker/DatePickerInput.tsx
+++ b/src/app-components/Datepicker/DatePickerInput.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { PatternFormat } from 'react-number-format';
+import type { Ref } from 'react';
 
 import { Textfield } from '@digdir/designsystemet-react';
 import { format, isValid } from 'date-fns';
@@ -22,15 +23,10 @@ export interface DatePickerInputProps {
   autoComplete?: 'bday';
 }
 
-export function DatePickerInput({
-  id,
-  value,
-  datepickerFormat,
-  timeStamp,
-  onValueChange,
-  readOnly,
-  autoComplete,
-}: DatePickerInputProps) {
+function DatePickerInputRef(
+  { id, value, datepickerFormat, timeStamp, onValueChange, readOnly, autoComplete }: DatePickerInputProps,
+  ref: Ref<HTMLInputElement>,
+) {
   const dateValue = strictParseISO(value);
   const formattedDateValue = dateValue ? format(dateValue, datepickerFormat) : value;
   const [inputValue, setInputValue] = useState(formattedDateValue ?? '');
@@ -58,6 +54,7 @@ export function DatePickerInput({
 
   return (
     <PatternFormat
+      getInputRef={ref}
       format={getFormatAsPatternFormat(datepickerFormat)}
       customInput={Textfield}
       mask='_'
@@ -77,3 +74,6 @@ export function DatePickerInput({
     />
   );
 }
+
+export const DatePickerInput = React.forwardRef(DatePickerInputRef);
+DatePickerInput.displayName = 'DatePickerInput';

--- a/src/app-components/Datepicker/Datepicker.tsx
+++ b/src/app-components/Datepicker/Datepicker.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import type { MonthCaption } from 'react-day-picker';
 
 import { CalendarIcon } from '@navikt/aksel-icons';
@@ -23,7 +23,6 @@ export type DatePickerControlProps = {
   minDate?: Date;
   maxDate?: Date;
   locale: string;
-  isMobile?: boolean;
   DropdownCaption: typeof MonthCaption;
   buttonAriaLabel: string;
   calendarIconTitle: string;
@@ -41,12 +40,12 @@ export const DatePickerControl: React.FC<DatePickerControlProps> = ({
   minDate,
   maxDate,
   locale,
-  isMobile = false,
   buttonAriaLabel,
   DropdownCaption,
   calendarIconTitle,
   autoComplete,
 }) => {
+  const inputRef = useRef<HTMLInputElement>(null);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const dateValue = new Date(value);
   const dayPickerDate = isValidDate(dateValue) ? dateValue : undefined;
@@ -69,6 +68,7 @@ export const DatePickerControl: React.FC<DatePickerControlProps> = ({
     >
       <div className={styles.calendarInputWrapper}>
         <DatePickerInput
+          ref={inputRef}
           id={id}
           value={value}
           datepickerFormat={dateFormat}
@@ -107,11 +107,11 @@ export const DatePickerControl: React.FC<DatePickerControlProps> = ({
             onSelect={(date) => {
               handleDayPickerSelect(date);
               setIsDialogOpen(false);
+              inputRef.current?.focus();
             }}
             minDate={minDate}
             maxDate={maxDate}
             required={required}
-            autoFocus={isMobile}
             DropdownCaption={DropdownCaption}
           />
         </DatePickerDialog>

--- a/src/app-components/DynamicForm/DynamicForm.tsx
+++ b/src/app-components/DynamicForm/DynamicForm.tsx
@@ -231,7 +231,6 @@ export function FieldRenderer({
             readOnly={false}
             required={required}
             locale={locale!}
-            isMobile={false}
             DropdownCaption={DropdownCaption}
             buttonAriaLabel={buttonAriaLabel}
             calendarIconTitle={calendarIconTitle}

--- a/src/layout/Datepicker/DatepickerComponent.tsx
+++ b/src/layout/Datepicker/DatepickerComponent.tsx
@@ -7,7 +7,6 @@ import { Label } from 'src/app-components/Label/Label';
 import { useDataModelBindings } from 'src/features/formData/useDataModelBindings';
 import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
 import { useLanguage } from 'src/features/language/useLanguage';
-import { useIsMobile } from 'src/hooks/useDeviceWidths';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
 import { DropdownCaption } from 'src/layout/Datepicker/DropdownCaption';
 import { getDatepickerFormat } from 'src/utils/dateUtils';
@@ -38,7 +37,6 @@ export function DatepickerComponent({ node, overrideDisplay }: IDatepickerProps)
   const calculatedMinDate = getDateConstraint(minDate, 'min');
   const calculatedMaxDate = getDateConstraint(maxDate, 'max');
   const dateFormat = getDatepickerFormat(getDateFormat(format, languageLocale));
-  const isMobile = useIsMobile();
 
   const { setValue, formData } = useDataModelBindings(dataModelBindings);
   const value = formData.simpleBinding;
@@ -76,7 +74,6 @@ export function DatepickerComponent({ node, overrideDisplay }: IDatepickerProps)
             readOnly={readOnly}
             required={required}
             locale={languageLocale}
-            isMobile={isMobile}
             minDate={calculatedMinDate}
             maxDate={calculatedMaxDate}
             DropdownCaption={DropdownCaption}


### PR DESCRIPTION
## Description

Tested Datepicker component with VoiceOver on Mac, in both Safari and Chrome. Fixed two issues:
- The dialog now brings focus back to the input field when the dialog is closed.
- Always using the 'autofucus' property makes the current date focussed when the dialog opens, or the selected date (if a date was already selected).

This should fix the remaining accessibility issues for Datepicker. The one thing I found to be problematic is when tabbing outside the dialog when it is open. I can't seem to get back in by using tab alone (and I'm not confined to the dialog in any way), but it's solvable by closing the dialog using the button next to the input and then open the dialog again. I'm not sure if we can confine the user to the dialog (and how that can be done), and trying to cheat the user back to the dialog by dynamically setting tabindex will surely result in a mess.

## Related Issue(s)

- closes #2938
- closes #33

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [x] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->
