### PR TITLE
Adds support for showing data type description in attachment list

### DIFF
--- a/src/components/atoms/AltinnAttachment.module.css
+++ b/src/components/atoms/AltinnAttachment.module.css
@@ -47,15 +47,15 @@
 
 .attachmentText {
   display: flex;
-  flex-direction: column;
+  flex-wrap: wrap;
   min-width: 0; /* Allows truncation to work in flex containers */
   width: 100%;
+  gap: 4px;
 }
 
 .description {
   word-break: break-word;
   color: var(--fds-semantic-text-neutral-default);
-  margin-bottom: 4px;
 }
 
 .filename {

--- a/src/components/atoms/AltinnAttachment.module.css
+++ b/src/components/atoms/AltinnAttachment.module.css
@@ -26,6 +26,7 @@
   font-size: 2.2rem;
   flex-shrink: 0;
   margin-right: 5px;
+  align-self: center;
 }
 
 .truncate,
@@ -36,4 +37,28 @@
 .truncate {
   text-overflow: ellipsis;
   overflow: hidden;
+}
+
+.attachmentContent {
+  display: flex;
+  align-items: center;
+  width: 100%;
+}
+
+.attachmentText {
+  display: flex;
+  flex-direction: column;
+  min-width: 0; /* Allows truncation to work in flex containers */
+  width: 100%;
+}
+
+.description {
+  word-break: break-word;
+  color: var(--fds-semantic-text-neutral-default);
+  margin-bottom: 4px;
+}
+
+.filename {
+  display: flex;
+  min-width: 0; /* Allows truncation to work in flex containers */
 }

--- a/src/components/atoms/AltinnAttachments.test.tsx
+++ b/src/components/atoms/AltinnAttachments.test.tsx
@@ -12,14 +12,23 @@ const mockAttachments = [
   {
     name: 'file1.pdf',
     url: 'https://example.com/file1.pdf',
+    description: {
+      nb: 'Beskrivelse av fil 1',
+      en: 'Description of file 1',
+    },
   },
   {
     name: 'file2.docx',
     url: 'https://example.com/file2.docx',
+    description: {
+      nb: 'Beskrivelse av fil 2',
+      en: 'Description of file 2',
+    },
   },
   {
     name: 'file3.xlsx',
     url: 'https://example.com/file3.xlsx',
+    description: undefined,
   },
 ] as unknown as IDisplayAttachment[];
 
@@ -245,5 +254,55 @@ describe('AltinnAttachments', () => {
     );
 
     expect(screen.getByTestId('attachment-list')).toHaveAttribute('id', id);
+  });
+
+  it('should show descriptions when showDescription is true and attachment has a description', () => {
+    mockUseCurrentLanguage.mockReturnValue('nb');
+
+    render(
+      <AltinnAttachments
+        attachments={mockAttachments}
+        showLinks={true}
+        showDescription={true}
+      />,
+    );
+
+    expect(screen.getByText('Beskrivelse av fil 1')).toBeInTheDocument();
+    expect(screen.getByText('Beskrivelse av fil 2')).toBeInTheDocument();
+    // File 3 doesn't have a description, so it shouldn't be shown
+    expect(screen.queryByText('Beskrivelse av fil 3')).not.toBeInTheDocument();
+  });
+
+  it('should not show descriptions when showDescription is false', () => {
+    mockUseCurrentLanguage.mockReturnValue('nb');
+
+    render(
+      <AltinnAttachments
+        attachments={mockAttachments}
+        showLinks={true}
+        showDescription={false}
+      />,
+    );
+
+    expect(screen.queryByText('Beskrivelse av fil 1')).not.toBeInTheDocument();
+    expect(screen.queryByText('Beskrivelse av fil 2')).not.toBeInTheDocument();
+  });
+
+  it('should show descriptions in the correct language', () => {
+    // Set language to English
+    mockUseCurrentLanguage.mockReturnValue('en');
+
+    render(
+      <AltinnAttachments
+        attachments={mockAttachments}
+        showLinks={true}
+        showDescription={true}
+      />,
+    );
+
+    expect(screen.getByText('Description of file 1')).toBeInTheDocument();
+    expect(screen.getByText('Description of file 2')).toBeInTheDocument();
+    expect(screen.queryByText('Beskrivelse av fil 1')).not.toBeInTheDocument();
+    expect(screen.queryByText('Beskrivelse av fil 2')).not.toBeInTheDocument();
   });
 });

--- a/src/components/atoms/AltinnAttachments.tsx
+++ b/src/components/atoms/AltinnAttachments.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
+import type { PropsWithChildren } from 'react';
 
 import { Link, List } from '@digdir/designsystemet-react';
 import cn from 'classnames';
 
-import { ConditionalWrapper } from 'src/app-components/ConditionalWrapper/ConditionalWrapper';
 import classes from 'src/components/atoms/AltinnAttachment.module.css';
 import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
 import { useLanguage } from 'src/features/language/useLanguage';
@@ -59,23 +59,13 @@ interface IAltinnAttachmentProps {
 }
 
 function Attachment({ attachment, showLink, showDescription }: IAltinnAttachmentProps) {
-  const { langAsString } = useLanguage();
   const currentLanguage = useCurrentLanguage();
 
   return (
     <List.Item>
-      <ConditionalWrapper
-        condition={showLink}
-        wrapper={(children) => (
-          <Link
-            href={attachment.url && makeUrlRelativeIfSameDomain(attachment.url)}
-            className={cn(classes.attachment, classes.attachmentLink)}
-            aria-label={langAsString('general.download', [`${attachment.name}`])}
-          >
-            {children}
-          </Link>
-        )}
-        otherwise={(children) => <span className={classes.attachment}>{children}</span>}
+      <AttachmentFileName
+        attachment={attachment}
+        showLink={showLink}
       >
         <div className={classes.attachmentContent}>
           <FileExtensionIcon
@@ -86,7 +76,7 @@ function Attachment({ attachment, showLink, showDescription }: IAltinnAttachment
             {showDescription && attachment.description?.[currentLanguage] && (
               <div className={classes.description}>
                 {attachment.description[currentLanguage]}
-                <span className={classes.separator}>&nbsp;&ndash;&ndash;&nbsp;</span>
+                <span>&nbsp;&ndash;&ndash;&nbsp;</span>
               </div>
             )}
             <div className={classes.filename}>
@@ -95,7 +85,31 @@ function Attachment({ attachment, showLink, showDescription }: IAltinnAttachment
             </div>
           </div>
         </div>
-      </ConditionalWrapper>
+      </AttachmentFileName>
     </List.Item>
   );
+}
+
+function AttachmentFileName({
+  attachment,
+  showLink,
+  children,
+}: PropsWithChildren<{ attachment: IDisplayAttachment; showLink: boolean }>) {
+  const { langAsString } = useLanguage();
+  const currentLanguage = useCurrentLanguage();
+
+  if (showLink) {
+    return (
+      <Link
+        href={attachment.url && makeUrlRelativeIfSameDomain(attachment.url)}
+        className={cn(classes.attachment, classes.attachmentLink)}
+        aria-label={langAsString('general.download', [`${attachment.name}`])}
+        aria-description={attachment.description?.[currentLanguage]}
+      >
+        {children}
+      </Link>
+    );
+  }
+
+  return <span className={classes.attachment}>{children}</span>;
 }

--- a/src/components/atoms/AltinnAttachments.tsx
+++ b/src/components/atoms/AltinnAttachments.tsx
@@ -17,9 +17,16 @@ interface IAltinnAttachmentsProps {
   id?: string;
   title?: React.ReactNode;
   showLinks: boolean | undefined;
+  showDescription?: boolean;
 }
 
-export function AltinnAttachments({ attachments, id, title, showLinks = true }: IAltinnAttachmentsProps) {
+export function AltinnAttachments({
+  attachments,
+  id,
+  title,
+  showLinks = true,
+  showDescription = false,
+}: IAltinnAttachmentsProps) {
   const selectedLanguage = useCurrentLanguage();
   const filteredAndSortedAttachments = attachments
     ?.filter((attachment) => attachment.name)
@@ -37,6 +44,7 @@ export function AltinnAttachments({ attachments, id, title, showLinks = true }: 
             key={index}
             attachment={attachment}
             showLink={showLinks}
+            showDescription={showDescription}
           />
         ))}
       </List.Unordered>
@@ -47,10 +55,13 @@ export function AltinnAttachments({ attachments, id, title, showLinks = true }: 
 interface IAltinnAttachmentProps {
   attachment: IDisplayAttachment;
   showLink: boolean;
+  showDescription: boolean;
 }
 
-function Attachment({ attachment, showLink }: IAltinnAttachmentProps) {
+function Attachment({ attachment, showLink, showDescription }: IAltinnAttachmentProps) {
   const { langAsString } = useLanguage();
+  const currentLanguage = useCurrentLanguage();
+
   return (
     <List.Item>
       <ConditionalWrapper
@@ -66,12 +77,21 @@ function Attachment({ attachment, showLink }: IAltinnAttachmentProps) {
         )}
         otherwise={(children) => <span className={classes.attachment}>{children}</span>}
       >
-        <FileExtensionIcon
-          fileEnding={getFileEnding(attachment.name)}
-          className={classes.attachmentIcon}
-        />
-        <span className={classes.truncate}>{removeFileEnding(attachment.name)}</span>
-        <span className={classes.extension}>{getFileEnding(attachment.name)}</span>
+        <div className={classes.attachmentContent}>
+          <FileExtensionIcon
+            fileEnding={getFileEnding(attachment.name)}
+            className={classes.attachmentIcon}
+          />
+          <div className={classes.attachmentText}>
+            {showDescription && attachment.description?.[currentLanguage] && (
+              <div className={classes.description}>{attachment.description[currentLanguage]}</div>
+            )}
+            <div className={classes.filename}>
+              <span className={classes.truncate}>{removeFileEnding(attachment.name)}</span>
+              <span className={classes.extension}>{getFileEnding(attachment.name)}</span>
+            </div>
+          </div>
+        </div>
       </ConditionalWrapper>
     </List.Item>
   );

--- a/src/components/atoms/AltinnAttachments.tsx
+++ b/src/components/atoms/AltinnAttachments.tsx
@@ -84,7 +84,10 @@ function Attachment({ attachment, showLink, showDescription }: IAltinnAttachment
           />
           <div className={classes.attachmentText}>
             {showDescription && attachment.description?.[currentLanguage] && (
-              <div className={classes.description}>{attachment.description[currentLanguage]}</div>
+              <div className={classes.description}>
+                {attachment.description[currentLanguage]}
+                <span className={classes.separator}>&nbsp;&ndash;&ndash;&nbsp;</span>
+              </div>
             )}
             <div className={classes.filename}>
               <span className={classes.truncate}>{removeFileEnding(attachment.name)}</span>

--- a/src/components/molecules/AltinnCollapsibleAttachments.tsx
+++ b/src/components/molecules/AltinnCollapsibleAttachments.tsx
@@ -14,6 +14,7 @@ interface IAltinnCollapsibleAttachmentsProps {
   title: React.ReactNode | undefined;
   hideCount?: boolean;
   showLinks: boolean | undefined;
+  showDescription: boolean;
 }
 
 export function AltinnCollapsibleAttachments({
@@ -21,6 +22,7 @@ export function AltinnCollapsibleAttachments({
   title,
   hideCount,
   showLinks = true,
+  showDescription,
 }: IAltinnCollapsibleAttachmentsProps) {
   const isCollapsible = useIsPrint() ? false : Boolean(attachments && attachments.length > 4);
   const [open, setOpen] = React.useState(true);
@@ -54,6 +56,7 @@ export function AltinnCollapsibleAttachments({
           <AltinnAttachments
             attachments={attachments}
             showLinks={showLinks}
+            showDescription={showDescription}
           />
         </AltinnCollapsible>
       </div>
@@ -70,6 +73,7 @@ export function AltinnCollapsibleAttachments({
       }
       attachments={attachments}
       showLinks={showLinks}
+      showDescription={showDescription}
     />
   );
 }

--- a/src/components/organisms/AttachmentGroupings.tsx
+++ b/src/components/organisms/AttachmentGroupings.tsx
@@ -9,6 +9,7 @@ interface IRenderAttachmentGroupings {
   collapsibleTitle: React.ReactNode;
   hideCollapsibleCount?: boolean;
   showLinks: boolean | undefined;
+  showDescription?: boolean;
 }
 
 const defaultGroupingKey = 'null';
@@ -18,6 +19,7 @@ export const AttachmentGroupings = ({
   collapsibleTitle,
   hideCollapsibleCount,
   showLinks = true,
+  showDescription = false,
 }: IRenderAttachmentGroupings) => {
   const langTools = useLanguage();
 
@@ -56,6 +58,7 @@ export const AttachmentGroupings = ({
             title={groupTitle === 'null' ? collapsibleTitle : groupTitle}
             hideCount={hideCollapsibleCount}
             showLinks={showLinks}
+            showDescription={showDescription}
           />
         ))}
     </>

--- a/src/features/applicationMetadata/types.ts
+++ b/src/features/applicationMetadata/types.ts
@@ -35,7 +35,7 @@ export interface IOnEntry {
   instanceSelection?: IInstanceSelection;
 }
 
-export type ShowTypes = 'new-instance' | 'select-instance' | LooseAutocomplete;
+export type ShowTypes = LooseAutocomplete<'new-instance' | 'select-instance'>;
 
 export type IInstanceSelection = {
   rowsPerPageOptions: number[];

--- a/src/features/language/LanguageProvider.tsx
+++ b/src/features/language/LanguageProvider.tsx
@@ -76,7 +76,7 @@ export const LanguageProvider = ({ children }: PropsWithChildren) => {
         setWithLanguageSelector,
       }}
     >
-      {children}
+      <div lang={current}>{children}</div>
     </Provider>
   );
 };

--- a/src/features/language/useLanguage.ts
+++ b/src/features/language/useLanguage.ts
@@ -27,7 +27,7 @@ import type { IApplicationSettings, IInstanceDataSources, IVariable } from 'src/
 type SimpleLangParam = string | number | undefined;
 export type ValidLangParam = SimpleLangParam | ReactNode | TextReference;
 export type TextReference = {
-  key: ValidLanguageKey | LooseAutocomplete | undefined;
+  key: LooseAutocomplete<ValidLanguageKey> | undefined;
   params?: ValidLangParam[];
   makeLowerCase?: boolean;
 };
@@ -35,11 +35,11 @@ export type TextReference = {
 export interface IUseLanguage {
   language: FixedLanguageList;
   lang(
-    key: ValidLanguageKey | LooseAutocomplete | undefined,
+    key: LooseAutocomplete<ValidLanguageKey> | undefined,
     params?: ValidLangParam[],
   ): string | JSX.Element | JSX.Element[] | null;
   langAsString(
-    key: ValidLanguageKey | LooseAutocomplete | undefined,
+    key: LooseAutocomplete<ValidLanguageKey> | undefined,
     params?: ValidLangParam[],
     makeLowerCase?: boolean,
   ): string;
@@ -48,9 +48,9 @@ export interface IUseLanguage {
     dataModelPath: IDataModelReference,
     params?: ValidLangParam[],
   ): string;
-  langAsNonProcessedString(key: ValidLanguageKey | LooseAutocomplete | undefined, params?: ValidLangParam[]): string;
+  langAsNonProcessedString(key: LooseAutocomplete<ValidLanguageKey> | undefined, params?: ValidLangParam[]): string;
   langAsNonProcessedStringUsingPathInDataModel(
-    key: ValidLanguageKey | LooseAutocomplete | undefined,
+    key: LooseAutocomplete<ValidLanguageKey> | undefined,
     dataModelPath: IDataModelReference,
     params?: ValidLangParam[],
   ): string;

--- a/src/layout/AttachmentList/AttachmentListComponent.test.tsx
+++ b/src/layout/AttachmentList/AttachmentListComponent.test.tsx
@@ -82,24 +82,28 @@ jest.mock('src/layout/ComponentStructureWrapper', () => ({
 
 // Mock the components that are conditionally rendered
 jest.mock('src/components/atoms/AltinnAttachments', () => ({
-  AltinnAttachments: jest.fn(({ attachments, title, showLinks }) => (
+  AltinnAttachments: jest.fn(({ attachments, title, showLinks, showDescription }) => (
     <div data-testid='altinn-attachments'>
       <div data-testid='altinn-attachments-title'>{title}</div>
       <div data-testid='altinn-attachments-showlinks'>{showLinks ? 'true' : 'false'}</div>
+      <div data-testid='altinn-attachments-showdescription'>{showDescription ? 'true' : 'false'}</div>
       <div data-testid='altinn-attachments-count'>{attachments?.length ?? 0}</div>
     </div>
   )),
 }));
 
 jest.mock('src/components/organisms/AttachmentGroupings', () => ({
-  AttachmentGroupings: jest.fn(({ attachments, collapsibleTitle, hideCollapsibleCount, showLinks }) => (
-    <div data-testid='attachment-groupings'>
-      <div data-testid='attachment-groupings-title'>{collapsibleTitle}</div>
-      <div data-testid='attachment-groupings-hidecount'>{hideCollapsibleCount ? 'true' : 'false'}</div>
-      <div data-testid='attachment-groupings-showlinks'>{showLinks ? 'true' : 'false'}</div>
-      <div data-testid='attachment-groupings-count'>{attachments?.length ?? 0}</div>
-    </div>
-  )),
+  AttachmentGroupings: jest.fn(
+    ({ attachments, collapsibleTitle, hideCollapsibleCount, showLinks, showDescription }) => (
+      <div data-testid='attachment-groupings'>
+        <div data-testid='attachment-groupings-title'>{collapsibleTitle}</div>
+        <div data-testid='attachment-groupings-hidecount'>{hideCollapsibleCount ? 'true' : 'false'}</div>
+        <div data-testid='attachment-groupings-showlinks'>{showLinks ? 'true' : 'false'}</div>
+        <div data-testid='attachment-groupings-showdescription'>{showDescription ? 'true' : 'false'}</div>
+        <div data-testid='attachment-groupings-count'>{attachments?.length ?? 0}</div>
+      </div>
+    ),
+  ),
 }));
 
 describe('AttachmentListComponent', () => {
@@ -112,6 +116,7 @@ describe('AttachmentListComponent', () => {
     textResourceBindings = { title: 'test-title' },
     links = true,
     dataTypeIds = ['dataType1', 'dataType2', 'dataType3'],
+    showDataTypeDescriptions = false,
   } = {}) => {
     mockUseNodeItem.mockImplementation((_node, selector) => {
       if (typeof selector === 'function') {
@@ -128,6 +133,9 @@ describe('AttachmentListComponent', () => {
         }
         if (selectorStr.includes('dataTypeIds')) {
           return dataTypeIds;
+        }
+        if (selectorStr.includes('showDataTypeDescriptions')) {
+          return showDataTypeDescriptions;
         }
       }
       return undefined;
@@ -310,5 +318,67 @@ describe('AttachmentListComponent', () => {
     // Should only include attachments from the current task (dataType1 and dataType2)
     // and exclude the attachment from a different task (dataType3)
     expect(screen.getByTestId('altinn-attachments-count')).toHaveTextContent('2');
+  });
+
+  it('should pass showDescription=false to AltinnAttachments by default', () => {
+    setupMockUseNodeItem({
+      groupByDataTypeGrouping: false,
+    });
+
+    render(
+      <AttachmentListComponent
+        node={{} as LayoutNode<'AttachmentList'>}
+        containerDivRef={React.createRef<HTMLDivElement>()}
+      />,
+    );
+
+    expect(screen.getByTestId('altinn-attachments-showdescription')).toHaveTextContent('false');
+  });
+
+  it('should pass showDescription=true to AltinnAttachments when showDataTypeDescriptions is true', () => {
+    setupMockUseNodeItem({
+      groupByDataTypeGrouping: false,
+      showDataTypeDescriptions: true,
+    });
+
+    render(
+      <AttachmentListComponent
+        node={{} as LayoutNode<'AttachmentList'>}
+        containerDivRef={React.createRef<HTMLDivElement>()}
+      />,
+    );
+
+    expect(screen.getByTestId('altinn-attachments-showdescription')).toHaveTextContent('true');
+  });
+
+  it('should pass showDescription=false to AttachmentGroupings by default', () => {
+    setupMockUseNodeItem({
+      groupByDataTypeGrouping: true,
+    });
+
+    render(
+      <AttachmentListComponent
+        node={{} as LayoutNode<'AttachmentList'>}
+        containerDivRef={React.createRef<HTMLDivElement>()}
+      />,
+    );
+
+    expect(screen.getByTestId('attachment-groupings-showdescription')).toHaveTextContent('false');
+  });
+
+  it('should pass showDescription=true to AttachmentGroupings when showDataTypeDescriptions is true', () => {
+    setupMockUseNodeItem({
+      groupByDataTypeGrouping: true,
+      showDataTypeDescriptions: true,
+    });
+
+    render(
+      <AttachmentListComponent
+        node={{} as LayoutNode<'AttachmentList'>}
+        containerDivRef={React.createRef<HTMLDivElement>()}
+      />,
+    );
+
+    expect(screen.getByTestId('attachment-groupings-showdescription')).toHaveTextContent('true');
   });
 });

--- a/src/layout/AttachmentList/AttachmentListComponent.test.tsx
+++ b/src/layout/AttachmentList/AttachmentListComponent.test.tsx
@@ -296,8 +296,6 @@ describe('AttachmentListComponent', () => {
       />,
     );
 
-    screen.debug();
-
     // Should include all attachments from mockInstanceData (dataType1, dataType2, and dataType3)
     expect(screen.getByTestId('attachment-groupings-count')).toHaveTextContent('3');
   });

--- a/src/layout/AttachmentList/AttachmentListComponent.tsx
+++ b/src/layout/AttachmentList/AttachmentListComponent.tsx
@@ -27,6 +27,7 @@ export function AttachmentListComponent({ node }: IAttachmentListProps) {
   const showLinks = useNodeItem(node, (i) => i.links);
   const allowedAttachmentTypes = new Set(useNodeItem(node, (i) => i.dataTypeIds) ?? []);
   const groupAttachments = useNodeItem(node, (i) => i.groupByDataTypeGrouping) ?? false;
+  const showDescription = useNodeItem(node, (i) => i.showDataTypeDescriptions) ?? false;
 
   const instanceData = useLaxInstanceData((data) => data.data) ?? [];
   const currentTaskId = useLaxProcessData()?.currentTask?.elementId;
@@ -75,12 +76,14 @@ export function AttachmentListComponent({ node }: IAttachmentListProps) {
           collapsibleTitle={<Lang id={textResourceBindings?.title} />}
           hideCollapsibleCount={true}
           showLinks={showLinks}
+          showDescription={showDescription}
         />
       ) : (
         <AltinnAttachments
           attachments={displayAttachments}
           title={<Lang id={textResourceBindings?.title} />}
           showLinks={showLinks}
+          showDescription={showDescription}
         />
       )}
     </ComponentStructureWrapper>

--- a/src/layout/AttachmentList/config.ts
+++ b/src/layout/AttachmentList/config.ts
@@ -46,4 +46,12 @@ export const Config = new CG.component({
       'groupByDataTypeGrouping',
       new CG.bool().optional({ default: false }).setDescription('Group attachments by their data type grouping'),
     ),
+  )
+  .addProperty(
+    new CG.prop(
+      'showDataTypeDescriptions',
+      new CG.bool()
+        .optional({ default: false })
+        .setDescription('Show the corresponding data type description for each attachment'),
+    ),
   );

--- a/src/layout/Datepicker/DatepickerComponent.test.tsx
+++ b/src/layout/Datepicker/DatepickerComponent.test.tsx
@@ -85,13 +85,11 @@ describe('DatepickerComponent', () => {
     await render();
 
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
-    screen.debug();
     await userEvent.click(
       screen.getByRole('button', {
         name: /Åpne datovelger/i,
       }),
     );
-    screen.debug();
     expect(screen.getByRole('dialog')).toBeInTheDocument();
     expect(screen.getByRole('gridcell', { name: new Date().getDate().toString() })).toHaveAttribute(
       'data-today',

--- a/src/layout/Group/__snapshots__/SummaryGroupComponent.test.tsx.snap
+++ b/src/layout/Group/__snapshots__/SummaryGroupComponent.test.tsx.snap
@@ -3,79 +3,83 @@
 exports[`SummaryGroupComponent SummaryGroupComponent -- should match snapshot 1`] = `
 <DocumentFragment>
   <div
-    style="display: none;"
-  >
-     
-  </div>
-  <div
-    data-testid="summary-group-component"
-    style="width: 100%;"
+    lang="nb"
   >
     <div
-      class="container"
+      style="display: none;"
     >
-      <span
-        class="label"
-      >
-        <span>
-          Mock group
-        </span>
-      </span>
-      <button
-        aria-label="Change: Mock group"
-        class="fds-btn fds-focus fds-btn--sm fds-btn--tertiary fds-btn--second editButton"
-        type="button"
-      >
-        Change
-        <svg
-          aria-hidden="true"
-          fill="none"
-          focusable="false"
-          font-size="1rem"
-          height="1em"
-          role="img"
-          viewBox="0 0 24 24"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            clip-rule="evenodd"
-            d="M19.638 4.417a3.25 3.25 0 0 0-4.608-.008l-9.378 9.379a.75.75 0 0 0-.191.324l-1.414 4.95a.75.75 0 0 0 .925.927l4.94-1.398a.75.75 0 0 0 .327-.191l9.39-9.391a3.25 3.25 0 0 0 .01-4.592M16.091 5.47a1.752 1.752 0 1 1 2.478 2.478l-.23.23-2.477-2.479zM14.8 6.76 6.85 14.71l-.991 3.47 3.457-.979 7.963-7.963z"
-            fill="currentColor"
-            fill-rule="evenodd"
-          />
-        </svg>
-      </button>
+       
     </div>
     <div
+      data-testid="summary-group-component"
       style="width: 100%;"
     >
       <div
-        class="border"
+        class="container"
+      >
+        <span
+          class="label"
+        >
+          <span>
+            Mock group
+          </span>
+        </span>
+        <button
+          aria-label="Change: Mock group"
+          class="fds-btn fds-focus fds-btn--sm fds-btn--tertiary fds-btn--second editButton"
+          type="button"
+        >
+          Change
+          <svg
+            aria-hidden="true"
+            fill="none"
+            focusable="false"
+            font-size="1rem"
+            height="1em"
+            role="img"
+            viewBox="0 0 24 24"
+            width="1em"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clip-rule="evenodd"
+              d="M19.638 4.417a3.25 3.25 0 0 0-4.608-.008l-9.378 9.379a.75.75 0 0 0-.191.324l-1.414 4.95a.75.75 0 0 0 .925.927l4.94-1.398a.75.75 0 0 0 .327-.191l9.39-9.391a3.25 3.25 0 0 0 .01-4.592M16.091 5.47a1.752 1.752 0 1 1 2.478 2.478l-.23.23-2.477-2.479zM14.8 6.76 6.85 14.71l-.991 3.47 3.457-.979 7.963-7.963z"
+              fill="currentColor"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </button>
+      </div>
+      <div
+        style="width: 100%;"
       >
         <div
-          data-testid="summary-item-compact"
+          class="border"
         >
-          <span>
-            Mock field 1 : 
-          </span>
-          <span
-            class="data"
+          <div
+            data-testid="summary-item-compact"
           >
-            1
-          </span>
-        </div>
-        <div
-          data-testid="summary-item-compact"
-        >
-          <span>
-            Mock field 2 : 
-          </span>
-          <span
-            class="data"
+            <span>
+              Mock field 1 : 
+            </span>
+            <span
+              class="data"
+            >
+              1
+            </span>
+          </div>
+          <div
+            data-testid="summary-item-compact"
           >
-            2
-          </span>
+            <span>
+              Mock field 2 : 
+            </span>
+            <span
+              class="data"
+            >
+              2
+            </span>
+          </div>
         </div>
       </div>
     </div>

--- a/src/layout/RepeatingGroup/Summary/__snapshots__/SummaryRepeatingGroup.test.tsx.snap
+++ b/src/layout/RepeatingGroup/Summary/__snapshots__/SummaryRepeatingGroup.test.tsx.snap
@@ -3,80 +3,84 @@
 exports[`SummaryRepeatingGroup SummaryRepeatingGroup -- should match snapshot 1`] = `
 <DocumentFragment>
   <div
-    style="display: none;"
-  >
-     
-  </div>
-  <div
-    data-testid="summary-group-component"
-    style="width: 100%;"
+    lang="nb"
   >
     <div
-      class="container"
+      style="display: none;"
     >
-      <span
-        class="label"
-      >
-        <span>
-          Mock group
-        </span>
-      </span>
-      <button
-        aria-label="Change: Mock group"
-        class="fds-btn fds-focus fds-btn--sm fds-btn--tertiary fds-btn--second editButton"
-        type="button"
-      >
-        Change
-        <svg
-          aria-hidden="true"
-          fill="none"
-          focusable="false"
-          font-size="1rem"
-          height="1em"
-          role="img"
-          viewBox="0 0 24 24"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            clip-rule="evenodd"
-            d="M19.638 4.417a3.25 3.25 0 0 0-4.608-.008l-9.378 9.379a.75.75 0 0 0-.191.324l-1.414 4.95a.75.75 0 0 0 .925.927l4.94-1.398a.75.75 0 0 0 .327-.191l9.39-9.391a3.25 3.25 0 0 0 .01-4.592M16.091 5.47a1.752 1.752 0 1 1 2.478 2.478l-.23.23-2.477-2.479zM14.8 6.76 6.85 14.71l-.991 3.47 3.457-.979 7.963-7.963z"
-            fill="currentColor"
-            fill-rule="evenodd"
-          />
-        </svg>
-      </button>
+       
     </div>
     <div
+      data-testid="summary-group-component"
       style="width: 100%;"
     >
       <div
-        class="border"
-        data-testid="summary-repeating-row"
+        class="container"
+      >
+        <span
+          class="label"
+        >
+          <span>
+            Mock group
+          </span>
+        </span>
+        <button
+          aria-label="Change: Mock group"
+          class="fds-btn fds-focus fds-btn--sm fds-btn--tertiary fds-btn--second editButton"
+          type="button"
+        >
+          Change
+          <svg
+            aria-hidden="true"
+            fill="none"
+            focusable="false"
+            font-size="1rem"
+            height="1em"
+            role="img"
+            viewBox="0 0 24 24"
+            width="1em"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clip-rule="evenodd"
+              d="M19.638 4.417a3.25 3.25 0 0 0-4.608-.008l-9.378 9.379a.75.75 0 0 0-.191.324l-1.414 4.95a.75.75 0 0 0 .925.927l4.94-1.398a.75.75 0 0 0 .327-.191l9.39-9.391a3.25 3.25 0 0 0 .01-4.592M16.091 5.47a1.752 1.752 0 1 1 2.478 2.478l-.23.23-2.477-2.479zM14.8 6.76 6.85 14.71l-.991 3.47 3.457-.979 7.963-7.963z"
+              fill="currentColor"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </button>
+      </div>
+      <div
+        style="width: 100%;"
       >
         <div
-          data-testid="summary-item-compact"
+          class="border"
+          data-testid="summary-repeating-row"
         >
-          <span>
-            Mock field 1 : 
-          </span>
-          <span
-            class="data"
+          <div
+            data-testid="summary-item-compact"
           >
-            1
-          </span>
-        </div>
-        <div
-          data-testid="summary-item-compact"
-        >
-          <span>
-            Mock field 2 : 
-          </span>
-          <span
-            class="data"
+            <span>
+              Mock field 1 : 
+            </span>
+            <span
+              class="data"
+            >
+              1
+            </span>
+          </div>
+          <div
+            data-testid="summary-item-compact"
           >
-            2
-          </span>
+            <span>
+              Mock field 2 : 
+            </span>
+            <span
+              class="data"
+            >
+              2
+            </span>
+          </div>
         </div>
       </div>
     </div>

--- a/src/layout/SigningActions/SigningActionsComponent.test.tsx
+++ b/src/layout/SigningActions/SigningActionsComponent.test.tsx
@@ -273,8 +273,6 @@ describe('SigningActionsComponent', () => {
       />,
     );
 
-    screen.debug();
-
     expect(screen.getByTestId('awaiting-other-signatures-panel')).toBeInTheDocument();
     expect(screen.getByTestId('has-signed')).toBeInTheDocument();
   });

--- a/src/queries/queries.ts
+++ b/src/queries/queries.ts
@@ -82,7 +82,7 @@ import type {
 } from 'src/types/shared';
 
 export const doSetSelectedParty = (partyId: number | string) =>
-  putWithoutConfig<'Party successfully updated' | LooseAutocomplete | null>(getSetSelectedPartyUrl(partyId));
+  putWithoutConfig<LooseAutocomplete<'Party successfully updated'> | null>(getSetSelectedPartyUrl(partyId));
 
 export const doInstantiateWithPrefill = async (data: Instantiation, language?: string): Promise<IInstance> =>
   cleanUpInstanceData((await httpPost(getInstantiateUrl(language), undefined, data)).data);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -48,4 +48,4 @@ export function isProcessTaskType(taskType: string): taskType is ProcessTaskType
   return Object.values(ProcessTaskType).includes(taskType as ProcessTaskType);
 }
 
-export type LooseAutocomplete = string & {}; // NOSONAR
+export type LooseAutocomplete<T extends string> = T | (string & {}); // NOSONAR

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -1,3 +1,5 @@
+import type { LooseAutocomplete } from 'src/types';
+
 export interface IAltinnOrg {
   name: ITitle;
   logo: string;
@@ -22,7 +24,7 @@ export interface IDisplayAttachment {
   name?: string;
   iconClass: string;
   grouping: string | undefined;
-  description: Partial<Record<'en' | 'nb' | 'nn' | (string & {}), string>> | undefined;
+  description: Partial<Record<LooseAutocomplete<'en' | 'nb' | 'nn'>, string>> | undefined;
   url?: string;
   dataType: string;
   tags?: string[];
@@ -50,7 +52,7 @@ export interface IData {
 
 export interface IDataType {
   id: string;
-  description?: Partial<Record<'en' | 'nb' | 'nn' | (string & {}), string>> | null;
+  description?: Partial<Record<LooseAutocomplete<'en' | 'nb' | 'nn'>, string>> | null;
   allowedContentTypes: string[] | null;
   allowedContributers?: string[] | null;
   allowedContributors?: string[] | null;

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -22,6 +22,7 @@ export interface IDisplayAttachment {
   name?: string;
   iconClass: string;
   grouping: string | undefined;
+  description: Record<'en' | 'nb' | 'nn' | (string & {}), string> | undefined;
   url?: string;
   dataType: string;
   tags?: string[];
@@ -49,7 +50,7 @@ export interface IData {
 
 export interface IDataType {
   id: string;
-  description?: string | null;
+  description?: Record<'en' | 'nb' | 'nn' | (string & {}), string> | null;
   allowedContentTypes: string[] | null;
   allowedContributers?: string[] | null;
   allowedContributors?: string[] | null;
@@ -261,10 +262,6 @@ export interface IVariable {
   key: string;
   dataSource: 'instanceContext' | 'applicationSettings' | 'dataModel.default' | `dataModel.${string}`;
   defaultValue?: string;
-}
-
-export interface IAttachmentGrouping {
-  [title: string]: IDisplayAttachment[];
 }
 
 export interface IApplicationSettings {

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -22,7 +22,7 @@ export interface IDisplayAttachment {
   name?: string;
   iconClass: string;
   grouping: string | undefined;
-  description: Record<'en' | 'nb' | 'nn' | (string & {}), string> | undefined;
+  description: Partial<Record<'en' | 'nb' | 'nn' | (string & {}), string>> | undefined;
   url?: string;
   dataType: string;
   tags?: string[];
@@ -50,7 +50,7 @@ export interface IData {
 
 export interface IDataType {
   id: string;
-  description?: Record<'en' | 'nb' | 'nn' | (string & {}), string> | null;
+  description?: Partial<Record<'en' | 'nb' | 'nn' | (string & {}), string>> | null;
   allowedContentTypes: string[] | null;
   allowedContributers?: string[] | null;
   allowedContributors?: string[] | null;

--- a/src/utils/attachmentsUtils.test.ts
+++ b/src/utils/attachmentsUtils.test.ts
@@ -372,7 +372,7 @@ describe(toDisplayAttachments.name, () => {
         } as unknown as IData,
         dataType: {
           id: 'type1',
-          description: 'Type 1 description',
+          description: { nb: 'Type 1 description' },
           grouping: 'group1',
         } as unknown as IDataType,
       },
@@ -387,7 +387,7 @@ describe(toDisplayAttachments.name, () => {
         } as unknown as IData,
         dataType: {
           id: 'type2',
-          description: 'Type 2 description',
+          description: { nb: 'Type 2 description' },
           grouping: 'group2',
         } as unknown as IDataType,
       },
@@ -400,7 +400,7 @@ describe(toDisplayAttachments.name, () => {
         iconClass: 'reg reg-attachment',
         dataType: 'type1',
         grouping: 'group1',
-        description: undefined,
+        description: { nb: 'Type 1 description' },
       },
       {
         name: 'file2.jpg',
@@ -408,7 +408,7 @@ describe(toDisplayAttachments.name, () => {
         iconClass: 'reg reg-attachment',
         dataType: 'type2',
         grouping: 'group2',
-        description: undefined,
+        description: { nb: 'Type 2 description' },
       },
     ];
 
@@ -457,7 +457,7 @@ describe(toDisplayAttachments.name, () => {
         } as unknown as IData,
         dataType: {
           id: 'type1',
-          description: 'Type 1 description',
+          description: { nb: 'Type 1 description' },
           // Missing grouping
         } as unknown as IDataType,
       },
@@ -470,7 +470,7 @@ describe(toDisplayAttachments.name, () => {
         iconClass: 'reg reg-attachment',
         dataType: 'type1',
         grouping: undefined,
-        description: undefined,
+        description: { nb: 'Type 1 description' },
       },
     ];
 
@@ -499,7 +499,7 @@ describe(toDisplayAttachments.name, () => {
         } as unknown as IData,
         dataType: {
           id: 'type1',
-          description: 'Type 1 description',
+          description: { nb: 'Type 1 description' },
           grouping: 'group1',
         } as unknown as IDataType,
       },
@@ -512,7 +512,7 @@ describe(toDisplayAttachments.name, () => {
         iconClass: 'reg reg-attachment',
         dataType: 'type1',
         grouping: 'group1',
-        description: undefined,
+        description: { nb: 'Type 1 description' },
       },
     ];
 

--- a/src/utils/attachmentsUtils.test.ts
+++ b/src/utils/attachmentsUtils.test.ts
@@ -400,6 +400,7 @@ describe(toDisplayAttachments.name, () => {
         iconClass: 'reg reg-attachment',
         dataType: 'type1',
         grouping: 'group1',
+        description: undefined,
       },
       {
         name: 'file2.jpg',
@@ -407,6 +408,7 @@ describe(toDisplayAttachments.name, () => {
         iconClass: 'reg reg-attachment',
         dataType: 'type2',
         grouping: 'group2',
+        description: undefined,
       },
     ];
 
@@ -436,6 +438,7 @@ describe(toDisplayAttachments.name, () => {
         iconClass: 'reg reg-attachment',
         dataType: 'type1',
         grouping: undefined,
+        description: undefined,
       },
     ];
 
@@ -467,6 +470,7 @@ describe(toDisplayAttachments.name, () => {
         iconClass: 'reg reg-attachment',
         dataType: 'type1',
         grouping: undefined,
+        description: undefined,
       },
     ];
 
@@ -508,6 +512,7 @@ describe(toDisplayAttachments.name, () => {
         iconClass: 'reg reg-attachment',
         dataType: 'type1',
         grouping: 'group1',
+        description: undefined,
       },
     ];
 

--- a/src/utils/attachmentsUtils.ts
+++ b/src/utils/attachmentsUtils.ts
@@ -56,6 +56,7 @@ export function toDisplayAttachments(data: AttachmentWithDataType[]): IDisplayAt
     iconClass: 'reg reg-attachment',
     dataType: attachment.dataType,
     grouping: dataType?.grouping ?? undefined,
+    description: dataType?.description ?? undefined,
   }));
 }
 

--- a/test/e2e/support/global.ts
+++ b/test/e2e/support/global.ts
@@ -146,7 +146,7 @@ declare global {
        * Must be called in the beginning of your test.
        */
       interceptLayout(
-        taskName: FrontendTestTask | LooseAutocomplete,
+        taskName: LooseAutocomplete<FrontendTestTask>,
         mutator?: (component: CompExternal) => void,
         wholeLayoutMutator?: (layoutSet: ILayoutCollection) => void,
         options?: { times?: number },


### PR DESCRIPTION
## Description
Shows corresponding data type description for each attachment in attachment list.

![image](https://github.com/user-attachments/assets/5cba718a-ef64-4dc6-a288-a126252b2015)
![image](https://github.com/user-attachments/assets/282b433e-16d2-4d9e-8da3-559b76e4c2d1)


## Related Issue(s)

- closes #3350

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [x] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [x] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->
