### PR TITLE
Add arrow navigation to language selector

### DIFF
--- a/src/components/presentation/LanguageSelector.tsx
+++ b/src/components/presentation/LanguageSelector.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import { Dropdown } from '@digdir/designsystemet-react';
+import { Dropdown, RovingFocusItem, RovingFocusRoot } from '@digdir/designsystemet-react';
 import { CheckmarkIcon, ChevronDownIcon, GlobeIcon } from '@navikt/aksel-icons';
 import cn from 'classnames';
 
@@ -62,28 +62,40 @@ export const LanguageSelector = () => {
             <Lang id='language.language_selection' />
           </Dropdown.Heading>
         )}
-        <Dropdown.List>
-          {appLanguages?.map((lang) => {
-            const selected = currentLanguage === lang;
+        <RovingFocusRoot
+          asChild
+          orientation='vertical'
+          activeValue={currentLanguage}
+        >
+          <Dropdown.List>
+            {appLanguages?.map((lang) => {
+              const selected = currentLanguage === lang;
 
-            return (
-              <Dropdown.Item key={lang}>
-                <Dropdown.Button
-                  onClick={() => updateLanguage(lang)}
-                  aria-checked={selected}
-                  role='menuitemradio'
+              return (
+                <RovingFocusItem
+                  key={lang}
+                  asChild
+                  value={lang}
                 >
-                  <CheckmarkIcon
-                    style={{ opacity: selected ? 1 : 0 }}
-                    className={cn(classes.icon, classes.checkmark)}
-                    aria-hidden
-                  />
-                  <Lang id={`language.full_name.${lang}`} />
-                </Dropdown.Button>
-              </Dropdown.Item>
-            );
-          })}
-        </Dropdown.List>
+                  <Dropdown.Item>
+                    <Dropdown.Button
+                      onClick={() => updateLanguage(lang)}
+                      aria-checked={selected}
+                      role='menuitemradio'
+                    >
+                      <CheckmarkIcon
+                        style={{ opacity: selected ? 1 : 0 }}
+                        className={cn(classes.icon, classes.checkmark)}
+                        aria-hidden
+                      />
+                      <Lang id={`language.full_name.${lang}`} />
+                    </Dropdown.Button>
+                  </Dropdown.Item>
+                </RovingFocusItem>
+              );
+            })}
+          </Dropdown.List>
+        </RovingFocusRoot>
       </Dropdown>
     </Dropdown.TriggerContext>
   );


### PR DESCRIPTION
## Description

Uses "RovingFocus" components from the design system to add arrow navigation to language selector.

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes #3500 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [x] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->
