### PR TITLE
Fixing flaky/broken pdf test

### DIFF
--- a/test/e2e/integration/frontend-test/pdf.ts
+++ b/test/e2e/integration/frontend-test/pdf.ts
@@ -13,6 +13,7 @@ const likertPage = new Likert();
 describe('PDF', () => {
   it('should generate PDF for message step', () => {
     cy.goto('message');
+    cy.get('#finishedLoading').should('exist');
 
     cy.testPdf({
       snapshotName: 'message',
@@ -33,6 +34,7 @@ describe('PDF', () => {
     const cookieOptions: Partial<Cypress.SetCookieOptions> = { domain, sameSite: 'lax' };
 
     cy.goto('message');
+    cy.get('#finishedLoading').should('exist');
 
     cy.testPdf({
       beforeReload: () => {


### PR DESCRIPTION
## Description

In the `frontend-test/pdf.ts` test, sometimes the `<instanceData>/pdf/format` endpoint would be called early (when we add `?pdf=1` to the URL), before we reload. In the case of the `downstream requests includes trace context header` test, this could end up intercepting requests before the reloading starts, which would also cause the required headers to not show up.

## Related Issue(s)

- closes #2874

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [x] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->
