### PR TITLE
Refactor: Make node object required in `useNodeItem()`

### DIFF
--- a/src/features/devtools/components/NodeInspector/NodeHierarchy.tsx
+++ b/src/features/devtools/components/NodeInspector/NodeHierarchy.tsx
@@ -123,14 +123,10 @@ const NodeHierarchyItem = ({ nodeId, onClick, selected }: INodeHierarchyItemProp
 };
 
 function RepeatingGroupExtensions({ nodeId, selected, onClick }: INodeHierarchyItemProps) {
-  const node = useNode(nodeId) as LayoutNode<'RepeatingGroup'> | undefined;
+  const node = useNode(nodeId) as LayoutNode<'RepeatingGroup'>;
   const nodeItem = useNodeItem(node);
   const rows = RepGroupHooks.useAllRowsWithHidden(node);
   const childIds = RepGroupHooks.useChildIds(node);
-
-  if (!nodeItem) {
-    return null;
-  }
 
   return (
     <>

--- a/src/features/form/layout/utils/makeIndexedId.ts
+++ b/src/features/form/layout/utils/makeIndexedId.ts
@@ -82,10 +82,9 @@ function findRepeatingParents(
   return repeating;
 }
 
-export function useIndexedComponentIds(componentIds: string[], dataModelLocation?: IDataModelReference): string[] {
+export function useIndexedComponentIds(componentIds: string[]): string[] {
   const lookups = useLayoutLookups();
-  const currentDataModelLocation = useCurrentDataModelLocation();
-  const location = dataModelLocation || currentDataModelLocation;
+  const location = useCurrentDataModelLocation();
   return componentIds.map((id) => {
     const indexed = makeIndexedId(id, location, lookups);
     if (indexed === undefined) {

--- a/src/features/pdf/PdfView2.tsx
+++ b/src/features/pdf/PdfView2.tsx
@@ -19,7 +19,7 @@ import { usePageOrder } from 'src/hooks/useNavigatePage';
 import { getComponentDef } from 'src/layout';
 import { GenericComponentById } from 'src/layout/GenericComponent';
 import { InstanceInformation } from 'src/layout/InstanceInformation/InstanceInformationComponent';
-import { SubformSummaryComponent2 } from 'src/layout/Subform/Summary/SubformSummaryComponent2';
+import { AllSubformSummaryComponent2 } from 'src/layout/Subform/Summary/SubformSummaryComponent2';
 import { SummaryComponentFor } from 'src/layout/Summary/SummaryComponent';
 import { ComponentSummary } from 'src/layout/Summary2/SummaryComponent2/ComponentSummary';
 import { SummaryComponent2 } from 'src/layout/Summary2/SummaryComponent2/SummaryComponent2';
@@ -69,7 +69,7 @@ export const PDFView2 = () => {
               pdfSettings={pdfSettings}
             />
           ))}
-        <SubformSummaryComponent2 />
+        <AllSubformSummaryComponent2 />
       </PdfWrapping>
     </DummyPresentation>
   );

--- a/src/features/pdf/PdfView2.tsx
+++ b/src/features/pdf/PdfView2.tsx
@@ -20,7 +20,7 @@ import { getComponentDef } from 'src/layout';
 import { GenericComponentById } from 'src/layout/GenericComponent';
 import { InstanceInformation } from 'src/layout/InstanceInformation/InstanceInformationComponent';
 import { SubformSummaryComponent2 } from 'src/layout/Subform/Summary/SubformSummaryComponent2';
-import { SummaryComponent } from 'src/layout/Summary/SummaryComponent';
+import { SummaryComponentFor } from 'src/layout/Summary/SummaryComponent';
 import { ComponentSummary } from 'src/layout/Summary2/SummaryComponent2/ComponentSummary';
 import { SummaryComponent2 } from 'src/layout/Summary2/SummaryComponent2/SummaryComponent2';
 import { isHidden, NodesInternal, useNode } from 'src/utils/layout/NodesContext';
@@ -198,10 +198,9 @@ function PdfForNode({ nodeId }: { nodeId: string }) {
   }
 
   return (
-    <SummaryComponent
-      summaryNode={undefined}
+    <SummaryComponentFor
+      targetNode={node}
       overrides={{
-        targetNode: node,
         largeGroup: node.isType('Group'),
         display: {
           hideChangeButton: true,

--- a/src/features/pdf/PdfView2.tsx
+++ b/src/features/pdf/PdfView2.tsx
@@ -183,10 +183,6 @@ function PdfForNode({ nodeId }: { nodeId: string }) {
   const node = useNode(nodeId);
   const target = useNodeItem(node, (i) => (i.type === 'Summary2' ? i.target : undefined));
 
-  if (!node) {
-    return null;
-  }
-
   if (node.isType('Summary2') && target?.taskId) {
     return (
       <SummaryComponent2

--- a/src/features/validation/ComponentValidations.tsx
+++ b/src/features/validation/ComponentValidations.tsx
@@ -14,14 +14,22 @@ import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 interface Props {
   validations: NodeValidation[] | undefined;
-  node?: LayoutNode;
+  node: LayoutNode;
 }
 
 export function AllComponentValidations({ node: _node }: { node?: LayoutNode }) {
   const currentNode = useCurrentNode();
   const node = _node ?? currentNode;
+  if (!node) {
+    throw new Error('No node provided to AllComponentValidations. Please report this bug.');
+  }
   const validations = useUnifiedValidationsForNode(node);
-  return <ComponentValidations validations={validations} />;
+  return (
+    <ComponentValidations
+      validations={validations}
+      node={node}
+    />
+  );
 }
 
 export function ComponentValidations({ validations, node: _node }: Props) {

--- a/src/layout/Address/AddressComponent.tsx
+++ b/src/layout/Address/AddressComponent.tsx
@@ -98,7 +98,10 @@ export function AddressComponent({ node }: IAddressProps) {
             />
           </Flex>
         </Label>
-        <ComponentValidations validations={bindingValidations?.address} />
+        <ComponentValidations
+          validations={bindingValidations?.address}
+          node={node}
+        />
       </div>
 
       {!simplified && (
@@ -131,7 +134,10 @@ export function AddressComponent({ node }: IAddressProps) {
                 readOnly={readOnly}
                 autoComplete='address-line2'
               />
-              <ComponentValidations validations={bindingValidations?.careOf} />
+              <ComponentValidations
+                validations={bindingValidations?.careOf}
+                node={node}
+              />
             </Flex>
           </Label>
         </div>
@@ -175,7 +181,10 @@ export function AddressComponent({ node }: IAddressProps) {
                 inputMode='numeric'
                 autoComplete='postal-code'
               />
-              <ComponentValidations validations={bindingValidations?.zipCode} />
+              <ComponentValidations
+                validations={bindingValidations?.zipCode}
+                node={node}
+              />
             </Flex>
           </Label>
         </Flex>
@@ -255,10 +264,16 @@ export function AddressComponent({ node }: IAddressProps) {
               </div>
             </Flex>
           </Label>
-          <ComponentValidations validations={bindingValidations?.houseNumber} />
+          <ComponentValidations
+            validations={bindingValidations?.houseNumber}
+            node={node}
+          />
         </div>
       )}
-      <ComponentValidations validations={componentValidations} />
+      <ComponentValidations
+        validations={componentValidations}
+        node={node}
+      />
     </div>
   );
 }

--- a/src/layout/Cards/CardsSummary.tsx
+++ b/src/layout/Cards/CardsSummary.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { SummaryComponent } from 'src/layout/Summary/SummaryComponent';
+import { SummaryComponentFor } from 'src/layout/Summary/SummaryComponent';
 import { EmptyChildrenBoundary } from 'src/layout/Summary2/isEmpty/EmptyChildrenContext';
 import { ComponentSummaryById, SummaryFlexForContainer } from 'src/layout/Summary2/SummaryComponent2/ComponentSummary';
 import { useSummaryProp } from 'src/layout/Summary2/summaryStoreContext';
@@ -9,21 +9,20 @@ import { useNodeItem } from 'src/utils/layout/useNodeItem';
 import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types';
 
-type Props = Pick<SummaryRendererProps<'Cards'>, 'targetNode' | 'summaryNode' | 'overrides'>;
+type Props = Pick<SummaryRendererProps<'Cards'>, 'targetNode' | 'overrides'>;
 
-function Child({ id, summaryNode, overrides }: { id: string | undefined } & Pick<Props, 'summaryNode' | 'overrides'>) {
+function Child({ id, overrides }: { id: string | undefined } & Pick<Props, 'overrides'>) {
   const child = useNode(id);
   if (!child) {
     return null;
   }
 
   return (
-    <SummaryComponent
+    <SummaryComponentFor
       key={child.id}
-      summaryNode={summaryNode}
+      targetNode={child}
       overrides={{
         ...overrides,
-        targetNode: child,
         grid: {},
         largeGroup: true,
       }}
@@ -31,7 +30,7 @@ function Child({ id, summaryNode, overrides }: { id: string | undefined } & Pick
   );
 }
 
-export function CardsSummary({ targetNode, summaryNode, overrides }: Props) {
+export function CardsSummary({ targetNode, overrides }: Props) {
   const cardsInternal = useNodeItem(targetNode, (i) => i.cardsInternal);
   const childIds = cardsInternal.map((card) => card.childIds).flat();
 
@@ -41,7 +40,6 @@ export function CardsSummary({ targetNode, summaryNode, overrides }: Props) {
         <Child
           key={childId}
           id={childId}
-          summaryNode={summaryNode}
           overrides={overrides}
         />
       ))}

--- a/src/layout/Cards/index.tsx
+++ b/src/layout/Cards/index.tsx
@@ -28,11 +28,10 @@ export class Cards extends CardsDef {
     );
   }
 
-  renderSummary({ summaryNode, targetNode, overrides }: SummaryRendererProps<'Cards'>): JSX.Element | null {
+  renderSummary({ targetNode, overrides }: SummaryRendererProps<'Cards'>): JSX.Element | null {
     return (
       <CardsSummary
         targetNode={targetNode}
-        summaryNode={summaryNode}
         overrides={overrides}
       />
     );

--- a/src/layout/FileUploadWithTag/EditWindowComponent.tsx
+++ b/src/layout/FileUploadWithTag/EditWindowComponent.tsx
@@ -228,7 +228,10 @@ export function EditWindowComponent({
             whiteSpace: 'pre-wrap',
           }}
         >
-          <ComponentValidations validations={attachmentValidations} />
+          <ComponentValidations
+            validations={attachmentValidations}
+            node={node}
+          />
         </div>
       ) : undefined}
     </div>

--- a/src/layout/GenericComponent.tsx
+++ b/src/layout/GenericComponent.tsx
@@ -7,7 +7,7 @@ import { NavigationResult, useFinishNodeNavigation } from 'src/features/form/lay
 import { Lang } from 'src/features/language/Lang';
 import { FormComponentContextProvider } from 'src/layout/FormComponentContext';
 import classes from 'src/layout/GenericComponent.module.css';
-import { SummaryComponent } from 'src/layout/Summary/SummaryComponent';
+import { SummaryComponentFor } from 'src/layout/Summary/SummaryComponent';
 import { pageBreakStyles } from 'src/utils/formComponentUtils';
 import { isDev } from 'src/utils/isDev';
 import { ComponentErrorBoundary } from 'src/utils/layout/ComponentErrorBoundary';
@@ -194,16 +194,14 @@ function ActualGenericComponent<Type extends CompTypes = CompTypes>({
 
   if (renderAsSummary) {
     const RenderSummary = 'renderSummary' in node.def ? node.def.renderSummary.bind(node.def) : null;
-
     if (!RenderSummary) {
       return null;
     }
 
     return (
-      <SummaryComponent
-        summaryNode={undefined}
+      <SummaryComponentFor
+        targetNode={node}
         overrides={{
-          targetNode: node,
           display: { hideChangeButton: true, hideValidationMessages: true },
         }}
       />

--- a/src/layout/Grid/GridComponent.tsx
+++ b/src/layout/Grid/GridComponent.tsx
@@ -185,7 +185,7 @@ interface CellWithTextProps extends PropsWithChildren, CellProps {
 }
 
 interface CellWithLabelProps extends CellProps {
-  labelFrom?: string;
+  labelFrom: string;
 }
 
 function CellWithComponent({

--- a/src/layout/Grid/GridSummaryComponent.tsx
+++ b/src/layout/Grid/GridSummaryComponent.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { useNodeIdsFromGrid } from 'src/layout/Grid/tools';
-import { SummaryComponent } from 'src/layout/Summary/SummaryComponent';
+import { SummaryComponentFor } from 'src/layout/Summary/SummaryComponent';
 import { useNode } from 'src/utils/layout/NodesContext';
 import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 
@@ -26,7 +26,6 @@ function Child({
   nodeId,
   isLast,
   overrides,
-  summaryNode,
 }: { nodeId: string; isLast: boolean } & Omit<SummaryRendererProps<'Grid'>, 'targetNode'>) {
   const node = useNode(nodeId);
 
@@ -35,11 +34,10 @@ function Child({
   }
 
   return (
-    <SummaryComponent
-      summaryNode={summaryNode}
+    <SummaryComponentFor
+      targetNode={node}
       overrides={{
         ...overrides,
-        targetNode: node,
         display: {
           ...overrides?.display,
           hideBottomBorder: isLast,

--- a/src/layout/Grid/tools.ts
+++ b/src/layout/Grid/tools.ts
@@ -7,7 +7,7 @@ import type { IsHiddenSelector } from 'src/utils/layout/NodesContext';
 
 const emptyArray: never[] = [];
 
-export function useNodeIdsFromGrid(grid: LayoutNode<'Grid'> | undefined, enabled = true) {
+export function useNodeIdsFromGrid(grid: LayoutNode<'Grid'>, enabled = true) {
   const isHiddenSelector = Hidden.useIsHiddenSelector();
   const rows = useNodeItem(grid, (item) => item.rowsInternal);
   return enabled && grid && rows ? nodeIdsFromGridRows(rows, isHiddenSelector) : emptyArray;

--- a/src/layout/Group/SummaryGroupComponent.test.tsx
+++ b/src/layout/Group/SummaryGroupComponent.test.tsx
@@ -21,13 +21,12 @@ describe('SummaryGroupComponent', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  function TestComponent({ node, groupId }: { node: LayoutNode<'Summary'>; groupId: string }) {
+  function TestComponent({ groupId }: { groupId: string }) {
     const groupNode = useNode(groupId) as LayoutNode<'Group'>;
     return (
       <SummaryGroupComponent
         changeText='Change'
         onChangeClick={mockHandleDataChange}
-        summaryNode={node}
         targetNode={groupNode}
       />
     );
@@ -37,12 +36,7 @@ describe('SummaryGroupComponent', () => {
     return await renderWithNode<true, LayoutNode<'Summary'>>({
       nodeId: 'mySummary',
       inInstance: true,
-      renderer: ({ node }) => (
-        <TestComponent
-          node={node}
-          groupId='groupComponent'
-        />
-      ),
+      renderer: () => <TestComponent groupId='groupComponent' />,
       queries: {
         fetchFormData: async () => ({
           mockGroup: [

--- a/src/layout/Group/SummaryGroupComponent.tsx
+++ b/src/layout/Group/SummaryGroupComponent.tsx
@@ -9,7 +9,7 @@ import { CompCategory } from 'src/layout/common';
 import { GroupComponent } from 'src/layout/Group/GroupComponent';
 import classes from 'src/layout/Group/SummaryGroupComponent.module.css';
 import { EditButton } from 'src/layout/Summary/EditButton';
-import { SummaryComponent } from 'src/layout/Summary/SummaryComponent';
+import { SummaryComponentFor } from 'src/layout/Summary/SummaryComponent';
 import { Hidden } from 'src/utils/layout/NodesContext';
 import { useNodeDirectChildren, useNodeItem } from 'src/utils/layout/useNodeItem';
 import type { CompTypes, ITextResourceBindings } from 'src/layout/layout';
@@ -19,14 +19,12 @@ import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 export function SummaryGroupComponent({
   onChangeClick,
   changeText,
-  summaryNode,
   targetNode,
   overrides,
 }: SummaryRendererProps<'Group'>) {
-  const summaryItem = useNodeItem(summaryNode);
   const targetItem = useNodeItem(targetNode);
-  const excludedChildren = summaryItem?.excludedChildren;
-  const display = overrides?.display || summaryItem?.display;
+  const excludedChildren = overrides?.excludedChildren;
+  const display = overrides?.display;
   const { langAsString } = useLanguage();
   const isHidden = Hidden.useIsHiddenSelector();
 
@@ -47,7 +45,7 @@ export function SummaryGroupComponent({
   const ariaLabel = langAsString(summaryAccessibleTitleTrb ?? summaryTitleTrb ?? titleTrb);
   const children = useNodeDirectChildren(targetNode).filter((n) => !inExcludedChildren(n));
 
-  const largeGroup = overrides?.largeGroup ?? summaryItem?.largeGroup ?? false;
+  const largeGroup = overrides?.largeGroup ?? false;
   if (largeGroup) {
     return (
       <GroupComponent
@@ -59,7 +57,6 @@ export function SummaryGroupComponent({
           <SummaryComponentFromNode
             key={node.id}
             targetNode={node}
-            summaryNode={summaryNode}
             overrides={overrides}
             inExcludedChildren={inExcludedChildren}
           />
@@ -80,7 +77,6 @@ export function SummaryGroupComponent({
         changeText={changeText}
         key={child.id}
         targetNode={child}
-        summaryNode={summaryNode}
         overrides={{}}
       />
     );
@@ -130,28 +126,21 @@ export function SummaryGroupComponent({
   );
 }
 
-interface SummaryComponentFromRefProps
-  extends Pick<SummaryRendererProps<CompTypes>, 'targetNode' | 'summaryNode' | 'overrides'> {
+interface SummaryComponentFromRefProps extends Pick<SummaryRendererProps<CompTypes>, 'targetNode' | 'overrides'> {
   inExcludedChildren: (node: LayoutNode) => boolean;
 }
 
-function SummaryComponentFromNode({
-  targetNode,
-  inExcludedChildren,
-  summaryNode,
-  overrides,
-}: SummaryComponentFromRefProps) {
+function SummaryComponentFromNode({ targetNode, inExcludedChildren, overrides }: SummaryComponentFromRefProps) {
   const isHidden = Hidden.useIsHidden(targetNode);
   if (inExcludedChildren(targetNode) || isHidden) {
     return null;
   }
 
   return (
-    <SummaryComponent
-      summaryNode={summaryNode}
+    <SummaryComponentFor
+      targetNode={targetNode}
       overrides={{
         ...overrides,
-        targetNode,
         grid: {},
         largeGroup: true,
       }}

--- a/src/layout/LayoutComponent.tsx
+++ b/src/layout/LayoutComponent.tsx
@@ -32,7 +32,7 @@ import type {
   ITextResourceBindingsExternal,
   NodeValidationProps,
 } from 'src/layout/layout';
-import type { ISummaryComponent } from 'src/layout/Summary/SummaryComponent';
+import type { LegacySummaryOverrides } from 'src/layout/Summary/SummaryComponent';
 import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types';
 import type { ChildClaim, ChildClaims } from 'src/utils/layout/generator/GeneratorContext';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
@@ -197,11 +197,10 @@ export abstract class PresentationComponent<Type extends CompTypes> extends AnyC
 }
 
 export interface SummaryRendererProps<Type extends CompTypes> {
-  summaryNode: LayoutNode<'Summary'>;
   targetNode: LayoutNode<Type>;
   onChangeClick: () => void;
   changeText: string | null;
-  overrides?: ISummaryComponent['overrides'];
+  overrides?: LegacySummaryOverrides;
 }
 
 abstract class _FormComponent<Type extends CompTypes> extends AnyComponent<Type> {

--- a/src/layout/LayoutComponent.tsx
+++ b/src/layout/LayoutComponent.tsx
@@ -197,7 +197,7 @@ export abstract class PresentationComponent<Type extends CompTypes> extends AnyC
 }
 
 export interface SummaryRendererProps<Type extends CompTypes> {
-  summaryNode: LayoutNode<'Summary'> | undefined;
+  summaryNode: LayoutNode<'Summary'>;
   targetNode: LayoutNode<Type>;
   onChangeClick: () => void;
   changeText: string | null;

--- a/src/layout/Likert/Summary/LikertSummaryComponent.tsx
+++ b/src/layout/Likert/Summary/LikertSummaryComponent.tsx
@@ -11,7 +11,7 @@ import { useLikertRows } from 'src/layout/Likert/rowUtils';
 import { LargeLikertSummaryContainer } from 'src/layout/Likert/Summary/LargeLikertSummaryContainer';
 import classes from 'src/layout/Likert/Summary/LikertSummaryComponent.module.css';
 import { EditButton } from 'src/layout/Summary/EditButton';
-import { SummaryComponent } from 'src/layout/Summary/SummaryComponent';
+import { SummaryComponentFor } from 'src/layout/Summary/SummaryComponent';
 import { DataModelLocationProvider } from 'src/utils/layout/DataModelLocation';
 import { Hidden, useNode } from 'src/utils/layout/NodesContext';
 import { useNodeItem } from 'src/utils/layout/useNodeItem';
@@ -24,14 +24,12 @@ import type { BaseRow } from 'src/utils/layout/types';
 export function LikertSummaryComponent({
   onChangeClick,
   changeText,
-  summaryNode,
   targetNode,
   overrides,
 }: SummaryRendererProps<'Likert'>) {
   const targetItem = useNodeItem(targetNode);
-  const summaryItem = useNodeItem(summaryNode);
-  const excludedChildren = summaryItem?.excludedChildren;
-  const display = overrides?.display || summaryItem?.display;
+  const excludedChildren = overrides?.excludedChildren;
+  const display = overrides?.display;
   const { lang, langAsString } = useLanguage();
   const isHidden = Hidden.useIsHiddenSelector();
 
@@ -51,7 +49,7 @@ export function LikertSummaryComponent({
   const ariaLabel = langAsString(summaryTitleTrb ?? summaryAccessibleTitleTrb ?? titleTrb);
 
   const rows = useLikertRows(targetNode);
-  const largeGroup = overrides?.largeGroup ?? summaryItem?.largeGroup ?? false;
+  const largeGroup = overrides?.largeGroup ?? false;
   if (largeGroup && rows.length) {
     return (
       <>
@@ -71,12 +69,11 @@ export function LikertSummaryComponent({
                 }
 
                 return (
-                  <SummaryComponent
+                  <SummaryComponentFor
                     key={n.id}
-                    summaryNode={summaryNode}
+                    targetNode={n}
                     overrides={{
                       ...overrides,
-                      targetNode: n,
                       grid: {},
                       largeGroup: false,
                     }}
@@ -122,7 +119,6 @@ export function LikertSummaryComponent({
                   inExcludedChildren={inExcludedChildren}
                   onChangeClick={onChangeClick}
                   changeText={changeText}
-                  summaryNode={summaryNode}
                   targetNode={targetNode}
                 />
               </DataModelLocationProvider>
@@ -151,13 +147,12 @@ export function LikertSummaryComponent({
   );
 }
 
-interface RowProps
-  extends Pick<SummaryRendererProps<'Likert'>, 'onChangeClick' | 'changeText' | 'summaryNode' | 'targetNode'> {
+interface RowProps extends Pick<SummaryRendererProps<'Likert'>, 'onChangeClick' | 'changeText' | 'targetNode'> {
   row: BaseRow;
   inExcludedChildren: (n: LayoutNode) => boolean;
 }
 
-function Row({ row, inExcludedChildren, summaryNode, onChangeClick, changeText, targetNode }: RowProps) {
+function Row({ row, inExcludedChildren, onChangeClick, changeText, targetNode }: RowProps) {
   const isHidden = Hidden.useIsHiddenSelector();
   const childId = makeLikertChildId(targetNode.id, row.index);
   const node = useNode(childId) as LayoutNode<'LikertItem'> | undefined;
@@ -180,7 +175,6 @@ function Row({ row, inExcludedChildren, summaryNode, onChangeClick, changeText, 
         changeText={changeText}
         key={node.id}
         targetNode={node}
-        summaryNode={summaryNode}
       />
     </div>
   );

--- a/src/layout/LikertItem/LikertItemComponent.tsx
+++ b/src/layout/LikertItem/LikertItemComponent.tsx
@@ -67,7 +67,10 @@ const RadioGroupTableRow = forwardRef<HTMLTableRowElement, PropsFromGenericCompo
             <RequiredIndicator required={required} />
           </span>
         </Label>
-        <ComponentValidations validations={validations} />
+        <ComponentValidations
+          validations={validations}
+          node={node}
+        />
       </Table.Cell>
       {calculatedOptions?.map((option, index) => {
         const isChecked = selectedValues[0] === option.value;

--- a/src/layout/PersonLookup/PersonLookupComponent.tsx
+++ b/src/layout/PersonLookup/PersonLookupComponent.tsx
@@ -186,7 +186,10 @@ export function PersonLookupComponent({ node, overrideDisplay }: PropsFromGeneri
             error={
               (ssnErrors?.length && <Lang id={ssnErrors.join(' ')} />) ||
               (hasValidationErrors(bindingValidations?.person_lookup_ssn) && (
-                <ComponentValidations validations={bindingValidations?.person_lookup_ssn} />
+                <ComponentValidations
+                  validations={bindingValidations?.person_lookup_ssn}
+                  node={node}
+                />
               ))
             }
             onValueChange={(e) => {
@@ -230,7 +233,10 @@ export function PersonLookupComponent({ node, overrideDisplay }: PropsFromGeneri
             error={
               (nameError && <Lang id={nameError} />) ||
               (hasValidationErrors(bindingValidations?.person_lookup_name) && (
-                <ComponentValidations validations={bindingValidations?.person_lookup_name} />
+                <ComponentValidations
+                  validations={bindingValidations?.person_lookup_name}
+                  node={node}
+                />
               ))
             }
             onChange={(e) => {

--- a/src/layout/RadioButtons/ControlledRadioGroup.tsx
+++ b/src/layout/RadioButtons/ControlledRadioGroup.tsx
@@ -34,9 +34,13 @@ export const ControlledRadioGroup = (props: IControlledRadioGroupProps) => {
     : null;
   const confirmChangeText = langAsString('form_filler.alert_confirm');
 
-  const leftColumnHeader = useNodeItem(node.parent instanceof LayoutNode ? node.parent : undefined, (i) =>
-    i.type === 'Likert' ? i.textResourceBindings?.leftColumnHeader : undefined,
-  );
+  let leftColumnHeader: string | undefined = undefined;
+  if (node.parent instanceof LayoutNode && node.parent.isType('Likert')) {
+    // The parent node type never changes, so this doesn't break the rule of hooks
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    leftColumnHeader = useNodeItem(node.parent, (i) => i.textResourceBindings?.leftColumnHeader);
+  }
+
   const labelText = (
     <LabelContent
       componentId={id}

--- a/src/layout/RepeatingGroup/Summary/SummaryRepeatingGroup.test.tsx
+++ b/src/layout/RepeatingGroup/Summary/SummaryRepeatingGroup.test.tsx
@@ -21,13 +21,12 @@ describe('SummaryRepeatingGroup', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  function TestComponent({ node, groupId }: { node: LayoutNode<'Summary'>; groupId: string }) {
+  function TestComponent({ groupId }: { groupId: string }) {
     const groupNode = useNode(groupId) as LayoutNode<'RepeatingGroup'>;
     return (
       <SummaryRepeatingGroup
         changeText='Change'
         onChangeClick={mockHandleDataChange}
-        summaryNode={node}
         targetNode={groupNode}
       />
     );
@@ -37,12 +36,7 @@ describe('SummaryRepeatingGroup', () => {
     return await renderWithNode<true, LayoutNode<'Summary'>>({
       nodeId: 'mySummary',
       inInstance: true,
-      renderer: ({ node }) => (
-        <TestComponent
-          node={node}
-          groupId='groupComponent'
-        />
-      ),
+      renderer: () => <TestComponent groupId='groupComponent' />,
       queries: {
         fetchFormData: async () => ({
           mockGroup: [

--- a/src/layout/RepeatingGroup/Summary/SummaryRepeatingGroup.tsx
+++ b/src/layout/RepeatingGroup/Summary/SummaryRepeatingGroup.tsx
@@ -10,7 +10,7 @@ import { LargeGroupSummaryContainer } from 'src/layout/RepeatingGroup/Summary/La
 import classes from 'src/layout/RepeatingGroup/Summary/SummaryRepeatingGroup.module.css';
 import { RepGroupHooks } from 'src/layout/RepeatingGroup/utils';
 import { EditButton } from 'src/layout/Summary/EditButton';
-import { SummaryComponent } from 'src/layout/Summary/SummaryComponent';
+import { SummaryComponentFor } from 'src/layout/Summary/SummaryComponent';
 import { DataModelLocationProvider } from 'src/utils/layout/DataModelLocation';
 import { Hidden } from 'src/utils/layout/NodesContext';
 import { useNodeDirectChildren, useNodeItem } from 'src/utils/layout/useNodeItem';
@@ -29,7 +29,7 @@ interface FullRowProps extends Omit<FullProps, 'rows'> {
 }
 
 export function SummaryRepeatingGroup(props: SummaryRendererProps<'RepeatingGroup'>) {
-  const { excludedChildren, largeGroup } = useNodeItem(props.summaryNode) ?? {};
+  const { excludedChildren, largeGroup } = props.overrides ?? {};
   const rows = RepGroupHooks.useVisibleRows(props.targetNode);
 
   const inExcludedChildren = (n: LayoutNode) =>
@@ -55,13 +55,10 @@ export function SummaryRepeatingGroup(props: SummaryRendererProps<'RepeatingGrou
 }
 
 function RegularRepeatingGroup(props: FullProps) {
-  const { onChangeClick, changeText, summaryNode, targetNode, overrides, rows: _rows } = props;
+  const { onChangeClick, changeText, targetNode, overrides, rows: _rows } = props;
   const rows = _rows.filter(typedBoolean);
-
-  const { display: summaryDisplay } = useNodeItem(summaryNode) ?? {};
   const { textResourceBindings: trb } = useNodeItem(targetNode);
-
-  const display = overrides?.display || summaryDisplay;
+  const display = overrides?.display;
   const { langAsString } = useLanguage();
 
   const groupValidations = useDeepValidationsForNode(targetNode);
@@ -127,14 +124,7 @@ function RegularRepeatingGroup(props: FullProps) {
   );
 }
 
-function RegularRepeatingGroupRow({
-  targetNode,
-  inExcludedChildren,
-  row,
-  onChangeClick,
-  changeText,
-  summaryNode,
-}: FullRowProps) {
+function RegularRepeatingGroupRow({ targetNode, inExcludedChildren, row, onChangeClick, changeText }: FullRowProps) {
   const isHidden = Hidden.useIsHiddenSelector();
   const children = useNodeDirectChildren(targetNode, row.index);
   const dataModelBindings = useNodeItem(targetNode, (i) => i.dataModelBindings);
@@ -164,7 +154,6 @@ function RegularRepeatingGroupRow({
             changeText={changeText}
             key={child.id}
             targetNode={child as never} // FIXME: Never type
-            summaryNode={summaryNode}
             overrides={{}}
           />
         ))}
@@ -173,7 +162,7 @@ function RegularRepeatingGroupRow({
   );
 }
 
-function LargeRepeatingGroup({ targetNode, summaryNode, overrides, inExcludedChildren, rows }: FullProps) {
+function LargeRepeatingGroup({ targetNode, overrides, inExcludedChildren, rows }: FullProps) {
   const isHidden = Hidden.useIsHiddenSelector();
   const groupBinding = useNodeItem(targetNode, (i) => i.dataModelBindings.group);
 
@@ -195,12 +184,11 @@ function LargeRepeatingGroup({ targetNode, summaryNode, overrides, inExcludedChi
               }
 
               return (
-                <SummaryComponent
+                <SummaryComponentFor
                   key={n.id}
-                  summaryNode={summaryNode}
+                  targetNode={n}
                   overrides={{
                     ...overrides,
-                    targetNode: n,
                     grid: {},
                     largeGroup: false,
                   }}

--- a/src/layout/RepeatingGroup/Summary2/RepeatingGroupTableSummary/RepeatingGroupTableSummary.tsx
+++ b/src/layout/RepeatingGroup/Summary2/RepeatingGroupTableSummary/RepeatingGroupTableSummary.tsx
@@ -24,7 +24,7 @@ import { EditButtonFirstVisible } from 'src/layout/Summary2/CommonSummaryCompone
 import { useReportSummaryRender } from 'src/layout/Summary2/isEmpty/EmptyChildrenContext';
 import { ComponentSummaryById, SummaryContains } from 'src/layout/Summary2/SummaryComponent2/ComponentSummary';
 import { useColumnStylesRepeatingGroups } from 'src/utils/formComponentUtils';
-import { DataModelLocationProvider, useDataModelLocationForRow } from 'src/utils/layout/DataModelLocation';
+import { DataModelLocationProvider } from 'src/utils/layout/DataModelLocation';
 import { useNode } from 'src/utils/layout/NodesContext';
 import { useNodeDirectChildren, useNodeItem } from 'src/utils/layout/useNodeItem';
 import type { ITableColumnFormatting } from 'src/layout/common.generated';
@@ -40,8 +40,7 @@ export const RepeatingGroupTableSummary = ({ componentNode }: { componentNode: L
   const errors = validationsOfSeverity(validations, 'error');
   const title = useNodeItem(componentNode, (i) => i.textResourceBindings?.title);
   const dataModelBindings = useNodeItem(componentNode, (i) => i.dataModelBindings);
-  const locationForFirstRow = useDataModelLocationForRow(dataModelBindings.group, 0);
-  const tableIds = useIndexedComponentIds(useTableComponentIds(componentNode), locationForFirstRow);
+  const tableIds = useTableComponentIds(componentNode);
   const { tableColumns } = useNodeItem(componentNode);
   const columnSettings = tableColumns ? structuredClone(tableColumns) : ({} as ITableColumnFormatting);
 
@@ -57,7 +56,7 @@ export const RepeatingGroupTableSummary = ({ componentNode }: { componentNode: L
             {tableIds.map((id) => (
               <HeaderCell
                 key={id}
-                nodeId={id}
+                baseComponentId={id}
                 columnSettings={columnSettings}
               />
             ))}
@@ -103,13 +102,18 @@ export const RepeatingGroupTableSummary = ({ componentNode }: { componentNode: L
   );
 };
 
-function HeaderCell({ nodeId, columnSettings }: { nodeId: string; columnSettings: ITableColumnFormatting }) {
-  const node = useNode(nodeId);
-  const style = useColumnStylesRepeatingGroups(node, columnSettings);
+function HeaderCell({
+  baseComponentId,
+  columnSettings,
+}: {
+  baseComponentId: string;
+  columnSettings: ITableColumnFormatting;
+}) {
+  const style = useColumnStylesRepeatingGroups(baseComponentId, columnSettings);
   return (
     <Table.HeaderCell style={style}>
       <RepeatingGroupTableTitle
-        node={node}
+        baseComponentId={baseComponentId}
         columnSettings={columnSettings}
       />
     </Table.HeaderCell>
@@ -187,8 +191,8 @@ function DataCell({ nodeId, columnSettings }: DataCellProps) {
 
 function NodeDataCell({ node, columnSettings }: { node: LayoutNode } & Pick<DataCellProps, 'columnSettings'>) {
   const { langAsString } = useLanguage();
-  const headerTitle = langAsString(useTableTitle(node));
-  const style = useColumnStylesRepeatingGroups(node, columnSettings);
+  const headerTitle = langAsString(useTableTitle(node.baseId));
+  const style = useColumnStylesRepeatingGroups(node.baseId, columnSettings);
   const displayData = useDisplayData(node);
   const required = useNodeItem(node, (i) => ('required' in i ? i.required : false));
 

--- a/src/layout/RepeatingGroup/Summary2/RepeatingGroupTableSummary/RepeatingGroupTableSummary.tsx
+++ b/src/layout/RepeatingGroup/Summary2/RepeatingGroupTableSummary/RepeatingGroupTableSummary.tsx
@@ -53,13 +53,18 @@ export const RepeatingGroupTableSummary = ({ componentNode }: { componentNode: L
         <Caption title={<Lang id={title} />} />
         <Table.Head>
           <Table.Row>
-            {tableIds.map((id) => (
-              <HeaderCell
-                key={id}
-                baseComponentId={id}
-                columnSettings={columnSettings}
-              />
-            ))}
+            <DataModelLocationProvider
+              groupBinding={dataModelBindings.group}
+              rowIndex={0} // Force the header row to show texts as if it is in the first row
+            >
+              {tableIds.map((id) => (
+                <HeaderCell
+                  key={id}
+                  baseComponentId={id}
+                  columnSettings={columnSettings}
+                />
+              ))}
+            </DataModelLocationProvider>
             {!pdfModeActive && !isSmall && (
               <Table.HeaderCell className={tableClasses.narrowLastColumn}>
                 <span className={tableClasses.visuallyHidden}>

--- a/src/layout/RepeatingGroup/Table/RepeatingGroupTable.tsx
+++ b/src/layout/RepeatingGroup/Table/RepeatingGroupTable.tsx
@@ -105,13 +105,18 @@ export function RepeatingGroupTable(): React.JSX.Element | null {
         {showTableHeader && !mobileView && (
           <Table.Head id={`group-${id}-table-header`}>
             <Table.Row>
-              {tableIds?.map((id) => (
-                <TitleCell
-                  key={id}
-                  baseCompnentId={id}
-                  columnSettings={columnSettings}
-                />
-              ))}
+              <DataModelLocationProvider
+                groupBinding={dataModelBindings.group}
+                rowIndex={0} // Force the header row to show texts as if it is in the first row
+              >
+                {tableIds?.map((id) => (
+                  <TitleCell
+                    key={id}
+                    baseCompnentId={id}
+                    columnSettings={columnSettings}
+                  />
+                ))}
+              </DataModelLocationProvider>
               {displayEditColumn && (
                 <Table.HeaderCell style={{ padding: 0, paddingRight: '10px' }}>
                   <span className={classes.visuallyHidden}>

--- a/src/layout/RepeatingGroup/Table/RepeatingGroupTable.tsx
+++ b/src/layout/RepeatingGroup/Table/RepeatingGroupTable.tsx
@@ -112,7 +112,7 @@ export function RepeatingGroupTable(): React.JSX.Element | null {
                 {tableIds?.map((id) => (
                   <TitleCell
                     key={id}
-                    baseCompnentId={id}
+                    baseComponentId={id}
                     columnSettings={columnSettings}
                   />
                 ))}
@@ -247,13 +247,13 @@ function ExtraRows({ where, extraCells, columnSettings }: ExtraRowsProps) {
 }
 
 function TitleCell({
-  baseCompnentId,
+  baseComponentId,
   columnSettings,
 }: {
-  baseCompnentId: string;
+  baseComponentId: string;
   columnSettings: ITableColumnFormatting;
 }) {
-  const style = useColumnStylesRepeatingGroups(baseCompnentId, columnSettings);
+  const style = useColumnStylesRepeatingGroups(baseComponentId, columnSettings);
 
   return (
     <Table.HeaderCell
@@ -261,7 +261,7 @@ function TitleCell({
       style={style}
     >
       <RepeatingGroupTableTitle
-        baseComponentId={baseCompnentId}
+        baseComponentId={baseComponentId}
         columnSettings={columnSettings}
       />
     </Table.HeaderCell>

--- a/src/layout/RepeatingGroup/Table/RepeatingGroupTable.tsx
+++ b/src/layout/RepeatingGroup/Table/RepeatingGroupTable.tsx
@@ -4,7 +4,6 @@ import { Table } from '@digdir/designsystemet-react';
 import cn from 'classnames';
 
 import { Caption } from 'src/components/form/caption/Caption';
-import { useIndexedComponentIds } from 'src/features/form/layout/utils/makeIndexedId';
 import { Lang } from 'src/features/language/Lang';
 import { useIsMobileOrTablet } from 'src/hooks/useDeviceWidths';
 import { GenericComponentById } from 'src/layout/GenericComponent';
@@ -23,9 +22,8 @@ import { RepeatingGroupTableTitle } from 'src/layout/RepeatingGroup/Table/Repeat
 import { useTableComponentIds } from 'src/layout/RepeatingGroup/useTableComponentIds';
 import { RepGroupHooks } from 'src/layout/RepeatingGroup/utils';
 import { useColumnStylesRepeatingGroups } from 'src/utils/formComponentUtils';
-import { DataModelLocationProvider, useDataModelLocationForRow } from 'src/utils/layout/DataModelLocation';
+import { DataModelLocationProvider } from 'src/utils/layout/DataModelLocation';
 import { LayoutNode } from 'src/utils/layout/LayoutNode';
-import { useNode } from 'src/utils/layout/NodesContext';
 import { useNodeItem } from 'src/utils/layout/useNodeItem';
 import type { ITableColumnFormatting } from 'src/layout/common.generated';
 import type { GridCellInternal } from 'src/layout/Grid/types';
@@ -40,8 +38,7 @@ export function RepeatingGroupTable(): React.JSX.Element | null {
   const required = !!minCount && minCount > 0;
 
   const columnSettings = tableColumns ? structuredClone(tableColumns) : ({} as ITableColumnFormatting);
-  const location = useDataModelLocationForRow(dataModelBindings.group, 0);
-  const tableIds = useIndexedComponentIds(useTableComponentIds(node), location);
+  const tableIds = useTableComponentIds(node);
   const numRows = rowsToDisplay.length;
   const firstRowId = numRows >= 1 ? rowsToDisplay[0].uuid : undefined;
 
@@ -111,7 +108,7 @@ export function RepeatingGroupTable(): React.JSX.Element | null {
               {tableIds?.map((id) => (
                 <TitleCell
                   key={id}
-                  nodeId={id}
+                  baseCompnentId={id}
                   columnSettings={columnSettings}
                 />
               ))}
@@ -244,9 +241,14 @@ function ExtraRows({ where, extraCells, columnSettings }: ExtraRowsProps) {
   );
 }
 
-function TitleCell({ nodeId, columnSettings }: { nodeId: string; columnSettings: ITableColumnFormatting }) {
-  const node = useNode(nodeId);
-  const style = useColumnStylesRepeatingGroups(node, columnSettings);
+function TitleCell({
+  baseCompnentId,
+  columnSettings,
+}: {
+  baseCompnentId: string;
+  columnSettings: ITableColumnFormatting;
+}) {
+  const style = useColumnStylesRepeatingGroups(baseCompnentId, columnSettings);
 
   return (
     <Table.HeaderCell
@@ -254,7 +256,7 @@ function TitleCell({ nodeId, columnSettings }: { nodeId: string; columnSettings:
       style={style}
     >
       <RepeatingGroupTableTitle
-        node={node}
+        baseComponentId={baseCompnentId}
         columnSettings={columnSettings}
       />
     </Table.HeaderCell>

--- a/src/layout/RepeatingGroup/Table/RepeatingGroupTableRow.tsx
+++ b/src/layout/RepeatingGroup/Table/RepeatingGroupTableRow.tsx
@@ -13,7 +13,6 @@ import { useAlertOnChange } from 'src/features/alertOnChange/useAlertOnChange';
 import { useDisplayDataFor } from 'src/features/displayData/useDisplayData';
 import { useLayoutLookups } from 'src/features/form/layout/LayoutsContext';
 import { useIndexedComponentIds } from 'src/features/form/layout/utils/makeIndexedId';
-import { FD } from 'src/features/formData/FormDataWrite';
 import { Lang } from 'src/features/language/Lang';
 import { useLanguage } from 'src/features/language/useLanguage';
 import { useDeepValidationsForNode } from 'src/features/validation/selectors/deepValidationsForNode';
@@ -26,7 +25,7 @@ import classes from 'src/layout/RepeatingGroup/RepeatingGroup.module.css';
 import { useTableComponentIds } from 'src/layout/RepeatingGroup/useTableComponentIds';
 import { RepGroupHooks } from 'src/layout/RepeatingGroup/utils';
 import { useColumnStylesRepeatingGroups } from 'src/utils/formComponentUtils';
-import { NodesInternal, useNode } from 'src/utils/layout/NodesContext';
+import { NodesInternal } from 'src/utils/layout/NodesContext';
 import { useNodeItem } from 'src/utils/layout/useNodeItem';
 import type { AlertOnChange } from 'src/features/alertOnChange/useAlertOnChange';
 import type { IUseLanguage } from 'src/features/language/useLanguage';
@@ -76,7 +75,7 @@ function getEditButtonText(
   return langTools.langAsString(buttonTextKey);
 }
 
-export const RepeatingGroupTableRow = React.memo(function RepeatingGroupTableRow({
+export const RepeatingGroupTableRow = React.memo(function ({
   className,
   uuid,
   index,
@@ -92,8 +91,6 @@ export const RepeatingGroupTableRow = React.memo(function RepeatingGroupTableRow
   const { langAsString } = langTools;
   const id = node.id;
   const group = useNodeItem(node);
-  const freshUuid = FD.useFreshRowUuid(group.dataModelBindings?.group, index);
-  const isFresh = freshUuid === uuid;
   const rowExpressions = RepGroupHooks.useRowWithExpressions(node, { uuid });
   const editForRow = rowExpressions?.edit;
   const editForGroup = group.edit;
@@ -166,8 +163,8 @@ export const RepeatingGroupTableRow = React.memo(function RepeatingGroupTableRow
             </Table.Cell>
           ) : (
             <NonEditableCell
-              key={item.id}
-              nodeId={item.id}
+              key={item.baseId}
+              baseComponentId={item.baseId}
               isEditingRow={isEditingRow}
               displayData={displayData[item.baseId] ?? ''}
               columnSettings={columnSettings}
@@ -247,7 +244,6 @@ export const RepeatingGroupTableRow = React.memo(function RepeatingGroupTableRow
                   onClick={() => toggleEditing({ index, uuid })}
                   aria-label={`${editButtonText} ${firstCellData ?? ''}`}
                   className={classes.tableButton}
-                  disabled={!isFresh}
                 >
                   {editButtonText}
                   {rowHasErrors ? (
@@ -284,7 +280,6 @@ export const RepeatingGroupTableRow = React.memo(function RepeatingGroupTableRow
                   firstCellData={firstCellData}
                   alertOnDeleteProps={alertOnDelete}
                   langAsString={langAsString}
-                  disabled={!isFresh}
                 >
                   {deleteButtonText}
                 </DeleteElement>
@@ -338,7 +333,6 @@ export const RepeatingGroupTableRow = React.memo(function RepeatingGroupTableRow
                   firstCellData={firstCellData}
                   alertOnDeleteProps={alertOnDelete}
                   langAsString={langAsString}
-                  disabled={!isFresh}
                 >
                   {isEditingRow || !mobileViewSmall ? deleteButtonText : null}
                 </DeleteElement>
@@ -432,18 +426,17 @@ function DeleteElement({
 }
 
 function NonEditableCell({
-  nodeId,
+  baseComponentId,
   columnSettings,
   isEditingRow,
   displayData,
 }: {
-  nodeId: string;
+  baseComponentId: string;
   columnSettings: ITableColumnFormatting | undefined;
   displayData: string;
   isEditingRow: boolean;
 }) {
-  const node = useNode(nodeId);
-  const style = useColumnStylesRepeatingGroups(node, columnSettings);
+  const style = useColumnStylesRepeatingGroups(baseComponentId, columnSettings);
   return (
     <Table.Cell className={classes.tableCell}>
       <span

--- a/src/layout/RepeatingGroup/Table/RepeatingGroupTableTitle.tsx
+++ b/src/layout/RepeatingGroup/Table/RepeatingGroupTableTitle.tsx
@@ -8,7 +8,7 @@ import type { ITableColumnFormatting } from 'src/layout/common.generated';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 interface IProps {
-  node: LayoutNode | undefined;
+  node: LayoutNode;
   columnSettings: ITableColumnFormatting;
 }
 
@@ -25,7 +25,7 @@ export const RepeatingGroupTableTitle = ({ node, columnSettings }: IProps) => {
   );
 };
 
-export function useTableTitle(node: LayoutNode | undefined) {
+export function useTableTitle(node: LayoutNode) {
   const textResourceBindings = useNodeItem(node, (i) => i.textResourceBindings);
 
   if (!textResourceBindings) {

--- a/src/layout/RepeatingGroup/Table/RepeatingGroupTableTitle.tsx
+++ b/src/layout/RepeatingGroup/Table/RepeatingGroupTableTitle.tsx
@@ -1,20 +1,22 @@
 import React from 'react';
 
+import { ExprVal } from 'src/features/expressions/types';
+import { useLayoutLookups } from 'src/features/form/layout/LayoutsContext';
 import { Lang } from 'src/features/language/Lang';
 import classes from 'src/layout/RepeatingGroup/RepeatingGroup.module.css';
 import { useColumnStylesRepeatingGroups } from 'src/utils/formComponentUtils';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useEvalExpression } from 'src/utils/layout/generator/useEvalExpression';
+import type { EvalExprOptions } from 'src/features/expressions';
 import type { ITableColumnFormatting } from 'src/layout/common.generated';
-import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 interface IProps {
-  node: LayoutNode;
+  baseComponentId: string;
   columnSettings: ITableColumnFormatting;
 }
 
-export const RepeatingGroupTableTitle = ({ node, columnSettings }: IProps) => {
-  const style = useColumnStylesRepeatingGroups(node, columnSettings);
-  const tableTitle = useTableTitle(node);
+export const RepeatingGroupTableTitle = ({ baseComponentId, columnSettings }: IProps) => {
+  const style = useColumnStylesRepeatingGroups(baseComponentId, columnSettings);
+  const tableTitle = useTableTitle(baseComponentId);
   return (
     <span
       className={classes.contentFormatting}
@@ -25,18 +27,21 @@ export const RepeatingGroupTableTitle = ({ node, columnSettings }: IProps) => {
   );
 };
 
-export function useTableTitle(node: LayoutNode) {
-  const textResourceBindings = useNodeItem(node, (i) => i.textResourceBindings);
+export function useTableTitle(baseComponentId: string): string {
+  const textResourceBindings = useLayoutLookups().getComponent(baseComponentId).textResourceBindings;
+  const exprOptions: EvalExprOptions<ExprVal.String> = {
+    returnType: ExprVal.String,
+    defaultValue: '',
+    errorIntroText: `Invalid expression in ${baseComponentId}`,
+  };
+  const tableTitle = useEvalExpression(
+    textResourceBindings && 'tableTitle' in textResourceBindings ? textResourceBindings.tableTitle : '',
+    exprOptions,
+  );
+  const title = useEvalExpression(
+    textResourceBindings && 'title' in textResourceBindings ? textResourceBindings.title : '',
+    exprOptions,
+  );
 
-  if (!textResourceBindings) {
-    return '';
-  }
-
-  if ('tableTitle' in textResourceBindings && textResourceBindings.tableTitle) {
-    return textResourceBindings?.tableTitle;
-  }
-  if ('title' in textResourceBindings && textResourceBindings.title) {
-    return textResourceBindings?.title;
-  }
-  return '';
+  return tableTitle || title || '';
 }

--- a/src/layout/Subform/Summary/SubformSummaryComponent2.tsx
+++ b/src/layout/Subform/Summary/SubformSummaryComponent2.tsx
@@ -137,7 +137,7 @@ const DoSummaryWrapper = ({
   );
 };
 
-export function SubformSummaryComponent2({ target }: Partial<Summary2Props<'Subform'>>) {
+export function SubformSummaryComponent2({ target }: Summary2Props<'Subform'>) {
   const displayType = useSummaryOverrides(target)?.display;
   const allOrOneSubformId = NodesInternal.useShallowSelector((state) =>
     Object.values(state.nodeData)

--- a/src/layout/Subform/Summary/SubformSummaryComponent2.tsx
+++ b/src/layout/Subform/Summary/SubformSummaryComponent2.tsx
@@ -137,19 +137,27 @@ const DoSummaryWrapper = ({
   );
 };
 
-export function SubformSummaryComponent2({ target }: Summary2Props<'Subform'>) {
-  const displayType = useSummaryOverrides(target)?.display;
-  const allOrOneSubformId = NodesInternal.useShallowSelector((state) =>
+export function AllSubformSummaryComponent2() {
+  const allIds = NodesInternal.useShallowSelector((state) =>
     Object.values(state.nodeData)
       .filter((data) => data.layout.type === 'Subform')
-      .filter((data) => {
-        if (!target?.id) {
-          return data;
-        }
-        return data.layout.id === target.id;
-      })
       .map((data) => data.layout.id),
   );
+
+  return (
+    <>
+      {allIds.map((childId, idx) => (
+        <SummarySubformWrapper
+          key={idx}
+          nodeId={childId}
+        />
+      ))}
+    </>
+  );
+}
+
+export function SubformSummaryComponent2({ target }: Summary2Props<'Subform'>) {
+  const displayType = useSummaryOverrides(target)?.display;
   const layoutSet = useNodeItem(target, (i) => i.layoutSet);
   const dataType = useDataTypeFromLayoutSet(layoutSet);
   const dataElements = useStrictDataElements(dataType);
@@ -161,32 +169,21 @@ export function SubformSummaryComponent2({ target }: Summary2Props<'Subform'>) {
     displayType === 'table' && target ? (
       <SubformSummaryTable targetNode={target} />
     ) : (
-      <>
-        {allOrOneSubformId.map((childId, idx) => (
-          <SummarySubformWrapper
-            key={idx}
-            nodeId={childId}
-          />
-        ))}
-      </>
+      <SummarySubformWrapper nodeId={target.id} />
     );
 
-  if (target) {
-    return (
-      <SummaryFlex
-        target={target}
-        content={
-          hasElements
-            ? SummaryContains.SomeUserContent
-            : required
-              ? SummaryContains.EmptyValueRequired
-              : SummaryContains.EmptyValueNotRequired
-        }
-      >
-        {inner}
-      </SummaryFlex>
-    );
-  }
-
-  return inner;
+  return (
+    <SummaryFlex
+      target={target}
+      content={
+        hasElements
+          ? SummaryContains.SomeUserContent
+          : required
+            ? SummaryContains.EmptyValueRequired
+            : SummaryContains.EmptyValueNotRequired
+      }
+    >
+      {inner}
+    </SummaryFlex>
+  );
 }

--- a/src/layout/Summary/SummaryComponent.tsx
+++ b/src/layout/Summary/SummaryComponent.tsx
@@ -57,6 +57,7 @@ export const SummaryComponentFor = React.forwardRef(function (
       grid={overrides?.display && overrides?.display.useComponentGrid ? overrides?.grid || targetItem?.grid : undefined}
       pageBreak={overrides?.pageBreak ?? targetItem?.pageBreak}
       largeGroup={overrides?.largeGroup}
+      excludedChildren={overrides?.excludedChildren}
     />
   );
 });

--- a/src/layout/Summary/SummaryComponent.tsx
+++ b/src/layout/Summary/SummaryComponent.tsx
@@ -23,43 +23,117 @@ import type { IGrid, IPageBreak } from 'src/layout/common.generated';
 import type { SummaryDisplayProperties } from 'src/layout/Summary/config.generated';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
-interface SummaryOverrides {
-  targetNode: LayoutNode;
+/**
+ * These overrides include all props from the Summary component that should be forwarded to underlying component
+ * summaries. This way we only fetch the settings in the SummaryComponent render cycle, and then pass the config
+ * down to the internal summary components, so that all underlying code can work the same regardless if there is an
+ * actual Summary component in the layout or not. Cases when there's not a real Summary component include:
+ * - Automatic PDF layout
+ * - Using the `renderAsSummary` prop on a component
+ */
+export interface LegacySummaryOverrides {
   grid?: IGrid;
   largeGroup?: boolean;
   display?: SummaryDisplayProperties;
   pageBreak?: ExprResolved<IPageBreak>;
+  excludedChildren?: string[];
 }
 
-export interface ISummaryComponent {
-  summaryNode: LayoutNode<'Summary'>;
-  overrides?: Partial<SummaryOverrides>;
-}
+export const SummaryComponentFor = React.forwardRef(function (
+  { targetNode, overrides }: { targetNode: LayoutNode; overrides?: LegacySummaryOverrides },
+  ref: React.Ref<HTMLDivElement>,
+) {
+  const targetItem = useNodeItem(targetNode);
 
-export const SummaryComponent = React.forwardRef(function SummaryComponent(
-  { summaryNode, overrides }: ISummaryComponent,
+  return (
+    <SummaryComponentInner
+      ref={ref}
+      targetNode={targetNode}
+      summaryTestId={targetNode.id}
+      originNodeId={targetNode.id}
+      componentId={`summary-${targetNode?.id}`}
+      componentBaseId={`summary-${targetNode.id}`}
+      display={overrides?.display}
+      grid={overrides?.display && overrides?.display.useComponentGrid ? overrides?.grid || targetItem?.grid : undefined}
+      pageBreak={overrides?.pageBreak ?? targetItem?.pageBreak}
+      largeGroup={overrides?.largeGroup}
+    />
+  );
+});
+
+SummaryComponentFor.displayName = 'SummaryComponentFor';
+
+/**
+ * This component renders the alternative where only a `summaryNode` is provided, and the target node is inferred
+ * from that `summaryNode`.
+ */
+export const SummaryComponent = React.forwardRef(function (
+  { summaryNode, overrides }: { summaryNode: LayoutNode<'Summary'>; overrides?: LegacySummaryOverrides },
   ref: React.Ref<HTMLDivElement>,
 ) {
   const summaryItem = useNodeItem(summaryNode);
-  const _targetNode = useNode(summaryItem?.componentRef);
-  const targetNode = overrides?.targetNode ?? _targetNode;
+  const targetNode = useNode(summaryItem.componentRef);
   const targetItem = useNodeItem(targetNode);
 
   if (!targetNode) {
     throw new Error(
-      `No target found for Summary '${summaryNode?.id}'. ` +
+      `No target found for Summary '${summaryNode.id}'. ` +
         `Check the 'componentRef' property and make sure the target component exists.`,
     );
   }
 
-  const display = overrides?.display ?? summaryItem?.display;
-  const pageBreak = overrides?.pageBreak ?? summaryItem?.pageBreak ?? targetItem?.pageBreak;
+  return (
+    <SummaryComponentInner
+      ref={ref}
+      targetNode={targetNode}
+      summaryTestId={summaryNode?.id ?? targetNode?.id ?? 'unknown'}
+      originNodeId={summaryNode?.id ?? targetNode?.id}
+      componentId={summaryNode?.id ?? `summary-${targetNode?.id}`}
+      componentBaseId={summaryNode?.baseId ?? `summary-${targetNode.id}`}
+      display={overrides?.display ?? summaryItem?.display}
+      grid={
+        overrides?.display && overrides?.display.useComponentGrid
+          ? overrides?.grid || targetItem?.grid
+          : overrides?.grid || summaryItem?.grid
+      }
+      pageBreak={overrides?.pageBreak ?? summaryItem?.pageBreak ?? targetItem?.pageBreak}
+      largeGroup={overrides?.largeGroup ?? summaryItem?.largeGroup}
+      excludedChildren={overrides?.excludedChildren ?? summaryItem?.excludedChildren}
+    />
+  );
+});
 
+SummaryComponent.displayName = 'SummaryComponent';
+
+interface ISummaryProps extends LegacySummaryOverrides {
+  originNodeId: string;
+  targetNode: LayoutNode;
+  summaryTestId: string;
+  componentId: string;
+  componentBaseId: string;
+}
+
+const SummaryComponentInner = React.forwardRef(function (
+  {
+    originNodeId,
+    targetNode,
+    display,
+    pageBreak,
+    grid,
+    componentId,
+    componentBaseId,
+    summaryTestId,
+    largeGroup,
+    excludedChildren,
+  }: ISummaryProps,
+  ref: React.Ref<HTMLDivElement>,
+) {
+  const targetItem = useNodeItem(targetNode);
   const { langAsString } = useLanguage();
   const getUniqueKeyFromObject = useGetUniqueKeyFromObject();
   const currentPageId = useNavigationParam('pageKey');
 
-  const targetView = targetNode?.pageKey;
+  const targetView = targetNode.pageKey;
   const targetIsHidden = Hidden.useIsHidden(targetNode);
 
   const validations = useUnifiedValidationsForNode(targetNode);
@@ -75,7 +149,7 @@ export const SummaryComponent = React.forwardRef(function SummaryComponent(
     }
 
     setReturnToView?.(currentPageId);
-    setNodeOfOrigin?.(summaryNode?.id ?? targetNode?.id);
+    setNodeOfOrigin?.(originNodeId);
     await navigateTo(targetNode, {
       shouldFocus: true,
       pageNavOptions: {
@@ -84,37 +158,29 @@ export const SummaryComponent = React.forwardRef(function SummaryComponent(
     });
   };
 
-  if (!targetNode || !targetItem || targetIsHidden || targetItem.type === 'Summary') {
-    // TODO: Show info to developers if target node is not found?
+  if (targetIsHidden || targetNode.type === 'Summary') {
     return null;
   }
 
-  const displayGrid =
-    display && display.useComponentGrid ? overrides?.grid || targetItem?.grid : overrides?.grid || summaryItem?.grid;
   const component = targetNode.def;
   const RenderSummary = 'renderSummary' in component ? component.renderSummary.bind(component) : null;
   const shouldShowBorder =
     RenderSummary && 'renderSummaryBoilerplate' in component && component?.renderSummaryBoilerplate();
-
-  // This logic is needlessly complex, but our tests depends on it being this way as of now.
-  const summaryTestId = overrides?.targetNode
-    ? overrides.targetNode.id
-    : (summaryNode?.id ?? targetNode?.id ?? 'unknown');
 
   return (
     <Flex
       ref={ref}
       item
       size={{
-        xs: displayGrid?.xs ?? 12,
-        sm: displayGrid?.sm,
-        md: displayGrid?.md,
-        lg: displayGrid?.lg,
-        xl: displayGrid?.xl,
+        xs: grid?.xs ?? 12,
+        sm: grid?.sm,
+        md: grid?.md,
+        lg: grid?.lg,
+        xl: grid?.xl,
       }}
       data-testid={`summary-${summaryTestId}`}
-      data-componentid={summaryNode?.id ?? `summary-${targetNode?.id}`}
-      data-componentbaseid={summaryNode?.baseId ?? `summary-${targetNode.id}`}
+      data-componentid={componentId}
+      data-componentbaseid={componentBaseId}
       className={cn(pageBreakStyles(pageBreak))}
     >
       <Flex
@@ -127,9 +193,8 @@ export const SummaryComponent = React.forwardRef(function SummaryComponent(
           <SummaryContent
             onChangeClick={onChangeClick}
             changeText={langAsString('form_filler.summary_item_change')}
-            summaryNode={summaryNode}
             targetNode={targetNode}
-            overrides={overrides}
+            overrides={{ largeGroup, display, pageBreak, grid, excludedChildren }}
             RenderSummary={RenderSummary}
           />
         ) : (
@@ -177,3 +242,5 @@ export const SummaryComponent = React.forwardRef(function SummaryComponent(
     </Flex>
   );
 });
+
+SummaryComponentInner.displayName = 'SummaryComponentInner';

--- a/src/layout/Summary/SummaryComponent.tsx
+++ b/src/layout/Summary/SummaryComponent.tsx
@@ -32,7 +32,7 @@ interface SummaryOverrides {
 }
 
 export interface ISummaryComponent {
-  summaryNode: LayoutNode<'Summary'> | undefined;
+  summaryNode: LayoutNode<'Summary'>;
   overrides?: Partial<SummaryOverrides>;
 }
 

--- a/src/layout/Summary/SummaryContent.tsx
+++ b/src/layout/Summary/SummaryContent.tsx
@@ -19,15 +19,13 @@ interface SummaryContentProps extends SummaryRendererProps<CompTypes> {
 export function SummaryContent({
   onChangeClick,
   changeText,
-  summaryNode,
   targetNode,
   overrides,
   RenderSummary,
 }: SummaryContentProps) {
   const { langAsString } = useLanguage();
-  const summaryItem = useNodeItem(summaryNode);
   const targetItem = useNodeItem(targetNode);
-  const display = overrides?.display || summaryItem?.display;
+  const display = overrides?.display;
   const readOnlyComponent = 'readOnly' in targetItem && targetItem.readOnly === true;
   const validations = useUnifiedValidationsForNode(targetNode);
   const hasErrors = hasValidationErrors(validations);
@@ -60,7 +58,6 @@ export function SummaryContent({
         <RenderSummary
           onChangeClick={onChangeClick}
           changeText={changeText}
-          summaryNode={summaryNode}
           targetNode={targetNode}
           overrides={overrides}
         />

--- a/src/layout/Tabs/TabsSummaryComponent.tsx
+++ b/src/layout/Tabs/TabsSummaryComponent.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import type { JSX } from 'react';
 
-import { SummaryComponent } from 'src/layout/Summary/SummaryComponent';
+import { SummaryComponentFor } from 'src/layout/Summary/SummaryComponent';
 import { useNode } from 'src/utils/layout/NodesContext';
 import { useNodeItem } from 'src/utils/layout/useNodeItem';
 import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 
-type Props = Pick<SummaryRendererProps<'Tabs'>, 'targetNode' | 'summaryNode' | 'overrides'>;
+type Props = Pick<SummaryRendererProps<'Tabs'>, 'targetNode' | 'overrides'>;
 
-export function TabsSummaryComponent({ targetNode, summaryNode, overrides }: Props): JSX.Element | null {
+export function TabsSummaryComponent({ targetNode, overrides }: Props): JSX.Element | null {
   const tabsInternal = useNodeItem(targetNode, (i) => i.tabsInternal);
   const childIds = tabsInternal.map((card) => card.childIds).flat();
 
@@ -18,7 +18,6 @@ export function TabsSummaryComponent({ targetNode, summaryNode, overrides }: Pro
         <Child
           key={childId}
           nodeId={childId}
-          summaryNode={summaryNode}
           overrides={overrides}
         />
       ))}
@@ -26,19 +25,18 @@ export function TabsSummaryComponent({ targetNode, summaryNode, overrides }: Pro
   );
 }
 
-function Child({ nodeId, summaryNode, overrides }: { nodeId: string } & Pick<Props, 'summaryNode' | 'overrides'>) {
+function Child({ nodeId, overrides }: { nodeId: string } & Pick<Props, 'overrides'>) {
   const node = useNode(nodeId);
   if (!node) {
     return null;
   }
 
   return (
-    <SummaryComponent
+    <SummaryComponentFor
       key={node.id}
-      summaryNode={summaryNode}
+      targetNode={node}
       overrides={{
         ...overrides,
-        targetNode: node,
         grid: {},
         largeGroup: true,
       }}

--- a/src/layout/Tabs/index.tsx
+++ b/src/layout/Tabs/index.tsx
@@ -17,11 +17,10 @@ export class Tabs extends TabsDef {
     },
   );
 
-  renderSummary({ summaryNode, targetNode, overrides }: SummaryRendererProps<'Tabs'>): JSX.Element | null {
+  renderSummary({ targetNode, overrides }: SummaryRendererProps<'Tabs'>): JSX.Element | null {
     return (
       <TabsSummaryComponent
         targetNode={targetNode}
-        summaryNode={summaryNode}
         overrides={overrides}
       />
     );

--- a/src/utils/formComponentUtils.ts
+++ b/src/utils/formComponentUtils.ts
@@ -1,8 +1,8 @@
 import type React from 'react';
 
 import { isAttachmentUploaded } from 'src/features/attachments';
+import { useLayoutLookups } from 'src/features/form/layout/LayoutsContext';
 import printStyles from 'src/styles/print.module.css';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
 import type { IAttachment } from 'src/features/attachments';
 import type { ExprResolved } from 'src/features/expressions/types';
 import type {
@@ -12,7 +12,6 @@ import type {
   ITableColumnProperties,
 } from 'src/layout/common.generated';
 import type { CompTypes, IDataModelBindings, ITextResourceBindings } from 'src/layout/layout';
-import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export type BindingToValues<B extends IDataModelBindings | undefined> = B extends undefined
   ? { [key: string]: undefined }
@@ -127,8 +126,9 @@ export const pageBreakStyles = (pageBreak: ExprResolved<IPageBreak> | undefined)
   };
 };
 
-export function useTextAlignment(node: LayoutNode): 'left' | 'center' | 'right' {
-  const formatting = useNodeItem(node, (i) => (i.type === 'Input' ? i.formatting : undefined));
+function useTextAlignment(baseComponentId: string): 'left' | 'center' | 'right' {
+  const component = useLayoutLookups().getComponent(baseComponentId);
+  const formatting = component.type === 'Input' ? component.formatting : undefined;
   if (!formatting) {
     return 'left';
   }
@@ -138,9 +138,12 @@ export function useTextAlignment(node: LayoutNode): 'left' | 'center' | 'right' 
   return formatting.number ? 'right' : 'left';
 }
 
-export function useColumnStylesRepeatingGroups(node: LayoutNode, columnSettings: ITableColumnFormatting | undefined) {
-  const textAlignment = useTextAlignment(node);
-  const column = columnSettings && node && columnSettings[node.baseId];
+export function useColumnStylesRepeatingGroups(
+  baseComponentId: string,
+  columnSettings: ITableColumnFormatting | undefined,
+) {
+  const textAlignment = useTextAlignment(baseComponentId);
+  const column = columnSettings && columnSettings[baseComponentId];
   if (!column) {
     return;
   }

--- a/src/utils/formComponentUtils.ts
+++ b/src/utils/formComponentUtils.ts
@@ -127,7 +127,7 @@ export const pageBreakStyles = (pageBreak: ExprResolved<IPageBreak> | undefined)
   };
 };
 
-export function useTextAlignment(node: LayoutNode | undefined): 'left' | 'center' | 'right' {
+export function useTextAlignment(node: LayoutNode): 'left' | 'center' | 'right' {
   const formatting = useNodeItem(node, (i) => (i.type === 'Input' ? i.formatting : undefined));
   if (!formatting) {
     return 'left';
@@ -138,10 +138,7 @@ export function useTextAlignment(node: LayoutNode | undefined): 'left' | 'center
   return formatting.number ? 'right' : 'left';
 }
 
-export function useColumnStylesRepeatingGroups(
-  node: LayoutNode | undefined,
-  columnSettings: ITableColumnFormatting | undefined,
-) {
+export function useColumnStylesRepeatingGroups(node: LayoutNode, columnSettings: ITableColumnFormatting | undefined) {
   const textAlignment = useTextAlignment(node);
   const column = columnSettings && node && columnSettings[node.baseId];
   if (!column) {

--- a/src/utils/layout/DataModelLocation.tsx
+++ b/src/utils/layout/DataModelLocation.tsx
@@ -80,6 +80,16 @@ export function DataModelLocationProviderFromNode({ nodeId, children }: PropsWit
   );
 }
 
+export function useDataModelLocationForRow(groupBinding: IDataModelReference, rowIndex: number) {
+  return useMemo(
+    () => ({
+      dataType: groupBinding.dataType,
+      field: `${groupBinding.field}[${rowIndex}]`,
+    }),
+    [groupBinding.dataType, groupBinding.field, rowIndex],
+  );
+}
+
 export function useComponentIdMutator(): IdMutator {
   const mutators = useCtx()?.idMutators;
   return useCallback(

--- a/src/utils/layout/DataModelLocation.tsx
+++ b/src/utils/layout/DataModelLocation.tsx
@@ -80,16 +80,6 @@ export function DataModelLocationProviderFromNode({ nodeId, children }: PropsWit
   );
 }
 
-export function useDataModelLocationForRow(groupBinding: IDataModelReference, rowIndex: number) {
-  return useMemo(
-    () => ({
-      dataType: groupBinding.dataType,
-      field: `${groupBinding.field}[${rowIndex}]`,
-    }),
-    [groupBinding.dataType, groupBinding.field, rowIndex],
-  );
-}
-
 export function useComponentIdMutator(): IdMutator {
   const mutators = useCtx()?.idMutators;
   return useCallback(

--- a/src/utils/layout/NodesContext.tsx
+++ b/src/utils/layout/NodesContext.tsx
@@ -692,6 +692,10 @@ function NodesLoader() {
  *
  * Usually, if you're looking for a specific component/node, useResolvedNode() is better.
  */
+export function useNode<T extends string | LayoutNode>(id: T): LayoutNode;
+// eslint-disable-next-line no-redeclare
+export function useNode<T extends string | undefined | LayoutNode>(id: T): LayoutNode | undefined;
+// eslint-disable-next-line no-redeclare
 export function useNode<T extends string | undefined | LayoutNode>(id: T): LayoutNode | undefined {
   const lastValue = useRef<LayoutNode | undefined | typeof NeverInitialized>(NeverInitialized);
   const nodes = useNodes();

--- a/src/utils/layout/useNodeItem.ts
+++ b/src/utils/layout/useNodeItem.ts
@@ -12,15 +12,9 @@ import type { NodeData, NodeItemFromNode } from 'src/utils/layout/types';
  * Use the item of a node. This re-renders when the item changes (or when the part of the item you select changes),
  * which doesn't happen if you use node.item directly.
  */
-export function useNodeItem<N extends LayoutNode | undefined, Out>(
-  node: N,
-  selector: (item: NodeItemFromNode<N>) => Out,
-): N extends undefined ? undefined : Out;
+export function useNodeItem<N extends LayoutNode, Out>(node: N, selector: (item: NodeItemFromNode<N>) => Out): Out;
 // eslint-disable-next-line no-redeclare
-export function useNodeItem<N extends LayoutNode | undefined>(
-  node: N,
-  selector?: undefined,
-): N extends undefined ? undefined : NodeItemFromNode<N>;
+export function useNodeItem<N extends LayoutNode>(node: N, selector?: undefined): NodeItemFromNode<N>;
 // eslint-disable-next-line no-redeclare
 export function useNodeItem(node: LayoutNode | undefined, selector: never): unknown {
   if (GeneratorInternal.useIsInsideGenerator()) {

--- a/src/utils/layout/useNodeItem.ts
+++ b/src/utils/layout/useNodeItem.ts
@@ -26,6 +26,13 @@ export function useNodeItem(node: LayoutNode | undefined, selector: never): unkn
     );
   }
 
+  if (!node) {
+    throw new Error(
+      'useNodeItem() requires a node object. If your component cannot guarantee that, make two different ' +
+        'components (one that has a node, one that does not) and render conditionally.',
+    );
+  }
+
   return NodesInternal.useNodeData(node, (data: NodeData, readiness) => {
     if (!data?.item) {
       throw new Error(


### PR DESCRIPTION
## Description

Before solving #3451 (evaluating expressions directly in `useNodeItem()` instead of looking up the evaluation results from the zustand store in NodesContext), `useNodeItem()` needed some fixing. Since we need to run some hooks that depend on the expressions we need to evaluate, the number and order of hooks called during a render can vary if the `node` argument is `undefined` one render and defined the next. This, of course, is breaking the rule of hooks, so that needs fixing. This PR makes the `node` object passed to `useNodeItem()` required, and some components needed refactoring to make that work (Summary1 was the worst of these).

Now, and in the future, when you want to evaluate expressions, you should always pass that same expression every render. When we get a chance to fuse all our data contexts into one zustand store, that requirement probably goes away again.

## Related Issue(s)

- #3147
- closes #3450
- unblocks #3443

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [x] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->
