### PR TITLE
Add more shared tests for ["text"] expression

### DIFF
--- a/src/features/expressions/shared-tests/functions/text/lookup-from-multiple-sources.json
+++ b/src/features/expressions/shared-tests/functions/text/lookup-from-multiple-sources.json
@@ -1,0 +1,48 @@
+{
+  "name": "Lookup from multiple sources with and without default values",
+  "expression": [
+    "text",
+    "found.key"
+  ],
+  "expects": "my-non-existing-setting [setting not found] [setting1 Value] non.existing [non existing] From dataModel!",
+  "textResources": [
+    {
+      "id": "found.key",
+      "value": "{5} {4} {3} {2} {1} {0}!",
+      "variables": [
+        {
+          "key": "Name",
+          "dataSource": "dataModel.default"
+        },
+        {
+          "key": "non.existing",
+          "dataSource": "dataModel.default",
+          "defaultValue": "[non existing]"
+        },
+        {
+          "key": "non.existing",
+          "dataSource": "dataModel.default"
+        },
+        {
+          "key": "mySetting1",
+          "dataSource": "applicationSettings"
+        },
+        {
+          "key": "my-non-existing-setting",
+          "dataSource": "applicationSettings",
+          "defaultValue": "[setting not found]"
+        },
+        {
+          "key": "my-non-existing-setting",
+          "dataSource": "applicationSettings"
+        }
+      ]
+    }
+  ],
+  "dataModel": {
+    "Name": "From dataModel"
+  },
+  "frontendSettings": {
+    "mySetting1": "[setting1 Value]"
+  }
+}

--- a/src/features/expressions/shared-tests/functions/text/lookup-instance-data.json
+++ b/src/features/expressions/shared-tests/functions/text/lookup-instance-data.json
@@ -1,0 +1,42 @@
+{
+  "name": "Lookup from multiple sources with and without default values",
+  "expression": [
+    "text",
+    "found.key"
+  ],
+  "expects": "!123/3b1d693c-83d8-486b-84a0-0e04607951d9 123 unknown ttd/app {4} {5}!",
+  "textResources": [
+    {
+      "id": "found.key",
+      "value": "!{0} {1} {2} {3} {4} {5}!",
+      "variables": [
+        {
+          "key": "instanceId",
+          "dataSource": "instanceContext"
+        },
+        {
+          "key": "instanceOwnerPartyId",
+          "dataSource": "instanceContext"
+        },
+        {
+          "key": "instanceOwnerPartyType",
+          "dataSource": "instanceContext"
+        },
+        {
+          "key": "appId",
+          "dataSource": "instanceContext"
+        }
+      ]
+    }
+  ],
+  "instance": {
+    "id": "123/3b1d693c-83d8-486b-84a0-0e04607951d9",
+    "instanceOwner": {
+      "partyId": "123",
+      "organisationNumber": null,
+      "personNumber": null,
+      "username": null
+    },
+    "appId": "ttd/app"
+  }
+}

--- a/src/features/expressions/shared-tests/functions/text/use-default-when-dataModel-null.json
+++ b/src/features/expressions/shared-tests/functions/text/use-default-when-dataModel-null.json
@@ -1,0 +1,29 @@
+{
+  "name": "Text should fall back to default value when dataModel is null",
+  "expression": [
+    "text",
+    "found.key"
+  ],
+  "expects": "Hei verden!",
+  "textResources": [
+    {
+      "id": "found.key",
+      "value": "{0} {1}!",
+      "variables": [
+        {
+          "key": "Hello",
+          "dataSource": "dataModel.default",
+          "defaultValue": "Hei"
+        },
+        {
+          "key": "World",
+          "dataSource": "dataModel.default"
+        }
+      ]
+    }
+  ],
+  "dataModel": {
+    "Hello": null,
+    "World": "verden"
+  }
+}


### PR DESCRIPTION
I wrote some extra tests to double check the backend implementation for ["text"] expressions, just want to sync up with frontend.