### PR TITLE
Rewriting required-banner to use layout lookups

### DIFF
--- a/src/components/form/Form.tsx
+++ b/src/components/form/Form.tsx
@@ -32,7 +32,6 @@ import { getPageTitle } from 'src/utils/getPageTitle';
 import { NodesInternal, useNode } from 'src/utils/layout/NodesContext';
 import type { NavigateToNodeOptions } from 'src/features/form/layout/NavigateToNode';
 import type { AnyValidation, BaseValidation, NodeRefValidation } from 'src/features/validation';
-import type { NodeData } from 'src/utils/layout/types';
 
 interface FormState {
   hasRequired: boolean;
@@ -206,12 +205,6 @@ function useSetExpandedWidth() {
 }
 
 const emptyArray = [];
-
-function nodeDataIsRequired(n: NodeData) {
-  const item = n.item;
-  return !!(item && 'required' in item && item.required === true);
-}
-
 function useFormState(currentPageId: string | undefined): FormState {
   const lookups = useLayoutLookups();
   const topLevelIds = currentPageId ? (lookups.topLevelComponents[currentPageId] ?? emptyArray) : emptyArray;
@@ -244,9 +237,13 @@ function useFormState(currentPageId: string | undefined): FormState {
     return [toMainLayout.reverse(), toErrorReport.reverse()];
   }, [hasErrors, lookups.allComponents, topLevelIds]);
 
-  const hasRequired = NodesInternal.useSelector((state) =>
-    Object.values(state.nodeData).some((node) => node.pageKey === currentPageId && nodeDataIsRequired(node)),
-  );
+  const hasRequired =
+    (currentPageId &&
+      lookups.allPerPage[currentPageId]?.some((id) => {
+        const layout = lookups.allComponents[id];
+        return layout && 'required' in layout && layout.required !== false;
+      })) ||
+    false;
 
   return {
     hasRequired,


### PR DESCRIPTION
## Description

We have a banner on the top of every page that will show up whenever any fields on the page are required:

![20250605_13h17m08s_grim](https://github.com/user-attachments/assets/e3776ac7-38a0-4934-a38f-59878bae72e9)

For a while this has been popping in/out in cases where the `required` properties vary (when expression results change and no more components are required any longer). This requires it to read the result of expressions, and thus read from `NodesContext`, which we want to get rid of. This change reads from the static layout instead, and will always show the banner _if any components on the page can be required_, not only when they _are required_. Minor change, slightly breaking, but I think we can get away with it. It's also no longer causing a potential vertical shift that annoys users when required fields are toggled.

## Related Issue(s)

- #3147

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->
