### PR TITLE
Improves screen reader experience for new page navigation

### DIFF
--- a/src/components/LandmarkShortcuts.tsx
+++ b/src/components/LandmarkShortcuts.tsx
@@ -27,7 +27,7 @@ export function LandmarkShortcuts({ shortcuts }: ILandmarkShortcutsProps) {
   };
 
   return (
-    <nav>
+    <nav aria-label='Til hovedinnhold'>
       {shortcuts.map((shortcut) => (
         <button
           key={shortcut.id}

--- a/src/features/navigation/AppNavigation.tsx
+++ b/src/features/navigation/AppNavigation.tsx
@@ -86,13 +86,17 @@ export function AppNavigation({ onNavigate }: { onNavigate?: () => void }) {
   return null;
 }
 
+export const appNavigationHeadingId = 'app-navigation-heading';
 export function AppNavigationHeading({
   showClose,
   onClose,
 }: { showClose?: undefined; onClose?: undefined } | { showClose: true; onClose: () => void }) {
   const { langAsString } = useLanguage();
   return (
-    <div className={classes.navigationHeading}>
+    <div
+      id={appNavigationHeadingId}
+      className={classes.navigationHeading}
+    >
       <Heading
         id='app-navigation-heading'
         level={3}

--- a/src/features/navigation/SidebarNavigation.tsx
+++ b/src/features/navigation/SidebarNavigation.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { useUiConfigContext } from 'src/features/form/layout/UiConfigContext';
-import { AppNavigation, AppNavigationHeading } from 'src/features/navigation/AppNavigation';
+import { AppNavigation, AppNavigationHeading, appNavigationHeadingId } from 'src/features/navigation/AppNavigation';
 import classes from 'src/features/navigation/SidebarNavigation.module.css';
 import { SIDEBAR_BREAKPOINT, useHasGroupedNavigation } from 'src/features/navigation/utils';
 import { useBrowserWidth } from 'src/hooks/useDeviceWidths';
@@ -18,7 +18,9 @@ export function SideBarNavigation() {
   return (
     <aside className={classes.sidebarContainer}>
       <AppNavigationHeading />
-      <AppNavigation />
+      <nav aria-labelledby={appNavigationHeadingId}>
+        <AppNavigation />
+      </nav>
     </aside>
   );
 }


### PR DESCRIPTION
## Description
Gjør sidenavigasjon om og til et landemerke med aria-label slik at det lett kan navigeres til med skjermlesere. 

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [x] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->
