### PR TITLE
add ApiTable summary mode support

### DIFF
--- a/src/layout/SimpleTable/ApiTableSummary.tsx
+++ b/src/layout/SimpleTable/ApiTableSummary.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+
+import { pick } from 'dot-object';
+
+import { AppTable } from 'src/app-components/Table/Table';
+import { Caption } from 'src/components/form/caption/Caption';
+import { useExternalApis } from 'src/features/externalApi/useExternalApi';
+import { Lang } from 'src/features/language/Lang';
+import { useIsMobile } from 'src/hooks/useDeviceWidths';
+import { isFormDataObject, isFormDataObjectArray } from 'src/layout/SimpleTable/typeguards';
+import { SummaryContains, SummaryFlex } from 'src/layout/Summary2/SummaryComponent2/ComponentSummary';
+import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import type { FormDataObject } from 'src/app-components/DynamicForm/DynamicForm';
+import type { LayoutNode } from 'src/utils/layout/LayoutNode';
+
+type ApiTableSummaryProps = {
+  componentNode: LayoutNode<'SimpleTable'>;
+};
+
+export function ApiTableSummary({ componentNode }: ApiTableSummaryProps) {
+  const { externalApi, textResourceBindings, columns, required } = useNodeItem(componentNode, (item) => ({
+    externalApi: item.externalApi,
+    textResourceBindings: item.textResourceBindings,
+    columns: item.columns,
+    required: item.required,
+  }));
+
+  const { title } = textResourceBindings ?? {};
+  const isMobile = useIsMobile();
+  const { data } = useExternalApis(externalApi ? [externalApi.id] : []);
+
+  if (!externalApi || !data[externalApi.id]) {
+    return null;
+  }
+
+  const value = pick(externalApi.path, data[externalApi.id]);
+
+  if (!value || (!isFormDataObject(value) && !isFormDataObjectArray(value))) {
+    return null;
+  }
+
+  let dataToDisplay: FormDataObject[] = [];
+
+  if (!Array.isArray(value)) {
+    dataToDisplay.push(value);
+  } else {
+    dataToDisplay = value;
+  }
+  return (
+    <SummaryFlex
+      target={componentNode}
+      content={
+        !Array.isArray(data) || data.length === 0
+          ? required
+            ? SummaryContains.EmptyValueRequired
+            : SummaryContains.EmptyValueNotRequired
+          : SummaryContains.SomeUserContent
+      }
+    >
+      <AppTable
+        caption={title && <Caption title={<Lang id={title} />} />}
+        data={dataToDisplay}
+        columns={columns.map((config) => ({
+          ...config,
+          header: <Lang id={config.header} />,
+        }))}
+        mobile={isMobile}
+        emptyText={<Lang id='general.empty_table' />}
+      />
+    </SummaryFlex>
+  );
+}

--- a/src/layout/SimpleTable/index.tsx
+++ b/src/layout/SimpleTable/index.tsx
@@ -1,6 +1,7 @@
 import React, { forwardRef } from 'react';
 
 import { ApiTable } from 'src/layout/SimpleTable/ApiTable';
+import { ApiTableSummary } from 'src/layout/SimpleTable/ApiTableSummary';
 import { SimpleTableDef } from 'src/layout/SimpleTable/config.def.generated';
 import { SimpleTableComponent } from 'src/layout/SimpleTable/SimpleTableComponent';
 import { SimpleTableFeatureFlagLayoutValidator } from 'src/layout/SimpleTable/SimpleTableFeatureFlagLayoutValidator';
@@ -39,7 +40,17 @@ export class SimpleTable extends SimpleTableDef {
     return false;
   }
   renderSummary2(props: Summary2Props<'SimpleTable'>): React.JSX.Element | null {
-    return <SimpleTableSummary componentNode={props.target} />;
+    const item = useNodeItem(props.target);
+
+    if (item.externalApi) {
+      return <ApiTableSummary componentNode={props.target} />;
+    }
+
+    if (item.dataModelBindings) {
+      return <SimpleTableSummary componentNode={props.target} />;
+    }
+
+    return null;
   }
   render = forwardRef<HTMLElement, PropsFromGenericComponent<'SimpleTable'>>(
     function LayoutComponentTableRender(props, _): React.JSX.Element | null {


### PR DESCRIPTION
## Description

Summary2 support was missing for tables with API data.

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->
