### PR TITLE
label instead of value for summary and summary2 on group

### DIFF
--- a/src/layout/Checkboxes/MultipleChoiceSummary.tsx
+++ b/src/layout/Checkboxes/MultipleChoiceSummary.tsx
@@ -38,7 +38,7 @@ export function MultipleChoiceSummary({ targetNode }: IMultipleChoiceSummaryProp
     .map((row) => (!relativeSimpleBindingPath ? true : dot.pick(relativeSimpleBindingPath, row)));
 
   const data = dataModelBindings.group
-    ? displayRows
+    ? getCommaSeparatedOptionsToText(displayRows?.join(','), options, langAsString)
     : getCommaSeparatedOptionsToText(rawFormData.simpleBinding, options, langAsString);
 
   return (

--- a/src/layout/Checkboxes/index.tsx
+++ b/src/layout/Checkboxes/index.tsx
@@ -61,7 +61,7 @@ export class Checkboxes extends CheckboxesDef {
       .map((row) => (!relativeSimpleBindingPath ? true : dot.pick(relativeSimpleBindingPath, row)));
 
     const data = dataModelBindings.group
-      ? displayRows
+      ? getCommaSeparatedOptionsToText(displayRows?.join(','), options, langAsString)
       : getCommaSeparatedOptionsToText(formData?.simpleBinding, options, langAsString);
 
     return Object.values(data).join(', ');

--- a/src/layout/Summary2/CommonSummaryComponents/MultipleValueSummary.tsx
+++ b/src/layout/Summary2/CommonSummaryComponents/MultipleValueSummary.tsx
@@ -69,9 +69,8 @@ export const MultipleValueSummary = ({
     .map((row) => (!relativeSimpleBindingPath ? true : dot.pick(relativeSimpleBindingPath, row)));
 
   const displayValues = dataModelBindings.group
-    ? displayRows
+    ? Object.values(getCommaSeparatedOptionsToText(displayRows?.join(','), options, langAsString))
     : Object.values(getCommaSeparatedOptionsToText(rawFormData.simpleBinding, options, langAsString));
-
   const validations = useUnifiedValidationsForNode(componentNode);
   const errors = validationsOfSeverity(validations, 'error');
 

--- a/test/e2e/integration/component-library/checkboxes.ts
+++ b/test/e2e/integration/component-library/checkboxes.ts
@@ -333,6 +333,51 @@ describe('Checkboxes component', () => {
       .find('span.fds-paragraph') // Targets the span with the summary text
       .should('have.text', expectedText);
   });
+  it('Renders the summary2 component with correct text for Checkboxes with group, hard deletion and Number', () => {
+    cy.interceptLayout('ComponentLayouts', (component) => {
+      if (component.type === 'Checkboxes' && component.id === 'CheckboxesPage-Checkboxes2') {
+        component.deletionStrategy = 'hard';
+        component.dataModelBindings.checked = undefined;
+        component.optionsId = 'personsNumber';
+      }
+    });
+    cy.startAppInstance(appFrontend.apps.componentLibrary, { authenticationLevel: '2' });
+    cy.gotoNavPage('Avkryssningsbokser');
+
+    const checkboxes = '[data-componentid=CheckboxesPage-Checkboxes2]';
+    const summary2 = '[data-componentid=CheckboxesPage-Header-Summary2-Component2]';
+
+    const checkboxText1 = 'Karoline';
+    const checkboxText2 = 'Kåre';
+    const checkboxText3 = 'Johanne';
+    const checkboxText4 = 'Kari';
+    const checkboxText5 = 'Petter';
+
+    //Check options in checkboxes component
+    cy.get(checkboxes).contains('label', checkboxText1).prev('input[type="checkbox"]').click();
+    cy.get(checkboxes).contains('label', checkboxText2).prev('input[type="checkbox"]').click();
+    cy.get(checkboxes).contains('label', checkboxText3).prev('input[type="checkbox"]').click();
+    cy.get(checkboxes).contains('label', checkboxText4).prev('input[type="checkbox"]').click();
+    cy.get(checkboxes).contains('label', checkboxText5).prev('input[type="checkbox"]').click();
+
+    //Uncheck
+    cy.get(checkboxes).contains('label', checkboxText4).prev('input[type="checkbox"]').click();
+    cy.get(checkboxes).contains('label', checkboxText5).prev('input[type="checkbox"]').click();
+
+    //Check that checkboxes is correct
+    cy.get(checkboxes).contains('label', checkboxText1).prev('input[type="checkbox"]').should('be.checked');
+    cy.get(checkboxes).contains('label', checkboxText2).prev('input[type="checkbox"]').should('be.checked');
+    cy.get(checkboxes).contains('label', checkboxText3).prev('input[type="checkbox"]').should('be.checked');
+    cy.get(checkboxes).contains('label', checkboxText4).prev('input[type="checkbox"]').should('not.be.checked');
+    cy.get(checkboxes).contains('label', checkboxText5).prev('input[type="checkbox"]').should('not.be.checked');
+
+    const expectedText = [checkboxText1, checkboxText2, checkboxText3].join(', ');
+
+    cy.get(`div${summary2}`)
+      .next()
+      .find('span.fds-paragraph') // Targets the span with the summary text
+      .should('have.text', expectedText);
+  });
 
   //Required
   it('Required validation shows when chekcbox is selected with simpleBinding', () => {
@@ -381,6 +426,29 @@ describe('Checkboxes component', () => {
         component.required = true;
         component.deletionStrategy = 'hard';
         component.dataModelBindings.checked = undefined;
+      }
+    });
+    cy.startAppInstance(appFrontend.apps.componentLibrary, { authenticationLevel: '2' });
+    cy.gotoNavPage('Oppsummering 2.0');
+    cy.findByRole('button', { name: 'Send inn' }).click();
+    cy.gotoNavPage('Avkryssningsbokser');
+
+    const checkboxes = '[data-componentid=CheckboxesPage-Checkboxes2]';
+
+    cy.get(checkboxes).contains('span', 'Du må fylle ut hva skal kjøretøyet brukes til?').should('exist');
+
+    const checkboxText1 = 'Karoline';
+    cy.contains('label', checkboxText1).prev('input[type="checkbox"]').check();
+
+    cy.get(checkboxes).contains('span', 'Du må fylle ut hva skal kjøretøyet brukes til?').should('not.exist');
+  });
+  it('Required validation shows when chekcbox is selected with group, hard delete and Number', () => {
+    cy.interceptLayout('ComponentLayouts', (component) => {
+      if (component.type === 'Checkboxes' && component.id === 'CheckboxesPage-Checkboxes2') {
+        component.required = true;
+        component.deletionStrategy = 'hard';
+        component.dataModelBindings.checked = undefined;
+        component.optionsId = 'personsNumber';
       }
     });
     cy.startAppInstance(appFrontend.apps.componentLibrary, { authenticationLevel: '2' });


### PR DESCRIPTION
When using group functionality using label instead of value for summary and summary2

## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes #3397


## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [x] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->
