### PR TITLE
Refactor: Moving the Likert layout fakery up to `LayoutsContext`

### DIFF
--- a/src/features/form/layout/LayoutsContext.tsx
+++ b/src/features/form/layout/LayoutsContext.tsx
@@ -15,7 +15,7 @@ import { useCurrentLayoutSetId } from 'src/features/form/layoutSets/useCurrentLa
 import { useHasInstance } from 'src/features/instance/InstanceContext';
 import { useLaxProcessData } from 'src/features/instance/ProcessContext';
 import { useNavigationParam } from 'src/features/routing/AppRoutingContext';
-import { makeLikertChildId } from 'src/layout/Likert/Generator/LikertGeneratorChildren';
+import { makeLikertChildId } from 'src/layout/Likert/Generator/makeLikertChildId';
 import type { QueryDefinition } from 'src/core/queries/usePrefetchQuery';
 import type { CompExternal, ILayoutCollection, ILayouts } from 'src/layout/layout';
 import type { IExpandedWidthLayouts, IHiddenLayoutsExternal } from 'src/types';

--- a/src/features/form/layout/LayoutsContext.tsx
+++ b/src/features/form/layout/LayoutsContext.tsx
@@ -15,8 +15,9 @@ import { useCurrentLayoutSetId } from 'src/features/form/layoutSets/useCurrentLa
 import { useHasInstance } from 'src/features/instance/InstanceContext';
 import { useLaxProcessData } from 'src/features/instance/ProcessContext';
 import { useNavigationParam } from 'src/features/routing/AppRoutingContext';
+import { makeLikertChildId } from 'src/layout/Likert/Generator/LikertGeneratorChildren';
 import type { QueryDefinition } from 'src/core/queries/usePrefetchQuery';
-import type { ILayoutCollection, ILayouts } from 'src/layout/layout';
+import type { CompExternal, ILayoutCollection, ILayouts } from 'src/layout/layout';
 import type { IExpandedWidthLayouts, IHiddenLayoutsExternal } from 'src/types';
 
 export interface LayoutContextValue {
@@ -124,6 +125,7 @@ function processLayouts(input: ILayoutCollection, layoutSetId: string, dataModel
 
   const withQuirksFixed = applyLayoutQuirks(layouts, layoutSetId);
   removeDuplicateComponentIds(withQuirksFixed, layoutSetId);
+  addLikertItemToLayout(withQuirksFixed);
 
   return {
     layouts: withQuirksFixed,
@@ -185,5 +187,41 @@ function removeDuplicateComponentIds(layouts: ILayouts, layoutSetId: string) {
     const _fullCode = `'${fullKey}': ${code.join('\n')},`;
     // Uncomment the next line to get the generated quirks code
     // debugger;
+  }
+}
+
+function addLikertItemToLayout(layouts: ILayouts) {
+  for (const pageKey of Object.keys(layouts)) {
+    const page = layouts[pageKey] || [];
+    for (const comp of page.values()) {
+      if (comp.type === 'Likert') {
+        const likertItem: CompExternal<'LikertItem'> = {
+          id: makeLikertChildId(comp.id, undefined),
+          type: 'LikertItem',
+          textResourceBindings: {
+            title: comp.textResourceBindings?.questions,
+          },
+          dataModelBindings: {
+            simpleBinding: comp.dataModelBindings?.answer,
+          },
+          options: comp.options,
+          optionsId: comp.optionsId,
+          mapping: comp.mapping,
+          required: comp.required,
+          secure: comp.secure,
+          queryParameters: comp.queryParameters,
+          readOnly: comp.readOnly,
+          sortOrder: comp.sortOrder,
+          showValidations: comp.showValidations,
+          grid: comp.grid,
+          source: comp.source,
+          hidden: comp.hidden,
+          pageBreak: comp.pageBreak,
+          renderAsSummary: comp.renderAsSummary,
+          columns: comp.columns,
+        };
+        page.push(likertItem);
+      }
+    }
   }
 }

--- a/src/layout/Likert/Generator/LikertGeneratorChildren.tsx
+++ b/src/layout/Likert/Generator/LikertGeneratorChildren.tsx
@@ -4,7 +4,7 @@ import { FD } from 'src/features/formData/FormDataWrite';
 import { getLikertStartStopIndex } from 'src/layout/Likert/rowUtils';
 import { GeneratorInternal, GeneratorRowProvider } from 'src/utils/layout/generator/GeneratorContext';
 import { GeneratorCondition, GeneratorRunProvider, StageAddNodes } from 'src/utils/layout/generator/GeneratorStages';
-import { GenerateNodeChildrenWithStaticLayout } from 'src/utils/layout/generator/LayoutSetGenerator';
+import { GenerateNodeChildren } from 'src/utils/layout/generator/LayoutSetGenerator';
 import {
   mutateComponentId,
   mutateComponentIdPlain,
@@ -12,7 +12,7 @@ import {
   mutateMapping,
 } from 'src/utils/layout/generator/NodeRepeatingChildren';
 import type { IDataModelReference } from 'src/layout/common.generated';
-import type { CompExternalExact, CompIntermediate } from 'src/layout/layout';
+import type { CompIntermediate } from 'src/layout/layout';
 import type { ChildClaims } from 'src/utils/layout/generator/GeneratorContext';
 
 export function LikertGeneratorChildren() {
@@ -69,35 +69,6 @@ const GenerateRow = React.memo(function GenerateRow({ rowIndex, questionsBinding
 
   const childId = makeLikertChildId(parentItem.id, undefined); // This needs to be the base ID
 
-  const externalItem = useMemo(
-    (): CompExternalExact<'LikertItem'> => ({
-      id: childId,
-      type: 'LikertItem',
-      textResourceBindings: {
-        title: parentItem.textResourceBindings?.questions,
-      },
-      dataModelBindings: {
-        simpleBinding: parentItem.dataModelBindings?.answer,
-      },
-      options: parentItem.options,
-      optionsId: parentItem.optionsId,
-      mapping: parentItem.mapping,
-      required: parentItem.required,
-      secure: parentItem.secure,
-      queryParameters: parentItem.queryParameters,
-      readOnly: parentItem.readOnly,
-      sortOrder: parentItem.sortOrder,
-      showValidations: parentItem.showValidations,
-      grid: parentItem.grid,
-      source: parentItem.source,
-      hidden: parentItem.hidden,
-      pageBreak: parentItem.pageBreak,
-      renderAsSummary: parentItem.renderAsSummary,
-      columns: parentItem.columns,
-    }),
-    [parentItem, childId],
-  );
-
   const childClaims = useMemo(
     (): ChildClaims => ({
       [childId]: {
@@ -105,13 +76,6 @@ const GenerateRow = React.memo(function GenerateRow({ rowIndex, questionsBinding
       },
     }),
     [childId],
-  );
-
-  const layoutMap = useMemo(
-    (): Record<string, CompExternalExact<'LikertItem'>> => ({
-      [childId]: externalItem,
-    }),
-    [childId, externalItem],
   );
 
   const recursiveMutators = useMemo(
@@ -131,9 +95,9 @@ const GenerateRow = React.memo(function GenerateRow({ rowIndex, questionsBinding
       groupBinding={questionsBinding}
       forceHidden={false}
     >
-      <GenerateNodeChildrenWithStaticLayout
+      <GenerateNodeChildren
         claims={childClaims}
-        staticLayoutMap={layoutMap}
+        pluginKey={'LikertRowsPlugin' as const}
       />
     </GeneratorRowProvider>
   );

--- a/src/layout/Likert/Generator/LikertGeneratorChildren.tsx
+++ b/src/layout/Likert/Generator/LikertGeneratorChildren.tsx
@@ -3,6 +3,7 @@ import React, { useMemo } from 'react';
 import { FD } from 'src/features/formData/FormDataWrite';
 import { makeLikertChildId } from 'src/layout/Likert/Generator/makeLikertChildId';
 import { getLikertStartStopIndex } from 'src/layout/Likert/rowUtils';
+import { DataModelLocationProvider } from 'src/utils/layout/DataModelLocation';
 import { GeneratorInternal, GeneratorRowProvider } from 'src/utils/layout/generator/GeneratorContext';
 import { GeneratorCondition, GeneratorRunProvider, StageAddNodes } from 'src/utils/layout/generator/GeneratorStages';
 import { GenerateNodeChildren } from 'src/utils/layout/generator/LayoutSetGenerator';
@@ -40,7 +41,7 @@ function LikertGeneratorChildrenWorker() {
     <>
       {filteredRows.map((row) => (
         <GeneratorRunProvider key={row.index}>
-          <GenerateRow
+          <GenerateLikertRow
             rowIndex={row.index}
             rowUuid={row.uuid}
             questionsBinding={questionsBinding}
@@ -57,7 +58,17 @@ interface GenerateRowProps {
   questionsBinding: IDataModelReference;
 }
 
-const GenerateRow = React.memo(function GenerateRow({ rowIndex, questionsBinding }: GenerateRowProps) {
+const GenerateLikertRow = React.memo((props: GenerateRowProps) => (
+  <DataModelLocationProvider
+    groupBinding={props.questionsBinding}
+    rowIndex={props.rowIndex}
+  >
+    <GenerateLikertRowInner {...props} />
+  </DataModelLocationProvider>
+));
+GenerateLikertRow.displayName = 'GenerateLikertRow';
+
+const GenerateLikertRowInner = React.memo(function ({ rowIndex, questionsBinding }: GenerateRowProps) {
   const parentItem = GeneratorInternal.useIntermediateItem() as CompIntermediate<'Likert'>;
   const depth = GeneratorInternal.useDepth();
 
@@ -97,4 +108,4 @@ const GenerateRow = React.memo(function GenerateRow({ rowIndex, questionsBinding
   );
 });
 
-GenerateRow.displayName = 'GenerateRow';
+GenerateLikertRowInner.displayName = 'GenerateLikertRowInner';

--- a/src/layout/Likert/Generator/LikertGeneratorChildren.tsx
+++ b/src/layout/Likert/Generator/LikertGeneratorChildren.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react';
 
 import { FD } from 'src/features/formData/FormDataWrite';
+import { makeLikertChildId } from 'src/layout/Likert/Generator/makeLikertChildId';
 import { getLikertStartStopIndex } from 'src/layout/Likert/rowUtils';
 import { GeneratorInternal, GeneratorRowProvider } from 'src/utils/layout/generator/GeneratorContext';
 import { GeneratorCondition, GeneratorRunProvider, StageAddNodes } from 'src/utils/layout/generator/GeneratorStages';
@@ -54,13 +55,6 @@ interface GenerateRowProps {
   rowIndex: number;
   rowUuid: string;
   questionsBinding: IDataModelReference;
-}
-
-export function makeLikertChildId(parentId: string, rowIndex: number | undefined) {
-  if (rowIndex === undefined) {
-    return `${parentId}-item`;
-  }
-  return `${parentId}-item-${rowIndex}`;
 }
 
 const GenerateRow = React.memo(function GenerateRow({ rowIndex, questionsBinding }: GenerateRowProps) {

--- a/src/layout/Likert/Generator/LikertRowsPlugin.tsx
+++ b/src/layout/Likert/Generator/LikertRowsPlugin.tsx
@@ -1,4 +1,5 @@
 import { CG } from 'src/codegen/CG';
+import { makeLikertChildId } from 'src/layout/Likert/Generator/LikertGeneratorChildren';
 import { NodeDefPlugin } from 'src/utils/layout/plugins/NodeDefPlugin';
 import type { ComponentConfig } from 'src/codegen/ComponentConfig';
 import type { IDataModelBindingsLikert } from 'src/layout/common.generated';
@@ -45,7 +46,9 @@ export class LikertRowsPlugin extends NodeDefPlugin<Config> implements NodeDefCh
     return `<${LikertGeneratorChildren} />`;
   }
 
-  claimChildren(_props: DefPluginChildClaimerProps<Config>) {}
+  claimChildren(props: DefPluginChildClaimerProps<Config>) {
+    props.claimChild(makeLikertChildId(props.item.id, undefined));
+  }
 
   isChildHidden(_state: DefPluginState<Config>, _childId: string): boolean {
     return false;

--- a/src/layout/Likert/Generator/LikertRowsPlugin.tsx
+++ b/src/layout/Likert/Generator/LikertRowsPlugin.tsx
@@ -1,5 +1,5 @@
 import { CG } from 'src/codegen/CG';
-import { makeLikertChildId } from 'src/layout/Likert/Generator/LikertGeneratorChildren';
+import { makeLikertChildId } from 'src/layout/Likert/Generator/makeLikertChildId';
 import { NodeDefPlugin } from 'src/utils/layout/plugins/NodeDefPlugin';
 import type { ComponentConfig } from 'src/codegen/ComponentConfig';
 import type { IDataModelBindingsLikert } from 'src/layout/common.generated';

--- a/src/layout/Likert/Generator/makeLikertChildId.ts
+++ b/src/layout/Likert/Generator/makeLikertChildId.ts
@@ -1,0 +1,6 @@
+export function makeLikertChildId(parentId: string, rowIndex: number | undefined) {
+  if (rowIndex === undefined) {
+    return `${parentId}-item`;
+  }
+  return `${parentId}-item-${rowIndex}`;
+}

--- a/src/layout/Likert/LikertComponent.tsx
+++ b/src/layout/Likert/LikertComponent.tsx
@@ -14,7 +14,7 @@ import { useIsMobileOrTablet } from 'src/hooks/useDeviceWidths';
 import { LayoutStyle } from 'src/layout/common.generated';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
 import { GenericComponentById } from 'src/layout/GenericComponent';
-import { makeLikertChildId } from 'src/layout/Likert/Generator/LikertGeneratorChildren';
+import { makeLikertChildId } from 'src/layout/Likert/Generator/makeLikertChildId';
 import { useLikertRows } from 'src/layout/Likert/rowUtils';
 import classes from 'src/layout/LikertItem/LikertItemComponent.module.css';
 import { DataModelLocationProvider } from 'src/utils/layout/DataModelLocation';

--- a/src/layout/Likert/Summary/LikertSummaryComponent.tsx
+++ b/src/layout/Likert/Summary/LikertSummaryComponent.tsx
@@ -6,7 +6,7 @@ import { useLanguage } from 'src/features/language/useLanguage';
 import { useDeepValidationsForNode } from 'src/features/validation/selectors/deepValidationsForNode';
 import { hasValidationErrors } from 'src/features/validation/utils';
 import { CompCategory } from 'src/layout/common';
-import { makeLikertChildId } from 'src/layout/Likert/Generator/LikertGeneratorChildren';
+import { makeLikertChildId } from 'src/layout/Likert/Generator/makeLikertChildId';
 import { useLikertRows } from 'src/layout/Likert/rowUtils';
 import { LargeLikertSummaryContainer } from 'src/layout/Likert/Summary/LargeLikertSummaryContainer';
 import classes from 'src/layout/Likert/Summary/LikertSummaryComponent.module.css';

--- a/src/layout/Likert/Summary2/LikertSummary.tsx
+++ b/src/layout/Likert/Summary2/LikertSummary.tsx
@@ -6,7 +6,7 @@ import { useDisplayData } from 'src/features/displayData/useDisplayData';
 import { Lang } from 'src/features/language/Lang';
 import { useUnifiedValidationsForNode } from 'src/features/validation/selectors/unifiedValidationsForNode';
 import { validationsOfSeverity } from 'src/features/validation/utils';
-import { makeLikertChildId } from 'src/layout/Likert/Generator/LikertGeneratorChildren';
+import { makeLikertChildId } from 'src/layout/Likert/Generator/makeLikertChildId';
 import { useLikertRows } from 'src/layout/Likert/rowUtils';
 import classes from 'src/layout/Likert/Summary2/LikertSummary.module.css';
 import { SingleValueSummary } from 'src/layout/Summary2/CommonSummaryComponents/SingleValueSummary';

--- a/src/layout/Likert/config.ts
+++ b/src/layout/Likert/config.ts
@@ -4,7 +4,7 @@ import { CompCategory } from 'src/layout/common';
 import { LikertRowsPlugin } from 'src/layout/Likert/Generator/LikertRowsPlugin';
 
 export const Config = new CG.component({
-  category: CompCategory.Form,
+  category: CompCategory.Container,
   directRendering: true,
   capabilities: {
     renderInTable: false,
@@ -16,10 +16,13 @@ export const Config = new CG.component({
     renderInTabs: true,
   },
   functionality: {
-    customExpressions: false,
+    customExpressions: true,
     displayData: false,
   },
 })
+  // Auto-generated LikertItem inside here is a form component, so this is a little bit of both a
+  // container and a form component
+  .extends(CG.common('FormComponentProps'))
   .addPlugin(new LikertRowsPlugin())
   .addTextResource(
     new CG.trb({

--- a/src/layout/Likert/index.tsx
+++ b/src/layout/Likert/index.tsx
@@ -9,7 +9,7 @@ import { LikertSummaryComponent } from 'src/layout/Likert/Summary/LikertSummaryC
 import { LikertSummary } from 'src/layout/Likert/Summary2/LikertSummary';
 import type { LayoutValidationCtx } from 'src/features/devtools/layoutValidation/types';
 import type { ComponentValidation } from 'src/features/validation';
-import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
+import type { ExprResolver, SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types';
 
 export class Likert extends LikertDef {
@@ -55,5 +55,13 @@ export class Likert extends LikertDef {
     }
 
     return errors;
+  }
+
+  evalExpressions(props: ExprResolver<'Likert'>) {
+    return {
+      ...this.evalDefaultExpressions(props),
+      required: props.evalBool(props.item.required, false),
+      readOnly: props.evalBool(props.item.readOnly, false),
+    };
   }
 }

--- a/src/utils/layout/generator/LayoutSetGenerator.tsx
+++ b/src/utils/layout/generator/LayoutSetGenerator.tsx
@@ -15,7 +15,7 @@ import { GeneratorCondition, StageAddNodes, StageMarkHidden } from 'src/utils/la
 import { useEvalExpressionInGenerator } from 'src/utils/layout/generator/useEvalExpression';
 import { LayoutPage } from 'src/utils/layout/LayoutPage';
 import { Hidden, NodesInternal, NodesStore, useNodes } from 'src/utils/layout/NodesContext';
-import type { CompExternal, CompExternalExact, CompTypes, ILayout } from 'src/layout/layout';
+import type { CompExternalExact, CompTypes, ILayout } from 'src/layout/layout';
 import type { NodeGeneratorProps } from 'src/layout/LayoutComponent';
 import type { ChildClaim, ChildClaims } from 'src/utils/layout/generator/GeneratorContext';
 import type { LayoutPages } from 'src/utils/layout/LayoutPages';
@@ -189,57 +189,14 @@ interface NodeChildrenProps {
 export function GenerateNodeChildren({ claims, pluginKey }: NodeChildrenProps) {
   const layoutMap = useLayoutLookups().allComponents;
   const filteredClaims = useFilteredClaims(claims, pluginKey);
-
-  return (
-    <GeneratorCondition
-      stage={StageAddNodes}
-      mustBeAdded='parent'
-    >
-      <GenerateNodeChildrenInternal
-        claims={filteredClaims}
-        layoutMap={layoutMap}
-      />
-    </GeneratorCondition>
-  );
-}
-
-interface NodeChildrenStaticLayoutProps {
-  staticLayoutMap: Record<string, CompExternal>;
-  claims: ChildClaims;
-  pluginKey?: string;
-}
-
-export function GenerateNodeChildrenWithStaticLayout({
-  claims,
-  pluginKey,
-  staticLayoutMap,
-}: NodeChildrenStaticLayoutProps) {
-  const filteredClaims = useFilteredClaims(claims, pluginKey);
-
-  return (
-    <GeneratorCondition
-      stage={StageAddNodes}
-      mustBeAdded='parent'
-    >
-      <GenerateNodeChildrenInternal
-        claims={filteredClaims}
-        layoutMap={staticLayoutMap}
-      />
-    </GeneratorCondition>
-  );
-}
-
-interface NodeChildrenInternalProps {
-  claims: ChildClaims;
-  layoutMap: Record<string, CompExternal | undefined>;
-}
-
-function GenerateNodeChildrenInternal({ claims, layoutMap }: NodeChildrenInternalProps) {
   const map = useLayoutLookups().childClaims;
 
   return (
-    <>
-      {Object.keys(claims).map((id) => {
+    <GeneratorCondition
+      stage={StageAddNodes}
+      mustBeAdded='parent'
+    >
+      {Object.keys(filteredClaims).map((id) => {
         const layout = layoutMap[id];
         if (!layout) {
           return null;
@@ -249,13 +206,13 @@ function GenerateNodeChildrenInternal({ claims, layoutMap }: NodeChildrenInterna
           <GeneratorErrorBoundary key={id}>
             <GenerateComponent
               layout={layout}
-              claim={claims[id]}
+              claim={filteredClaims[id]}
               childClaims={map[id]}
             />
           </GeneratorErrorBoundary>
         );
       })}
-    </>
+    </GeneratorCondition>
   );
 }
 


### PR DESCRIPTION
## Description

The Likert component relies on using a trick where `LikertItem` components are generated for every `Likert` component, and the `Likert` component acts as a repeating group which adopts all the `LikertItem` components (one for each row in the data model). This was done in the hierarchy generator using a concept implemented there for 'static layouts' that were generated on the fly. This solution didn't work properly when refactoring `useNodeItem()`, as the `LikertItem` component was not available in `layoutLookups`. This change will make it easier to refactor us away from the node generator without having to do special stuff for Likert.

## Related Issue(s)

- #3147

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [x] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->
