### PR TITLE
Refactor: No longer passing node object to `useNodeItem()`

### DIFF
--- a/src/components/label/Label.tsx
+++ b/src/components/label/Label.tsx
@@ -9,7 +9,7 @@ import { Flex } from 'src/app-components/Flex/Flex';
 import classes from 'src/components/label/Label.module.css';
 import { LabelContent } from 'src/components/label/LabelContent';
 import { useFormComponentCtx } from 'src/layout/FormComponentContext';
-import { useNodeItemFor } from 'src/utils/layout/useNodeItem';
+import { useItemFor } from 'src/utils/layout/useNodeItem';
 import type { LabelContentProps } from 'src/components/label/LabelContent';
 import type { ExprResolved } from 'src/features/expressions/types';
 import type { IGridStyling, TRBLabel } from 'src/layout/common.generated';
@@ -31,7 +31,7 @@ export type LabelProps = PropsWithChildren<{
 type LabelInnerProps = Omit<LabelProps, 'node'> & { item: CompInternal; nodeId: string };
 
 export function Label(props: LabelProps) {
-  const item = useNodeItemFor(props.node.baseId);
+  const item = useItemFor(props.node.baseId);
   return (
     <LabelInner
       item={item}

--- a/src/components/label/Label.tsx
+++ b/src/components/label/Label.tsx
@@ -9,7 +9,7 @@ import { Flex } from 'src/app-components/Flex/Flex';
 import classes from 'src/components/label/Label.module.css';
 import { LabelContent } from 'src/components/label/LabelContent';
 import { useFormComponentCtx } from 'src/layout/FormComponentContext';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useNodeItemFor } from 'src/utils/layout/useNodeItem';
 import type { LabelContentProps } from 'src/components/label/LabelContent';
 import type { ExprResolved } from 'src/features/expressions/types';
 import type { IGridStyling, TRBLabel } from 'src/layout/common.generated';
@@ -31,10 +31,10 @@ export type LabelProps = PropsWithChildren<{
 type LabelInnerProps = Omit<LabelProps, 'node'> & { item: CompInternal; nodeId: string };
 
 export function Label(props: LabelProps) {
-  const _item = useNodeItem(props.node);
+  const item = useNodeItemFor(props.node.baseId);
   return (
     <LabelInner
-      item={_item}
+      item={item}
       nodeId={props.node.id}
       {...props}
     />

--- a/src/components/message/ErrorReport.tsx
+++ b/src/components/message/ErrorReport.tsx
@@ -16,6 +16,7 @@ import { isAxiosError } from 'src/utils/isAxiosError';
 import { DataModelLocationProviderFromNode } from 'src/utils/layout/DataModelLocation';
 import { Hidden, useNode } from 'src/utils/layout/NodesContext';
 import { HttpStatusCodes } from 'src/utils/network/networking';
+import { splitDashedKey } from 'src/utils/splitDashedKey';
 import { useGetUniqueKeyFromObject } from 'src/utils/useGetKeyFromObject';
 import type { UploadedAttachment } from 'src/features/attachments';
 import type { AnyValidation, BaseValidation, NodeRefValidation } from 'src/features/validation';
@@ -87,13 +88,16 @@ export function ErrorReportList({ formErrors, taskErrors }: ErrorReportListProps
   const allAttachments = useAllAttachments();
 
   const infectedFileErrors: NodeRefValidation[] = Object.entries(allAttachments || {}).flatMap(
-    ([nodeId, attachments]) =>
-      (attachments || [])
+    ([nodeId, attachments]) => {
+      const { baseComponentId } = splitDashedKey(nodeId);
+
+      return (attachments || [])
         .filter((attachment) => attachment.uploaded && attachment.data.fileScanResult === FileScanResults.Infected)
         .map((attachment) => {
           const uploadedAttachment = attachment as UploadedAttachment;
           return {
             nodeId,
+            baseComponentId,
             source: 'Frontend',
             code: 'InfectedFile',
             dataElementId: uploadedAttachment.data.id,
@@ -104,7 +108,8 @@ export function ErrorReportList({ formErrors, taskErrors }: ErrorReportListProps
             severity: 'error',
             category: 0,
           };
-        }),
+        });
+    },
   );
 
   return (

--- a/src/features/devtools/components/NodeInspector/DefaultNodeInspector.tsx
+++ b/src/features/devtools/components/NodeInspector/DefaultNodeInspector.tsx
@@ -8,7 +8,7 @@ import { NodeInspectorDataModelBindings } from 'src/features/devtools/components
 import { NodeInspectorTextResourceBindings } from 'src/features/devtools/components/NodeInspector/NodeInspectorTextResourceBindings';
 import { useExternalItem } from 'src/utils/layout/hooks';
 import { Hidden } from 'src/utils/layout/NodesContext';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useNodeItemFor } from 'src/utils/layout/useNodeItem';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 interface DefaultNodeInspectorParams {
@@ -19,7 +19,7 @@ interface DefaultNodeInspectorParams {
 export function DefaultNodeInspector({ node, ignoredProperties }: DefaultNodeInspectorParams) {
   // Hidden state is removed from the item by the hierarchy generator, but we simulate adding it back here (but only
   // if it's an expression). This allows app developers to inspect this as well.
-  const _item = useNodeItem(node);
+  const _item = useNodeItemFor(node.baseId);
   const hidden = Hidden.useIsHidden(node);
   const component = useExternalItem(node.baseId);
   const hiddenIsExpression = Array.isArray(component?.hidden);

--- a/src/features/devtools/components/NodeInspector/DefaultNodeInspector.tsx
+++ b/src/features/devtools/components/NodeInspector/DefaultNodeInspector.tsx
@@ -8,7 +8,7 @@ import { NodeInspectorDataModelBindings } from 'src/features/devtools/components
 import { NodeInspectorTextResourceBindings } from 'src/features/devtools/components/NodeInspector/NodeInspectorTextResourceBindings';
 import { useExternalItem } from 'src/utils/layout/hooks';
 import { Hidden } from 'src/utils/layout/NodesContext';
-import { useNodeItemFor } from 'src/utils/layout/useNodeItem';
+import { useItemFor } from 'src/utils/layout/useNodeItem';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 interface DefaultNodeInspectorParams {
@@ -19,7 +19,7 @@ interface DefaultNodeInspectorParams {
 export function DefaultNodeInspector({ node, ignoredProperties }: DefaultNodeInspectorParams) {
   // Hidden state is removed from the item by the hierarchy generator, but we simulate adding it back here (but only
   // if it's an expression). This allows app developers to inspect this as well.
-  const _item = useNodeItemFor(node.baseId);
+  const _item = useItemFor(node.baseId);
   const hidden = Hidden.useIsHidden(node);
   const component = useExternalItem(node.baseId);
   const hiddenIsExpression = Array.isArray(component?.hidden);

--- a/src/features/devtools/components/NodeInspector/NodeHierarchy.tsx
+++ b/src/features/devtools/components/NodeInspector/NodeHierarchy.tsx
@@ -11,7 +11,7 @@ import { nodeIdsFromGridRow } from 'src/layout/Grid/tools';
 import { RepGroupHooks } from 'src/layout/RepeatingGroup/utils';
 import { DataModelLocationProvider, useComponentIdMutator } from 'src/utils/layout/DataModelLocation';
 import { Hidden, useNode } from 'src/utils/layout/NodesContext';
-import { useNodeDirectChildren, useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useNodeDirectChildren, useNodeItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { GridRows } from 'src/layout/common.generated';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
@@ -127,7 +127,7 @@ const NodeHierarchyItem = ({ nodeId, onClick, selected }: INodeHierarchyItemProp
 
 function RepeatingGroupExtensions({ nodeId, selected, onClick }: INodeHierarchyItemProps) {
   const node = useNode(nodeId) as LayoutNode<'RepeatingGroup'>;
-  const nodeItem = useNodeItem(node);
+  const nodeItem = useNodeItemWhenType(node.baseId, 'RepeatingGroup');
   const rows = RepGroupHooks.useAllRowsWithHidden(node);
   const childIds = RepGroupHooks.useChildIds(node);
 

--- a/src/features/devtools/components/NodeInspector/NodeHierarchy.tsx
+++ b/src/features/devtools/components/NodeInspector/NodeHierarchy.tsx
@@ -11,7 +11,7 @@ import { nodeIdsFromGridRow } from 'src/layout/Grid/tools';
 import { RepGroupHooks } from 'src/layout/RepeatingGroup/utils';
 import { DataModelLocationProvider, useComponentIdMutator } from 'src/utils/layout/DataModelLocation';
 import { Hidden, useNode } from 'src/utils/layout/NodesContext';
-import { useNodeDirectChildren, useNodeItemWhenType } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType, useNodeDirectChildren } from 'src/utils/layout/useNodeItem';
 import type { GridRows } from 'src/layout/common.generated';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
@@ -127,7 +127,7 @@ const NodeHierarchyItem = ({ nodeId, onClick, selected }: INodeHierarchyItemProp
 
 function RepeatingGroupExtensions({ nodeId, selected, onClick }: INodeHierarchyItemProps) {
   const node = useNode(nodeId) as LayoutNode<'RepeatingGroup'>;
-  const nodeItem = useNodeItemWhenType(node.baseId, 'RepeatingGroup');
+  const nodeItem = useItemWhenType(node.baseId, 'RepeatingGroup');
   const rows = RepGroupHooks.useAllRowsWithHidden(node);
   const childIds = RepGroupHooks.useChildIds(node);
 

--- a/src/features/devtools/components/NodeInspector/NodeInspectorDataField.tsx
+++ b/src/features/devtools/components/NodeInspector/NodeInspectorDataField.tsx
@@ -141,8 +141,8 @@ function ExpandArray(props: { path: string[]; property: string; elements: unknow
 
 export function NodeInspectorDataField({ path, property, value: inputValue }: NodeInspectorDataFieldParams) {
   const { node } = useNodeInspectorContext();
-  const firstRowExpr = RepGroupHooks.useRowWithExpressions(node?.isType('RepeatingGroup') ? node : undefined, 'first');
-  const itemWithExpressions = useIntermediateItem(node?.baseId);
+  const firstRowExpr = RepGroupHooks.useRowWithExpressions(node.isType('RepeatingGroup') ? node : undefined, 'first');
+  const itemWithExpressions = useIntermediateItem(node.baseId);
 
   let value = inputValue;
   const preEvaluatedValue = dot.pick(path.join('.'), itemWithExpressions);

--- a/src/features/devtools/components/NodeInspector/NodeInspectorDataField.tsx
+++ b/src/features/devtools/components/NodeInspector/NodeInspectorDataField.tsx
@@ -11,6 +11,7 @@ import { canBeExpression } from 'src/features/expressions/validation';
 import { RepGroupHooks } from 'src/layout/RepeatingGroup/utils';
 import { useIntermediateItem } from 'src/utils/layout/hooks';
 import { LayoutNode } from 'src/utils/layout/LayoutNode';
+import type { GroupExpressions } from 'src/layout/RepeatingGroup/types';
 
 interface NodeInspectorDataFieldParams {
   path: string[];
@@ -139,11 +140,51 @@ function ExpandArray(props: { path: string[]; property: string; elements: unknow
   );
 }
 
-export function NodeInspectorDataField({ path, property, value: inputValue }: NodeInspectorDataFieldParams) {
+export function NodeInspectorDataField(props: NodeInspectorDataFieldParams) {
   const { node } = useNodeInspectorContext();
-  const firstRowExpr = RepGroupHooks.useRowWithExpressions(node.isType('RepeatingGroup') ? node : undefined, 'first');
-  const itemWithExpressions = useIntermediateItem(node.baseId);
+  if (node && node.isType('RepeatingGroup')) {
+    return (
+      <NodeInspectorDataFieldForFirstRow
+        node={node}
+        {...props}
+      />
+    );
+  }
+  if (node) {
+    return (
+      <NodeInspectorDataFieldInner
+        node={node}
+        {...props}
+      />
+    );
+  }
 
+  return null;
+}
+
+function NodeInspectorDataFieldForFirstRow({
+  node,
+  ...rest
+}: NodeInspectorDataFieldParams & { node: LayoutNode<'RepeatingGroup'> }) {
+  const firstRowExpr = RepGroupHooks.useRowWithExpressions(node, 'first');
+
+  return (
+    <NodeInspectorDataFieldInner
+      node={node}
+      firstRowExpr={firstRowExpr}
+      {...rest}
+    />
+  );
+}
+
+function NodeInspectorDataFieldInner({
+  node,
+  firstRowExpr,
+  path,
+  property,
+  value: inputValue,
+}: NodeInspectorDataFieldParams & { node: LayoutNode; firstRowExpr?: GroupExpressions }) {
+  const itemWithExpressions = useIntermediateItem(node.baseId);
   let value = inputValue;
   const preEvaluatedValue = dot.pick(path.join('.'), itemWithExpressions);
   const isExpression =
@@ -151,7 +192,7 @@ export function NodeInspectorDataField({ path, property, value: inputValue }: No
     canBeExpression(value, true);
 
   let exprText = 'Ble evaluert til:';
-  if (isExpression && node?.isType('RepeatingGroup') && firstRowExpr) {
+  if (isExpression && firstRowExpr) {
     const realValue = dot.pick(path.join('.'), firstRowExpr);
     if (realValue !== undefined) {
       value = realValue;

--- a/src/features/devtools/components/NodeInspector/NodeInspectorTextResourceBindings.tsx
+++ b/src/features/devtools/components/NodeInspector/NodeInspectorTextResourceBindings.tsx
@@ -6,7 +6,7 @@ import { canBeExpression } from 'src/features/expressions/validation';
 import { useTextResources } from 'src/features/language/textResources/TextResourcesProvider';
 import { useLanguage } from 'src/features/language/useLanguage';
 import { RepGroupHooks } from 'src/layout/RepeatingGroup/utils';
-import { useNodeItemIfType } from 'src/utils/layout/useNodeItem';
+import { useItemIfType } from 'src/utils/layout/useNodeItem';
 import type { ITextResourceBindings } from 'src/layout/layout';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
@@ -18,7 +18,7 @@ interface Props {
 export function NodeInspectorTextResourceBindings({ node, textResourceBindings }: Props) {
   const textResources = useTextResources();
   const { langAsString } = useLanguage();
-  const item = useNodeItemIfType(node.baseId, 'RepeatingGroup');
+  const item = useItemIfType(node.baseId, 'RepeatingGroup');
   const firstRowExpr = RepGroupHooks.useRowWithExpressions(node.isType('RepeatingGroup') ? node : undefined, 'first');
 
   let actualTextResourceBindings = textResourceBindings || {};

--- a/src/features/devtools/components/NodeInspector/NodeInspectorTextResourceBindings.tsx
+++ b/src/features/devtools/components/NodeInspector/NodeInspectorTextResourceBindings.tsx
@@ -8,6 +8,7 @@ import { useLanguage } from 'src/features/language/useLanguage';
 import { RepGroupHooks } from 'src/layout/RepeatingGroup/utils';
 import { useItemIfType } from 'src/utils/layout/useNodeItem';
 import type { ITextResourceBindings } from 'src/layout/layout';
+import type { GroupExpressions } from 'src/layout/RepeatingGroup/types';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 interface Props {
@@ -16,10 +17,45 @@ interface Props {
 }
 
 export function NodeInspectorTextResourceBindings({ node, textResourceBindings }: Props) {
+  if (node.isType('RepeatingGroup')) {
+    return (
+      <NodeNodeInspectorTextResourceBindingsForFirstRow
+        node={node}
+        textResourceBindings={textResourceBindings}
+      />
+    );
+  }
+
+  return (
+    <NodeInspectorTextResourceBindingsInner
+      node={node}
+      textResourceBindings={textResourceBindings}
+    />
+  );
+}
+
+function NodeNodeInspectorTextResourceBindingsForFirstRow({
+  node,
+  textResourceBindings,
+}: Props & { node: LayoutNode<'RepeatingGroup'> }) {
+  const firstRowExpr = RepGroupHooks.useRowWithExpressions(node, 'first');
+  return (
+    <NodeInspectorTextResourceBindingsInner
+      node={node}
+      textResourceBindings={textResourceBindings}
+      firstRowExpr={firstRowExpr}
+    />
+  );
+}
+
+function NodeInspectorTextResourceBindingsInner({
+  node,
+  textResourceBindings,
+  firstRowExpr,
+}: Props & { firstRowExpr?: GroupExpressions }) {
   const textResources = useTextResources();
   const { langAsString } = useLanguage();
   const item = useItemIfType(node.baseId, 'RepeatingGroup');
-  const firstRowExpr = RepGroupHooks.useRowWithExpressions(node.isType('RepeatingGroup') ? node : undefined, 'first');
 
   let actualTextResourceBindings = textResourceBindings || {};
   let isRepGroup = false;

--- a/src/features/devtools/components/NodeInspector/NodeInspectorTextResourceBindings.tsx
+++ b/src/features/devtools/components/NodeInspector/NodeInspectorTextResourceBindings.tsx
@@ -6,7 +6,7 @@ import { canBeExpression } from 'src/features/expressions/validation';
 import { useTextResources } from 'src/features/language/textResources/TextResourcesProvider';
 import { useLanguage } from 'src/features/language/useLanguage';
 import { RepGroupHooks } from 'src/layout/RepeatingGroup/utils';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useNodeItemIfType } from 'src/utils/layout/useNodeItem';
 import type { ITextResourceBindings } from 'src/layout/layout';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
@@ -18,12 +18,12 @@ interface Props {
 export function NodeInspectorTextResourceBindings({ node, textResourceBindings }: Props) {
   const textResources = useTextResources();
   const { langAsString } = useLanguage();
-  const item = useNodeItem(node);
+  const item = useNodeItemIfType(node.baseId, 'RepeatingGroup');
   const firstRowExpr = RepGroupHooks.useRowWithExpressions(node.isType('RepeatingGroup') ? node : undefined, 'first');
 
   let actualTextResourceBindings = textResourceBindings || {};
   let isRepGroup = false;
-  if (item.type === 'RepeatingGroup') {
+  if (item) {
     // Text resource bindings are resolved per-row for repeating groups. We'll show the
     // first row here, and inform the user.
     isRepGroup = true;

--- a/src/features/devtools/components/NodeInspector/ValidationInspector.tsx
+++ b/src/features/devtools/components/NodeInspector/ValidationInspector.tsx
@@ -9,8 +9,8 @@ import { Lang } from 'src/features/language/Lang';
 import { ValidationMask } from 'src/features/validation';
 import { isValidationVisible } from 'src/features/validation/utils';
 import { implementsAnyValidation } from 'src/layout';
+import { useDataModelBindingsFor } from 'src/utils/layout/hooks';
 import { NodesInternal } from 'src/utils/layout/NodesContext';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
 import type { FileUploaderNode } from 'src/features/attachments';
 import type { AttachmentValidation, NodeValidation, ValidationSeverity } from 'src/features/validation';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
@@ -31,7 +31,8 @@ const categories = [
 export const ValidationInspector = ({ node }: ValidationInspectorProps) => {
   const validations = NodesInternal.useRawValidations(node);
   const nodeVisibility = NodesInternal.useRawValidationVisibility(node);
-  const { dataModelBindings, type } = useNodeItem(node);
+  const dataModelBindings = useDataModelBindingsFor(node.baseId);
+  const type = node.type;
   const attachments = useAttachmentsFor(node as FileUploaderNode);
 
   if (!implementsAnyValidation(node.def)) {

--- a/src/features/form/layout/PageNavigationContext.tsx
+++ b/src/features/form/layout/PageNavigationContext.tsx
@@ -62,10 +62,10 @@ export const useSetReturnToView = () => {
   return func === ContextNotProvided ? undefined : func;
 };
 
-export const useSummaryNodeOfOrigin = (): LayoutNode<'Summary'> | undefined => {
+export const useSummaryNodeOfOrigin = (): LayoutNode | undefined => {
   const func = useLaxSelector((ctx) => ctx.summaryNodeOfOrigin);
   const node = useNode(func === ContextNotProvided ? undefined : func);
-  return func === ContextNotProvided ? undefined : (node as LayoutNode<'Summary'>);
+  return func === ContextNotProvided ? undefined : (node as LayoutNode);
 };
 
 export const useSetSummaryNodeOfOrigin = () => {

--- a/src/features/form/layout/makeLayoutLookups.ts
+++ b/src/features/form/layout/makeLayoutLookups.ts
@@ -55,7 +55,7 @@ interface LookupFunctions {
   // Get the component config for a given ID and component type, or crash
   getComponent<ID extends string | undefined, T extends CompTypes | undefined = CompTypes>(
     id: ID,
-    type?: T,
+    type?: T | ((type: CompTypes) => boolean),
   ): ID extends undefined ? undefined : CompExternal<T extends CompTypes ? T : CompTypes>;
 }
 
@@ -172,8 +172,11 @@ function makeLookupFunctions(lookups: PlainLayoutLookups & RelationshipLookups):
     if (!component) {
       throw new Error(`Component '${id}' does not exist`);
     }
-    if (type && component.type !== type) {
+    if (typeof type === 'string' && component.type !== type) {
       throw new Error(`Component '${id}' is of type '${component.type}', not '${type}'`);
+    }
+    if (typeof type === 'function' && !type(component.type)) {
+      throw new Error(`Component '${id}' is of type '${component.type}', not one of the expected types`);
     }
     return component as CompExternal<typeof type extends CompTypes ? typeof type : CompTypes>;
   }) as LayoutLookups['getComponent'];

--- a/src/features/pdf/PdfView2.tsx
+++ b/src/features/pdf/PdfView2.tsx
@@ -25,7 +25,7 @@ import { SummaryComponentFor } from 'src/layout/Summary/SummaryComponent';
 import { ComponentSummary } from 'src/layout/Summary2/SummaryComponent2/ComponentSummary';
 import { SummaryComponent2 } from 'src/layout/Summary2/SummaryComponent2/SummaryComponent2';
 import { isHidden, NodesInternal, useNode } from 'src/utils/layout/NodesContext';
-import { useNodeItemIfType } from 'src/utils/layout/useNodeItem';
+import { useItemIfType } from 'src/utils/layout/useNodeItem';
 import type { IPdfFormat } from 'src/features/pdf/types';
 import type { CompTypes } from 'src/layout/layout';
 import type { NodeData } from 'src/utils/layout/types';
@@ -177,7 +177,7 @@ function PdfForPage({ pageKey, pdfSettings }: { pageKey: string; pdfSettings: IP
 
 function PdfForNode({ nodeId }: { nodeId: string }) {
   const node = useNode(nodeId);
-  const item = useNodeItemIfType(node.baseId, 'Summary2');
+  const item = useItemIfType(node.baseId, 'Summary2');
 
   if (node.isType('Summary2') && item?.target?.taskId) {
     return (

--- a/src/features/pdf/PdfView2.tsx
+++ b/src/features/pdf/PdfView2.tsx
@@ -25,7 +25,7 @@ import { SummaryComponentFor } from 'src/layout/Summary/SummaryComponent';
 import { ComponentSummary } from 'src/layout/Summary2/SummaryComponent2/ComponentSummary';
 import { SummaryComponent2 } from 'src/layout/Summary2/SummaryComponent2/SummaryComponent2';
 import { isHidden, NodesInternal, useNode } from 'src/utils/layout/NodesContext';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useNodeItemIfType } from 'src/utils/layout/useNodeItem';
 import type { IPdfFormat } from 'src/features/pdf/types';
 import type { CompTypes } from 'src/layout/layout';
 import type { NodeData } from 'src/utils/layout/types';
@@ -177,9 +177,9 @@ function PdfForPage({ pageKey, pdfSettings }: { pageKey: string; pdfSettings: IP
 
 function PdfForNode({ nodeId }: { nodeId: string }) {
   const node = useNode(nodeId);
-  const target = useNodeItem(node, (i) => (i.type === 'Summary2' ? i.target : undefined));
+  const item = useNodeItemIfType(node.baseId, 'Summary2');
 
-  if (node.isType('Summary2') && target?.taskId) {
+  if (node.isType('Summary2') && item?.target?.taskId) {
     return (
       <SummaryComponent2
         key={node.id}

--- a/src/features/saveToGroup/useValidateGroupIsEmpty.ts
+++ b/src/features/saveToGroup/useValidateGroupIsEmpty.ts
@@ -4,18 +4,18 @@ import { FD } from 'src/features/formData/FormDataWrite';
 import { toRelativePath } from 'src/features/saveToGroup/useSaveToGroup';
 import { FrontendValidationSource, ValidationMask } from 'src/features/validation';
 import { getFieldNameKey } from 'src/utils/formComponentUtils';
-import { useNodeFormDataWhenType, useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useNodeFormDataWhenType, useNodeItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { ComponentValidation } from 'src/features/validation';
-import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
-export function useValidateGroupIsEmpty(
-  node: LayoutNode<'Checkboxes' | 'MultipleSelect' | 'List'>,
+export function useValidateGroupIsEmpty<T extends 'Checkboxes' | 'MultipleSelect' | 'List'>(
+  baseComponentId: string,
+  type: T,
 ): ComponentValidation[] {
-  const item = useNodeItem(node);
+  const item = useNodeItemWhenType(baseComponentId, type);
   const required = item && 'required' in item ? item.required : false;
   const dataModelBindings = item.dataModelBindings;
   const textResourceBindings = item.textResourceBindings;
-  const formData = useNodeFormDataWhenType<'Checkboxes' | 'MultipleSelect' | 'List'>(node.baseId, node.type);
+  const formData = useNodeFormDataWhenType(baseComponentId, type);
 
   const invalidDataSelector = FD.useInvalidDebouncedSelector();
   if (!required || !dataModelBindings) {

--- a/src/features/saveToGroup/useValidateGroupIsEmpty.ts
+++ b/src/features/saveToGroup/useValidateGroupIsEmpty.ts
@@ -4,14 +4,14 @@ import { FD } from 'src/features/formData/FormDataWrite';
 import { toRelativePath } from 'src/features/saveToGroup/useSaveToGroup';
 import { FrontendValidationSource, ValidationMask } from 'src/features/validation';
 import { getFieldNameKey } from 'src/utils/formComponentUtils';
-import { useNodeFormDataWhenType, useNodeItemWhenType } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType, useNodeFormDataWhenType } from 'src/utils/layout/useNodeItem';
 import type { ComponentValidation } from 'src/features/validation';
 
 export function useValidateGroupIsEmpty<T extends 'Checkboxes' | 'MultipleSelect' | 'List'>(
   baseComponentId: string,
   type: T,
 ): ComponentValidation[] {
-  const item = useNodeItemWhenType(baseComponentId, type);
+  const item = useItemWhenType(baseComponentId, type);
   const required = item && 'required' in item ? item.required : false;
   const dataModelBindings = item.dataModelBindings;
   const textResourceBindings = item.textResourceBindings;

--- a/src/features/validation/ComponentValidations.tsx
+++ b/src/features/validation/ComponentValidations.tsx
@@ -7,7 +7,7 @@ import classes from 'src/features/validation/ComponentValidations.module.css';
 import { useUnifiedValidationsForNode } from 'src/features/validation/selectors/unifiedValidationsForNode';
 import { validationsOfSeverity } from 'src/features/validation/utils';
 import { useCurrentNode } from 'src/layout/FormComponentContext';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useNodeItemIfType } from 'src/utils/layout/useNodeItem';
 import { useGetUniqueKeyFromObject } from 'src/utils/useGetKeyFromObject';
 import type { BaseValidation, NodeValidation } from 'src/features/validation';
 import type { AlertSeverity } from 'src/layout/Alert/config.generated';
@@ -36,9 +36,11 @@ export function AllComponentValidations({ node: _node }: { node?: LayoutNode }) 
 export function ComponentValidations({ validations, node: _node }: Props) {
   const currentNode = useCurrentNode();
   const node = _node ?? currentNode;
-  const inputMaxLength = useNodeItem(node, (i) =>
-    i.type === 'Input' || i.type === 'TextArea' ? i.maxLength : undefined,
+  const inputItem = useNodeItemIfType<'Input' | 'TextArea'>(
+    node.baseId,
+    (type) => type === 'Input' || type === 'TextArea',
   );
+  const inputMaxLength = inputItem?.maxLength;
 
   // If maxLength is set in both schema and component, don't display the schema error message here.
   // TODO: This should preferably be implemented in the Input component, via ValidationFilter, but that causes

--- a/src/features/validation/ComponentValidations.tsx
+++ b/src/features/validation/ComponentValidations.tsx
@@ -7,7 +7,7 @@ import classes from 'src/features/validation/ComponentValidations.module.css';
 import { useUnifiedValidationsForNode } from 'src/features/validation/selectors/unifiedValidationsForNode';
 import { validationsOfSeverity } from 'src/features/validation/utils';
 import { useCurrentNode } from 'src/layout/FormComponentContext';
-import { useNodeItemIfType } from 'src/utils/layout/useNodeItem';
+import { useItemIfType } from 'src/utils/layout/useNodeItem';
 import { useGetUniqueKeyFromObject } from 'src/utils/useGetKeyFromObject';
 import type { BaseValidation, NodeValidation } from 'src/features/validation';
 import type { AlertSeverity } from 'src/layout/Alert/config.generated';
@@ -36,10 +36,7 @@ export function AllComponentValidations({ node: _node }: { node?: LayoutNode }) 
 export function ComponentValidations({ validations, node: _node }: Props) {
   const currentNode = useCurrentNode();
   const node = _node ?? currentNode;
-  const inputItem = useNodeItemIfType<'Input' | 'TextArea'>(
-    node.baseId,
-    (type) => type === 'Input' || type === 'TextArea',
-  );
+  const inputItem = useItemIfType<'Input' | 'TextArea'>(node.baseId, (type) => type === 'Input' || type === 'TextArea');
   const inputMaxLength = inputItem?.maxLength;
 
   // If maxLength is set in both schema and component, don't display the schema error message here.

--- a/src/features/validation/ValidationStorePlugin.tsx
+++ b/src/features/validation/ValidationStorePlugin.tsx
@@ -6,6 +6,7 @@ import { FrontendValidationSource, ValidationMask } from 'src/features/validatio
 import { selectValidations } from 'src/features/validation/utils';
 import { isHidden, nodesProduce } from 'src/utils/layout/NodesContext';
 import { NodeDataPlugin } from 'src/utils/layout/plugins/NodeDataPlugin';
+import { splitDashedKey } from 'src/utils/splitDashedKey';
 import type { LayoutLookups } from 'src/features/form/layout/makeLayoutLookups';
 import type {
   AnyValidation,
@@ -180,15 +181,19 @@ export class ValidationStorePlugin extends NodeDataPlugin<ValidationStorePluginC
               severity?: ValidationSeverity,
               includeHidden: boolean = false,
             ) =>
-            (state: NodesContext) =>
-              getValidations({
+            (state: NodesContext) => {
+              const id = typeof nodeOrId === 'string' ? nodeOrId : nodeOrId.id;
+              const { baseComponentId } = splitDashedKey(id);
+              return getValidations({
                 state,
-                id: typeof nodeOrId === 'string' ? nodeOrId : nodeOrId.id,
+                id,
+                baseId: baseComponentId,
                 mask,
                 severity,
                 includeHidden,
                 lookups,
-              }),
+              });
+            },
         }) satisfies ValidationsSelector;
       },
       useLaxValidationsSelector: () => {
@@ -202,15 +207,19 @@ export class ValidationStorePlugin extends NodeDataPlugin<ValidationStorePluginC
               severity?: ValidationSeverity,
               includeHidden: boolean = false,
             ) =>
-            (state: NodesContext) =>
-              getValidations({
+            (state: NodesContext) => {
+              const id = typeof nodeOrId === 'string' ? nodeOrId : nodeOrId.id;
+              const { baseComponentId } = splitDashedKey(id);
+              return getValidations({
                 state,
-                id: typeof nodeOrId === 'string' ? nodeOrId : nodeOrId.id,
+                id,
+                baseId: baseComponentId,
                 mask,
                 severity,
                 includeHidden,
                 lookups,
-              }),
+              });
+            },
         }) satisfies ValidationsSelector;
       },
       useAllValidations: (mask, severity, includeHidden) => {

--- a/src/features/validation/callbacks/onGroupCloseValidation.ts
+++ b/src/features/validation/callbacks/onGroupCloseValidation.ts
@@ -26,6 +26,7 @@ export function useOnGroupCloseValidation() {
       const state = nodeStore.getState();
       const nodesWithErrors = getRecursiveValidations({
         id: node.id,
+        baseId: node.baseId,
         includeHidden: false,
         includeSelf: false,
         severity: 'error',

--- a/src/features/validation/index.ts
+++ b/src/features/validation/index.ts
@@ -200,6 +200,7 @@ export type NodeValidation<Validation extends AnyValidation<any> = AnyValidation
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type NodeRefValidation<Validation extends AnyValidation<any> = AnyValidation<any>> = Validation & {
+  baseComponentId: string;
   nodeId: string;
 };
 

--- a/src/features/validation/nodeValidation/emptyFieldValidation.ts
+++ b/src/features/validation/nodeValidation/emptyFieldValidation.ts
@@ -2,22 +2,21 @@ import { FD } from 'src/features/formData/FormDataWrite';
 import { type ComponentValidation, FrontendValidationSource, ValidationMask } from 'src/features/validation';
 import { getFieldNameKey } from 'src/utils/formComponentUtils';
 import { useDataModelBindingsFor } from 'src/utils/layout/hooks';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useNodeItemFor } from 'src/utils/layout/useNodeItem';
 import type { ValidLanguageKey } from 'src/features/language/useLanguage';
 import type { IDataModelReference } from 'src/layout/common.generated';
-import type { CompTypes, CompWithBinding } from 'src/layout/layout';
-import type { LayoutNode } from 'src/utils/layout/LayoutNode';
+import type { CompTypes } from 'src/layout/layout';
 
 /**
  * Default implementation of useEmptyFieldValidation
  * Checks all the component's dataModelBindings and returns one error for each one missing data
  */
 export function useEmptyFieldValidationAllBindings<Type extends CompTypes>(
-  node: LayoutNode<Type>,
+  baseComponentId: string,
   defaultText: ValidLanguageKey = 'form_filler.error_required',
 ): ComponentValidation[] {
-  const dataModelBindings = useDataModelBindingsFor<Type>(node.baseId);
-  const item = useNodeItem(node);
+  const dataModelBindings = useDataModelBindingsFor<Type>(baseComponentId);
+  const item = useNodeItemFor(baseComponentId);
   const required = 'required' in item ? item.required : false;
   const trb = item.textResourceBindings;
   const formDataSelector = FD.useDebouncedSelector();
@@ -55,13 +54,13 @@ export function useEmptyFieldValidationAllBindings<Type extends CompTypes>(
  * like options-based components that can store the label and metadata about the options alongside the actual value
  */
 export function useEmptyFieldValidationOnlyOneBinding<Binding extends string>(
-  node: LayoutNode<CompWithBinding<Binding>>,
+  baseComponentId: string,
   binding: Binding,
   defaultText: ValidLanguageKey = 'form_filler.error_required',
 ): ComponentValidation[] {
-  const item = useNodeItem(node);
+  const item = useNodeItemFor(baseComponentId);
   const required = 'required' in item ? item.required : false;
-  const reference = useDataModelBindingsFor(node.baseId)?.[binding as string] as IDataModelReference | undefined;
+  const reference = item.dataModelBindings?.[binding as string] as IDataModelReference | undefined;
   const trb = item.textResourceBindings;
   const validData = FD.useDebouncedPick(reference);
   const invalidData = FD.useInvalidDebouncedPick(reference);

--- a/src/features/validation/nodeValidation/emptyFieldValidation.ts
+++ b/src/features/validation/nodeValidation/emptyFieldValidation.ts
@@ -2,7 +2,7 @@ import { FD } from 'src/features/formData/FormDataWrite';
 import { type ComponentValidation, FrontendValidationSource, ValidationMask } from 'src/features/validation';
 import { getFieldNameKey } from 'src/utils/formComponentUtils';
 import { useDataModelBindingsFor } from 'src/utils/layout/hooks';
-import { useNodeItemFor } from 'src/utils/layout/useNodeItem';
+import { useItemFor } from 'src/utils/layout/useNodeItem';
 import type { ValidLanguageKey } from 'src/features/language/useLanguage';
 import type { IDataModelReference } from 'src/layout/common.generated';
 import type { CompTypes } from 'src/layout/layout';
@@ -16,7 +16,7 @@ export function useEmptyFieldValidationAllBindings<Type extends CompTypes>(
   defaultText: ValidLanguageKey = 'form_filler.error_required',
 ): ComponentValidation[] {
   const dataModelBindings = useDataModelBindingsFor<Type>(baseComponentId);
-  const item = useNodeItemFor(baseComponentId);
+  const item = useItemFor(baseComponentId);
   const required = 'required' in item ? item.required : false;
   const trb = item.textResourceBindings;
   const formDataSelector = FD.useDebouncedSelector();
@@ -58,7 +58,7 @@ export function useEmptyFieldValidationOnlyOneBinding<Binding extends string>(
   binding: Binding,
   defaultText: ValidLanguageKey = 'form_filler.error_required',
 ): ComponentValidation[] {
-  const item = useNodeItemFor(baseComponentId);
+  const item = useItemFor(baseComponentId);
   const required = 'required' in item ? item.required : false;
   const reference = item.dataModelBindings?.[binding as string] as IDataModelReference | undefined;
   const trb = item.textResourceBindings;

--- a/src/features/validation/nodeValidation/useNodeValidation.ts
+++ b/src/features/validation/nodeValidation/useNodeValidation.ts
@@ -30,8 +30,7 @@ export function useNodeValidation(node: LayoutNode): AnyValidation[] {
   // the same validator hooks (and thus in practice we will never actually break the rule of hooks, only the linter).
   const unfiltered: AnyValidation[] = [];
   if (implementsValidateEmptyField(node.def)) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    unfiltered.push(...node.def.useEmptyFieldValidation(node as any));
+    unfiltered.push(...node.def.useEmptyFieldValidation(node.baseId));
   }
 
   if (implementsValidateComponent(node.def)) {

--- a/src/features/validation/selectors/bindingValidationsForNode.ts
+++ b/src/features/validation/selectors/bindingValidationsForNode.ts
@@ -3,8 +3,8 @@ import { useMemo } from 'react';
 import type { ComponentValidation, FieldValidation, NodeValidation } from '..';
 
 import { Validation } from 'src/features/validation/validationContext';
+import { useDataModelBindingsFor } from 'src/utils/layout/hooks';
 import { NodesInternal } from 'src/utils/layout/NodesContext';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
 import type { CompTypes, IDataModelBindings } from 'src/layout/layout';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
@@ -20,7 +20,7 @@ export function useBindingValidationsForNode<
 >(node: N): { [binding in keyof NonNullable<IDataModelBindings<T>>]: OutValues } | undefined {
   const showAll = Validation.useShowAllBackendErrors();
   const component = NodesInternal.useVisibleValidations(node, showAll);
-  const dataModelBindings = useNodeItem(node).dataModelBindings;
+  const dataModelBindings = useDataModelBindingsFor(node.baseId);
 
   return useMemo(() => {
     if (!dataModelBindings) {

--- a/src/layout/Accordion/Accordion.tsx
+++ b/src/layout/Accordion/Accordion.tsx
@@ -10,13 +10,13 @@ import { useIsInAccordionGroup } from 'src/layout/AccordionGroup/AccordionGroupC
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
 import { GenericComponentByBaseId } from 'src/layout/GenericComponent';
 import { useHasCapability } from 'src/utils/layout/canRenderIn';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useNodeItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 type IAccordionProps = PropsFromGenericComponent<'Accordion'>;
 
 export const Accordion = ({ node }: IAccordionProps) => {
-  const { textResourceBindings, children, openByDefault } = useNodeItem(node);
+  const { textResourceBindings, children, openByDefault } = useNodeItemWhenType(node.baseId, 'Accordion');
   const { langAsString } = useLanguage();
   const canRender = useHasCapability('renderInAccordion');
   const renderAsAccordionItem = useIsInAccordionGroup();

--- a/src/layout/Accordion/Accordion.tsx
+++ b/src/layout/Accordion/Accordion.tsx
@@ -10,13 +10,13 @@ import { useIsInAccordionGroup } from 'src/layout/AccordionGroup/AccordionGroupC
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
 import { GenericComponentByBaseId } from 'src/layout/GenericComponent';
 import { useHasCapability } from 'src/utils/layout/canRenderIn';
-import { useNodeItemWhenType } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 type IAccordionProps = PropsFromGenericComponent<'Accordion'>;
 
 export const Accordion = ({ node }: IAccordionProps) => {
-  const { textResourceBindings, children, openByDefault } = useNodeItemWhenType(node.baseId, 'Accordion');
+  const { textResourceBindings, children, openByDefault } = useItemWhenType(node.baseId, 'Accordion');
   const { langAsString } = useLanguage();
   const canRender = useHasCapability('renderInAccordion');
   const renderAsAccordionItem = useIsInAccordionGroup();

--- a/src/layout/Accordion/SummaryAccordion.tsx
+++ b/src/layout/Accordion/SummaryAccordion.tsx
@@ -9,7 +9,7 @@ import { ComponentSummaryById, SummaryFlexForContainer } from 'src/layout/Summar
 import { useSummaryProp } from 'src/layout/Summary2/summaryStoreContext';
 import { useHasCapability } from 'src/utils/layout/canRenderIn';
 import { useComponentIdMutator } from 'src/utils/layout/DataModelLocation';
-import { useNodeItemWhenType } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types';
 
@@ -31,7 +31,7 @@ function getHeadingLevel(headingLevel: number | undefined) {
 }
 
 export function SummaryAccordionComponent({ targetNode }: SummaryRendererProps<'Accordion'>) {
-  const { textResourceBindings, headingLevel, children } = useNodeItemWhenType(targetNode.baseId, 'Accordion');
+  const { textResourceBindings, headingLevel, children } = useItemWhenType(targetNode.baseId, 'Accordion');
   const { langAsString } = useLanguage();
 
   const title = langAsString(textResourceBindings?.title);
@@ -57,7 +57,7 @@ export function SummaryAccordionComponent({ targetNode }: SummaryRendererProps<'
 export function SummaryAccordionComponent2({ target }: Summary2Props<'Accordion'>) {
   const idMutator = useComponentIdMutator();
   const canRenderInAccordion = useHasCapability('renderInAccordion');
-  const { textResourceBindings, headingLevel, children } = useNodeItemWhenType(target.baseId, 'Accordion');
+  const { textResourceBindings, headingLevel, children } = useItemWhenType(target.baseId, 'Accordion');
   const { langAsString } = useLanguage();
 
   const hideEmptyFields = useSummaryProp('hideEmptyFields');

--- a/src/layout/Accordion/SummaryAccordion.tsx
+++ b/src/layout/Accordion/SummaryAccordion.tsx
@@ -9,7 +9,7 @@ import { ComponentSummaryById, SummaryFlexForContainer } from 'src/layout/Summar
 import { useSummaryProp } from 'src/layout/Summary2/summaryStoreContext';
 import { useHasCapability } from 'src/utils/layout/canRenderIn';
 import { useComponentIdMutator } from 'src/utils/layout/DataModelLocation';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useNodeItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types';
 
@@ -31,7 +31,7 @@ function getHeadingLevel(headingLevel: number | undefined) {
 }
 
 export function SummaryAccordionComponent({ targetNode }: SummaryRendererProps<'Accordion'>) {
-  const { textResourceBindings, headingLevel, children } = useNodeItem(targetNode);
+  const { textResourceBindings, headingLevel, children } = useNodeItemWhenType(targetNode.baseId, 'Accordion');
   const { langAsString } = useLanguage();
 
   const title = langAsString(textResourceBindings?.title);
@@ -57,7 +57,7 @@ export function SummaryAccordionComponent({ targetNode }: SummaryRendererProps<'
 export function SummaryAccordionComponent2({ target }: Summary2Props<'Accordion'>) {
   const idMutator = useComponentIdMutator();
   const canRenderInAccordion = useHasCapability('renderInAccordion');
-  const { textResourceBindings, headingLevel, children } = useNodeItem(target);
+  const { textResourceBindings, headingLevel, children } = useNodeItemWhenType(target.baseId, 'Accordion');
   const { langAsString } = useLanguage();
 
   const hideEmptyFields = useSummaryProp('hideEmptyFields');

--- a/src/layout/AccordionGroup/AccordionGroup.tsx
+++ b/src/layout/AccordionGroup/AccordionGroup.tsx
@@ -5,19 +5,19 @@ import { Card } from '@digdir/designsystemet-react';
 import { AccordionGroupProvider } from 'src/layout/AccordionGroup/AccordionGroupContext';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
 import { GenericComponentByBaseId } from 'src/layout/GenericComponent';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useExternalItem } from 'src/utils/layout/hooks';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 type IAccordionGroupProps = PropsFromGenericComponent<'AccordionGroup'>;
 
 export const AccordionGroup = ({ node }: IAccordionGroupProps) => {
-  const { children } = useNodeItem(node);
+  const children = useExternalItem(node.baseId, 'AccordionGroup')?.children;
 
   return (
     <AccordionGroupProvider>
       <ComponentStructureWrapper node={node}>
         <Card data-color='neutral'>
-          {children.map((id) => (
+          {children?.map((id) => (
             <GenericComponentByBaseId
               key={id}
               id={id}

--- a/src/layout/AccordionGroup/SummaryAccordionGroupComponent.tsx
+++ b/src/layout/AccordionGroup/SummaryAccordionGroupComponent.tsx
@@ -6,14 +6,14 @@ import { SummaryFlexForContainer } from 'src/layout/Summary2/SummaryComponent2/C
 import { useSummaryProp } from 'src/layout/Summary2/summaryStoreContext';
 import { useHasCapability } from 'src/utils/layout/canRenderIn';
 import { useIndexedId } from 'src/utils/layout/DataModelLocation';
+import { useExternalItem } from 'src/utils/layout/hooks';
 import { useNode } from 'src/utils/layout/NodesContext';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
 import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types';
 
 export const SummaryAccordionGroupComponent = ({ targetNode, ...rest }: SummaryRendererProps<'AccordionGroup'>) => {
-  const { children } = useNodeItem(targetNode);
-  return children.map((childId) => (
+  const children = useExternalItem(targetNode.baseId, 'AccordionGroup')?.children;
+  return children?.map((childId) => (
     <Child
       key={childId}
       id={childId}
@@ -23,7 +23,7 @@ export const SummaryAccordionGroupComponent = ({ targetNode, ...rest }: SummaryR
 };
 
 export const SummaryAccordionGroupComponent2 = ({ target, ...rest }: Summary2Props<'AccordionGroup'>) => {
-  const { children } = useNodeItem(target);
+  const children = useExternalItem(target.baseId, 'AccordionGroup')?.children;
   const canRender = useHasCapability('renderInAccordionGroup');
   const hideEmptyFields = useSummaryProp('hideEmptyFields');
   return (
@@ -31,7 +31,7 @@ export const SummaryAccordionGroupComponent2 = ({ target, ...rest }: Summary2Pro
       hideWhen={hideEmptyFields}
       target={target}
     >
-      {children.filter(canRender).map((childId) => (
+      {children?.filter(canRender).map((childId) => (
         <Child2
           target={target}
           key={childId}

--- a/src/layout/ActionButton/ActionButtonComponent.tsx
+++ b/src/layout/ActionButton/ActionButtonComponent.tsx
@@ -9,7 +9,7 @@ import { useProcessNext } from 'src/features/instance/useProcessNext';
 import { Lang } from 'src/features/language/Lang';
 import { useIsSubformPage } from 'src/features/routing/AppRoutingContext';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
-import { useNodeItemWhenType } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { ActionButtonStyle } from 'src/layout/ActionButton/config.generated';
 
 export const buttonStyles: { [style in ActionButtonStyle]: { color: ButtonColor; variant: ButtonVariant } } = {
@@ -24,7 +24,7 @@ export function ActionButtonComponent({ node }: IActionButton) {
   const { performProcess, isAnyProcessing, isThisProcessing } = useIsProcessing();
   const isAuthorized = useIsAuthorized();
 
-  const { action, buttonStyle, id, textResourceBindings } = useNodeItemWhenType(node.baseId, 'ActionButton');
+  const { action, buttonStyle, id, textResourceBindings } = useItemWhenType(node.baseId, 'ActionButton');
   const disabled = !isAuthorized(action) || isAnyProcessing;
 
   if (useIsSubformPage()) {

--- a/src/layout/ActionButton/ActionButtonComponent.tsx
+++ b/src/layout/ActionButton/ActionButtonComponent.tsx
@@ -9,7 +9,7 @@ import { useProcessNext } from 'src/features/instance/useProcessNext';
 import { Lang } from 'src/features/language/Lang';
 import { useIsSubformPage } from 'src/features/routing/AppRoutingContext';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useNodeItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { ActionButtonStyle } from 'src/layout/ActionButton/config.generated';
 
 export const buttonStyles: { [style in ActionButtonStyle]: { color: ButtonColor; variant: ButtonVariant } } = {
@@ -24,7 +24,7 @@ export function ActionButtonComponent({ node }: IActionButton) {
   const { performProcess, isAnyProcessing, isThisProcessing } = useIsProcessing();
   const isAuthorized = useIsAuthorized();
 
-  const { action, buttonStyle, id, textResourceBindings } = useNodeItem(node);
+  const { action, buttonStyle, id, textResourceBindings } = useNodeItemWhenType(node.baseId, 'ActionButton');
   const disabled = !isAuthorized(action) || isAnyProcessing;
 
   if (useIsSubformPage()) {

--- a/src/layout/AddToList/AddToList.tsx
+++ b/src/layout/AddToList/AddToList.tsx
@@ -12,7 +12,7 @@ import { ALTINN_ROW_ID } from 'src/features/formData/types';
 import { useDataModelBindings } from 'src/features/formData/useDataModelBindings';
 import { useLanguage } from 'src/features/language/useLanguage';
 import { DropdownCaption } from 'src/layout/Datepicker/DropdownCaption';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useDataModelBindingsFor } from 'src/utils/layout/hooks';
 import type { FormDataObject } from 'src/app-components/DynamicForm/DynamicForm';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type { IDataModelReference } from 'src/layout/common.generated';
@@ -122,9 +122,8 @@ export function AddToListModal({
 }
 
 export function AddToListComponent({ node }: AddToListProps) {
-  const item = useNodeItem(node);
-
-  const { formData } = useDataModelBindings(item.dataModelBindings, 1, 'raw');
+  const dataModelBindings = useDataModelBindingsFor(node.baseId, 'AddToList');
+  const { formData } = useDataModelBindings(dataModelBindings, 1, 'raw');
   const setMultiLeafValues = FD.useSetMultiLeafValues();
 
   const modalRef = useRef<HTMLDialogElement>(null);
@@ -134,13 +133,13 @@ export function AddToListComponent({ node }: AddToListProps) {
     <div>
       {showForm && (
         <AddToListModal
-          dataModelReference={item.dataModelBindings.data}
+          dataModelReference={dataModelBindings.data}
           modalRef={modalRef}
           onChange={(formProps) => {
             const changes = Object.entries(formProps).map((entry) => ({
               reference: {
-                dataType: item.dataModelBindings.data.dataType,
-                field: `${item.dataModelBindings.data.field}[${(formData.data as []).length - 1}].${entry[0]}`,
+                dataType: dataModelBindings.data.dataType,
+                field: `${dataModelBindings.data.field}[${(formData.data as []).length - 1}].${entry[0]}`,
               },
               newValue: `${entry[1]}`,
             }));

--- a/src/layout/Address/AddressComponent.tsx
+++ b/src/layout/Address/AddressComponent.tsx
@@ -17,7 +17,7 @@ import { hasValidationErrors } from 'src/features/validation/utils';
 import { usePostPlaceQuery } from 'src/hooks/queries/usePostPlaceQuery';
 import { useEffectEvent } from 'src/hooks/useEffectEvent';
 import classes from 'src/layout/Address/AddressComponent.module.css';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useNodeItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type { IDataModelBindingsForAddress } from 'src/layout/Address/config.generated';
 
@@ -41,7 +41,7 @@ export function AddressComponent({ node }: IAddressProps) {
     textResourceBindings,
     dataModelBindings,
     labelSettings,
-  } = useNodeItem(node);
+  } = useNodeItemWhenType(node.baseId, 'Address');
   const { langAsString } = useLanguage();
 
   const bindingValidations = useBindingValidationsForNode(node);

--- a/src/layout/Address/AddressComponent.tsx
+++ b/src/layout/Address/AddressComponent.tsx
@@ -17,7 +17,7 @@ import { hasValidationErrors } from 'src/features/validation/utils';
 import { usePostPlaceQuery } from 'src/hooks/queries/usePostPlaceQuery';
 import { useEffectEvent } from 'src/hooks/useEffectEvent';
 import classes from 'src/layout/Address/AddressComponent.module.css';
-import { useNodeItemWhenType } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type { IDataModelBindingsForAddress } from 'src/layout/Address/config.generated';
 
@@ -41,7 +41,7 @@ export function AddressComponent({ node }: IAddressProps) {
     textResourceBindings,
     dataModelBindings,
     labelSettings,
-  } = useNodeItemWhenType(node.baseId, 'Address');
+  } = useItemWhenType(node.baseId, 'Address');
   const { langAsString } = useLanguage();
 
   const bindingValidations = useBindingValidationsForNode(node);

--- a/src/layout/Address/AddressSummary/AddressSummary.tsx
+++ b/src/layout/Address/AddressSummary/AddressSummary.tsx
@@ -9,7 +9,7 @@ import { SingleValueSummary } from 'src/layout/Summary2/CommonSummaryComponents/
 import { useHasNoDataInBindings } from 'src/layout/Summary2/isEmpty/isEmptyComponent';
 import { SummaryContains, SummaryFlex } from 'src/layout/Summary2/SummaryComponent2/ComponentSummary';
 import { useSummaryOverrides, useSummaryProp } from 'src/layout/Summary2/summaryStoreContext';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useNodeItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 interface AddressSummaryProps {
@@ -17,12 +17,8 @@ interface AddressSummaryProps {
 }
 
 export function AddressSummary({ componentNode }: AddressSummaryProps) {
-  const { textResourceBindings, dataModelBindings, simplified, required } = useNodeItem(componentNode, (i) => ({
-    textResourceBindings: i.textResourceBindings,
-    dataModelBindings: i.dataModelBindings,
-    simplified: i.simplified,
-    required: i.required,
-  }));
+  const item = useNodeItemWhenType(componentNode.baseId, 'Address');
+  const { textResourceBindings, dataModelBindings, simplified, required } = item;
   const { title, careOfTitle, zipCodeTitle, postPlaceTitle, houseNumberTitle } = textResourceBindings ?? {};
   const { formData } = useDataModelBindings(dataModelBindings);
   const { address, postPlace, zipCode, careOf, houseNumber } = formData;

--- a/src/layout/Address/AddressSummary/AddressSummary.tsx
+++ b/src/layout/Address/AddressSummary/AddressSummary.tsx
@@ -9,7 +9,7 @@ import { SingleValueSummary } from 'src/layout/Summary2/CommonSummaryComponents/
 import { useHasNoDataInBindings } from 'src/layout/Summary2/isEmpty/isEmptyComponent';
 import { SummaryContains, SummaryFlex } from 'src/layout/Summary2/SummaryComponent2/ComponentSummary';
 import { useSummaryOverrides, useSummaryProp } from 'src/layout/Summary2/summaryStoreContext';
-import { useNodeItemWhenType } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 interface AddressSummaryProps {
@@ -17,7 +17,7 @@ interface AddressSummaryProps {
 }
 
 export function AddressSummary({ componentNode }: AddressSummaryProps) {
-  const item = useNodeItemWhenType(componentNode.baseId, 'Address');
+  const item = useItemWhenType(componentNode.baseId, 'Address');
   const { textResourceBindings, dataModelBindings, simplified, required } = item;
   const { title, careOfTitle, zipCodeTitle, postPlaceTitle, houseNumberTitle } = textResourceBindings ?? {};
   const { formData } = useDataModelBindings(dataModelBindings);

--- a/src/layout/Alert/Alert.tsx
+++ b/src/layout/Alert/Alert.tsx
@@ -5,13 +5,13 @@ import { useLanguage } from 'src/features/language/useLanguage';
 import { AlertBaseComponent } from 'src/layout/Alert/AlertBaseComponent';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
 import { useExternalItem } from 'src/utils/layout/hooks';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export type AlertProps = PropsFromGenericComponent<'Alert'>;
 
 export const Alert = ({ node }: AlertProps) => {
-  const { severity, textResourceBindings } = useNodeItem(node);
+  const { severity, textResourceBindings } = useItemWhenType(node.baseId, 'Alert');
   const { langAsString } = useLanguage();
 
   // If the 'hidden' property is an expression, we should alert screen readers whenever this becomes visible

--- a/src/layout/AttachmentList/AttachmentListComponent.test.tsx
+++ b/src/layout/AttachmentList/AttachmentListComponent.test.tsx
@@ -5,9 +5,10 @@ import { render, screen } from '@testing-library/react';
 
 import { useLaxInstanceData } from 'src/features/instance/InstanceContext';
 import { AttachmentListComponent } from 'src/layout/AttachmentList/AttachmentListComponent';
+import { CompInternal } from 'src/layout/layout';
 import { DataTypeReference } from 'src/utils/attachmentsUtils';
 import { LayoutNode } from 'src/utils/layout/LayoutNode';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { IData, IDataType } from 'src/types/shared';
 
 // Mock application metadata data types with only the properties used in tests
@@ -107,7 +108,7 @@ jest.mock('src/components/organisms/AttachmentGroupings', () => ({
 }));
 
 describe('AttachmentListComponent', () => {
-  const mockUseNodeItem = jest.mocked(useNodeItem<LayoutNode<'AttachmentList'>, unknown>);
+  const mockUseItemWhenType = jest.mocked(useItemWhenType<'AttachmentList'>);
   const mockUseLaxInstanceData = jest.mocked(useLaxInstanceData);
 
   // Helper function to set up mockUseNodeItem with specific values
@@ -118,28 +119,16 @@ describe('AttachmentListComponent', () => {
     dataTypeIds = ['dataType1', 'dataType2', 'dataType3'],
     showDataTypeDescriptions = false,
   } = {}) => {
-    mockUseNodeItem.mockImplementation((_node, selector) => {
-      if (typeof selector === 'function') {
-        const selectorStr = selector.toString();
-
-        if (selectorStr.includes('groupByDataTypeGrouping')) {
-          return groupByDataTypeGrouping;
-        }
-        if (selectorStr.includes('textResourceBindings')) {
-          return textResourceBindings;
-        }
-        if (selectorStr.includes('links')) {
-          return links;
-        }
-        if (selectorStr.includes('dataTypeIds')) {
-          return dataTypeIds;
-        }
-        if (selectorStr.includes('showDataTypeDescriptions')) {
-          return showDataTypeDescriptions;
-        }
-      }
-      return undefined;
-    });
+    mockUseItemWhenType.mockImplementation(
+      (_baseId) =>
+        ({
+          groupByDataTypeGrouping,
+          textResourceBindings,
+          links,
+          dataTypeIds,
+          showDataTypeDescriptions,
+        }) as CompInternal<'AttachmentList'>,
+    );
   };
 
   beforeEach(() => {

--- a/src/layout/AttachmentList/AttachmentListComponent.tsx
+++ b/src/layout/AttachmentList/AttachmentListComponent.tsx
@@ -14,7 +14,7 @@ import {
   getRefAsPdfAttachments,
   toDisplayAttachments,
 } from 'src/utils/attachmentsUtils';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type { IDataType } from 'src/types/shared';
 
@@ -23,11 +23,12 @@ export type IAttachmentListProps = PropsFromGenericComponent<'AttachmentList'>;
 const emptyDataTypeArray: IDataType[] = [];
 
 export function AttachmentListComponent({ node }: IAttachmentListProps) {
-  const textResourceBindings = useNodeItem(node, (i) => i.textResourceBindings);
-  const showLinks = useNodeItem(node, (i) => i.links);
-  const allowedAttachmentTypes = new Set(useNodeItem(node, (i) => i.dataTypeIds) ?? []);
-  const groupAttachments = useNodeItem(node, (i) => i.groupByDataTypeGrouping) ?? false;
-  const showDescription = useNodeItem(node, (i) => i.showDataTypeDescriptions) ?? false;
+  const item = useItemWhenType(node.baseId, 'AttachmentList');
+  const textResourceBindings = item.textResourceBindings;
+  const showLinks = item.links;
+  const allowedAttachmentTypes = new Set(item.dataTypeIds ?? []);
+  const groupAttachments = item.groupByDataTypeGrouping ?? false;
+  const showDescription = item.showDataTypeDescriptions ?? false;
 
   const instanceData = useLaxInstanceData((data) => data.data) ?? [];
   const currentTaskId = useLaxProcessData()?.currentTask?.elementId;

--- a/src/layout/Audio/Audio.tsx
+++ b/src/layout/Audio/Audio.tsx
@@ -3,14 +3,14 @@ import React from 'react';
 import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
 import { useLanguage } from 'src/features/language/useLanguage';
 import { useParentCard } from 'src/layout/Cards/CardContext';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export type IAudioProps = PropsFromGenericComponent<'Audio'>;
 
 export function AudioComponent({ node }: IAudioProps) {
   const { langAsString } = useLanguage();
-  const { id, audio, textResourceBindings } = useNodeItem(node);
+  const { id, audio, textResourceBindings } = useItemWhenType(node.baseId, 'Audio');
   const languageKey = useCurrentLanguage();
   const altText = textResourceBindings?.altText ? langAsString(textResourceBindings.altText) : undefined;
   const audioSrc = audio?.src?.[languageKey] || '';

--- a/src/layout/Button/ButtonComponent.tsx
+++ b/src/layout/Button/ButtonComponent.tsx
@@ -13,7 +13,7 @@ import { getComponentFromMode } from 'src/layout/Button/getComponentFromMode';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
 import { alignStyle } from 'src/layout/RepeatingGroup/Container/RepeatingGroupContainer';
 import { ProcessTaskType } from 'src/types';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type { CompInternal } from 'src/layout/layout';
 
@@ -23,7 +23,7 @@ export type IButtonProvidedProps =
   | (PropsFromGenericComponent<'InstantiationButton'> & CompInternal<'InstantiationButton'>);
 
 export const ButtonComponent = ({ node, ...componentProps }: IButtonReceivedProps) => {
-  const item = useNodeItem(node);
+  const item = useItemWhenType(node.baseId, node.type);
   const { mode } = item;
   const { langAsString } = useLanguage();
   const props: IButtonProvidedProps = { ...componentProps, ...item, node };

--- a/src/layout/ButtonGroup/ButtonGroupComponent.tsx
+++ b/src/layout/ButtonGroup/ButtonGroupComponent.tsx
@@ -9,13 +9,12 @@ import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper'
 import { GenericComponent } from 'src/layout/GenericComponent';
 import { useHasCapability } from 'src/utils/layout/canRenderIn';
 import { useIndexedId } from 'src/utils/layout/DataModelLocation';
+import { useExternalItem } from 'src/utils/layout/hooks';
 import { useNode } from 'src/utils/layout/NodesContext';
 import { useLabel } from 'src/utils/layout/useLabel';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
 
 export function ButtonGroupComponent({ node, overrideDisplay }: PropsFromGenericComponent<'ButtonGroup'>) {
-  const { grid, children } = useNodeItem(node);
-
+  const { grid, children } = useExternalItem(node.baseId, 'ButtonGroup');
   const { labelText, getDescriptionComponent, getHelpTextComponent } = useLabel({ node, overrideDisplay });
 
   return (

--- a/src/layout/Cards/Cards.tsx
+++ b/src/layout/Cards/Cards.tsx
@@ -9,8 +9,8 @@ import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper'
 import { GenericComponent } from 'src/layout/GenericComponent';
 import { useHasCapability } from 'src/utils/layout/canRenderIn';
 import { useIndexedId } from 'src/utils/layout/DataModelLocation';
+import { useExternalItem } from 'src/utils/layout/hooks';
 import { useNode } from 'src/utils/layout/NodesContext';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
 import { typedBoolean } from 'src/utils/typing';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
@@ -27,7 +27,13 @@ const colorVariantMap: Record<string, 'tinted' | 'default'> = {
 };
 
 export const Cards = ({ node }: ICardsProps) => {
-  const { cards, minMediaHeight, minWidth, color, mediaPosition: _mediaPosition } = useNodeItem(node);
+  const {
+    cards,
+    minMediaHeight,
+    minWidth,
+    color,
+    mediaPosition: _mediaPosition,
+  } = useExternalItem(node.baseId, 'Cards');
   const processedMinWidth = parseSize(minWidth, '250px');
   const processedMinMediaHeight = parseSize(minMediaHeight, '150px');
   const mediaPosition = _mediaPosition ?? 'top';

--- a/src/layout/Cards/CardsSummary.tsx
+++ b/src/layout/Cards/CardsSummary.tsx
@@ -6,8 +6,8 @@ import { ComponentSummaryById, SummaryFlexForContainer } from 'src/layout/Summar
 import { useSummaryProp } from 'src/layout/Summary2/summaryStoreContext';
 import { useHasCapability } from 'src/utils/layout/canRenderIn';
 import { useComponentIdMutator, useIndexedId } from 'src/utils/layout/DataModelLocation';
+import { useExternalItem } from 'src/utils/layout/hooks';
 import { useNode } from 'src/utils/layout/NodesContext';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
 import { typedBoolean } from 'src/utils/typing';
 import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types';
@@ -36,8 +36,9 @@ function Child({ baseId, overrides }: { baseId: string | undefined } & Pick<Prop
 }
 
 export function CardsSummary({ targetNode, overrides }: Props) {
-  const cardsInternal = useNodeItem(targetNode, (i) => i.cards);
-  const children = cardsInternal.map((card) => card.children).flat();
+  const children = useExternalItem(targetNode.baseId, 'Cards')
+    .cards.map((card) => card.children)
+    .flat();
 
   return (
     <>
@@ -55,7 +56,9 @@ export function CardsSummary({ targetNode, overrides }: Props) {
 export function CardsSummary2({ target }: Summary2Props<'Cards'>) {
   const canRender = useHasCapability('renderInCards');
   const idMutator = useComponentIdMutator();
-  const children = useNodeItem(target, (i) => i.cards.map((c) => c.children).flat())
+  const children = useExternalItem(target.baseId, 'Cards')
+    .cards.map((c) => c.children)
+    .flat()
     .filter(canRender)
     .filter(typedBoolean);
   const hideEmptyFields = useSummaryProp('hideEmptyFields');

--- a/src/layout/Checkboxes/CheckboxesContainerComponent.tsx
+++ b/src/layout/Checkboxes/CheckboxesContainerComponent.tsx
@@ -14,14 +14,12 @@ import classes from 'src/layout/Checkboxes/CheckboxesContainerComponent.module.c
 import { WrappedCheckbox } from 'src/layout/Checkboxes/WrappedCheckbox';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
 import { shouldUseRowLayout } from 'src/utils/layout';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { IOptionInternal } from 'src/features/options/castOptionsToStrings';
 import type { PropsFromGenericComponent } from 'src/layout';
 
-export type ICheckboxContainerProps = PropsFromGenericComponent<'Checkboxes'>;
-
-export const CheckboxContainerComponent = ({ node, overrideDisplay }: ICheckboxContainerProps) => {
-  const item = useNodeItem(node);
+export const CheckboxContainerComponent = ({ node, overrideDisplay }: PropsFromGenericComponent<'Checkboxes'>) => {
+  const item = useItemWhenType(node.baseId, 'Checkboxes');
   const {
     id,
     layout,

--- a/src/layout/Checkboxes/CheckboxesSummary.tsx
+++ b/src/layout/Checkboxes/CheckboxesSummary.tsx
@@ -8,7 +8,7 @@ import {
 } from 'src/layout/Summary2/CommonSummaryComponents/MultipleValueSummary';
 import { SummaryContains, SummaryFlex } from 'src/layout/Summary2/SummaryComponent2/ComponentSummary';
 import { useSummaryOverrides, useSummaryProp } from 'src/layout/Summary2/summaryStoreContext';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types';
 
 export function CheckboxesSummary({ target }: Summary2Props<'Checkboxes'>) {
@@ -21,8 +21,9 @@ export function CheckboxesSummary({ target }: Summary2Props<'Checkboxes'>) {
   const showAsList =
     summaryOverride?.displayType === 'list' ||
     (!summaryOverride?.displayType && displayData?.length >= maxStringLength);
-  const title = useNodeItem(componentNode, (i) => i.textResourceBindings?.title);
-  const required = useNodeItem(componentNode, (i) => i.required);
+  const item = useItemWhenType(componentNode.baseId, 'Checkboxes');
+  const title = item.textResourceBindings?.title;
+  const required = item.required;
   const displayValues = useMultipleValuesForSummary(target);
 
   return (

--- a/src/layout/Checkboxes/MultipleChoiceSummary.tsx
+++ b/src/layout/Checkboxes/MultipleChoiceSummary.tsx
@@ -8,7 +8,8 @@ import { useLanguage } from 'src/features/language/useLanguage';
 import { getCommaSeparatedOptionsToText } from 'src/features/options/getCommaSeparatedOptionsToText';
 import { useOptionsFor } from 'src/features/options/useOptionsFor';
 import classes from 'src/layout/Checkboxes/MultipleChoiceSummary.module.css';
-import { useNodeFormData, useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useDataModelBindingsFor } from 'src/utils/layout/hooks';
+import { useNodeFormData } from 'src/utils/layout/useNodeItem';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 type Row = Record<string, string | number | boolean>;
@@ -19,7 +20,10 @@ export interface IMultipleChoiceSummaryProps {
 
 export function MultipleChoiceSummary({ targetNode }: IMultipleChoiceSummaryProps) {
   const rawFormData = useNodeFormData(targetNode);
-  const { dataModelBindings } = useNodeItem(targetNode);
+  const dataModelBindings = useDataModelBindingsFor<'Checkboxes' | 'MultipleSelect'>(
+    targetNode.baseId,
+    (t) => t === 'Checkboxes' || t === 'MultipleSelect',
+  );
   const options = useOptionsFor(targetNode.baseId, 'multi').options;
   const { langAsString } = useLanguage();
 

--- a/src/layout/Checkboxes/index.tsx
+++ b/src/layout/Checkboxes/index.tsx
@@ -74,8 +74,8 @@ export class Checkboxes extends CheckboxesDef {
     return <CheckboxesSummary {...props} />;
   }
 
-  useEmptyFieldValidation(node: LayoutNode<'Checkboxes'>): ComponentValidation[] {
-    return useValidateGroupIsEmpty(node);
+  useEmptyFieldValidation(baseComponentId: string): ComponentValidation[] {
+    return useValidateGroupIsEmpty(baseComponentId, 'Checkboxes');
   }
 
   renderLayoutValidators(props: NodeValidationProps<'Checkboxes'>): JSX.Element | null {

--- a/src/layout/ComponentStructureWrapper.tsx
+++ b/src/layout/ComponentStructureWrapper.tsx
@@ -5,7 +5,7 @@ import { Flex } from 'src/app-components/Flex/Flex';
 import { Label } from 'src/components/label/Label';
 import { AllComponentValidations } from 'src/features/validation/ComponentValidations';
 import { useFormComponentCtx } from 'src/layout/FormComponentContext';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useExternalItem } from 'src/utils/layout/hooks';
 import type { LabelProps } from 'src/components/label/Label';
 import type { CompTypes } from 'src/layout/layout';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
@@ -25,8 +25,8 @@ export function ComponentStructureWrapper<Type extends CompTypes = CompTypes>({
   style,
 }: PropsWithChildren<ComponentStructureWrapperProps<Type>>) {
   const overrideItemProps = useFormComponentCtx()?.overrideItemProps;
-  const _grid = useNodeItem(node, (i) => i.grid);
-  const grid = overrideItemProps?.grid ?? _grid;
+  const component = useExternalItem(node.baseId);
+  const grid = overrideItemProps?.grid ?? component?.grid;
   const layoutComponent = node.def;
   const showValidationMessages = layoutComponent.renderDefaultValidations();
 

--- a/src/layout/Custom/CustomWebComponent.tsx
+++ b/src/layout/Custom/CustomWebComponent.tsx
@@ -7,7 +7,7 @@ import { useDataModelBindings } from 'src/features/formData/useDataModelBindings
 import { useLanguage } from 'src/features/language/useLanguage';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
 import { Hidden } from 'src/utils/layout/NodesContext';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { IUseLanguage } from 'src/features/language/useLanguage';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type { CompInternal, ITextResourceBindings } from 'src/layout/layout';
@@ -36,7 +36,10 @@ export function CustomWebComponent({
   const langTools = useLanguage();
   const langAsString = langTools.langAsString;
   const legacyLanguage = useLegacyNestedTexts();
-  const { tagName, textResourceBindings, dataModelBindings, ...passThroughPropsFromNode } = useNodeItem(node);
+  const { tagName, textResourceBindings, dataModelBindings, ...passThroughPropsFromNode } = useItemWhenType(
+    node.baseId,
+    'Custom',
+  );
 
   const { containerDivRef: _unused, ...restFromGeneric } = passThroughPropsFromGenericComponent;
 

--- a/src/layout/Custom/index.tsx
+++ b/src/layout/Custom/index.tsx
@@ -7,7 +7,7 @@ import { CustomWebComponent } from 'src/layout/Custom/CustomWebComponent';
 import { SummaryItemSimple } from 'src/layout/Summary/SummaryItemSimple';
 import { useHasBindingsAndNoData } from 'src/layout/Summary2/isEmpty/isEmptyComponent';
 import { SummaryContains, SummaryFlex } from 'src/layout/Summary2/SummaryComponent2/ComponentSummary';
-import { useNodeFormData, useNodeFormDataWhenType, useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType, useNodeFormData, useNodeFormDataWhenType } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types';
@@ -32,7 +32,7 @@ export class Custom extends CustomDef {
   renderSummary2(props: Summary2Props<'Custom'>): JSX.Element | null {
     const formData = useNodeFormData(props.target);
     const isEmpty = useHasBindingsAndNoData(props.target);
-    const required = useNodeItem(props.target, (i) => i.required);
+    const required = useItemWhenType(props.target.baseId, 'Custom').required;
     return (
       <SummaryFlex
         target={props.target}

--- a/src/layout/CustomButton/CustomButtonComponent.tsx
+++ b/src/layout/CustomButton/CustomButtonComponent.tsx
@@ -17,7 +17,7 @@ import { useNavigatePage } from 'src/hooks/useNavigatePage';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
 import { isSpecificClientAction } from 'src/layout/CustomButton/typeHelpers';
 import { NodesInternal } from 'src/utils/layout/NodesContext';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { ButtonColor, ButtonVariant } from 'src/app-components/Button/Button';
 import type { BackendValidationIssueGroups } from 'src/features/validation';
 import type { PropsFromGenericComponent } from 'src/layout';
@@ -230,7 +230,10 @@ function toShorthandSize(size?: CBTypes.CustomButtonSize): 'sm' | 'md' | 'lg' {
 }
 
 export const CustomButtonComponent = ({ node }: Props) => {
-  const { textResourceBindings, actions, id, buttonColor, buttonSize, buttonStyle } = useNodeItem(node);
+  const { textResourceBindings, actions, id, buttonColor, buttonSize, buttonStyle } = useItemWhenType(
+    node.baseId,
+    'CustomButton',
+  );
 
   const acquireLock = FD.useLocking(id);
   const isAuthorized = useIsAuthorized();

--- a/src/layout/Date/DateComponent.tsx
+++ b/src/layout/Date/DateComponent.tsx
@@ -10,15 +10,13 @@ import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
 import { useLanguage } from 'src/features/language/useLanguage';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
 import { formatDateLocale } from 'src/utils/dateUtils';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export const DateComponent = ({ node }: PropsFromGenericComponent<'Date'>) => {
-  const textResourceBindings = useNodeItem(node, (i) => i.textResourceBindings);
-  const direction = useNodeItem(node, (i) => i.direction) ?? 'horizontal';
-  const value = useNodeItem(node, (i) => i.value);
-  const icon = useNodeItem(node, (i) => i.icon);
-  const format = useNodeItem(node, (i) => i.format);
+  const item = useItemWhenType(node.baseId, 'Date');
+  const { textResourceBindings, direction: _direction, value, icon, format } = item;
+  const direction = _direction ?? 'horizontal';
   const { langAsString } = useLanguage();
   const language = useCurrentLanguage();
   const parsedValue = parseISO(value);

--- a/src/layout/Date/DateSummary.tsx
+++ b/src/layout/Date/DateSummary.tsx
@@ -7,7 +7,7 @@ import { validationsOfSeverity } from 'src/features/validation/utils';
 import { SingleValueSummary } from 'src/layout/Summary2/CommonSummaryComponents/SingleValueSummary';
 import { SummaryContains, SummaryFlex } from 'src/layout/Summary2/SummaryComponent2/ComponentSummary';
 import { useSummaryOverrides, useSummaryProp } from 'src/layout/Summary2/summaryStoreContext';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types';
 
 export const DateSummary = ({ target }: Summary2Props<'Date'>) => {
@@ -17,8 +17,8 @@ export const DateSummary = ({ target }: Summary2Props<'Date'>) => {
   const displayData = useDisplayData(componentNode);
   const validations = useUnifiedValidationsForNode(componentNode);
   const errors = validationsOfSeverity(validations, 'error');
-  const title = useNodeItem(componentNode, (i) => i.textResourceBindings?.title);
-  const direction = useNodeItem(componentNode, (i) => i.direction);
+  const { textResourceBindings, direction } = useItemWhenType(componentNode.baseId, 'Date');
+  const title = textResourceBindings?.title;
 
   const compact = (direction === 'horizontal' && isCompact == undefined) || isCompact;
 

--- a/src/layout/Date/index.tsx
+++ b/src/layout/Date/index.tsx
@@ -6,7 +6,6 @@ import { formatDate, isValid, parseISO } from 'date-fns';
 import { DateDef } from 'src/layout/Date/config.def.generated';
 import { DateComponent } from 'src/layout/Date/DateComponent';
 import { DateSummary } from 'src/layout/Date/DateSummary';
-import { useIndexedId } from 'src/utils/layout/DataModelLocation';
 import { useNodeItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { DisplayData } from 'src/features/displayData';
 import type { PropsFromGenericComponent } from 'src/layout';
@@ -15,8 +14,7 @@ import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types'
 
 export class Date extends DateDef implements DisplayData {
   useDisplayData(baseComponentId: string): string {
-    const nodeId = useIndexedId(baseComponentId);
-    const item = useNodeItemWhenType(nodeId, 'Date');
+    const item = useNodeItemWhenType(baseComponentId, 'Date');
     const dateString = item?.value;
     const format = item?.format;
 

--- a/src/layout/Date/index.tsx
+++ b/src/layout/Date/index.tsx
@@ -6,7 +6,7 @@ import { formatDate, isValid, parseISO } from 'date-fns';
 import { DateDef } from 'src/layout/Date/config.def.generated';
 import { DateComponent } from 'src/layout/Date/DateComponent';
 import { DateSummary } from 'src/layout/Date/DateSummary';
-import { useNodeItemWhenType } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { DisplayData } from 'src/features/displayData';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type { ExprResolver } from 'src/layout/LayoutComponent';
@@ -14,7 +14,7 @@ import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types'
 
 export class Date extends DateDef implements DisplayData {
   useDisplayData(baseComponentId: string): string {
-    const item = useNodeItemWhenType(baseComponentId, 'Date');
+    const item = useItemWhenType(baseComponentId, 'Date');
     const dateString = item?.value;
     const format = item?.format;
 

--- a/src/layout/Datepicker/DatepickerComponent.tsx
+++ b/src/layout/Datepicker/DatepickerComponent.tsx
@@ -11,7 +11,7 @@ import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper'
 import { DropdownCaption } from 'src/layout/Datepicker/DropdownCaption';
 import { getDatepickerFormat } from 'src/utils/dateUtils';
 import { useLabel } from 'src/utils/layout/useLabel';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 import 'react-day-picker/style.css';
@@ -32,7 +32,7 @@ export function DatepickerComponent({ node, overrideDisplay }: IDatepickerProps)
     dataModelBindings,
     grid,
     autocomplete,
-  } = useNodeItem(node);
+  } = useItemWhenType(node.baseId, 'Datepicker');
 
   const calculatedMinDate = getDateConstraint(minDate, 'min');
   const calculatedMaxDate = getDateConstraint(maxDate, 'max');

--- a/src/layout/Datepicker/DatepickerSummary.tsx
+++ b/src/layout/Datepicker/DatepickerSummary.tsx
@@ -7,7 +7,7 @@ import { validationsOfSeverity } from 'src/features/validation/utils';
 import { SingleValueSummary } from 'src/layout/Summary2/CommonSummaryComponents/SingleValueSummary';
 import { SummaryContains, SummaryFlex } from 'src/layout/Summary2/SummaryComponent2/ComponentSummary';
 import { useSummaryOverrides, useSummaryProp } from 'src/layout/Summary2/summaryStoreContext';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types';
 
 export const DatepickerSummary = ({ target }: Summary2Props<'Datepicker'>) => {
@@ -16,8 +16,8 @@ export const DatepickerSummary = ({ target }: Summary2Props<'Datepicker'>) => {
   const displayData = useDisplayData(target);
   const validations = useUnifiedValidationsForNode(target);
   const errors = validationsOfSeverity(validations, 'error');
-  const title = useNodeItem(target, (i) => i.textResourceBindings?.title);
-  const required = useNodeItem(target, (i) => i.required);
+  const item = useItemWhenType(target.baseId, 'Datepicker');
+  const title = item.textResourceBindings?.title;
 
   return (
     <SummaryFlex
@@ -25,7 +25,7 @@ export const DatepickerSummary = ({ target }: Summary2Props<'Datepicker'>) => {
       content={
         displayData
           ? SummaryContains.SomeUserContent
-          : required
+          : item.required
             ? SummaryContains.EmptyValueRequired
             : SummaryContains.EmptyValueNotRequired
       }

--- a/src/layout/Dropdown/DropdownComponent.tsx
+++ b/src/layout/Dropdown/DropdownComponent.tsx
@@ -17,14 +17,14 @@ import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper'
 import classes from 'src/layout/Dropdown/DropdownComponent.module.css';
 import comboboxClasses from 'src/styles/combobox.module.css';
 import { useLabel } from 'src/utils/layout/useLabel';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import { optionSearchFilter } from 'src/utils/options';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export type IDropdownProps = PropsFromGenericComponent<'Dropdown'>;
 
 export function DropdownComponent({ node, overrideDisplay }: IDropdownProps) {
-  const item = useNodeItem(node);
+  const item = useItemWhenType(node.baseId, 'Dropdown');
   const isValid = useIsValid(node);
   const { id, readOnly, textResourceBindings, alertOnChange, grid, required } = item;
   const { langAsString, lang } = useLanguage();

--- a/src/layout/Dropdown/DropdownSummary.tsx
+++ b/src/layout/Dropdown/DropdownSummary.tsx
@@ -7,7 +7,7 @@ import { validationsOfSeverity } from 'src/features/validation/utils';
 import { SingleValueSummary } from 'src/layout/Summary2/CommonSummaryComponents/SingleValueSummary';
 import { SummaryContains, SummaryFlex } from 'src/layout/Summary2/SummaryComponent2/ComponentSummary';
 import { useSummaryOverrides, useSummaryProp } from 'src/layout/Summary2/summaryStoreContext';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types';
 
 export const DropdownSummary = ({ target }: Summary2Props<'Dropdown'>) => {
@@ -16,8 +16,8 @@ export const DropdownSummary = ({ target }: Summary2Props<'Dropdown'>) => {
   const displayData = useDisplayData(target);
   const validations = useUnifiedValidationsForNode(target);
   const errors = validationsOfSeverity(validations, 'error');
-  const title = useNodeItem(target, (i) => i.textResourceBindings?.title);
-  const required = useNodeItem(target, (i) => i.required);
+  const item = useItemWhenType(target.baseId, 'Dropdown');
+  const title = item.textResourceBindings?.title;
 
   return (
     <SummaryFlex
@@ -25,7 +25,7 @@ export const DropdownSummary = ({ target }: Summary2Props<'Dropdown'>) => {
       content={
         displayData
           ? SummaryContains.SomeUserContent
-          : required
+          : item.required
             ? SummaryContains.EmptyValueRequired
             : SummaryContains.EmptyValueNotRequired
       }

--- a/src/layout/Dropdown/index.tsx
+++ b/src/layout/Dropdown/index.tsx
@@ -55,8 +55,8 @@ export class Dropdown extends DropdownDef {
     return <DropdownSummary {...props} />;
   }
 
-  useEmptyFieldValidation(node: LayoutNode<'Dropdown'>): ComponentValidation[] {
-    return useEmptyFieldValidationOnlyOneBinding(node, 'simpleBinding');
+  useEmptyFieldValidation(baseComponentId: string): ComponentValidation[] {
+    return useEmptyFieldValidationOnlyOneBinding(baseComponentId, 'simpleBinding');
   }
 
   useDataModelBindingValidation(node: LayoutNode<'Dropdown'>, bindings: IDataModelBindings<'Dropdown'>): string[] {

--- a/src/layout/FileUpload/AttachmentSummaryComponent2.tsx
+++ b/src/layout/FileUpload/AttachmentSummaryComponent2.tsx
@@ -11,7 +11,7 @@ import { FileTable } from 'src/layout/FileUpload/FileUploadTable/FileTable';
 import classes from 'src/layout/FileUpload/FileUploadTable/FileTableComponent.module.css';
 import { useUploaderSummaryData } from 'src/layout/FileUpload/Summary/summary';
 import { SummaryContains, SummaryFlex } from 'src/layout/Summary2/SummaryComponent2/ComponentSummary';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useExternalItem } from 'src/utils/layout/hooks';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export interface IAttachmentSummaryComponent {
@@ -34,7 +34,11 @@ export function AttachmentSummaryComponent2({ targetNode }: IAttachmentSummaryCo
     return attachment.data.tags && attachment.data.tags?.length > 0;
   });
   const isEmpty = filteredAttachments.length === 0;
-  const required = useNodeItem(targetNode, (i) => i.minNumberOfAttachments > 0);
+  const required =
+    useExternalItem<'FileUpload' | 'FileUploadWithTag'>(
+      targetNode.baseId,
+      (t) => t === 'FileUpload' || t === 'FileUploadWithTag',
+    ).minNumberOfAttachments > 0;
 
   return (
     <SummaryFlex

--- a/src/layout/FileUpload/FileUploadComponent.tsx
+++ b/src/layout/FileUpload/FileUploadComponent.tsx
@@ -18,13 +18,16 @@ import { InfectedFileAlert } from 'src/layout/FileUpload/Error/InfectedFileAlert
 import classes from 'src/layout/FileUpload/FileUploadComponent.module.css';
 import { FileTable } from 'src/layout/FileUpload/FileUploadTable/FileTable';
 import { RejectedFileError } from 'src/layout/FileUpload/RejectedFileError';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export type IFileUploadWithTagProps = PropsFromGenericComponent<'FileUpload' | 'FileUploadWithTag'>;
 
 export function FileUploadComponent({ node }: IFileUploadWithTagProps): React.JSX.Element {
-  const item = useNodeItem(node);
+  const item = useItemWhenType<'FileUpload' | 'FileUploadWithTag'>(
+    node.baseId,
+    (t) => t === 'FileUpload' || t === 'FileUploadWithTag',
+  );
   const {
     id,
     maxFileSizeInMB,

--- a/src/layout/FileUpload/FileUploadTable/FileTable.tsx
+++ b/src/layout/FileUpload/FileUploadTable/FileTable.tsx
@@ -8,14 +8,15 @@ import { FileTableRow } from 'src/layout/FileUpload/FileUploadTable/FileTableRow
 import { FileTableRowProvider } from 'src/layout/FileUpload/FileUploadTable/FileTableRowContext';
 import { EditWindowComponent } from 'src/layout/FileUploadWithTag/EditWindowComponent';
 import { atLeastOneTagExists } from 'src/utils/formComponentUtils';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { IAttachment } from 'src/features/attachments';
 import type { IOptionInternal } from 'src/features/options/castOptionsToStrings';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type { FileTableRowContext } from 'src/layout/FileUpload/FileUploadTable/FileTableRowContext';
+import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export interface FileTableProps {
-  node: PropsFromGenericComponent<'FileUpload' | 'FileUploadWithTag'>['node'];
+  node: LayoutNode<'FileUpload' | 'FileUploadWithTag'>;
   attachments: IAttachment[];
   mobileView: boolean;
   options?: IOptionInternal[];
@@ -31,7 +32,7 @@ export function FileTable({
   isSummary,
   isFetching,
 }: FileTableProps): React.JSX.Element | null {
-  const { textResourceBindings, type, readOnly } = useNodeItem(node);
+  const { textResourceBindings, type, readOnly } = useItemWhenType(node.baseId, node.type);
   const hasTag = type === 'FileUploadWithTag';
   const pdfModeActive = usePdfModeActive();
   const [editIndex, setEditIndex] = React.useState<number>(-1);

--- a/src/layout/FileUpload/FileUploadTable/FileTableButtons.tsx
+++ b/src/layout/FileUpload/FileUploadTable/FileTableButtons.tsx
@@ -12,7 +12,7 @@ import { Lang } from 'src/features/language/Lang';
 import { useLanguage } from 'src/features/language/useLanguage';
 import classes from 'src/layout/FileUpload/FileUploadTable/FileTableRow.module.css';
 import { useFileTableRow } from 'src/layout/FileUpload/FileUploadTable/FileTableRowContext';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { IAttachment } from 'src/features/attachments';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
@@ -24,7 +24,7 @@ interface IFileTableButtonsProps {
 }
 
 export function FileTableButtons({ node, attachment, mobileView, editWindowIsOpen }: IFileTableButtonsProps) {
-  const { alertOnDelete, type, dataModelBindings, readOnly } = useNodeItem(node);
+  const { alertOnDelete, type, dataModelBindings, readOnly } = useItemWhenType(node.baseId, node.type);
   const hasTag = type === 'FileUploadWithTag';
   const showEditButton = hasTag && !editWindowIsOpen && !readOnly;
   const { langAsString } = useLanguage();

--- a/src/layout/FileUpload/Summary/AttachmentSummaryComponent.tsx
+++ b/src/layout/FileUpload/Summary/AttachmentSummaryComponent.tsx
@@ -6,7 +6,7 @@ import { useLanguage } from 'src/features/language/useLanguage';
 import { useOptionsFor } from 'src/features/options/useOptionsFor';
 import classes from 'src/layout/FileUpload/Summary/AttachmentSummaryComponent.module.css';
 import { useUploaderSummaryData } from 'src/layout/FileUpload/Summary/summary';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export interface IAttachmentSummaryComponent {
@@ -16,7 +16,7 @@ export interface IAttachmentSummaryComponent {
 export function AttachmentSummaryComponent({ targetNode }: IAttachmentSummaryComponent) {
   const attachments = useUploaderSummaryData(targetNode);
   const { langAsString } = useLanguage();
-  const component = useNodeItem(targetNode);
+  const component = useItemWhenType(targetNode.baseId, targetNode.type);
   const hasTag = component.type === 'FileUploadWithTag';
 
   const { options: allOptions } = useOptionsFor(targetNode.baseId, 'single');

--- a/src/layout/FileUploadWithTag/EditWindowComponent.tsx
+++ b/src/layout/FileUploadWithTag/EditWindowComponent.tsx
@@ -19,14 +19,14 @@ import { FileTableButtons } from 'src/layout/FileUpload/FileUploadTable/FileTabl
 import { useFileTableRow } from 'src/layout/FileUpload/FileUploadTable/FileTableRowContext';
 import classes from 'src/layout/FileUploadWithTag/EditWindowComponent.module.css';
 import comboboxClasses from 'src/styles/combobox.module.css';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import { optionSearchFilter } from 'src/utils/options';
 import type { IAttachment } from 'src/features/attachments';
 import type { IOptionInternal } from 'src/features/options/castOptionsToStrings';
-import type { PropsFromGenericComponent } from 'src/layout';
+import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export interface EditWindowProps {
-  node: PropsFromGenericComponent<'FileUploadWithTag'>['node'];
+  node: LayoutNode<'FileUploadWithTag'>;
   attachment: IAttachment;
   mobileView: boolean;
   options?: IOptionInternal[];
@@ -40,7 +40,7 @@ export function EditWindowComponent({
   options,
   isFetching,
 }: EditWindowProps): React.JSX.Element {
-  const { textResourceBindings } = useNodeItem(node);
+  const { textResourceBindings } = useItemWhenType(node.baseId, 'FileUploadWithTag');
   const { langAsString } = useLanguage();
   const { setEditIndex } = useFileTableRow();
   const uploadedAttachment = isAttachmentUploaded(attachment) ? attachment : undefined;

--- a/src/layout/FileUploadWithTag/useValidateMissingTag.ts
+++ b/src/layout/FileUploadWithTag/useValidateMissingTag.ts
@@ -1,12 +1,12 @@
 import { isAttachmentUploaded } from 'src/features/attachments';
 import { FrontendValidationSource, ValidationMask } from 'src/features/validation';
 import { NodesInternal } from 'src/utils/layout/NodesContext';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { AttachmentValidation, ComponentValidation } from 'src/features/validation';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export function useValidateMissingTag(node: LayoutNode<'FileUploadWithTag'>): ComponentValidation[] {
-  const item = useNodeItem(node);
+  const item = useItemWhenType(node.baseId, 'FileUploadWithTag');
   const tagKey = item?.textResourceBindings?.tagTitle;
   const attachments = NodesInternal.useAttachments(node.id);
   const validations: ComponentValidation[] = [];

--- a/src/layout/Grid/GridComponent.tsx
+++ b/src/layout/Grid/GridComponent.tsx
@@ -28,13 +28,13 @@ import { LayoutNode } from 'src/utils/layout/LayoutNode';
 import { LayoutPage } from 'src/utils/layout/LayoutPage';
 import { Hidden, useNode } from 'src/utils/layout/NodesContext';
 import { useLabel } from 'src/utils/layout/useLabel';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemFor, useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type { GridRow, ITableColumnFormatting, ITableColumnProperties } from 'src/layout/common.generated';
 
 export function RenderGrid(props: PropsFromGenericComponent<'Grid'>) {
   const { node } = props;
-  const { rows, textResourceBindings, labelSettings } = useNodeItem(node);
+  const { rows, textResourceBindings, labelSettings } = useItemWhenType(node.baseId, 'Grid');
   const { title, description, help } = textResourceBindings ?? {};
   const shouldHaveFullWidth = node.parent instanceof LayoutPage;
   const columnSettings: ITableColumnFormatting = {};
@@ -255,11 +255,9 @@ function CellWithText({ children, className, columnStyleOptions, help, isHeader 
 function CellWithLabel({ className, columnStyleOptions, labelFrom, isHeader = false }: CellWithLabelProps) {
   const columnStyles = columnStyleOptions && getColumnStyles(columnStyleOptions);
   const labelFromNode = useNode(labelFrom);
-  const { trb, required = false } =
-    useNodeItem(labelFromNode, (i) => ({
-      trb: 'textResourceBindings' in i ? i.textResourceBindings : {},
-      required: 'required' in i ? i.required : false,
-    })) ?? {};
+  const item = useItemFor(labelFromNode.baseId);
+  const trb = item.textResourceBindings;
+  const required = 'required' in item && item.required;
 
   const title = trb && 'title' in trb ? trb.title : undefined;
   const help = trb && 'help' in trb ? trb.help : undefined;
@@ -285,7 +283,6 @@ function CellWithLabel({ className, columnStyleOptions, labelFrom, isHeader = fa
 }
 
 function MobileGrid({ node, overrideDisplay }: PropsFromGenericComponent<'Grid'>) {
-  const { id } = useNodeItem(node);
   const nodeIds = useNodeIdsFromGrid(node);
   const isHidden = Hidden.useIsHiddenSelector();
 
@@ -293,7 +290,7 @@ function MobileGrid({ node, overrideDisplay }: PropsFromGenericComponent<'Grid'>
 
   return (
     <Fieldset
-      id={id}
+      id={node.id}
       size='sm'
       legend={labelText}
       description={getDescriptionComponent()}

--- a/src/layout/Grid/GridSummary.tsx
+++ b/src/layout/Grid/GridSummary.tsx
@@ -37,7 +37,7 @@ import { getColumnStyles } from 'src/utils/formComponentUtils';
 import { useHasCapability } from 'src/utils/layout/canRenderIn';
 import { useComponentIdMutator, useIndexedId } from 'src/utils/layout/DataModelLocation';
 import { Hidden, useNode } from 'src/utils/layout/NodesContext';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemFor, useItemWhenType } from 'src/utils/layout/useNodeItem';
 import { typedBoolean } from 'src/utils/typing';
 import type {
   GridCell,
@@ -57,7 +57,7 @@ type GridSummaryProps = Readonly<{
 }>;
 
 export const GridSummary = ({ componentNode }: GridSummaryProps) => {
-  const { rows, textResourceBindings } = useNodeItem(componentNode);
+  const { rows, textResourceBindings } = useItemWhenType(componentNode.baseId, 'Grid');
   const { title } = textResourceBindings ?? {};
 
   const columnSettings: ITableColumnFormatting = {};
@@ -299,10 +299,10 @@ function SummaryCell(props: CellProps) {
 
 function SummaryCellInnerWithLabel(props: CellProps & { labelFrom: LayoutNode }) {
   const { langAsString, langAsNonProcessedString } = useLanguage();
-  const required = useNodeItem(props.labelFrom, (i) => ('required' in i ? i.required : false));
-  const title = useNodeItem(props.labelFrom, (i) =>
-    i.textResourceBindings && 'title' in i.textResourceBindings ? i.textResourceBindings.title : undefined,
-  );
+  const item = useItemFor(props.labelFrom.baseId);
+  const required = 'required' in item ? item.required : false;
+  const title =
+    item.textResourceBindings && 'title' in item.textResourceBindings ? item.textResourceBindings.title : undefined;
   const requiredIndicator = required ? ` ${langAsNonProcessedString('form_filler.required_label')}` : '';
   const headerTitle = `${langAsString(title || '')}${requiredIndicator}`;
 
@@ -431,8 +431,9 @@ function SummaryCellWithComponent({
   const errors = validationsOfSeverity(validations, 'error');
   const isHidden = Hidden.useIsHidden(node);
   const columnStyles = columnStyleOptions && getColumnStyles(columnStyleOptions);
-  const textResourceBindings = useNodeItem(node, (i) => i.textResourceBindings);
-  const required = useNodeItem(node, (i) => ('required' in i ? i.required : false));
+  const item = useItemFor(node.baseId);
+  const textResourceBindings = item.textResourceBindings;
+  const required = 'required' in item ? item.required : false;
   const content = getComponentCellData(node, displayData, textResourceBindings);
 
   const isEmpty = typeof content === 'string' && content.trim() === '';
@@ -517,7 +518,7 @@ function SummaryCellWithLabel({
   isSmall,
 }: CellWithLabelProps) {
   const referenceNode = useNode(cell.labelFrom);
-  const refItem = useNodeItem(referenceNode);
+  const refItem = useItemFor(referenceNode.baseId);
   const columnStyles = columnStyleOptions && getColumnStyles(columnStyleOptions);
   const trb = (refItem && 'textResourceBindings' in refItem ? refItem.textResourceBindings : {}) as
     | ITextResourceBindings

--- a/src/layout/Grid/tools.ts
+++ b/src/layout/Grid/tools.ts
@@ -1,7 +1,7 @@
 import { useHasCapability } from 'src/utils/layout/canRenderIn';
 import { useComponentIdMutator } from 'src/utils/layout/DataModelLocation';
+import { useExternalItem } from 'src/utils/layout/hooks';
 import { Hidden } from 'src/utils/layout/NodesContext';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
 import type {
   GridCell,
   GridCellLabelFrom,
@@ -18,7 +18,7 @@ const emptyArray: never[] = [];
 
 export function useNodeIdsFromGrid(grid: LayoutNode<'Grid'>, enabled = true) {
   const isHiddenSelector = Hidden.useIsHiddenSelector();
-  const rows = useNodeItem(grid, (item) => item.rows);
+  const rows = useExternalItem(grid.baseId, 'Grid').rows;
   const idMutator = useComponentIdMutator();
   return enabled && grid && rows ? nodeIdsFromGridRows(rows, isHiddenSelector, idMutator) : emptyArray;
 }

--- a/src/layout/Group/GroupComponent.tsx
+++ b/src/layout/Group/GroupComponent.tsx
@@ -11,7 +11,7 @@ import { Lang } from 'src/features/language/Lang';
 import classes from 'src/layout/Group/GroupComponent.module.css';
 import { LayoutNode } from 'src/utils/layout/LayoutNode';
 import { Hidden, NodesInternal } from 'src/utils/layout/NodesContext';
-import { useNodeDirectChildren, useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType, useNodeDirectChildren } from 'src/utils/layout/useNodeItem';
 import type { HeadingLevel } from 'src/layout/common.generated';
 
 export interface IGroupComponent {
@@ -39,7 +39,7 @@ export function GroupComponent({
   isSummary,
   renderLayoutNode,
 }: IGroupComponent) {
-  const container = useNodeItem(groupNode);
+  const container = useItemWhenType(groupNode.baseId, 'Group');
   const { title, summaryTitle, description } = container.textResourceBindings ?? {};
   const isHidden = Hidden.useIsHidden(groupNode);
 

--- a/src/layout/Group/GroupSummary.tsx
+++ b/src/layout/Group/GroupSummary.tsx
@@ -12,7 +12,7 @@ import { ComponentSummary, SummaryFlexForContainer } from 'src/layout/Summary2/S
 import { useSummaryProp } from 'src/layout/Summary2/summaryStoreContext';
 import { useIndexedId } from 'src/utils/layout/DataModelLocation';
 import { useNode } from 'src/utils/layout/NodesContext';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 type GroupComponentSummaryProps = {
@@ -60,13 +60,13 @@ function ChildComponent({ id: _id, hierarchyLevel }: ChildComponentProps) {
 }
 
 export const GroupSummary = ({ componentNode, hierarchyLevel = 0 }: GroupComponentSummaryProps) => {
-  const title = useNodeItem(componentNode, (i) => i.textResourceBindings?.title);
-  const summaryTitle = useNodeItem(componentNode, (i) => i.textResourceBindings?.summaryTitle);
+  const item = useItemWhenType(componentNode.baseId, 'Group');
+  const title = item.textResourceBindings?.title;
+  const summaryTitle = item.textResourceBindings?.summaryTitle;
   const headingLevel = getHeadingLevel(hierarchyLevel);
   const isNestedGroup = hierarchyLevel > 0;
 
   const dataTestId = hierarchyLevel > 0 ? `summary-group-component-${hierarchyLevel}` : 'summary-group-component';
-  const children = useNodeItem(componentNode, (i) => i.children);
   const hideEmptyFields = useSummaryProp('hideEmptyFields');
 
   return (
@@ -98,7 +98,7 @@ export const GroupSummary = ({ componentNode, hierarchyLevel = 0 }: GroupCompone
           spacing={6}
           alignItems='flex-start'
         >
-          {children.map((childId) => (
+          {item.children.map((childId) => (
             <ChildComponent
               key={childId}
               id={childId}

--- a/src/layout/Group/SummaryGroupComponent.tsx
+++ b/src/layout/Group/SummaryGroupComponent.tsx
@@ -11,7 +11,7 @@ import classes from 'src/layout/Group/SummaryGroupComponent.module.css';
 import { EditButton } from 'src/layout/Summary/EditButton';
 import { SummaryComponentFor } from 'src/layout/Summary/SummaryComponent';
 import { Hidden } from 'src/utils/layout/NodesContext';
-import { useNodeDirectChildren, useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType, useNodeDirectChildren } from 'src/utils/layout/useNodeItem';
 import type { CompTypes, ITextResourceBindings } from 'src/layout/layout';
 import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
@@ -22,7 +22,7 @@ export function SummaryGroupComponent({
   targetNode,
   overrides,
 }: SummaryRendererProps<'Group'>) {
-  const targetItem = useNodeItem(targetNode);
+  const targetItem = useItemWhenType(targetNode.baseId, 'Group');
   const excludedChildren = overrides?.excludedChildren;
   const display = overrides?.display;
   const { langAsString } = useLanguage();

--- a/src/layout/Header/HeaderComponent.tsx
+++ b/src/layout/Header/HeaderComponent.tsx
@@ -6,7 +6,7 @@ import { HelpTextContainer } from 'src/components/form/HelpTextContainer';
 import { Lang } from 'src/features/language/Lang';
 import { useLanguage } from 'src/features/language/useLanguage';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export type IHeaderProps = PropsFromGenericComponent<'Header'>;
@@ -44,7 +44,7 @@ function getHeaderProps(size?: string): HeadingProps {
 }
 
 export const HeaderComponent = ({ node }: IHeaderProps) => {
-  const { id, size, textResourceBindings } = useNodeItem(node);
+  const { id, size, textResourceBindings } = useItemWhenType(node.baseId, 'Header');
   const { langAsString } = useLanguage();
   return (
     <ComponentStructureWrapper node={node}>

--- a/src/layout/IFrame/IFrameComponent.tsx
+++ b/src/layout/IFrame/IFrameComponent.tsx
@@ -7,14 +7,14 @@ import { Lang } from 'src/features/language/Lang';
 import { useLanguage } from 'src/features/language/useLanguage';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
 import { getSandboxProperties } from 'src/layout/IFrame/utils';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export type IFrameComponentProps = PropsFromGenericComponent<'IFrame'>;
 
 export const IFrameComponent = ({ node }: IFrameComponentProps): JSX.Element => {
   const { langAsNonProcessedString } = useLanguage();
-  const { textResourceBindings, sandbox } = useNodeItem(node);
+  const { textResourceBindings, sandbox } = useItemWhenType(node.baseId, 'IFrame');
 
   const sandboxProperties = getSandboxProperties(sandbox);
   const iFrameTitle = textResourceBindings?.title;

--- a/src/layout/Image/ImageComponent.tsx
+++ b/src/layout/Image/ImageComponent.tsx
@@ -7,14 +7,14 @@ import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
 import { useLanguage } from 'src/features/language/useLanguage';
 import { useParentCard } from 'src/layout/Cards/CardContext';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export type IImageProps = PropsFromGenericComponent<'Image'>;
 
 export function ImageComponent({ node }: IImageProps) {
   const { langAsString } = useLanguage();
-  const { id, image, textResourceBindings } = useNodeItem(node);
+  const { id, image, textResourceBindings } = useItemWhenType(node.baseId, 'Image');
   const languageKey = useCurrentLanguage();
   const width = image?.width ?? '100%';
   const align = image?.align ?? 'center';

--- a/src/layout/Input/InputComponent.tsx
+++ b/src/layout/Input/InputComponent.tsx
@@ -14,7 +14,7 @@ import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper'
 import classes from 'src/layout/Input/InputComponent.module.css';
 import { isNumberFormat, isPatternFormat } from 'src/layout/Input/number-format-helpers';
 import { useLabel } from 'src/utils/layout/useLabel';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { InputProps } from 'src/app-components/Input/Input';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type {
@@ -114,7 +114,7 @@ export const InputVariant = ({ node, overrideDisplay }: Pick<IInputProps, 'node'
     saveWhileTyping,
     autocomplete,
     maxLength,
-  } = useNodeItem(node);
+  } = useItemWhenType(node.baseId, 'Input');
   const {
     formData: { simpleBinding: realFormValue },
     setValue,
@@ -235,7 +235,7 @@ export const InputVariant = ({ node, overrideDisplay }: Pick<IInputProps, 'node'
 };
 
 export const InputComponent: React.FunctionComponent<IInputProps> = ({ node, overrideDisplay }) => {
-  const { grid, id, required } = useNodeItem(node);
+  const { grid, id, required } = useItemWhenType(node.baseId, 'Input');
 
   const { labelText, getRequiredComponent, getOptionalComponent, getHelpTextComponent, getDescriptionComponent } =
     useLabel({ node, overrideDisplay });

--- a/src/layout/Input/InputSummary.tsx
+++ b/src/layout/Input/InputSummary.tsx
@@ -7,7 +7,7 @@ import { validationsOfSeverity } from 'src/features/validation/utils';
 import { SingleValueSummary } from 'src/layout/Summary2/CommonSummaryComponents/SingleValueSummary';
 import { SummaryContains, SummaryFlex } from 'src/layout/Summary2/SummaryComponent2/ComponentSummary';
 import { useSummaryOverrides, useSummaryProp } from 'src/layout/Summary2/summaryStoreContext';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types';
 
 export const InputSummary = ({ target }: Summary2Props<'Input'>) => {
@@ -16,8 +16,8 @@ export const InputSummary = ({ target }: Summary2Props<'Input'>) => {
   const displayData = useDisplayData(target);
   const validations = useUnifiedValidationsForNode(target);
   const errors = validationsOfSeverity(validations, 'error');
-  const title = useNodeItem(target, (i) => i.textResourceBindings?.title);
-  const required = useNodeItem(target, (i) => i.required);
+  const item = useItemWhenType(target.baseId, 'Input');
+  const title = item.textResourceBindings?.title;
 
   return (
     <SummaryFlex
@@ -25,7 +25,7 @@ export const InputSummary = ({ target }: Summary2Props<'Input'>) => {
       content={
         displayData
           ? SummaryContains.SomeUserContent
-          : required
+          : item.required
             ? SummaryContains.EmptyValueRequired
             : SummaryContains.EmptyValueNotRequired
       }

--- a/src/layout/Input/index.tsx
+++ b/src/layout/Input/index.tsx
@@ -12,7 +12,7 @@ import { InputSummary } from 'src/layout/Input/InputSummary';
 import { SummaryItemSimple } from 'src/layout/Summary/SummaryItemSimple';
 import { formatNumericText } from 'src/utils/formattingUtils';
 import { validateDataModelBindingsSimple } from 'src/utils/layout/generator/validation/hooks';
-import { useNodeFormDataWhenType, useNodeItemWhenType } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType, useNodeFormDataWhenType } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type { IDataModelBindings } from 'src/layout/layout';
 import type { ExprResolver, SummaryRendererProps } from 'src/layout/LayoutComponent';
@@ -28,7 +28,7 @@ export class Input extends InputDef {
 
   useDisplayData(baseComponentId: string): string {
     const formData = useNodeFormDataWhenType(baseComponentId, 'Input');
-    const item = useNodeItemWhenType(baseComponentId, 'Input');
+    const item = useItemWhenType(baseComponentId, 'Input');
     const formatting = item?.formatting;
     const currentLanguage = useCurrentLanguage();
     const text = formData?.simpleBinding || '';

--- a/src/layout/InstanceInformation/InstanceInformationComponent.tsx
+++ b/src/layout/InstanceInformation/InstanceInformationComponent.tsx
@@ -13,8 +13,8 @@ import { useLanguage } from 'src/features/language/useLanguage';
 import { useInstanceOwnerParty } from 'src/features/party/PartiesProvider';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
 import { toTimeZonedDate } from 'src/utils/dateUtils';
+import { useExternalItem } from 'src/utils/layout/hooks';
 import { useLabel } from 'src/utils/layout/useLabel';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
 import type { SummaryDataObject } from 'src/components/table/AltinnSummaryTable';
 import type { IUseLanguage } from 'src/features/language/useLanguage';
 import type { CompInternal } from 'src/layout/layout';
@@ -102,9 +102,7 @@ export function InstanceInformationComponent({
   node,
   overrideDisplay,
 }: PropsFromGenericComponent<'InstanceInformation'>) {
-  const elements = useNodeItem(node, (i) => i.elements);
-
-  const { grid } = useNodeItem(node);
+  const { grid, elements } = useExternalItem(node.baseId, 'InstanceInformation');
   const { labelText, getDescriptionComponent, getHelpTextComponent } = useLabel({ node, overrideDisplay });
 
   return (

--- a/src/layout/InstantiationButton/InstantiationButtonComponent.tsx
+++ b/src/layout/InstantiationButton/InstantiationButtonComponent.tsx
@@ -5,7 +5,7 @@ import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper'
 import { InstantiationButton } from 'src/layout/InstantiationButton/InstantiationButton';
 import classes from 'src/layout/InstantiationButton/InstantiationButton.module.css';
 import { LayoutPage } from 'src/utils/layout/LayoutPage';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type { IButtonProvidedProps } from 'src/layout/Button/ButtonComponent';
 
@@ -13,7 +13,7 @@ export type IInstantiationButtonComponentReceivedProps = PropsFromGenericCompone
 export type IInstantiationButtonComponentProvidedProps = IButtonProvidedProps;
 
 export function InstantiationButtonComponent({ node, ...componentProps }: IInstantiationButtonComponentReceivedProps) {
-  const item = useNodeItem(node);
+  const item = useItemWhenType(node.baseId, 'InstantiationButton');
   const props: IInstantiationButtonComponentProvidedProps = { ...componentProps, ...item, node };
 
   const parentIsPage = props.node.parent instanceof LayoutPage;

--- a/src/layout/LayoutComponent.tsx
+++ b/src/layout/LayoutComponent.tsx
@@ -238,14 +238,11 @@ export abstract class ActionComponent<Type extends CompTypes> extends AnyCompone
   }
 }
 
-export abstract class FormComponent<Type extends CompTypes>
-  extends _FormComponent<Type>
-  implements ValidateEmptyField<Type>
-{
+export abstract class FormComponent<Type extends CompTypes> extends _FormComponent<Type> implements ValidateEmptyField {
   readonly category = CompCategory.Form;
 
-  useEmptyFieldValidation(node: LayoutNode<Type>): ComponentValidation[] {
-    return useEmptyFieldValidationAllBindings(node);
+  useEmptyFieldValidation(baseComponentId: string): ComponentValidation[] {
+    return useEmptyFieldValidationAllBindings(baseComponentId);
   }
 }
 

--- a/src/layout/Likert/LikertComponent.tsx
+++ b/src/layout/Likert/LikertComponent.tsx
@@ -18,20 +18,17 @@ import { makeLikertChildId } from 'src/layout/Likert/Generator/makeLikertChildId
 import classes from 'src/layout/Likert/LikertComponent.module.css';
 import { useLikertRows } from 'src/layout/Likert/rowUtils';
 import { DataModelLocationProvider } from 'src/utils/layout/DataModelLocation';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { IGenericComponentProps } from 'src/layout/GenericComponent';
 
 type LikertComponentProps = PropsFromGenericComponent<'Likert'>;
 
 export const LikertComponent = ({ node }: LikertComponentProps) => {
-  const groupBinding = useNodeItem(node, (item) => item.dataModelBindings.questions);
-  const textResourceBindings = useNodeItem(node, (item) => item.textResourceBindings);
+  const { id, dataModelBindings, textResourceBindings, columns } = useItemWhenType(node.baseId, 'Likert');
+  const groupBinding = dataModelBindings.questions;
   const mobileView = useIsMobileOrTablet();
   const rows = useLikertRows(node);
   const { options: calculatedOptions, isFetching } = useOptionsFor(makeLikertChildId(node.baseId, undefined), 'single');
-  const columns = useNodeItem(node, (item) => item.columns);
-
-  const id = node.id;
 
   const title = textResourceBindings?.title;
   const description = textResourceBindings?.description;

--- a/src/layout/Likert/Summary/LargeLikertSummaryContainer.tsx
+++ b/src/layout/Likert/Summary/LargeLikertSummaryContainer.tsx
@@ -7,12 +7,12 @@ import { Fieldset } from 'src/app-components/Label/Fieldset';
 import { Lang } from 'src/features/language/Lang';
 import classes from 'src/layout/Likert/Summary/LikertSummaryComponent.module.css';
 import { Hidden, NodesInternal } from 'src/utils/layout/NodesContext';
-import { useNodeDirectChildren, useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType, useNodeDirectChildren } from 'src/utils/layout/useNodeItem';
 import type { HeadingLevel } from 'src/layout/common.generated';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export interface IDisplayLikertContainer {
-  groupNode: LayoutNode<'Likert'>;
+  likertNode: LayoutNode<'Likert'>;
   divRef?: React.Ref<HTMLDivElement>;
   id?: string;
   restriction?: number | undefined;
@@ -29,16 +29,16 @@ const headingSizes: { [k in HeadingLevel]: Parameters<typeof Heading>[0]['data-s
 
 export function LargeLikertSummaryContainer({
   divRef,
-  groupNode,
+  likertNode,
   id,
   restriction,
   renderLayoutNode,
 }: IDisplayLikertContainer) {
-  const container = useNodeItem(groupNode);
+  const container = useItemWhenType(likertNode.baseId, 'Likert');
   const { title, summaryTitle } = container.textResourceBindings ?? {};
-  const isHidden = Hidden.useIsHidden(groupNode);
-  const depth = NodesInternal.useSelector((state) => state.nodeData?.[groupNode.id]?.depth);
-  const children = useNodeDirectChildren(groupNode, restriction);
+  const isHidden = Hidden.useIsHidden(likertNode);
+  const depth = NodesInternal.useSelector((state) => state.nodeData?.[likertNode.id]?.depth);
+  const children = useNodeDirectChildren(likertNode, restriction);
 
   if (isHidden) {
     return null;
@@ -61,8 +61,8 @@ export function LargeLikertSummaryContainer({
         )
       }
       className={classes.summary}
-      data-componentid={groupNode.id}
-      data-componentbaseid={groupNode.baseId}
+      data-componentid={likertNode.id}
+      data-componentbaseid={likertNode.baseId}
     >
       <div
         ref={divRef}

--- a/src/layout/Likert/Summary/LikertSummaryComponent.tsx
+++ b/src/layout/Likert/Summary/LikertSummaryComponent.tsx
@@ -13,8 +13,9 @@ import classes from 'src/layout/Likert/Summary/LikertSummaryComponent.module.css
 import { EditButton } from 'src/layout/Summary/EditButton';
 import { SummaryComponentFor } from 'src/layout/Summary/SummaryComponent';
 import { DataModelLocationProvider } from 'src/utils/layout/DataModelLocation';
+import { useDataModelBindingsFor } from 'src/utils/layout/hooks';
 import { Hidden, useNode } from 'src/utils/layout/NodesContext';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import { typedBoolean } from 'src/utils/typing';
 import type { ITextResourceBindings } from 'src/layout/layout';
 import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
@@ -27,7 +28,7 @@ export function LikertSummaryComponent({
   targetNode,
   overrides,
 }: SummaryRendererProps<'Likert'>) {
-  const targetItem = useNodeItem(targetNode);
+  const targetItem = useItemWhenType(targetNode.baseId, 'Likert');
   const excludedChildren = overrides?.excludedChildren;
   const display = overrides?.display;
   const { lang, langAsString } = useLanguage();
@@ -39,7 +40,7 @@ export function LikertSummaryComponent({
   const groupValidations = useDeepValidationsForNode(targetNode);
   const groupHasErrors = hasValidationErrors(groupValidations);
 
-  const groupBinding = useNodeItem(targetNode, (i) => i.dataModelBindings.questions);
+  const dataModelBindings = useDataModelBindingsFor(targetNode.baseId, 'Likert');
   const textBindings = targetItem.textResourceBindings as ITextResourceBindings;
   const summaryAccessibleTitleTrb =
     textBindings && 'summaryAccessibleTitle' in textBindings ? textBindings.summaryAccessibleTitle : undefined;
@@ -56,12 +57,12 @@ export function LikertSummaryComponent({
         {rows.map((row) => (
           <DataModelLocationProvider
             key={`summary-${targetNode.id}-${row.uuid}`}
-            groupBinding={groupBinding}
+            groupBinding={dataModelBindings.questions}
             rowIndex={row.index}
           >
             <LargeLikertSummaryContainer
               id={`summary-${targetNode.id}-${row.index}`}
-              groupNode={targetNode}
+              likertNode={targetNode}
               restriction={row.index}
               renderLayoutNode={(n) => {
                 if (inExcludedChildren(n) || isHidden(n)) {
@@ -111,7 +112,7 @@ export function LikertSummaryComponent({
             rows.filter(typedBoolean).map((row) => (
               <DataModelLocationProvider
                 key={row.index}
-                groupBinding={groupBinding}
+                groupBinding={dataModelBindings.questions}
                 rowIndex={row.index}
               >
                 <Row

--- a/src/layout/Likert/Summary2/LikertSummary.tsx
+++ b/src/layout/Likert/Summary2/LikertSummary.tsx
@@ -19,7 +19,7 @@ import {
 import { useSummaryOverrides, useSummaryProp } from 'src/layout/Summary2/summaryStoreContext';
 import { DataModelLocationProvider } from 'src/utils/layout/DataModelLocation';
 import { useNode } from 'src/utils/layout/NodesContext';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import { typedBoolean } from 'src/utils/typing';
 import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
@@ -28,13 +28,10 @@ export function LikertSummary({ target }: Summary2Props<'Likert'>) {
   const emptyFieldText = useSummaryOverrides(target)?.emptyFieldText;
   const isCompact = useSummaryProp('isCompact');
   const rows = useLikertRows(target);
-  const groupBinding = useNodeItem(target, (i) => i.dataModelBindings.questions);
-  const readOnly = useNodeItem(target, (item) => item.readOnly);
+  const { textResourceBindings, dataModelBindings, readOnly, required } = useItemWhenType(target.baseId, 'Likert');
 
   const validations = useUnifiedValidationsForNode(target);
   const errors = validationsOfSeverity(validations, 'error');
-  const title = useNodeItem(target, (i) => i.textResourceBindings?.title);
-  const required = useNodeItem(target, (i) => i.required);
   const hideEmptyFields = useSummaryProp('hideEmptyFields');
 
   if (!rows.length || rows.length <= 0) {
@@ -44,7 +41,7 @@ export function LikertSummary({ target }: Summary2Props<'Likert'>) {
         content={required ? SummaryContains.EmptyValueRequired : SummaryContains.EmptyValueNotRequired}
       >
         <SingleValueSummary
-          title={<Lang id={title} />}
+          title={<Lang id={textResourceBindings?.title} />}
           componentNode={target}
           errors={errors}
           hideEditButton={readOnly}
@@ -67,13 +64,13 @@ export function LikertSummary({ target }: Summary2Props<'Likert'>) {
               data-size='xs'
               level={4}
             >
-              <Lang id={title} />
+              <Lang id={textResourceBindings?.title} />
             </Heading>
           </div>
           {rows.filter(typedBoolean).map((row) => (
             <DataModelLocationProvider
               key={row.index}
-              groupBinding={groupBinding}
+              groupBinding={dataModelBindings.questions}
               rowIndex={row.index}
             >
               <LikertRowSummary
@@ -127,8 +124,7 @@ function LikertRowSummaryInner({
 }: LikertRowSummaryProps & {
   node: LayoutNode<'LikertItem'>;
 }) {
-  const title = useNodeItem(node, (i) => i.textResourceBindings?.title);
-  const required = useNodeItem(node, (i) => i.required);
+  const { textResourceBindings, required } = useItemWhenType(node.baseId, 'LikertItem');
   const displayData = useDisplayData(node);
   const validations = useUnifiedValidationsForNode(node);
   const errors = validationsOfSeverity(validations, 'error');
@@ -143,7 +139,7 @@ function LikertRowSummaryInner({
 
   return (
     <SingleValueSummary
-      title={<Lang id={title} />}
+      title={<Lang id={textResourceBindings?.title} />}
       isCompact={isCompact}
       componentNode={node}
       displayData={displayData}

--- a/src/layout/Likert/rowUtils.ts
+++ b/src/layout/Likert/rowUtils.ts
@@ -1,6 +1,5 @@
 import { FD } from 'src/features/formData/FormDataWrite';
-import { useDataModelBindingsFor } from 'src/utils/layout/hooks';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useDataModelBindingsFor, useExternalItem } from 'src/utils/layout/hooks';
 import { typedBoolean } from 'src/utils/typing';
 import type { ILikertFilter } from 'src/layout/Likert/config.generated';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
@@ -22,7 +21,7 @@ export const getLikertStartStopIndex = (lastIndex: number, filters: ILikertFilte
 
 export function useLikertRows(node: LayoutNode<'Likert'>) {
   const groupBinding = useDataModelBindingsFor(node.baseId, 'Likert')?.questions;
-  const filter = useNodeItem(node, (i) => i.filter);
+  const filter = useExternalItem(node.baseId, 'Likert').filter;
   const rows = FD.useFreshRows(groupBinding);
   const lastIndex = rows.length - 1;
   const { startIndex, stopIndex } = getLikertStartStopIndex(lastIndex, filter);

--- a/src/layout/LikertItem/LikertItemComponent.tsx
+++ b/src/layout/LikertItem/LikertItemComponent.tsx
@@ -12,13 +12,14 @@ import { LayoutStyle } from 'src/layout/common.generated';
 import classes from 'src/layout/LikertItem/LikertItemComponent.module.css';
 import { ControlledRadioGroup } from 'src/layout/RadioButtons/ControlledRadioGroup';
 import { useRadioButtons } from 'src/layout/RadioButtons/radioButtonsUtils';
+import { useExternalItem } from 'src/utils/layout/hooks';
 import { LayoutNode } from 'src/utils/layout/LayoutNode';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export const LikertItemComponent = forwardRef<HTMLTableRowElement, PropsFromGenericComponent<'LikertItem'>>(
   (props, ref) => {
-    const item = useNodeItem(props.node);
+    const item = useItemWhenType(props.node.baseId, 'LikertItem');
     const overriddenLayout = props.overrideItemProps?.layout;
     const layout = overriddenLayout ?? item.layout;
 
@@ -41,10 +42,10 @@ const RadioGroupTableRow = forwardRef<HTMLTableRowElement, PropsFromGenericCompo
   const { selectedValues, handleChange, calculatedOptions, fetchingOptions } = useRadioButtons(props);
   const validations = useUnifiedValidationsForNode(node);
 
-  const { id, readOnly, textResourceBindings, required } = useNodeItem(node);
+  const { id, readOnly, textResourceBindings, required } = useItemWhenType(node.baseId, 'LikertItem');
   const groupContainer = node.parent instanceof LayoutNode && node.parent.isType('Likert') ? node.parent : undefined;
 
-  const columns = useNodeItem(props.node, (i) => i.columns);
+  const columns = useExternalItem(props.node.baseId, 'LikertItem').columns;
 
   return (
     <Table.Row

--- a/src/layout/LikertItem/index.tsx
+++ b/src/layout/LikertItem/index.tsx
@@ -48,8 +48,8 @@ export class LikertItem extends LikertItemDef {
     return <SummaryItemSimple formDataAsString={displayData} />;
   }
 
-  useEmptyFieldValidation(node: LayoutNode<'LikertItem'>): ComponentValidation[] {
-    return useEmptyFieldValidationOnlyOneBinding(node, 'simpleBinding');
+  useEmptyFieldValidation(baseComponentId: string): ComponentValidation[] {
+    return useEmptyFieldValidationOnlyOneBinding(baseComponentId, 'simpleBinding');
   }
 
   useDataModelBindingValidation(node: LayoutNode<'LikertItem'>, bindings: IDataModelBindings<'LikertItem'>): string[] {

--- a/src/layout/Link/LinkComponent.tsx
+++ b/src/layout/Link/LinkComponent.tsx
@@ -7,7 +7,7 @@ import { Lang } from 'src/features/language/Lang';
 import { useLanguage } from 'src/features/language/useLanguage';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
 import { alignStyle } from 'src/layout/RepeatingGroup/Container/RepeatingGroupContainer';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { LinkStyle } from 'src/layout/Link/config.generated';
 
 export const buttonStyles: {
@@ -29,7 +29,7 @@ export function LinkComponent({ node }: ILinkComponent) {
     size,
     fullWidth,
     textAlign,
-  } = useNodeItem(node);
+  } = useItemWhenType(node.baseId, 'Link');
   const { langAsString } = useLanguage();
 
   const downloadName = textResourceBindings?.download;

--- a/src/layout/List/ListComponent.test.tsx
+++ b/src/layout/List/ListComponent.test.tsx
@@ -9,7 +9,7 @@ import { useDataModelBindings } from 'src/features/formData/useDataModelBindings
 import * as useDeviceWidths from 'src/hooks/useDeviceWidths';
 import { ListComponent } from 'src/layout/List/ListComponent';
 import { renderGenericComponentTest } from 'src/test/renderWithProviders';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useDataModelBindingsFor } from 'src/utils/layout/hooks';
 import type { JsonPatch } from 'src/features/formData/jsonPatch/types';
 import type { doPatchFormData } from 'src/queries/queries';
 import type { RenderGenericComponentTestProps } from 'src/test/renderWithProviders';
@@ -57,7 +57,7 @@ const countries = [
 
 function RenderCounter({ node }: { node: LayoutNode<'List'> }) {
   const renderCount = React.useRef(0);
-  const dataModelBindings = useNodeItem(node).dataModelBindings;
+  const dataModelBindings = useDataModelBindingsFor(node.baseId, 'List');
 
   // This simulates the List component data model fetching. It will trigger a re-render of the component once every
   // time any of the data model bindings change.

--- a/src/layout/List/ListComponent.tsx
+++ b/src/layout/List/ListComponent.tsx
@@ -26,7 +26,7 @@ import { useSaveObjectToGroup } from 'src/features/saveToGroup/useSaveToGroup';
 import { useIsMobile } from 'src/hooks/useDeviceWidths';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
 import classes from 'src/layout/List/ListComponent.module.css';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { Filter } from 'src/features/dataLists/useDataListQuery';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type { IDataModelBindingsForList } from 'src/layout/List/config.generated';
@@ -36,7 +36,7 @@ type Row = Record<string, string | number | boolean>;
 
 export const ListComponent = ({ node }: IListProps) => {
   const isMobile = useIsMobile();
-  const item = useNodeItem(node);
+  const item = useItemWhenType(node.baseId, 'List');
   const {
     tableHeaders,
     pagination,

--- a/src/layout/List/ListSummary.tsx
+++ b/src/layout/List/ListSummary.tsx
@@ -14,7 +14,7 @@ import { EditButton } from 'src/layout/Summary2/CommonSummaryComponents/EditButt
 import { SingleValueSummary } from 'src/layout/Summary2/CommonSummaryComponents/SingleValueSummary';
 import { SummaryContains, SummaryFlex } from 'src/layout/Summary2/SummaryComponent2/ComponentSummary';
 import { useSummaryOverrides, useSummaryProp } from 'src/layout/Summary2/summaryStoreContext';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types';
 
 type Row = Record<string, string | number | boolean>;
@@ -25,9 +25,9 @@ export const ListSummary = ({ target }: Summary2Props<'List'>) => {
   const displayData = useDisplayData(target);
   const validations = useUnifiedValidationsForNode(target);
   const errors = validationsOfSeverity(validations, 'error');
-  const title = useNodeItem(target, (i) => i.textResourceBindings?.summaryTitle || i.textResourceBindings?.title);
 
-  const { tableHeaders, dataModelBindings, required } = useNodeItem(target);
+  const { tableHeaders, dataModelBindings, required, textResourceBindings } = useItemWhenType(target.baseId, 'List');
+  const title = textResourceBindings?.summaryTitle || textResourceBindings?.title;
   const { formData } = useDataModelBindings(dataModelBindings, DEFAULT_DEBOUNCE_TIMEOUT, 'raw');
 
   const relativeCheckedPath =

--- a/src/layout/List/index.tsx
+++ b/src/layout/List/index.tsx
@@ -87,8 +87,8 @@ export class List extends ListDef {
     return <ListSummary {...props} />;
   }
 
-  useEmptyFieldValidation(node: LayoutNode<'List'>): ComponentValidation[] {
-    return useValidateGroupIsEmpty(node);
+  useEmptyFieldValidation(baseComponentId: string): ComponentValidation[] {
+    return useValidateGroupIsEmpty(baseComponentId, 'List');
   }
 
   renderLayoutValidators(props: NodeValidationProps<'List'>): JSX.Element | null {

--- a/src/layout/Map/Map.tsx
+++ b/src/layout/Map/Map.tsx
@@ -28,7 +28,7 @@ import {
   locationToTuple,
   parseGeometries,
 } from 'src/layout/Map/utils';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { Location } from 'src/layout/Map/config.generated';
 import type { RawGeometry } from 'src/layout/Map/types';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
@@ -80,7 +80,7 @@ export function Map({
     centerLocation: customCenterLocation,
     zoom: customZoom,
     geometryType,
-  } = useNodeItem(mapNode);
+  } = useItemWhenType(mapNode.baseId, 'Map');
 
   const isPdf = useIsPdf();
   const isInteractive = !readOnly && !isSummary;

--- a/src/layout/Map/MapComponent.tsx
+++ b/src/layout/Map/MapComponent.tsx
@@ -11,7 +11,7 @@ import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper'
 import { Map } from 'src/layout/Map/Map';
 import classes from 'src/layout/Map/MapComponent.module.css';
 import { isLocationValid, parseLocation } from 'src/layout/Map/utils';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useDataModelBindingsFor } from 'src/utils/layout/hooks';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type { Location } from 'src/layout/Map/config.generated';
 import type { RawGeometry } from 'src/layout/Map/types';
@@ -20,7 +20,7 @@ export type IMapComponentProps = PropsFromGenericComponent<'Map'>;
 
 export function MapComponent({ node }: IMapComponentProps) {
   const isValid = useIsValid(node);
-  const dataModelBindings = useNodeItem(node, (item) => item.dataModelBindings);
+  const dataModelBindings = useDataModelBindingsFor(node.baseId, 'Map');
   const markerBinding = dataModelBindings.simpleBinding;
 
   const { formData, setValue } = useDataModelBindings(dataModelBindings, DEFAULT_DEBOUNCE_TIMEOUT, 'raw');

--- a/src/layout/Map/MapComponentSummary.tsx
+++ b/src/layout/Map/MapComponentSummary.tsx
@@ -6,7 +6,8 @@ import { Lang } from 'src/features/language/Lang';
 import { Map } from 'src/layout/Map/Map';
 import classes from 'src/layout/Map/MapComponent.module.css';
 import { isLocationValid, parseLocation } from 'src/layout/Map/utils';
-import { useNodeFormData, useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useDataModelBindingsFor } from 'src/utils/layout/hooks';
+import { useNodeFormData } from 'src/utils/layout/useNodeItem';
 import type { RawGeometry } from 'src/layout/Map/types';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
@@ -15,7 +16,7 @@ export interface IMapComponentSummary {
 }
 
 export function MapComponentSummary({ targetNode }: IMapComponentSummary) {
-  const markerBinding = useNodeItem(targetNode, (item) => item.dataModelBindings.simpleBinding);
+  const markerBinding = useDataModelBindingsFor(targetNode.baseId, 'Map').simpleBinding;
   const formData = useNodeFormData(targetNode);
   const markerLocation = parseLocation(formData.simpleBinding);
   const markerLocationIsValid = isLocationValid(markerLocation);

--- a/src/layout/Map/Summary2/MapSummary.tsx
+++ b/src/layout/Map/Summary2/MapSummary.tsx
@@ -14,23 +14,22 @@ import { EditButton } from 'src/layout/Summary2/CommonSummaryComponents/EditButt
 import { SingleValueSummary } from 'src/layout/Summary2/CommonSummaryComponents/SingleValueSummary';
 import { SummaryContains, SummaryFlex } from 'src/layout/Summary2/SummaryComponent2/ComponentSummary';
 import { useSummaryOverrides, useSummaryProp } from 'src/layout/Summary2/summaryStoreContext';
-import { useNodeFormData, useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType, useNodeFormData } from 'src/utils/layout/useNodeItem';
 import type { RawGeometry } from 'src/layout/Map/types';
 import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types';
 
 export function MapSummary({ target }: Summary2Props<'Map'>) {
   const emptyFieldText = useSummaryOverrides(target)?.emptyFieldText;
   const isCompact = useSummaryProp('isCompact');
-  const markerBinding = useNodeItem(target, (item) => item.dataModelBindings.simpleBinding);
-  const readOnly = useNodeItem(target, (item) => item.readOnly);
+  const { dataModelBindings, readOnly, textResourceBindings, required } = useItemWhenType(target.baseId, 'Map');
+  const markerBinding = dataModelBindings.simpleBinding;
   const formData = useNodeFormData(target);
   const markerLocation = parseLocation(formData.simpleBinding);
   const markerLocationIsValid = isLocationValid(markerLocation);
   const geometries = formData.geometries as RawGeometry[] | undefined;
   const validations = useUnifiedValidationsForNode(target);
   const errors = validationsOfSeverity(validations, 'error');
-  const title = useNodeItem(target, (i) => i.textResourceBindings?.title);
-  const required = useNodeItem(target, (i) => i.required);
+  const title = textResourceBindings?.title;
 
   if (markerBinding && !markerLocationIsValid) {
     return (

--- a/src/layout/MultipleSelect/MultipleSelectComponent.tsx
+++ b/src/layout/MultipleSelect/MultipleSelectComponent.tsx
@@ -16,13 +16,13 @@ import { useIsValid } from 'src/features/validation/selectors/isValid';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
 import utilclasses from 'src/styles/utils.module.css';
 import { useLabel } from 'src/utils/layout/useLabel';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import { optionFilter } from 'src/utils/options';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export type IMultipleSelectProps = PropsFromGenericComponent<'MultipleSelect'>;
 export function MultipleSelectComponent({ node, overrideDisplay }: IMultipleSelectProps) {
-  const item = useNodeItem(node);
+  const item = useItemWhenType(node.baseId, 'MultipleSelect');
   const isValid = useIsValid(node);
   const { id, readOnly, textResourceBindings, alertOnChange, grid, required, dataModelBindings } = item;
   const {

--- a/src/layout/MultipleSelect/MultipleSelectSummary.tsx
+++ b/src/layout/MultipleSelect/MultipleSelectSummary.tsx
@@ -8,7 +8,7 @@ import {
 } from 'src/layout/Summary2/CommonSummaryComponents/MultipleValueSummary';
 import { SummaryContains, SummaryFlex } from 'src/layout/Summary2/SummaryComponent2/ComponentSummary';
 import { useSummaryOverrides, useSummaryProp } from 'src/layout/Summary2/summaryStoreContext';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types';
 
 export function MultipleSelectSummary({ target }: Summary2Props<'MultipleSelect'>) {
@@ -20,8 +20,7 @@ export function MultipleSelectSummary({ target }: Summary2Props<'MultipleSelect'
 
   const showAsList =
     overrides?.displayType === 'list' || (!overrides?.displayType && displayData?.length >= maxStringLength);
-  const title = useNodeItem(target, (i) => i.textResourceBindings?.title);
-  const required = useNodeItem(target, (i) => i.required);
+  const { textResourceBindings, required } = useItemWhenType(target.baseId, 'MultipleSelect');
   const displayValues = useMultipleValuesForSummary(target);
 
   return (
@@ -36,7 +35,7 @@ export function MultipleSelectSummary({ target }: Summary2Props<'MultipleSelect'
       }
     >
       <MultipleValueSummary
-        title={<Lang id={title} />}
+        title={<Lang id={textResourceBindings?.title} />}
         componentNode={target}
         displayValues={displayValues}
         showAsList={showAsList}

--- a/src/layout/MultipleSelect/index.tsx
+++ b/src/layout/MultipleSelect/index.tsx
@@ -73,8 +73,8 @@ export class MultipleSelect extends MultipleSelectDef {
     return <MultipleSelectSummary {...props} />;
   }
 
-  useEmptyFieldValidation(node: LayoutNode<'MultipleSelect'>): ComponentValidation[] {
-    return useValidateGroupIsEmpty(node);
+  useEmptyFieldValidation(baseComponentId: string): ComponentValidation[] {
+    return useValidateGroupIsEmpty(baseComponentId, 'MultipleSelect');
   }
 
   renderLayoutValidators(props: NodeValidationProps<'MultipleSelect'>): JSX.Element | null {

--- a/src/layout/NavigationBar/NavigationBarComponent.tsx
+++ b/src/layout/NavigationBar/NavigationBarComponent.tsx
@@ -14,7 +14,7 @@ import { useIsMobile } from 'src/hooks/useDeviceWidths';
 import { useNavigatePage } from 'src/hooks/useNavigatePage';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
 import classes from 'src/layout/NavigationBar/NavigationBarComponent.module.css';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export type INavigationBar = PropsFromGenericComponent<'NavigationBar'>;
@@ -50,7 +50,7 @@ const NavigationButton = React.forwardRef(
 NavigationButton.displayName = 'NavigationButton';
 
 export const NavigationBarComponent = ({ node }: INavigationBar) => {
-  const { compact, validateOnForward, validateOnBackward } = useNodeItem(node);
+  const { compact, validateOnForward, validateOnBackward } = useItemWhenType(node.baseId, 'NavigationBar');
   const [showMenu, setShowMenu] = React.useState(false);
   const isMobile = useIsMobile() || compact === true;
   const { langAsString } = useLanguage();

--- a/src/layout/NavigationButtons/NavigationButtonsComponent.tsx
+++ b/src/layout/NavigationButtons/NavigationButtonsComponent.tsx
@@ -18,7 +18,7 @@ type Props = Pick<PropsFromGenericComponent<'NavigationButtons'>, 'node'>;
 export function NavigationButtonsComponent({ node }: Props) {
   const summaryNode = useSummaryNodeOfOrigin();
 
-  if (summaryNode) {
+  if (summaryNode && summaryNode.isType('Summary')) {
     return (
       <WithSummary
         node={node}

--- a/src/layout/NavigationButtons/NavigationButtonsComponent.tsx
+++ b/src/layout/NavigationButtons/NavigationButtonsComponent.tsx
@@ -9,7 +9,7 @@ import { useOnPageNavigationValidation } from 'src/features/validation/callbacks
 import { useNavigatePage, useNextPageKey, usePreviousPageKey } from 'src/hooks/useNavigatePage';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
 import classes from 'src/layout/NavigationButtons/NavigationButtonsComponent.module.css';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
@@ -37,7 +37,7 @@ export function NavigationButtonsComponent({ node }: Props) {
 }
 
 function WithSummary({ node, summaryNode }: Props & { summaryNode: LayoutNode<'Summary'> }) {
-  const summaryItem = useNodeItem(summaryNode);
+  const summaryItem = useItemWhenType(summaryNode.baseId, 'Summary');
   const returnToViewText =
     summaryItem?.textResourceBindings?.returnToSummaryButtonTitle ?? 'form_filler.back_to_summary';
   const showNextButtonSummary = summaryItem?.display != null && summaryItem?.display?.nextButton === true;
@@ -56,7 +56,10 @@ function NavigationButtonsComponentInner({
   returnToViewText,
   showNextButtonSummary,
 }: Props & { returnToViewText: string; showNextButtonSummary: boolean }) {
-  const { id, showBackButton, textResourceBindings, validateOnNext, validateOnPrevious } = useNodeItem(node);
+  const { id, showBackButton, textResourceBindings, validateOnNext, validateOnPrevious } = useItemWhenType(
+    node.baseId,
+    'NavigationButtons',
+  );
   const { navigateToNextPage, navigateToPreviousPage, navigateToPage, maybeSaveOnPageChange } = useNavigatePage();
   const hasNext = !!useNextPageKey();
   const hasPrevious = !!usePreviousPageKey();

--- a/src/layout/Number/NumberComponent.tsx
+++ b/src/layout/Number/NumberComponent.tsx
@@ -8,15 +8,18 @@ import { getLabelId } from 'src/components/label/Label';
 import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
 import { useLanguage } from 'src/features/language/useLanguage';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export const NumberComponent = ({ node }: PropsFromGenericComponent<'Number'>) => {
-  const textResourceBindings = useNodeItem(node, (i) => i.textResourceBindings);
-  const value = useNodeItem(node, (i) => i.value);
-  const icon = useNodeItem(node, (i) => i.icon);
-  const direction = useNodeItem(node, (i) => i.direction) ?? 'horizontal';
-  const formatting = useNodeItem(node, (i) => i.formatting);
+  const {
+    textResourceBindings,
+    value,
+    icon,
+    direction: _direction,
+    formatting,
+  } = useItemWhenType(node.baseId, 'Number');
+  const direction = _direction ?? 'horizontal';
   const { langAsString } = useLanguage();
   const currentLanguage = useCurrentLanguage();
 

--- a/src/layout/Number/NumberSummary.tsx
+++ b/src/layout/Number/NumberSummary.tsx
@@ -7,7 +7,7 @@ import { validationsOfSeverity } from 'src/features/validation/utils';
 import { SingleValueSummary } from 'src/layout/Summary2/CommonSummaryComponents/SingleValueSummary';
 import { SummaryContains, SummaryFlex } from 'src/layout/Summary2/SummaryComponent2/ComponentSummary';
 import { useSummaryOverrides, useSummaryProp } from 'src/layout/Summary2/summaryStoreContext';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types';
 
 export const NumberSummary = ({ target }: Summary2Props<'Number'>) => {
@@ -16,8 +16,9 @@ export const NumberSummary = ({ target }: Summary2Props<'Number'>) => {
   const displayData = useDisplayData(target);
   const validations = useUnifiedValidationsForNode(target);
   const errors = validationsOfSeverity(validations, 'error');
-  const title = useNodeItem(target, (i) => i.textResourceBindings?.title);
-  const direction = useNodeItem(target, (i) => i.direction);
+  const item = useItemWhenType(target.baseId, 'Number');
+  const title = item.textResourceBindings?.title;
+  const direction = item.direction;
 
   const compact = (direction === 'horizontal' && isCompact == undefined) || isCompact;
 

--- a/src/layout/Number/index.tsx
+++ b/src/layout/Number/index.tsx
@@ -8,7 +8,6 @@ import { NumberDef } from 'src/layout/Number/config.def.generated';
 import { NumberComponent } from 'src/layout/Number/NumberComponent';
 import { NumberSummary } from 'src/layout/Number/NumberSummary';
 import { formatNumericText } from 'src/utils/formattingUtils';
-import { useIndexedId } from 'src/utils/layout/DataModelLocation';
 import { useNodeItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { DisplayData } from 'src/features/displayData';
 import type { PropsFromGenericComponent } from 'src/layout';
@@ -17,8 +16,7 @@ import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types'
 
 export class Number extends NumberDef implements DisplayData {
   useDisplayData(baseComponentId: string): string {
-    const nodeId = useIndexedId(baseComponentId);
-    const item = useNodeItemWhenType(nodeId, 'Number');
+    const item = useNodeItemWhenType(baseComponentId, 'Number');
     const number = item?.value;
     const formatting = item?.formatting;
     const currentLanguage = useCurrentLanguage();

--- a/src/layout/Number/index.tsx
+++ b/src/layout/Number/index.tsx
@@ -8,7 +8,7 @@ import { NumberDef } from 'src/layout/Number/config.def.generated';
 import { NumberComponent } from 'src/layout/Number/NumberComponent';
 import { NumberSummary } from 'src/layout/Number/NumberSummary';
 import { formatNumericText } from 'src/utils/formattingUtils';
-import { useNodeItemWhenType } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { DisplayData } from 'src/features/displayData';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type { ExprResolver } from 'src/layout/LayoutComponent';
@@ -16,7 +16,7 @@ import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types'
 
 export class Number extends NumberDef implements DisplayData {
   useDisplayData(baseComponentId: string): string {
-    const item = useNodeItemWhenType(baseComponentId, 'Number');
+    const item = useItemWhenType(baseComponentId, 'Number');
     const number = item?.value;
     const formatting = item?.formatting;
     const currentLanguage = useCurrentLanguage();

--- a/src/layout/Option/OptionComponent.tsx
+++ b/src/layout/Option/OptionComponent.tsx
@@ -9,15 +9,14 @@ import { useLanguage } from 'src/features/language/useLanguage';
 import { useGetOptions } from 'src/features/options/useGetOptions';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
 import classes from 'src/layout/Option/Option.module.css';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export const OptionComponent = ({ node }: PropsFromGenericComponent<'Option'>) => {
-  const textResourceBindings = useNodeItem(node, (i) => i.textResourceBindings);
-  const direction = useNodeItem(node, (i) => i.direction);
+  const item = useItemWhenType(node.baseId, 'Option');
 
-  if (!textResourceBindings?.title) {
+  if (!item.textResourceBindings?.title) {
     return (
       <Text
         node={node}
@@ -35,7 +34,7 @@ export const OptionComponent = ({ node }: PropsFromGenericComponent<'Option'>) =
         className: cn(
           classes.label,
           classes.optionComponent,
-          direction === 'vertical' ? classes.vertical : classes.horizontal,
+          item.direction === 'vertical' ? classes.vertical : classes.horizontal,
         ),
       }}
     >
@@ -53,9 +52,7 @@ interface TextProps {
 }
 
 function Text({ node, usingLabel }: TextProps) {
-  const textResourceBindings = useNodeItem(node, (i) => i.textResourceBindings);
-  const icon = useNodeItem(node, (i) => i.icon);
-  const value = useNodeItem(node, (i) => i.value);
+  const { textResourceBindings, icon, value } = useItemWhenType(node.baseId, 'Option');
   const { options, isFetching } = useGetOptions(node.baseId, 'single');
   const { langAsString } = useLanguage();
   const selectedOption = options.find((option) => option.value === value);

--- a/src/layout/Option/OptionSummary.tsx
+++ b/src/layout/Option/OptionSummary.tsx
@@ -7,7 +7,7 @@ import { validationsOfSeverity } from 'src/features/validation/utils';
 import { SingleValueSummary } from 'src/layout/Summary2/CommonSummaryComponents/SingleValueSummary';
 import { SummaryContains, SummaryFlex } from 'src/layout/Summary2/SummaryComponent2/ComponentSummary';
 import { useSummaryOverrides, useSummaryProp } from 'src/layout/Summary2/summaryStoreContext';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types';
 
 export const OptionSummary = ({ target }: Summary2Props<'Option'>) => {
@@ -16,8 +16,8 @@ export const OptionSummary = ({ target }: Summary2Props<'Option'>) => {
   const displayData = useDisplayData(target);
   const validations = useUnifiedValidationsForNode(target);
   const errors = validationsOfSeverity(validations, 'error');
-  const title = useNodeItem(target, (i) => i.textResourceBindings?.title);
-  const direction = useNodeItem(target, (i) => i.direction);
+  const { textResourceBindings, direction } = useItemWhenType(target.baseId, 'Option');
+  const title = textResourceBindings?.title;
   const compact = (direction === 'horizontal' && isCompact == undefined) || isCompact;
 
   return (

--- a/src/layout/Option/index.tsx
+++ b/src/layout/Option/index.tsx
@@ -7,7 +7,7 @@ import { useOptionsFor } from 'src/features/options/useOptionsFor';
 import { OptionDef } from 'src/layout/Option/config.def.generated';
 import { OptionComponent } from 'src/layout/Option/OptionComponent';
 import { OptionSummary } from 'src/layout/Option/OptionSummary';
-import { useNodeItemWhenType } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { DisplayData } from 'src/features/displayData';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type { ExprResolver } from 'src/layout/LayoutComponent';
@@ -15,7 +15,7 @@ import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types'
 
 export class Option extends OptionDef implements DisplayData {
   useDisplayData(baseComponentId: string): string {
-    const item = useNodeItemWhenType(baseComponentId, 'Option');
+    const item = useItemWhenType(baseComponentId, 'Option');
     const value = item?.value ?? '';
     const options = useOptionsFor(baseComponentId, 'single').options;
     const langTools = useLanguage();

--- a/src/layout/Option/index.tsx
+++ b/src/layout/Option/index.tsx
@@ -7,7 +7,6 @@ import { useOptionsFor } from 'src/features/options/useOptionsFor';
 import { OptionDef } from 'src/layout/Option/config.def.generated';
 import { OptionComponent } from 'src/layout/Option/OptionComponent';
 import { OptionSummary } from 'src/layout/Option/OptionSummary';
-import { useIndexedId } from 'src/utils/layout/DataModelLocation';
 import { useNodeItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { DisplayData } from 'src/features/displayData';
 import type { PropsFromGenericComponent } from 'src/layout';
@@ -16,8 +15,7 @@ import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types'
 
 export class Option extends OptionDef implements DisplayData {
   useDisplayData(baseComponentId: string): string {
-    const nodeId = useIndexedId(baseComponentId);
-    const item = useNodeItemWhenType(nodeId, 'Option');
+    const item = useNodeItemWhenType(baseComponentId, 'Option');
     const value = item?.value ?? '';
     const options = useOptionsFor(baseComponentId, 'single').options;
     const langTools = useLanguage();

--- a/src/layout/OrganisationLookup/OrganisationLookupComponent.tsx
+++ b/src/layout/OrganisationLookup/OrganisationLookupComponent.tsx
@@ -19,7 +19,7 @@ import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper'
 import classes from 'src/layout/OrganisationLookup/OrganisationLookupComponent.module.css';
 import { validateOrganisationLookupResponse, validateOrgnr } from 'src/layout/OrganisationLookup/validation';
 import { useLabel } from 'src/utils/layout/useLabel';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import { httpGet } from 'src/utils/network/networking';
 import { appPath } from 'src/utils/urls/appUrlHelper';
 
@@ -68,7 +68,7 @@ export function OrganisationLookupComponent({
   node,
   overrideDisplay,
 }: PropsFromGenericComponent<'OrganisationLookup'>) {
-  const { id, dataModelBindings, required } = useNodeItem(node);
+  const { id, dataModelBindings, required } = useItemWhenType(node.baseId, 'OrganisationLookup');
   const { labelText, getHelpTextComponent, getDescriptionComponent } = useLabel({ node, overrideDisplay });
   const [tempOrgNr, setTempOrgNr] = useState('');
   const [orgNrErrors, setOrgNrErrors] = useState<string[]>();

--- a/src/layout/OrganisationLookup/OrganisationLookupSummary.tsx
+++ b/src/layout/OrganisationLookup/OrganisationLookupSummary.tsx
@@ -10,7 +10,7 @@ import classes from 'src/layout/OrganisationLookup/OrganisationLookupSummary.mod
 import { SingleValueSummary } from 'src/layout/Summary2/CommonSummaryComponents/SingleValueSummary';
 import { SummaryContains, SummaryFlex } from 'src/layout/Summary2/SummaryComponent2/ComponentSummary';
 import { useSummaryOverrides, useSummaryProp } from 'src/layout/Summary2/summaryStoreContext';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 interface OrganisationLookupSummaryProps {
@@ -18,11 +18,11 @@ interface OrganisationLookupSummaryProps {
 }
 
 export function OrganisationLookupSummary({ componentNode }: OrganisationLookupSummaryProps) {
-  const { dataModelBindings, title, required } = useNodeItem(componentNode, (i) => ({
-    dataModelBindings: i.dataModelBindings,
-    title: i.textResourceBindings?.title,
-    required: i.required,
-  }));
+  const { dataModelBindings, textResourceBindings, required } = useItemWhenType(
+    componentNode.baseId,
+    'OrganisationLookup',
+  );
+  const title = textResourceBindings?.title;
   const { formData } = useDataModelBindings(dataModelBindings);
   const { organisation_lookup_orgnr, organisation_lookup_name } = formData;
   const emptyFieldText = useSummaryOverrides(componentNode)?.emptyFieldText;

--- a/src/layout/OrganisationLookup/index.tsx
+++ b/src/layout/OrganisationLookup/index.tsx
@@ -36,9 +36,9 @@ export class OrganisationLookup extends OrganisationLookupDef {
     return null;
   }
 
-  useEmptyFieldValidation(node: LayoutNode<'OrganisationLookup'>): ComponentValidation[] {
+  useEmptyFieldValidation(baseComponentId: string): ComponentValidation[] {
     return useEmptyFieldValidationOnlyOneBinding(
-      node,
+      baseComponentId,
       'organisation_lookup_orgnr',
       'organisation_lookup.error_required',
     );

--- a/src/layout/PDFPreviewButton/PDFPreviewButtonComponent.tsx
+++ b/src/layout/PDFPreviewButton/PDFPreviewButtonComponent.tsx
@@ -6,11 +6,9 @@ import { PDFGeneratorPreview } from 'src/components/PDFGeneratorPreview/PDFGener
 import { useApplicationMetadata } from 'src/features/applicationMetadata/ApplicationMetadataProvider';
 import { useStrictInstanceId } from 'src/features/instance/InstanceContext';
 import { NodesInternal } from 'src/utils/layout/NodesContext';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import { isAtLeastVersion } from 'src/utils/versionCompare';
 import type { NodeValidationProps } from 'src/layout/layout';
-
-export type IActionButton = PropsFromGenericComponent<'PDFPreviewButton'>;
 
 export function PDFPreviewButtonRenderLayoutValidator({ node }: NodeValidationProps<'PDFPreviewButton'>) {
   const instanceId = useStrictInstanceId();
@@ -39,7 +37,7 @@ export function PDFPreviewButtonRenderLayoutValidator({ node }: NodeValidationPr
   return null;
 }
 
-export function PDFPreviewButtonComponent({ node }: IActionButton) {
-  const { textResourceBindings } = useNodeItem(node);
+export function PDFPreviewButtonComponent({ node }: PropsFromGenericComponent<'PDFPreviewButton'>) {
+  const { textResourceBindings } = useItemWhenType(node.baseId, 'PDFPreviewButton');
   return <PDFGeneratorPreview buttonTitle={textResourceBindings?.title} />;
 }

--- a/src/layout/Panel/PanelComponent.tsx
+++ b/src/layout/Panel/PanelComponent.tsx
@@ -6,13 +6,13 @@ import { Lang } from 'src/features/language/Lang';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
 import { LayoutPage } from 'src/utils/layout/LayoutPage';
 import { NodesInternal } from 'src/utils/layout/NodesContext';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 type IPanelProps = PropsFromGenericComponent<'Panel'>;
 
 export const PanelComponent = ({ node }: IPanelProps) => {
-  const { textResourceBindings, variant, showIcon, grid } = useNodeItem(node);
+  const { textResourceBindings, variant, showIcon, grid } = useItemWhenType(node.baseId, 'Panel');
   const fullWidth = !grid && node.parent instanceof LayoutPage;
 
   const { isOnBottom, isOnTop } = NodesInternal.useShallowSelector((state) => {

--- a/src/layout/Paragraph/ParagraphComponent.tsx
+++ b/src/layout/Paragraph/ParagraphComponent.tsx
@@ -5,13 +5,13 @@ import { Lang, LangAsParagraph } from 'src/features/language/Lang';
 import { useLanguage } from 'src/features/language/useLanguage';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
 import classes from 'src/layout/Paragraph/ParagraphComponent.module.css';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export type IParagraphProps = PropsFromGenericComponent<'Paragraph'>;
 
 export function ParagraphComponent({ node }: IParagraphProps) {
-  const { id, textResourceBindings } = useNodeItem(node);
+  const { id, textResourceBindings } = useItemWhenType(node.baseId, 'Paragraph');
   const { langAsString } = useLanguage();
 
   return (

--- a/src/layout/Payment/PaymentComponent.tsx
+++ b/src/layout/Payment/PaymentComponent.tsx
@@ -13,7 +13,7 @@ import { useIsSubformPage } from 'src/features/routing/AppRoutingContext';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
 import classes from 'src/layout/Payment/PaymentComponent.module.css';
 import { PaymentDetailsTable } from 'src/layout/PaymentDetails/PaymentDetailsTable';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export const PaymentComponent = ({ node }: PropsFromGenericComponent<'Payment'>) => {
@@ -21,7 +21,7 @@ export const PaymentComponent = ({ node }: PropsFromGenericComponent<'Payment'>)
   const { performProcess, isAnyProcessing, process } = useIsProcessing<'next' | 'reject'>();
   const paymentInfo = usePaymentInformation();
   const { performPayment, paymentError } = usePayment();
-  const { title, description } = useNodeItem(node, (i) => i.textResourceBindings) ?? {};
+  const { title, description } = useItemWhenType(node.baseId, 'Payment').textResourceBindings ?? {};
 
   if (useIsSubformPage()) {
     throw new Error('Cannot use PaymentComponent in a subform');

--- a/src/layout/Payment/PaymentSummary.tsx
+++ b/src/layout/Payment/PaymentSummary.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { PaymentReceiptDetails } from 'src/layout/Payment/PaymentReceiptDetails/PaymentReceiptDetails';
 import { SummaryContains, SummaryFlex } from 'src/layout/Summary2/SummaryComponent2/ComponentSummary';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export type PaymentSummaryProps = {
@@ -10,7 +10,7 @@ export type PaymentSummaryProps = {
 };
 
 export function PaymentSummary({ componentNode }: PaymentSummaryProps) {
-  const title = useNodeItem(componentNode, (i) => i.textResourceBindings?.title);
+  const title = useItemWhenType(componentNode.baseId, 'Payment').textResourceBindings?.title;
 
   return (
     <SummaryFlex

--- a/src/layout/Payment/SummaryPaymentComponent.tsx
+++ b/src/layout/Payment/SummaryPaymentComponent.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 
 import { PaymentReceiptDetails } from 'src/layout/Payment/PaymentReceiptDetails/PaymentReceiptDetails';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 
 export const SummaryPaymentComponent = ({ targetNode }: SummaryRendererProps<'Payment'>) => {
-  const title = useNodeItem(targetNode, (i) => i.textResourceBindings?.title);
+  const title = useItemWhenType(targetNode.baseId, 'Payment').textResourceBindings?.title;
   return <PaymentReceiptDetails title={title} />;
 };

--- a/src/layout/PaymentDetails/PaymentDetailsComponent.tsx
+++ b/src/layout/PaymentDetails/PaymentDetailsComponent.tsx
@@ -7,7 +7,7 @@ import { FD } from 'src/features/formData/FormDataWrite';
 import { useOrderDetails, useRefetchOrderDetails } from 'src/features/payment/OrderDetailsProvider';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
 import { PaymentDetailsTable } from 'src/layout/PaymentDetails/PaymentDetailsTable';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export type IPaymentDetailsProps = PropsFromGenericComponent<'PaymentDetails'>;
@@ -15,8 +15,8 @@ export type IPaymentDetailsProps = PropsFromGenericComponent<'PaymentDetails'>;
 export function PaymentDetailsComponent({ node }: IPaymentDetailsProps) {
   const orderDetails = useOrderDetails();
   const refetchOrderDetails = useRefetchOrderDetails();
-  const { title, description } = useNodeItem(node, (i) => i.textResourceBindings || {});
-  const mapping = useNodeItem(node, (i) => i.mapping);
+  const { mapping, textResourceBindings } = useItemWhenType(node.baseId, 'PaymentDetails');
+  const { title, description } = textResourceBindings || {};
   const hasUnsavedChanges = FD.useHasUnsavedChanges();
 
   const mappedValues = FD.useMapping(mapping, DataModels.useDefaultDataType());

--- a/src/layout/PersonLookup/PersonLookupComponent.tsx
+++ b/src/layout/PersonLookup/PersonLookupComponent.tsx
@@ -21,7 +21,7 @@ import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper'
 import classes from 'src/layout/PersonLookup/PersonLookupComponent.module.css';
 import { validatePersonLookupResponse, validateSsn } from 'src/layout/PersonLookup/validation';
 import { useLabel } from 'src/utils/layout/useLabel';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import { httpPost } from 'src/utils/network/networking';
 import { appPath } from 'src/utils/urls/appUrlHelper';
 import type { PropsFromGenericComponent } from 'src/layout';
@@ -80,7 +80,7 @@ async function fetchPerson(
 }
 
 export function PersonLookupComponent({ node, overrideDisplay }: PropsFromGenericComponent<'PersonLookup'>) {
-  const { id, dataModelBindings, required } = useNodeItem(node);
+  const { id, dataModelBindings, required } = useItemWhenType(node.baseId, 'PersonLookup');
   const { labelText, getDescriptionComponent, getHelpTextComponent } = useLabel({ node, overrideDisplay });
   const [tempSsn, setTempSsn] = useState('');
   const [tempName, setTempName] = useState('');

--- a/src/layout/PersonLookup/PersonLookupSummary.tsx
+++ b/src/layout/PersonLookup/PersonLookupSummary.tsx
@@ -10,7 +10,7 @@ import classes from 'src/layout/PersonLookup/PersonLookupSummary.module.css';
 import { SingleValueSummary } from 'src/layout/Summary2/CommonSummaryComponents/SingleValueSummary';
 import { SummaryContains, SummaryFlex } from 'src/layout/Summary2/SummaryComponent2/ComponentSummary';
 import { useSummaryOverrides, useSummaryProp } from 'src/layout/Summary2/summaryStoreContext';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 interface PersonLookupSummaryProps {
@@ -18,11 +18,7 @@ interface PersonLookupSummaryProps {
 }
 
 export function PersonLookupSummary({ componentNode }: PersonLookupSummaryProps) {
-  const { dataModelBindings, title, required } = useNodeItem(componentNode, (i) => ({
-    dataModelBindings: i.dataModelBindings,
-    title: i.textResourceBindings?.title,
-    required: i.required,
-  }));
+  const { dataModelBindings, textResourceBindings, required } = useItemWhenType(componentNode.baseId, 'PersonLookup');
   const { formData } = useDataModelBindings(dataModelBindings);
   const { person_lookup_name, person_lookup_ssn } = formData;
   const emptyFieldText = useSummaryOverrides(componentNode)?.emptyFieldText;
@@ -46,7 +42,7 @@ export function PersonLookupSummary({ componentNode }: PersonLookupSummaryProps)
           data-size='sm'
           level={2}
         >
-          <Lang id={title} />
+          <Lang id={textResourceBindings?.title} />
         </Heading>
         <div className={classes.personLookupComponent}>
           <div className={classes.personLookupComponentSsn}>

--- a/src/layout/PersonLookup/index.tsx
+++ b/src/layout/PersonLookup/index.tsx
@@ -39,8 +39,8 @@ export class PersonLookup extends PersonLookupDef {
     return false;
   }
 
-  useEmptyFieldValidation(node: LayoutNode<'PersonLookup'>): ComponentValidation[] {
-    return useEmptyFieldValidationAllBindings(node, 'person_lookup.error_required');
+  useEmptyFieldValidation(baseComponentId: string): ComponentValidation[] {
+    return useEmptyFieldValidationAllBindings(baseComponentId, 'person_lookup.error_required');
   }
 
   useDataModelBindingValidation(

--- a/src/layout/PrintButton/PrintButtonComponent.tsx
+++ b/src/layout/PrintButton/PrintButtonComponent.tsx
@@ -5,10 +5,10 @@ import type { PropsFromGenericComponent } from '..';
 import { Button } from 'src/app-components/Button/Button';
 import { Lang } from 'src/features/language/Lang';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 
 export const PrintButtonComponent = ({ node }: PropsFromGenericComponent<'PrintButton'>) => {
-  const { textResourceBindings } = useNodeItem(node);
+  const { textResourceBindings } = useItemWhenType(node.baseId, 'PrintButton');
 
   return (
     <ComponentStructureWrapper node={node}>

--- a/src/layout/RadioButtons/ControlledRadioGroup.tsx
+++ b/src/layout/RadioButtons/ControlledRadioGroup.tsx
@@ -16,7 +16,7 @@ import { useRadioButtons } from 'src/layout/RadioButtons/radioButtonsUtils';
 import utilClasses from 'src/styles/utils.module.css';
 import { shouldUseRowLayout } from 'src/utils/layout';
 import { LayoutNode } from 'src/utils/layout/LayoutNode';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export type IControlledRadioGroupProps = PropsFromGenericComponent<'RadioButtons' | 'LikertItem'>;
@@ -24,7 +24,10 @@ export type IControlledRadioGroupProps = PropsFromGenericComponent<'RadioButtons
 export const ControlledRadioGroup = (props: IControlledRadioGroupProps) => {
   const { node, overrideDisplay } = props;
   const isValid = useIsValid(node);
-  const item = useNodeItem(node);
+  const item = useItemWhenType<'RadioButtons' | 'LikertItem'>(
+    node.baseId,
+    (t) => t === 'RadioButtons' || t === 'LikertItem',
+  );
   const { id, layout, readOnly, textResourceBindings, required, showLabelsInTable } = item;
   const showAsCard = 'showAsCard' in item ? item.showAsCard : false;
   const { selectedValues, handleChange, fetchingOptions, calculatedOptions } = useRadioButtons(props);
@@ -49,7 +52,7 @@ export const ControlledRadioGroup = (props: IControlledRadioGroupProps) => {
   if (node.parent instanceof LayoutNode && node.parent.isType('Likert')) {
     // The parent node type never changes, so this doesn't break the rule of hooks
     // eslint-disable-next-line react-hooks/rules-of-hooks
-    leftColumnHeader = useNodeItem(node.parent, (i) => i.textResourceBindings?.leftColumnHeader);
+    leftColumnHeader = useItemWhenType(node.parent.baseId, 'Likert').textResourceBindings?.leftColumnHeader;
   }
 
   const labelText = (

--- a/src/layout/RadioButtons/RadioButtonsSummary.tsx
+++ b/src/layout/RadioButtons/RadioButtonsSummary.tsx
@@ -7,7 +7,7 @@ import { validationsOfSeverity } from 'src/features/validation/utils';
 import { SingleValueSummary } from 'src/layout/Summary2/CommonSummaryComponents/SingleValueSummary';
 import { SummaryContains, SummaryFlex } from 'src/layout/Summary2/SummaryComponent2/ComponentSummary';
 import { useSummaryOverrides, useSummaryProp } from 'src/layout/Summary2/summaryStoreContext';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types';
 
 export const RadioButtonsSummary = ({ target }: Summary2Props<'RadioButtons'>) => {
@@ -16,8 +16,8 @@ export const RadioButtonsSummary = ({ target }: Summary2Props<'RadioButtons'>) =
   const validations = useUnifiedValidationsForNode(target);
   const displayData = useDisplayData(target);
   const errors = validationsOfSeverity(validations, 'error');
-  const title = useNodeItem(target, (i) => i.textResourceBindings?.title);
-  const required = useNodeItem(target, (i) => i.required);
+  const { textResourceBindings, required } = useItemWhenType(target.baseId, 'RadioButtons');
+  const title = textResourceBindings?.title;
 
   return (
     <SummaryFlex

--- a/src/layout/RadioButtons/index.tsx
+++ b/src/layout/RadioButtons/index.tsx
@@ -51,8 +51,8 @@ export class RadioButtons extends RadioButtonsDef {
     return <RadioButtonsSummary {...props} />;
   }
 
-  useEmptyFieldValidation(node: LayoutNode<'RadioButtons'>): ComponentValidation[] {
-    return useEmptyFieldValidationOnlyOneBinding(node, 'simpleBinding');
+  useEmptyFieldValidation(baseComponentId: string): ComponentValidation[] {
+    return useEmptyFieldValidationOnlyOneBinding(baseComponentId, 'simpleBinding');
   }
 
   useDataModelBindingValidation(node: LayoutNode<'RadioButtons'>, dmb: IDataModelBindings<'RadioButtons'>): string[] {

--- a/src/layout/RepeatingGroup/Container/RepeatingGroupContainer.tsx
+++ b/src/layout/RepeatingGroup/Container/RepeatingGroupContainer.tsx
@@ -22,15 +22,16 @@ import { useRepeatingGroupsFocusContext } from 'src/layout/RepeatingGroup/Provid
 import { RepeatingGroupTable } from 'src/layout/RepeatingGroup/Table/RepeatingGroupTable';
 import { RepGroupHooks } from 'src/layout/RepeatingGroup/utils';
 import { DataModelLocationProvider } from 'src/utils/layout/DataModelLocation';
+import { useDataModelBindingsFor, useExternalItem } from 'src/utils/layout/hooks';
 import { LayoutNode } from 'src/utils/layout/LayoutNode';
 import { Hidden } from 'src/utils/layout/NodesContext';
 import { useLabel } from 'src/utils/layout/useLabel';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { ButtonPosition } from 'src/layout/common.generated';
 
 export const RepeatingGroupContainer = forwardRef((_, ref: React.ForwardedRef<HTMLDivElement>): JSX.Element | null => {
   const { node } = useRepeatingGroup();
-  const mode = useNodeItem(node, (i) => i.edit?.mode);
+  const mode = useExternalItem(node.baseId, 'RepeatingGroup').edit?.mode;
 
   const editingId = useRepeatingGroupSelector((state) => state.editingId);
   const isHidden = Hidden.useIsHidden(node);
@@ -76,8 +77,8 @@ function ModeOnlyEdit({ editingId }: { editingId: string }) {
   const { node } = useRepeatingGroup();
   const isNested = node.parent instanceof LayoutNode;
 
-  const groupBinding = useNodeItem(node, (i) => i.dataModelBindings.group);
-  const grid = useNodeItem(node, (i) => i.grid);
+  const groupBinding = useDataModelBindingsFor(node.baseId, 'RepeatingGroup').group;
+  const grid = useExternalItem(node.baseId, 'RepeatingGroup').grid;
   const rowIndex = RepGroupHooks.useAllBaseRows(node).find((r) => r.uuid === editingId)?.index;
   const { labelText, getDescriptionComponent, getHelpTextComponent } = useLabel({ node, overrideDisplay: undefined });
 
@@ -117,8 +118,8 @@ function ModeShowAll() {
   const numRows = rowsToDisplay.length;
   const lastIndex = rowsToDisplay[numRows - 1];
 
-  const groupBinding = useNodeItem(node, (i) => i.dataModelBindings.group);
-  const grid = useNodeItem(node, (i) => i.grid);
+  const groupBinding = useDataModelBindingsFor(node.baseId, 'RepeatingGroup').group;
+  const grid = useExternalItem(node.baseId, 'RepeatingGroup').grid;
   const { labelText, getDescriptionComponent, getHelpTextComponent } = useLabel({ node, overrideDisplay: undefined });
 
   return (
@@ -179,7 +180,7 @@ function AddButton() {
     currentlyAddingRow: state.addingIds.length > 0,
   }));
 
-  const item = useNodeItem(node);
+  const item = useItemWhenType(node.baseId, 'RepeatingGroup');
   const { textResourceBindings, id, edit, addButton } = item;
   const { add_button, add_button_full } = textResourceBindings || {};
 

--- a/src/layout/RepeatingGroup/EditContainer/RepeatingGroupEditContext.tsx
+++ b/src/layout/RepeatingGroup/EditContainer/RepeatingGroupEditContext.tsx
@@ -5,9 +5,9 @@ import { createContext } from 'src/core/contexts/context';
 import { useRegisterNodeNavigationHandler } from 'src/features/form/layout/NavigateToNode';
 import { useRepeatingGroup } from 'src/layout/RepeatingGroup/Providers/RepeatingGroupContext';
 import { RepGroupHooks } from 'src/layout/RepeatingGroup/utils';
+import { useExternalItem } from 'src/utils/layout/hooks';
 import { LayoutNode } from 'src/utils/layout/LayoutNode';
 import { LayoutPage } from 'src/utils/layout/LayoutPage';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
 
 interface RepeatingGroupEditRowContext {
   multiPageEnabled: boolean;
@@ -26,9 +26,8 @@ const { Provider, useCtx } = createContext<RepeatingGroupEditRowContext>({
 function useRepeatingGroupEditRowState(
   node: LayoutNode<'RepeatingGroup'>,
 ): RepeatingGroupEditRowContext & { setMultiPageIndex: (index: number) => void } {
-  const edit = useNodeItem(node, (i) => i.edit);
   const lastPage = RepGroupHooks.useLastMultiPageIndex(node) ?? 0;
-  const multiPageEnabled = edit?.multiPage ?? false;
+  const multiPageEnabled = useExternalItem(node.baseId, 'RepeatingGroup').edit?.multiPage ?? false;
   const [multiPageIndex, setMultiPageIndex] = useState(0);
 
   const nextMultiPage = useCallback(() => {

--- a/src/layout/RepeatingGroup/EditContainer/RepeatingGroupsEditContainer.tsx
+++ b/src/layout/RepeatingGroup/EditContainer/RepeatingGroupsEditContainer.tsx
@@ -21,7 +21,7 @@ import classes from 'src/layout/RepeatingGroup/RepeatingGroup.module.css';
 import { RepGroupHooks } from 'src/layout/RepeatingGroup/utils';
 import { LayoutNode } from 'src/utils/layout/LayoutNode';
 import { useNode } from 'src/utils/layout/NodesContext';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { CompInternal } from 'src/layout/layout';
 import type { RepGroupRow } from 'src/layout/RepeatingGroup/utils';
 
@@ -33,7 +33,6 @@ export interface IRepeatingGroupsEditContainer {
 
 export function RepeatingGroupsEditContainer({ editId, ...props }: IRepeatingGroupsEditContainer): JSX.Element | null {
   const { node } = useRepeatingGroup();
-  const group = useNodeItem(node);
   const rows = RepGroupHooks.useVisibleRows(node);
   const row = rows.find((r) => r && r.uuid === editId);
   if (!row) {
@@ -44,7 +43,6 @@ export function RepeatingGroupsEditContainer({ editId, ...props }: IRepeatingGro
     <RepeatingGroupEditRowProvider>
       <RepeatingGroupsEditContainerInternal
         editId={editId}
-        group={group}
         row={row}
         {...props}
       />
@@ -56,10 +54,8 @@ function RepeatingGroupsEditContainerInternal({
   className,
   editId,
   forceHideSaveButton,
-  group,
   row,
 }: IRepeatingGroupsEditContainer & {
-  group: CompInternal<'RepeatingGroup'>;
   row: RepGroupRow;
 }): JSX.Element | null {
   const { node, closeForEditing, deleteRow, openNextForEditing, isDeleting } = useRepeatingGroup();
@@ -81,10 +77,10 @@ function RepeatingGroupsEditContainerInternal({
   const rowWithExpressions = RepGroupHooks.useRowWithExpressions(node, { uuid: row.uuid });
   const textsForRow = rowWithExpressions?.textResourceBindings;
   const editForRow = rowWithExpressions?.edit;
-  const editForGroup = group.edit;
+  const { textResourceBindings, edit: editForGroup, tableColumns } = useItemWhenType(node.baseId, 'RepeatingGroup');
   const { refSetter } = useRepeatingGroupsFocusContext();
   const texts = {
-    ...group.textResourceBindings,
+    ...textResourceBindings,
     ...textsForRow,
   };
 
@@ -160,7 +156,7 @@ function RepeatingGroupsEditContainerInternal({
               nodeId={nodeId}
               multiPageIndex={multiPageIndex}
               multiPageEnabled={multiPageEnabled}
-              tableColumns={group.tableColumns}
+              tableColumns={tableColumns}
             />
           ))}
         </Flex>

--- a/src/layout/RepeatingGroup/Pagination/RepeatingGroupPagination.tsx
+++ b/src/layout/RepeatingGroup/Pagination/RepeatingGroupPagination.tsx
@@ -14,7 +14,7 @@ import {
 } from 'src/layout/RepeatingGroup/Providers/RepeatingGroupContext';
 import { RepGroupHooks } from 'src/layout/RepeatingGroup/utils';
 import { NodesInternal } from 'src/utils/layout/NodesContext';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import { splitDashedKey } from 'src/utils/splitDashedKey';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 interface RepeatingGroupPaginationProps {
@@ -39,7 +39,7 @@ function RGPagination({ inTable = true }: RepeatingGroupPaginationProps) {
   const isTablet = useIsMobileOrTablet();
   const isMobile = useIsMobile();
   const isMini = useIsMini();
-  const textResourceBindings = useNodeItem(node, (i) => i.textResourceBindings || {});
+  const textResourceBindings = useItemWhenType(node.baseId, 'RepeatingGroup').textResourceBindings || {};
   const getScrollPosition = useCallback(
     () => document.querySelector(`[data-pagination-id="${node.id}"]`)?.getClientRects().item(0)?.y,
     [node],

--- a/src/layout/RepeatingGroup/Providers/OpenByDefaultProvider.tsx
+++ b/src/layout/RepeatingGroup/Providers/OpenByDefaultProvider.tsx
@@ -7,7 +7,7 @@ import {
   useRepeatingGroupRowState,
   useRepeatingGroupSelector,
 } from 'src/layout/RepeatingGroup/Providers/RepeatingGroupContext';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 interface Props {
@@ -16,7 +16,7 @@ interface Props {
 
 export function OpenByDefaultProvider({ node, children }: PropsWithChildren<Props>) {
   const groupId = node.id;
-  const item = useNodeItem(node);
+  const item = useItemWhenType(node.baseId, 'RepeatingGroup');
   const openByDefault = item.edit?.openByDefault;
   const isFirstRender = useRef(true);
   const { addRow, openForEditing } = useRepeatingGroup();

--- a/src/layout/RepeatingGroup/Providers/RepeatingGroupContext.tsx
+++ b/src/layout/RepeatingGroup/Providers/RepeatingGroupContext.tsx
@@ -13,9 +13,8 @@ import { ALTINN_ROW_ID } from 'src/features/formData/types';
 import { useOnGroupCloseValidation } from 'src/features/validation/callbacks/onGroupCloseValidation';
 import { OpenByDefaultProvider } from 'src/layout/RepeatingGroup/Providers/OpenByDefaultProvider';
 import { RepGroupHooks } from 'src/layout/RepeatingGroup/utils';
-import { useDataModelBindingsFor } from 'src/utils/layout/hooks';
+import { useDataModelBindingsFor, useExternalItem } from 'src/utils/layout/hooks';
 import { NodesInternal } from 'src/utils/layout/NodesContext';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
 import type { CompInternal } from 'src/layout/layout';
 import type { IGroupEditProperties } from 'src/layout/RepeatingGroup/config.generated';
 import type { RepGroupRow, RepGroupRowWithButtons } from 'src/layout/RepeatingGroup/utils';
@@ -318,7 +317,7 @@ function newStore({ getRows, editMode, pagination }: NewStoreProps) {
 
 function useExtendedRepeatingGroupState(node: LayoutNode<'RepeatingGroup'>): ExtendedContext {
   const stateRef = ZStore.useSelectorAsRef((state) => state);
-  const validateOnSaveRow = useNodeItem(node, (i) => i.validateOnSaveRow);
+  const { pagination, validateOnSaveRow } = useExternalItem(node.baseId, 'RepeatingGroup');
   const groupBinding = useBinding(node);
 
   const autoSaving = usePageSettings().autoSaveBehavior !== 'onChangePage';
@@ -330,7 +329,6 @@ function useExtendedRepeatingGroupState(node: LayoutNode<'RepeatingGroup'>): Ext
   const onGroupCloseValidation = useOnGroupCloseValidation();
   const markNodesNotReady = NodesInternal.useMarkNotReady();
 
-  const pagination = useNodeItem(node, (i) => i.pagination);
   const getRows = RepGroupHooks.useGetFreshRowsWithButtons(node);
   const getState = useCallback(() => produceStateFromRows(getRows() ?? []), [getRows]);
   const getPaginationState = useCallback(
@@ -574,8 +572,9 @@ interface Props {
 }
 
 export function RepeatingGroupProvider({ node, children }: PropsWithChildren<Props>) {
-  const pagination = useNodeItem(node, (i) => i.pagination);
-  const editMode = useNodeItem(node, (i) => i.edit?.mode);
+  const component = useExternalItem(node.baseId, 'RepeatingGroup');
+  const pagination = component.pagination;
+  const editMode = component.edit?.mode;
   const getRows = RepGroupHooks.useGetFreshRowsWithButtons(node);
 
   return (
@@ -609,7 +608,7 @@ export const useRepeatingGroupRowState = () => {
 export const useRepeatingGroupPagination = () => {
   const node = useRepeatingGroupNode();
   const nodeState = useRepeatingGroupRowState();
-  const pagination = useNodeItem(node, (i) => i.pagination);
+  const { pagination } = useExternalItem(node.baseId, 'RepeatingGroup');
   const currentPage = ZStore.useSelector((state) => state.currentPage);
   return producePaginationState(currentPage, pagination, nodeState.visibleRows);
 };

--- a/src/layout/RepeatingGroup/Providers/RepeatingGroupFocusContext.tsx
+++ b/src/layout/RepeatingGroup/Providers/RepeatingGroupFocusContext.tsx
@@ -5,8 +5,8 @@ import { createContext } from 'src/core/contexts/context';
 import { useRegisterNodeNavigationHandler } from 'src/features/form/layout/NavigateToNode';
 import { FD } from 'src/features/formData/FormDataWrite';
 import { useRepeatingGroup } from 'src/layout/RepeatingGroup/Providers/RepeatingGroupContext';
+import { useIntermediateItem } from 'src/utils/layout/hooks';
 import { LayoutNode } from 'src/utils/layout/LayoutNode';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
 import type { LayoutPage } from 'src/utils/layout/LayoutPage';
 
 type FocusableHTMLElement =
@@ -40,10 +40,7 @@ export function RepeatingGroupsFocusProvider({ children }: PropsWithChildren) {
   const waitingForFocus = useRef<number | null>(null);
 
   const { node, openForEditing, changePageToRow } = useRepeatingGroup();
-  const groupBinding = useNodeItem(node, (i) => i.dataModelBindings.group);
-  const pagination = useNodeItem(node, (i) => i.pagination);
-  const mode = useNodeItem(node, (i) => i.edit?.mode);
-  const tableColumns = useNodeItem(node, (i) => i.tableColumns);
+  const { dataModelBindings, pagination, tableColumns, edit } = useIntermediateItem(node.baseId, 'RepeatingGroup');
   const rowsSelector = FD.useDebouncedRowsSelector();
 
   useRegisterNodeNavigationHandler(async (targetNode) => {
@@ -68,7 +65,7 @@ export function RepeatingGroupsFocusProvider({ children }: PropsWithChildren) {
       return false;
     }
 
-    const rows = rowsSelector(groupBinding);
+    const rows = rowsSelector(dataModelBindings.group);
     const row = rows.find((r) => r.index === targetChild?.rowIndex);
 
     // If pagination is used, navigate to the correct page
@@ -80,7 +77,7 @@ export function RepeatingGroupsFocusProvider({ children }: PropsWithChildren) {
       }
     }
 
-    if (mode === 'showAll' || mode === 'onlyTable') {
+    if (edit?.mode === 'showAll' || edit?.mode === 'onlyTable') {
       // We're already showing all nodes, so nothing further to do
       return true;
     }

--- a/src/layout/RepeatingGroup/Summary/LargeGroupSummaryContainer.tsx
+++ b/src/layout/RepeatingGroup/Summary/LargeGroupSummaryContainer.tsx
@@ -9,7 +9,7 @@ import classes from 'src/layout/RepeatingGroup/Summary/LargeGroupSummaryContaine
 import { pageBreakStyles } from 'src/utils/formComponentUtils';
 import { LayoutNode } from 'src/utils/layout/LayoutNode';
 import { Hidden, NodesInternal } from 'src/utils/layout/NodesContext';
-import { useNodeDirectChildren, useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType, useNodeDirectChildren } from 'src/utils/layout/useNodeItem';
 import type { HeadingLevel } from 'src/layout/common.generated';
 
 export interface IDisplayRepAsLargeGroup {
@@ -28,7 +28,7 @@ const headingSizes: { [k in HeadingLevel]: Parameters<typeof Heading>[0]['data-s
 };
 
 export function LargeGroupSummaryContainer({ groupNode, id, restriction, renderLayoutNode }: IDisplayRepAsLargeGroup) {
-  const item = useNodeItem(groupNode);
+  const item = useItemWhenType(groupNode.baseId, 'RepeatingGroup');
   const isHidden = Hidden.useIsHidden(groupNode);
   const depth = NodesInternal.useSelector((state) => state.nodeData?.[groupNode.id]?.depth);
   const children = useNodeDirectChildren(groupNode, restriction);

--- a/src/layout/RepeatingGroup/Summary/SummaryRepeatingGroup.tsx
+++ b/src/layout/RepeatingGroup/Summary/SummaryRepeatingGroup.tsx
@@ -128,7 +128,7 @@ function RegularRepeatingGroup(props: FullProps) {
 function RegularRepeatingGroupRow({ targetNode, inExcludedChildren, row, onChangeClick, changeText }: FullRowProps) {
   const isHidden = Hidden.useIsHiddenSelector();
   const children = useNodeDirectChildren(targetNode, row.index);
-  const dataModelBindings = useDataModelBindingsFor(targetNode.baseId);
+  const dataModelBindings = useDataModelBindingsFor(targetNode.baseId, 'RepeatingGroup');
 
   const childSummaryComponents = children
     .filter((n) => !inExcludedChildren(n))

--- a/src/layout/RepeatingGroup/Summary/SummaryRepeatingGroup.tsx
+++ b/src/layout/RepeatingGroup/Summary/SummaryRepeatingGroup.tsx
@@ -12,8 +12,9 @@ import { RepGroupHooks } from 'src/layout/RepeatingGroup/utils';
 import { EditButton } from 'src/layout/Summary/EditButton';
 import { SummaryComponentFor } from 'src/layout/Summary/SummaryComponent';
 import { DataModelLocationProvider } from 'src/utils/layout/DataModelLocation';
+import { useDataModelBindingsFor } from 'src/utils/layout/hooks';
 import { Hidden } from 'src/utils/layout/NodesContext';
-import { useNodeDirectChildren, useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType, useNodeDirectChildren } from 'src/utils/layout/useNodeItem';
 import { typedBoolean } from 'src/utils/typing';
 import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
@@ -57,7 +58,7 @@ export function SummaryRepeatingGroup(props: SummaryRendererProps<'RepeatingGrou
 function RegularRepeatingGroup(props: FullProps) {
   const { onChangeClick, changeText, targetNode, overrides, rows: _rows } = props;
   const rows = _rows.filter(typedBoolean);
-  const { textResourceBindings: trb } = useNodeItem(targetNode);
+  const { textResourceBindings: trb } = useItemWhenType(targetNode.baseId, 'RepeatingGroup');
   const display = overrides?.display;
   const { langAsString } = useLanguage();
 
@@ -127,7 +128,7 @@ function RegularRepeatingGroup(props: FullProps) {
 function RegularRepeatingGroupRow({ targetNode, inExcludedChildren, row, onChangeClick, changeText }: FullRowProps) {
   const isHidden = Hidden.useIsHiddenSelector();
   const children = useNodeDirectChildren(targetNode, row.index);
-  const dataModelBindings = useNodeItem(targetNode, (i) => i.dataModelBindings);
+  const dataModelBindings = useDataModelBindingsFor(targetNode.baseId);
 
   const childSummaryComponents = children
     .filter((n) => !inExcludedChildren(n))
@@ -164,7 +165,7 @@ function RegularRepeatingGroupRow({ targetNode, inExcludedChildren, row, onChang
 
 function LargeRepeatingGroup({ targetNode, overrides, inExcludedChildren, rows }: FullProps) {
   const isHidden = Hidden.useIsHiddenSelector();
-  const groupBinding = useNodeItem(targetNode, (i) => i.dataModelBindings.group);
+  const groupBinding = useDataModelBindingsFor(targetNode.baseId, 'RepeatingGroup').group;
 
   return (
     <>

--- a/src/layout/RepeatingGroup/Summary2/RepeatingGroupSummary.tsx
+++ b/src/layout/RepeatingGroup/Summary2/RepeatingGroupSummary.tsx
@@ -21,7 +21,7 @@ import {
 import { useSummaryOverrides, useSummaryProp } from 'src/layout/Summary2/summaryStoreContext';
 import { DataModelLocationProvider } from 'src/utils/layout/DataModelLocation';
 import { LayoutNode } from 'src/utils/layout/LayoutNode';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types';
 
 export const RepeatingGroupSummary = ({ target }: Summary2Props<'RepeatingGroup'>) => {
@@ -33,12 +33,12 @@ export const RepeatingGroupSummary = ({ target }: Summary2Props<'RepeatingGroup'
   const rows = RepGroupHooks.useVisibleRows(target);
   const validations = useUnifiedValidationsForNode(componentNode);
   const errors = validationsOfSeverity(validations, 'error');
-  const title = useNodeItem(componentNode, (i) => i.textResourceBindings?.title);
-  const dataModelBindings = useNodeItem(componentNode, (i) => i.dataModelBindings);
+  const { textResourceBindings, dataModelBindings, minCount } = useItemWhenType(componentNode.baseId, 'RepeatingGroup');
+  const title = textResourceBindings?.title;
   const isNested = componentNode.parent instanceof LayoutNode;
   const hideEmptyFields = useSummaryProp('hideEmptyFields');
 
-  const required = useNodeItem(componentNode, (i) => i.minCount !== undefined && i.minCount > 0);
+  const required = minCount !== undefined && minCount > 0;
   const { className } = useSummarySoftHidden(hideEmptyFields && rows.length === 0 && !required);
 
   if (rows.length === 0) {

--- a/src/layout/RepeatingGroup/Summary2/RepeatingGroupTableSummary/RepeatingGroupTableSummary.tsx
+++ b/src/layout/RepeatingGroup/Summary2/RepeatingGroupTableSummary/RepeatingGroupTableSummary.tsx
@@ -26,8 +26,9 @@ import { ComponentSummaryById, SummaryContains } from 'src/layout/Summary2/Summa
 import utilClasses from 'src/styles/utils.module.css';
 import { useColumnStylesRepeatingGroups } from 'src/utils/formComponentUtils';
 import { DataModelLocationProvider } from 'src/utils/layout/DataModelLocation';
+import { useDataModelBindingsFor } from 'src/utils/layout/hooks';
 import { useNode } from 'src/utils/layout/NodesContext';
-import { useNodeDirectChildren, useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemFor, useItemWhenType, useNodeDirectChildren } from 'src/utils/layout/useNodeItem';
 import type { ITableColumnFormatting } from 'src/layout/common.generated';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 import type { BaseRow } from 'src/utils/layout/types';
@@ -39,10 +40,12 @@ export const RepeatingGroupTableSummary = ({ componentNode }: { componentNode: L
   const rows = RepGroupHooks.useVisibleRows(componentNode);
   const validations = useUnifiedValidationsForNode(componentNode);
   const errors = validationsOfSeverity(validations, 'error');
-  const title = useNodeItem(componentNode, (i) => i.textResourceBindings?.title);
-  const dataModelBindings = useNodeItem(componentNode, (i) => i.dataModelBindings);
+  const { textResourceBindings, dataModelBindings, tableColumns } = useItemWhenType(
+    componentNode.baseId,
+    'RepeatingGroup',
+  );
+  const title = textResourceBindings?.title;
   const tableIds = useTableComponentIds(componentNode);
-  const { tableColumns } = useNodeItem(componentNode);
   const columnSettings = tableColumns ? structuredClone(tableColumns) : ({} as ITableColumnFormatting);
 
   return (
@@ -139,7 +142,7 @@ function DataRow({ row, node, pdfModeActive, columnSettings }: DataRowProps) {
   const rawIds = useTableComponentIds(node);
   const indexedIds = useIndexedComponentIds(rawIds);
   const otherChildren = useNodeDirectChildren(node, row?.index)?.map((n) => n.id);
-  const dataModelBindings = useNodeItem(node, (i) => i.dataModelBindings);
+  const dataModelBindings = useDataModelBindingsFor(node.baseId, 'RepeatingGroup');
 
   if (!row) {
     return null;
@@ -201,7 +204,8 @@ function NodeDataCell({ node, columnSettings }: { node: LayoutNode } & Pick<Data
   const headerTitle = langAsString(useTableTitle(node.baseId));
   const style = useColumnStylesRepeatingGroups(node.baseId, columnSettings);
   const displayData = useDisplayData(node);
-  const required = useNodeItem(node, (i) => ('required' in i ? i.required : false));
+  const item = useItemFor(node.baseId);
+  const required = 'required' in item ? item.required : false;
 
   useReportSummaryRender(
     displayData.trim() === ''

--- a/src/layout/RepeatingGroup/Table/RepeatingGroupTable.tsx
+++ b/src/layout/RepeatingGroup/Table/RepeatingGroupTable.tsx
@@ -24,8 +24,9 @@ import { RepGroupHooks } from 'src/layout/RepeatingGroup/utils';
 import utilClasses from 'src/styles/utils.module.css';
 import { useColumnStylesRepeatingGroups } from 'src/utils/formComponentUtils';
 import { DataModelLocationProvider } from 'src/utils/layout/DataModelLocation';
+import { useExternalItem } from 'src/utils/layout/hooks';
 import { LayoutNode } from 'src/utils/layout/LayoutNode';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { GridCell, ITableColumnFormatting } from 'src/layout/common.generated';
 
 export function RepeatingGroupTable(): React.JSX.Element | null {
@@ -34,7 +35,7 @@ export function RepeatingGroupTable(): React.JSX.Element | null {
   const { rowsToDisplay } = useRepeatingGroupPagination();
   const rows = RepGroupHooks.useAllRowsWithButtons(node);
   const { textResourceBindings, labelSettings, id, edit, minCount, stickyHeader, tableColumns, dataModelBindings } =
-    useNodeItem(node);
+    useItemWhenType(node.baseId, 'RepeatingGroup');
   const required = !!minCount && minCount > 0;
 
   const columnSettings = tableColumns ? structuredClone(tableColumns) : ({} as ITableColumnFormatting);
@@ -200,10 +201,10 @@ function ExtraRows({ where, extraCells, columnSettings }: ExtraRowsProps) {
   const { node } = useRepeatingGroup();
   const { visibleRows } = useRepeatingGroupRowState();
   const isEmpty = visibleRows.length === 0;
-  const item = useNodeItem(node);
+  const { rowsBefore, rowsAfter } = useExternalItem(node.baseId, 'RepeatingGroup');
   const isNested = node.parent instanceof LayoutNode;
 
-  const rows = where === 'Before' ? item.rowsBefore : item.rowsAfter;
+  const rows = where === 'Before' ? rowsBefore : rowsAfter;
   const mobileNodeIds = useNodeIdsFromGridRows(rows, mobileView);
   if (isEmpty || !rows) {
     return null;

--- a/src/layout/RepeatingGroup/Table/RepeatingGroupTableRow.tsx
+++ b/src/layout/RepeatingGroup/Table/RepeatingGroupTableRow.tsx
@@ -11,13 +11,12 @@ import { DeleteWarningPopover } from 'src/features/alertOnChange/DeleteWarningPo
 import { useAlertOnChange } from 'src/features/alertOnChange/useAlertOnChange';
 import { useDisplayDataFor } from 'src/features/displayData/useDisplayData';
 import { useLayoutLookups } from 'src/features/form/layout/LayoutsContext';
-import { useIndexedComponentIds } from 'src/features/form/layout/utils/makeIndexedId';
 import { Lang } from 'src/features/language/Lang';
 import { useLanguage } from 'src/features/language/useLanguage';
 import { useDeepValidationsForNode } from 'src/features/validation/selectors/deepValidationsForNode';
 import { useIsMobile } from 'src/hooks/useDeviceWidths';
 import { getComponentDef } from 'src/layout';
-import { GenericComponentById } from 'src/layout/GenericComponent';
+import { GenericComponentByBaseId } from 'src/layout/GenericComponent';
 import { useRepeatingGroup } from 'src/layout/RepeatingGroup/Providers/RepeatingGroupContext';
 import { useRepeatingGroupsFocusContext } from 'src/layout/RepeatingGroup/Providers/RepeatingGroupFocusContext';
 import classes from 'src/layout/RepeatingGroup/RepeatingGroup.module.css';
@@ -100,10 +99,8 @@ export const RepeatingGroupTableRow = React.memo(function ({
   const layoutLookups = useLayoutLookups();
   const rawTableIds = useTableComponentIds(node);
   const displayData = useDisplayDataFor(rawTableIds);
-  const tableIds = useIndexedComponentIds(rawTableIds);
-  const tableItems = rawTableIds.map((baseId, index) => ({
+  const tableItems = rawTableIds.map((baseId) => ({
     baseId,
-    id: tableIds[index],
     type: layoutLookups.getComponent(baseId).type,
   }));
   const firstCellData = Object.values(displayData).find((c) => !!c);
@@ -112,12 +109,12 @@ export const RepeatingGroupTableRow = React.memo(function ({
 
   // If the row has errors we should highlight the row, unless the errors are for components that are shown in the table,
   // then the component getting highlighted is enough
-  const tableEditingNodeIds = tableItems
+  const tableEditingIds = tableItems
     .filter((i) => shouldEditInTable(editForGroup, i.baseId, i.type, columnSettings))
-    .map((i) => i.id);
+    .map((i) => i.baseId);
   const rowValidations = useDeepValidationsForNode(node, false, index);
   const rowHasErrors = rowValidations.some(
-    (validation) => validation.severity === 'error' && !tableEditingNodeIds.includes(validation.nodeId),
+    (validation) => validation.severity === 'error' && !tableEditingIds.includes(validation.baseComponentId),
   );
 
   const editButtonText = rowHasErrors
@@ -141,12 +138,12 @@ export const RepeatingGroupTableRow = React.memo(function ({
         tableItems.map((item) =>
           shouldEditInTable(editForGroup, item.baseId, item.type, columnSettings) ? (
             <Table.Cell
-              key={item.id}
+              key={item.baseId}
               className={classes.tableCell}
             >
-              <div ref={(ref) => refSetter && refSetter(index, `component-${item.id}`, ref)}>
-                <GenericComponentById
-                  id={item.id}
+              <div ref={(ref) => refSetter && refSetter(index, `component-${item.baseId}`, ref)}>
+                <GenericComponentByBaseId
+                  id={item.baseId}
                   overrideDisplay={{
                     renderedInTable: true,
                     renderLabel: false,
@@ -181,11 +178,11 @@ export const RepeatingGroupTableRow = React.memo(function ({
                   <Flex
                     container
                     item
-                    key={item.id}
-                    ref={(ref) => refSetter && refSetter(index, `component-${item.id}`, ref)}
+                    key={item.baseId}
+                    ref={(ref) => refSetter && refSetter(index, `component-${item.baseId}`, ref)}
                   >
-                    <GenericComponentById
-                      id={item.id}
+                    <GenericComponentByBaseId
+                      id={item.baseId}
                       overrideItemProps={{
                         grid: {},
                       }}
@@ -195,12 +192,12 @@ export const RepeatingGroupTableRow = React.memo(function ({
                   <Flex
                     container
                     item
-                    key={item.id}
+                    key={item.baseId}
                   >
                     <b className={cn(classes.contentFormatting, classes.spaceAfterContent)}>
                       <TableTitle
-                        nodeId={item.id}
-                        nodeType={item.type}
+                        baseComponentId={item.baseId}
+                        compType={item.type}
                       />
                       :
                     </b>
@@ -440,7 +437,7 @@ function NonEditableCell({
   );
 }
 
-function TableTitle({ nodeId, nodeType }: { nodeId: string; nodeType: CompTypes }) {
-  const item = useNodeItemWhenType(nodeId, nodeType);
+function TableTitle({ baseComponentId, compType }: { baseComponentId: string; compType: CompTypes }) {
+  const item = useNodeItemWhenType(baseComponentId, compType);
   return <Lang id={getTableTitle(item?.textResourceBindings ?? {})} />;
 }

--- a/src/layout/RepeatingGroup/Table/RepeatingGroupTableRow.tsx
+++ b/src/layout/RepeatingGroup/Table/RepeatingGroupTableRow.tsx
@@ -23,7 +23,7 @@ import classes from 'src/layout/RepeatingGroup/RepeatingGroup.module.css';
 import { useTableComponentIds } from 'src/layout/RepeatingGroup/useTableComponentIds';
 import { RepGroupHooks } from 'src/layout/RepeatingGroup/utils';
 import { useColumnStylesRepeatingGroups } from 'src/utils/formComponentUtils';
-import { useNodeItem, useNodeItemWhenType } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { AlertOnChange } from 'src/features/alertOnChange/useAlertOnChange';
 import type { IUseLanguage } from 'src/features/language/useLanguage';
 import type { ITableColumnFormatting } from 'src/layout/common.generated';
@@ -87,12 +87,10 @@ export const RepeatingGroupTableRow = React.memo(function ({
   const langTools = useLanguage();
   const { langAsString } = langTools;
   const id = node.id;
-  const group = useNodeItem(node);
+  const { edit: editForGroup, tableColumns: columnSettings } = useItemWhenType(node.baseId, 'RepeatingGroup');
   const rowExpressions = RepGroupHooks.useRowWithExpressions(node, { uuid });
   const editForRow = rowExpressions?.edit;
-  const editForGroup = group.edit;
   const trbForRow = rowExpressions?.textResourceBindings;
-  const columnSettings = group.tableColumns;
 
   const alertOnDelete = useAlertOnChange(Boolean(editForRow?.alertOnDelete), deleteRow);
 
@@ -438,6 +436,6 @@ function NonEditableCell({
 }
 
 function TableTitle({ baseComponentId, compType }: { baseComponentId: string; compType: CompTypes }) {
-  const item = useNodeItemWhenType(baseComponentId, compType);
+  const item = useItemWhenType(baseComponentId, compType);
   return <Lang id={getTableTitle(item?.textResourceBindings ?? {})} />;
 }

--- a/src/layout/RepeatingGroup/utils.ts
+++ b/src/layout/RepeatingGroup/utils.ts
@@ -67,8 +67,8 @@ export const RepGroupHooks = {
   },
 
   useAllRowsWithHidden(node: LayoutNode<'RepeatingGroup'>): RepGroupRow[] {
-    const component = useExternalItem(node?.baseId, 'RepeatingGroup');
-    const groupBinding = useDataModelBindingsFor(node?.baseId, 'RepeatingGroup')?.group;
+    const component = useExternalItem(node.baseId, 'RepeatingGroup');
+    const groupBinding = useDataModelBindingsFor(node.baseId, 'RepeatingGroup')?.group;
     const dataSources = useExpressionDataSources(component?.hiddenRow);
     const rows = RepGroupHooks.useAllBaseRows(node);
 
@@ -85,8 +85,8 @@ export const RepGroupHooks = {
   },
 
   useAllRowsWithButtons(node: LayoutNode<'RepeatingGroup'>): RepGroupRowWithButtons[] {
-    const component = useExternalItem(node?.baseId, 'RepeatingGroup');
-    const groupBinding = useDataModelBindingsFor(node?.baseId, 'RepeatingGroup')?.group;
+    const component = useExternalItem(node.baseId, 'RepeatingGroup');
+    const groupBinding = useDataModelBindingsFor(node.baseId, 'RepeatingGroup')?.group;
     const hiddenRow = component?.hiddenRow;
     const editButton = component?.edit?.editButton;
     const deleteButton = component?.edit?.deleteButton;
@@ -111,8 +111,8 @@ export const RepGroupHooks = {
   },
 
   useGetFreshRowsWithButtons(node: LayoutNode<'RepeatingGroup'>): () => RepGroupRowWithButtons[] {
-    const component = useExternalItem(node?.baseId, 'RepeatingGroup');
-    const groupBinding = useDataModelBindingsFor(node?.baseId, 'RepeatingGroup')?.group;
+    const component = useExternalItem(node.baseId, 'RepeatingGroup');
+    const groupBinding = useDataModelBindingsFor(node.baseId, 'RepeatingGroup')?.group;
     const hiddenRow = component?.hiddenRow;
     const editButton = component?.edit?.editButton;
     const deleteButton = component?.edit?.deleteButton;
@@ -137,8 +137,8 @@ export const RepGroupHooks = {
     node: LayoutNode<'RepeatingGroup'>,
     _row: 'first' | { uuid: string } | { index: number },
   ): RepGroupRowWithExpressions | undefined {
-    const component = useExternalItem(node?.baseId, 'RepeatingGroup');
-    const groupBinding = useDataModelBindingsFor(node?.baseId, 'RepeatingGroup')?.group;
+    const component = useExternalItem(node.baseId, 'RepeatingGroup');
+    const groupBinding = useDataModelBindingsFor(node.baseId, 'RepeatingGroup')?.group;
     const hiddenRow = component?.hiddenRow;
     const edit = component?.edit;
     const trb = component?.textResourceBindings;
@@ -195,8 +195,8 @@ export const RepGroupHooks = {
     return lastMultiPageIndex;
   },
 
-  useChildIds(node: LayoutNode<'RepeatingGroup'> | undefined) {
-    const component = useLayoutLookups().getComponent(node?.baseId, 'RepeatingGroup');
+  useChildIds(node: LayoutNode<'RepeatingGroup'>) {
+    const component = useLayoutLookups().getComponent(node.baseId, 'RepeatingGroup');
     const idMutator = useComponentIdMutator();
     if (!component?.edit?.multiPage) {
       return component?.children.map(idMutator) ?? [];

--- a/src/layout/RepeatingGroup/utils.ts
+++ b/src/layout/RepeatingGroup/utils.ts
@@ -61,12 +61,12 @@ function evalBool({ expr, defaultValue = false, dataSources, groupBinding, rowIn
 }
 
 export const RepGroupHooks = {
-  useAllBaseRows(node: LayoutNode<'RepeatingGroup'> | undefined) {
-    const groupBinding = useDataModelBindingsFor(node?.baseId, 'RepeatingGroup')?.group;
+  useAllBaseRows(node: LayoutNode<'RepeatingGroup'>) {
+    const groupBinding = useDataModelBindingsFor(node.baseId, 'RepeatingGroup')?.group;
     return FD.useFreshRows(groupBinding);
   },
 
-  useAllRowsWithHidden(node: LayoutNode<'RepeatingGroup'> | undefined): RepGroupRow[] {
+  useAllRowsWithHidden(node: LayoutNode<'RepeatingGroup'>): RepGroupRow[] {
     const component = useExternalItem(node?.baseId, 'RepeatingGroup');
     const groupBinding = useDataModelBindingsFor(node?.baseId, 'RepeatingGroup')?.group;
     const dataSources = useExpressionDataSources(component?.hiddenRow);
@@ -134,7 +134,7 @@ export const RepGroupHooks = {
   },
 
   useRowWithExpressions(
-    node: LayoutNode<'RepeatingGroup'> | undefined,
+    node: LayoutNode<'RepeatingGroup'>,
     _row: 'first' | { uuid: string } | { index: number },
   ): RepGroupRowWithExpressions | undefined {
     const component = useExternalItem(node?.baseId, 'RepeatingGroup');

--- a/src/layout/SigneeList/SigneeListComponent.test.tsx
+++ b/src/layout/SigneeList/SigneeListComponent.test.tsx
@@ -13,7 +13,7 @@ import { type fetchSigneeList, NotificationStatus, useSigneeList } from 'src/lay
 import { SigneeListComponent } from 'src/layout/SigneeList/SigneeListComponent';
 import { SigneeListError } from 'src/layout/SigneeList/SigneeListError';
 import { ProcessTaskType } from 'src/types';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 jest.mock('src/utils/layout/useNodeItem');
@@ -82,13 +82,13 @@ describe('SigneeListComponent', () => {
       partyId: 'partyId',
       instanceGuid: randomUUID(),
     });
-    jest.mocked(useNodeItem).mockReturnValue({
+    jest.mocked(useItemWhenType).mockReturnValue({
       textResourceBindings: {
         title: 'Signee List',
         description: 'description',
         help: 'help',
       },
-    } as ReturnType<typeof useNodeItem>);
+    } as ReturnType<typeof useItemWhenType>);
   });
 
   it('should render correctly', () => {

--- a/src/layout/SigneeList/SigneeListComponent.tsx
+++ b/src/layout/SigneeList/SigneeListComponent.tsx
@@ -9,14 +9,14 @@ import { useSigneeList } from 'src/layout/SigneeList/api';
 import classes from 'src/layout/SigneeList/SigneeListComponent.module.css';
 import { SigneeListError } from 'src/layout/SigneeList/SigneeListError';
 import { SigneeStateTag } from 'src/layout/SigneeList/SigneeStateTag';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export function SigneeListComponent({ node }: PropsFromGenericComponent<'SigneeList'>) {
   const { instanceOwnerPartyId, instanceGuid, taskId } = useParams();
   const { langAsString } = useLanguage();
 
-  const { textResourceBindings } = useNodeItem(node);
+  const { textResourceBindings } = useItemWhenType(node.baseId, 'SigneeList');
 
   const { data, isLoading, error } = useSigneeList(instanceOwnerPartyId, instanceGuid, taskId);
 

--- a/src/layout/SigneeList/SigneeListSummary.test.tsx
+++ b/src/layout/SigneeList/SigneeListSummary.test.tsx
@@ -12,7 +12,7 @@ import { SigneeListSummary } from 'src/layout/SigneeList/SigneeListSummary';
 import { LayoutNode } from 'src/utils/layout/LayoutNode';
 import { LayoutPage } from 'src/utils/layout/LayoutPage';
 import { Hidden } from 'src/utils/layout/NodesContext';
-import { useItemWhenType } from 'src/utils/layout/useNodeItem';
+import { useItemFor, useItemWhenType } from 'src/utils/layout/useNodeItem';
 
 jest.mock('src/layout/SigneeList/api');
 jest.mock('react-router-dom');
@@ -23,6 +23,7 @@ jest.mock('src/features/language/Lang');
 describe('SigneeListSummary', () => {
   const mockedUseSigneeList = jest.mocked(useSigneeList);
   const mockedUseItemWhenType = jest.mocked(useItemWhenType);
+  const mockedUseItemFor = jest.mocked(useItemFor);
   const mockedUseIsHidden = jest.mocked(Hidden.useIsHidden);
   const mockedNode = new LayoutNode({
     type: 'SigneeList',
@@ -45,6 +46,15 @@ describe('SigneeListSummary', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (baseComponentId, type): any => {
         if (baseComponentId !== mockedNode.baseId || type !== mockedNode.type) {
+          throw new Error('Component id in useItemWhenType() is not the mocked one');
+        }
+        return { ...mockedItem, ...extras };
+      },
+    );
+    mockedUseItemFor.mockImplementation(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (baseComponentId): any => {
+        if (baseComponentId !== mockedNode.baseId) {
           throw new Error('Component id in useItemWhenType() is not the mocked one');
         }
         return { ...mockedItem, ...extras };

--- a/src/layout/SigneeList/SigneeListSummary.test.tsx
+++ b/src/layout/SigneeList/SigneeListSummary.test.tsx
@@ -12,7 +12,7 @@ import { SigneeListSummary } from 'src/layout/SigneeList/SigneeListSummary';
 import { LayoutNode } from 'src/utils/layout/LayoutNode';
 import { LayoutPage } from 'src/utils/layout/LayoutPage';
 import { Hidden } from 'src/utils/layout/NodesContext';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 
 jest.mock('src/layout/SigneeList/api');
 jest.mock('react-router-dom');
@@ -22,7 +22,7 @@ jest.mock('src/features/language/Lang');
 
 describe('SigneeListSummary', () => {
   const mockedUseSigneeList = jest.mocked(useSigneeList);
-  const mockedUseNodeItem = jest.mocked(useNodeItem);
+  const mockedUseItemWhenType = jest.mocked(useItemWhenType);
   const mockedUseIsHidden = jest.mocked(Hidden.useIsHidden);
   const mockedNode = new LayoutNode({
     type: 'SigneeList',
@@ -41,14 +41,13 @@ describe('SigneeListSummary', () => {
   };
 
   function mockNodeItem(extras: Partial<CompInternal<'SigneeList'>> = {}) {
-    mockedUseNodeItem.mockImplementation(
+    mockedUseItemWhenType.mockImplementation(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (node: LayoutNode, selector: ((item: CompInternal<'SigneeList'>) => unknown) | undefined): any => {
-        if (!node || node !== mockedNode) {
-          throw new Error('node in useNodeItem() is not the mocked one');
+      (baseComponentId, type): any => {
+        if (baseComponentId !== mockedNode.baseId || type !== mockedNode.type) {
+          throw new Error('Component id in useItemWhenType() is not the mocked one');
         }
-        const full = { ...mockedItem, ...extras };
-        return selector ? selector(full) : full;
+        return { ...mockedItem, ...extras };
       },
     );
   }

--- a/src/layout/SigneeList/SigneeListSummary.tsx
+++ b/src/layout/SigneeList/SigneeListSummary.tsx
@@ -12,7 +12,7 @@ import { type SigneeState, useSigneeList } from 'src/layout/SigneeList/api';
 import classes from 'src/layout/SigneeList/SigneeListSummary.module.css';
 import { SummaryContains, SummaryFlex } from 'src/layout/Summary2/SummaryComponent2/ComponentSummary';
 import { toTimeZonedDate } from 'src/utils/dateUtils';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 interface SigneeListSummaryProps {
@@ -24,7 +24,7 @@ export function SigneeListSummary({ componentNode, titleOverride }: SigneeListSu
   const { instanceOwnerPartyId, instanceGuid, taskId } = useParams();
   const { data, isLoading, error } = useSigneeList(instanceOwnerPartyId, instanceGuid, taskId);
 
-  const originalTitle = useNodeItem(componentNode, (i) => i.textResourceBindings?.title);
+  const originalTitle = useItemWhenType(componentNode.baseId, 'SigneeList').textResourceBindings?.title;
   const title = titleOverride === undefined ? originalTitle : titleOverride;
   const heading = title ? <Lang id={title} /> : undefined;
 

--- a/src/layout/SigneeList/index.tsx
+++ b/src/layout/SigneeList/index.tsx
@@ -7,7 +7,7 @@ import { SigneeListComponent } from 'src/layout/SigneeList/SigneeListComponent';
 import { SigneeListSummary } from 'src/layout/SigneeList/SigneeListSummary';
 import { ProcessTaskType } from 'src/types';
 import { NodesInternal } from 'src/utils/layout/NodesContext';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type { NodeValidationProps } from 'src/layout/layout';
 import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types';
@@ -34,7 +34,7 @@ export class SigneeList extends SigneeListDef {
   }
 
   renderSummary2({ target }: Summary2Props<'SigneeList'>): JSX.Element | null {
-    const textResourceBindings = useNodeItem(target, (i) => i.textResourceBindings);
+    const { textResourceBindings } = useItemWhenType(target.baseId, 'SigneeList');
 
     return (
       <SigneeListSummary

--- a/src/layout/SigningActions/PanelAwaitingCurrentUserSignature.tsx
+++ b/src/layout/SigningActions/PanelAwaitingCurrentUserSignature.tsx
@@ -19,7 +19,7 @@ import { OnBehalfOfChooser } from 'src/layout/SigningActions/OnBehalfOfChooser';
 import { SigningPanel } from 'src/layout/SigningActions/PanelSigning';
 import classes from 'src/layout/SigningActions/SigningActions.module.css';
 import { SubmitSigningButton } from 'src/layout/SigningActions/SubmitSigningButton';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 type AwaitingCurrentUserSignaturePanelProps = {
@@ -39,7 +39,7 @@ export function AwaitingCurrentUserSignaturePanel({
   const canWrite = isAuthorized('write');
 
   const currentUserPartyId = useProfile()?.partyId;
-  const textResourceBindings = useNodeItem(node, (i) => i.textResourceBindings);
+  const { textResourceBindings } = useItemWhenType(node.baseId, 'SigningActions');
   const { langAsString } = useLanguage();
 
   const title = textResourceBindings?.awaitingSignaturePanelTitle ?? 'signing.awaiting_signature_panel_title';

--- a/src/layout/SigningActions/PanelAwaitingOtherSignatures.tsx
+++ b/src/layout/SigningActions/PanelAwaitingOtherSignatures.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from 'react';
 import { Button } from 'src/app-components/Button/Button';
 import { Lang } from 'src/features/language/Lang';
 import { SigningPanel } from 'src/layout/SigningActions/PanelSigning';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 type AwaitingOtherSignaturesPanelProps = {
@@ -12,7 +12,7 @@ type AwaitingOtherSignaturesPanelProps = {
 };
 
 export function AwaitingOtherSignaturesPanel({ node, hasSigned }: AwaitingOtherSignaturesPanelProps) {
-  const textResourceBindings = useNodeItem(node, (i) => i.textResourceBindings);
+  const { textResourceBindings } = useItemWhenType(node.baseId, 'SigningActions');
   const [userTriedToSubmit, setUserTriedToSubmit] = useState<boolean>(false);
 
   useEffect(() => {

--- a/src/layout/SigningActions/PanelNoActionRequired.tsx
+++ b/src/layout/SigningActions/PanelNoActionRequired.tsx
@@ -7,7 +7,7 @@ import { Lang } from 'src/features/language/Lang';
 import { useProfile } from 'src/features/profile/ProfileProvider';
 import { SigningPanel } from 'src/layout/SigningActions/PanelSigning';
 import classes from 'src/layout/SigningActions/SigningActions.module.css';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import { getMessageBoxUrl } from 'src/utils/urls/urlHelper';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
@@ -18,7 +18,7 @@ type NoActionRequiredPanelProps = {
 
 export function NoActionRequiredPanel({ node, hasSigned }: NoActionRequiredPanelProps) {
   const currentUserPartyId = useProfile()?.partyId;
-  const textResourceBindings = useNodeItem(node, (i) => i.textResourceBindings);
+  const { textResourceBindings } = useItemWhenType(node.baseId, 'SigningActions');
 
   const titleHasSigned =
     textResourceBindings?.noActionRequiredPanelTitleHasSigned ?? 'signing.no_action_required_panel_title_has_signed';

--- a/src/layout/SigningActions/PanelSigning.tsx
+++ b/src/layout/SigningActions/PanelSigning.tsx
@@ -10,7 +10,7 @@ import { useIsAuthorized } from 'src/features/instance/ProcessContext';
 import { useProcessNext } from 'src/features/instance/useProcessNext';
 import { Lang } from 'src/features/language/Lang';
 import classes from 'src/layout/SigningActions/SigningActions.module.css';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { PanelProps } from 'src/app-components/Panel/Panel';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
@@ -70,7 +70,7 @@ function RejectButton({ node }: RejectTextProps) {
   const modalRef = useRef<HTMLDialogElement>(null);
   const rejectButtonRef = useRef<HTMLButtonElement>(null);
   const processNext = useProcessNext();
-  const textResourceBindings = useNodeItem(node, (i) => i.textResourceBindings);
+  const { textResourceBindings } = useItemWhenType(node.baseId, 'SigningActions');
 
   const modalTitle = textResourceBindings?.rejectModalTitle ?? 'signing.reject_modal_title';
   const modalDescription = textResourceBindings?.rejectModalDescription ?? 'signing.reject_modal_description';

--- a/src/layout/SigningActions/PanelSubmit.tsx
+++ b/src/layout/SigningActions/PanelSubmit.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Lang } from 'src/features/language/Lang';
 import { SigningPanel } from 'src/layout/SigningActions/PanelSigning';
 import { SubmitSigningButton } from 'src/layout/SigningActions/SubmitSigningButton';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 type SubmitPanelProps = {
@@ -11,7 +11,7 @@ type SubmitPanelProps = {
 };
 
 export function SubmitPanel({ node }: SubmitPanelProps) {
-  const { textResourceBindings } = useNodeItem(node, (i) => ({ textResourceBindings: i.textResourceBindings }));
+  const { textResourceBindings } = useItemWhenType(node.baseId, 'SigningActions');
 
   const titleReadyForSubmit = textResourceBindings?.submitPanelTitle ?? 'signing.submit_panel_title';
   const descriptionReadyForSubmit = textResourceBindings?.submitPanelDescription ?? 'signing.submit_panel_description';

--- a/src/layout/SigningActions/SubmitSigningButton.tsx
+++ b/src/layout/SigningActions/SubmitSigningButton.tsx
@@ -6,15 +6,13 @@ import { Button } from 'src/app-components/Button/Button';
 import { useProcessNext } from 'src/features/instance/useProcessNext';
 import { Lang } from 'src/features/language/Lang';
 import { signingQueries } from 'src/layout/SigneeList/api';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export function SubmitSigningButton({ node }: { node: LayoutNode<'SigningActions'> }) {
   const processNext = useProcessNext();
 
-  const { textResourceBindings } = useNodeItem(node, (i) => ({
-    textResourceBindings: i.textResourceBindings,
-  }));
+  const { textResourceBindings } = useItemWhenType(node.baseId, 'SigningActions');
   const queryClient = useQueryClient();
   const isAnyProcessing = useIsMutating() > 0;
 

--- a/src/layout/SigningDocumentList/index.tsx
+++ b/src/layout/SigningDocumentList/index.tsx
@@ -7,7 +7,7 @@ import { SigningDocumentListComponent } from 'src/layout/SigningDocumentList/Sig
 import { SummaryContains, SummaryFlex } from 'src/layout/Summary2/SummaryComponent2/ComponentSummary';
 import { ProcessTaskType } from 'src/types';
 import { NodesInternal } from 'src/utils/layout/NodesContext';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type { NodeValidationProps } from 'src/layout/layout';
 import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types';
@@ -15,7 +15,7 @@ import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types'
 export class SigningDocumentList extends SigningDocumentListDef {
   render = forwardRef<HTMLElement, PropsFromGenericComponent<'SigningDocumentList'>>(
     function SigningDocumentListComponentRender(props, _): JSX.Element | null {
-      const textResourceBindings = useNodeItem(props.node, (i) => i.textResourceBindings);
+      const { textResourceBindings } = useItemWhenType(props.node.baseId, 'SigningDocumentList');
       return <SigningDocumentListComponent textResourceBindings={textResourceBindings} />;
     },
   );
@@ -35,7 +35,7 @@ export class SigningDocumentList extends SigningDocumentListDef {
   }
 
   renderSummary2({ target }: Summary2Props<'SigningDocumentList'>): JSX.Element | null {
-    const textResourceBindings = useNodeItem(target, (i) => i.textResourceBindings);
+    const { textResourceBindings } = useItemWhenType(target.baseId, 'SigningDocumentList');
 
     return (
       <SummaryFlex

--- a/src/layout/SimpleTable/ApiTable.tsx
+++ b/src/layout/SimpleTable/ApiTable.tsx
@@ -10,7 +10,7 @@ import { Lang } from 'src/features/language/Lang';
 import { useLanguage } from 'src/features/language/useLanguage';
 import { useIsMobile } from 'src/hooks/useDeviceWidths';
 import { isFormDataObject, isFormDataObjectArray } from 'src/layout/SimpleTable/typeguards';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { FormDataObject } from 'src/app-components/DynamicForm/DynamicForm';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type { DataConfig } from 'src/layout/SimpleTable/config.generated';
@@ -20,8 +20,8 @@ interface ApiTableProps extends PropsFromGenericComponent<'SimpleTable'> {
 }
 
 export function ApiTable({ node, externalApi }: ApiTableProps) {
-  const item = useNodeItem(node);
-  const { title, description, help } = item.textResourceBindings ?? {};
+  const { textResourceBindings, zebra, size, columns } = useItemWhenType(node.baseId, 'SimpleTable');
+  const { title, description, help } = textResourceBindings ?? {};
   const { elementAsString } = useLanguage();
   const accessibleTitle = elementAsString(title);
   const isMobile = useIsMobile();
@@ -51,8 +51,8 @@ export function ApiTable({ node, externalApi }: ApiTableProps) {
 
   return (
     <AppTable
-      zebra={item.zebra}
-      size={item.size}
+      zebra={zebra}
+      size={size}
       schema={{}}
       caption={
         title && (
@@ -66,7 +66,7 @@ export function ApiTable({ node, externalApi }: ApiTableProps) {
       data={dataToDisplay}
       stickyHeader={true}
       emptyText={<Lang id='general.empty_table' />}
-      columns={item.columns.map((config) => {
+      columns={columns.map((config) => {
         const { component } = config;
         const header = <Lang id={config.header} />;
         let renderCell;

--- a/src/layout/SimpleTable/ApiTableSummary.tsx
+++ b/src/layout/SimpleTable/ApiTableSummary.tsx
@@ -9,7 +9,7 @@ import { Lang } from 'src/features/language/Lang';
 import { useIsMobile } from 'src/hooks/useDeviceWidths';
 import { isFormDataObject, isFormDataObjectArray } from 'src/layout/SimpleTable/typeguards';
 import { SummaryContains, SummaryFlex } from 'src/layout/Summary2/SummaryComponent2/ComponentSummary';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { FormDataObject } from 'src/app-components/DynamicForm/DynamicForm';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
@@ -18,12 +18,7 @@ type ApiTableSummaryProps = {
 };
 
 export function ApiTableSummary({ componentNode }: ApiTableSummaryProps) {
-  const { externalApi, textResourceBindings, columns, required } = useNodeItem(componentNode, (item) => ({
-    externalApi: item.externalApi,
-    textResourceBindings: item.textResourceBindings,
-    columns: item.columns,
-    required: item.required,
-  }));
+  const { externalApi, textResourceBindings, columns, required } = useItemWhenType(componentNode.baseId, 'SimpleTable');
 
   const { title } = textResourceBindings ?? {};
   const isMobile = useIsMobile();

--- a/src/layout/SimpleTable/SimpleTableComponent.tsx
+++ b/src/layout/SimpleTable/SimpleTableComponent.tsx
@@ -17,7 +17,7 @@ import { useIsMobile } from 'src/hooks/useDeviceWidths';
 import { AddToListModal } from 'src/layout/AddToList/AddToList';
 import { DropdownCaption } from 'src/layout/Datepicker/DropdownCaption';
 import { isFormDataObjectArray, isValidItemsSchema } from 'src/layout/SimpleTable/typeguards';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { FormDataObject } from 'src/app-components/DynamicForm/DynamicForm';
 import type { TableActionButton } from 'src/app-components/Table/Table';
 import type { PropsFromGenericComponent } from 'src/layout';
@@ -28,10 +28,13 @@ interface TableComponentProps extends PropsFromGenericComponent<'SimpleTable'> {
 }
 
 export function SimpleTableComponent({ node, dataModelBindings }: TableComponentProps) {
-  const item = useNodeItem(node);
+  const { textResourceBindings, enableDelete, enableEdit, zebra, size, columns } = useItemWhenType(
+    node.baseId,
+    'SimpleTable',
+  );
   const { formData } = useDataModelBindings(dataModelBindings, 1, 'raw');
   const removeFromList = FD.useRemoveFromListCallback();
-  const { title, description, help } = item.textResourceBindings ?? {};
+  const { title, description, help } = textResourceBindings ?? {};
   const { elementAsString } = useLanguage();
   const accessibleTitle = elementAsString(title);
   const isMobile = useIsMobile();
@@ -49,7 +52,7 @@ export function SimpleTableComponent({ node, dataModelBindings }: TableComponent
 
   const actionButtons: TableActionButton[] = [];
 
-  if (item.enableDelete) {
+  if (enableDelete) {
     actionButtons.push({
       onClick: (idx) => {
         removeFromList({
@@ -67,7 +70,7 @@ export function SimpleTableComponent({ node, dataModelBindings }: TableComponent
     });
   }
 
-  if (item.enableEdit) {
+  if (enableEdit) {
     actionButtons.push({
       onClick: (idx, _) => {
         setEditItemIndex(idx);
@@ -136,8 +139,8 @@ export function SimpleTableComponent({ node, dataModelBindings }: TableComponent
       )}
 
       <AppTable
-        zebra={item.zebra}
-        size={item.size}
+        zebra={zebra}
+        size={size}
         schema={schema}
         mobile={isMobile}
         actionButtons={actionButtons}
@@ -154,7 +157,7 @@ export function SimpleTableComponent({ node, dataModelBindings }: TableComponent
         }
         data={data}
         stickyHeader={true}
-        columns={item.columns.map((config) => {
+        columns={columns.map((config) => {
           const { component } = config;
           const header = <Lang id={config.header} />;
           let renderCell;

--- a/src/layout/SimpleTable/SimpleTableSummary.tsx
+++ b/src/layout/SimpleTable/SimpleTableSummary.tsx
@@ -8,7 +8,7 @@ import { Lang } from 'src/features/language/Lang';
 import { useIsMobile } from 'src/hooks/useDeviceWidths';
 import { isJSONSchema7Definition } from 'src/layout/AddToList/AddToList';
 import { SummaryContains, SummaryFlex } from 'src/layout/Summary2/SummaryComponent2/ComponentSummary';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 type TableSummaryProps = {
@@ -18,12 +18,10 @@ type TableSummaryProps = {
 const emptyArray: never[] = [];
 
 export function SimpleTableSummary({ componentNode }: TableSummaryProps) {
-  const { dataModelBindings, textResourceBindings, columns, required } = useNodeItem(componentNode, (item) => ({
-    dataModelBindings: item.dataModelBindings,
-    textResourceBindings: item.textResourceBindings,
-    columns: item.columns,
-    required: item.required,
-  }));
+  const { dataModelBindings, textResourceBindings, columns, required } = useItemWhenType(
+    componentNode.baseId,
+    'SimpleTable',
+  );
 
   const { formData } = useDataModelBindings(dataModelBindings, 1, 'raw');
   const { title } = textResourceBindings ?? {};

--- a/src/layout/SimpleTable/index.tsx
+++ b/src/layout/SimpleTable/index.tsx
@@ -9,7 +9,7 @@ import { SimpleTableComponent } from 'src/layout/SimpleTable/SimpleTableComponen
 import { SimpleTableFeatureFlagLayoutValidator } from 'src/layout/SimpleTable/SimpleTableFeatureFlagLayoutValidator';
 import { SimpleTableSummary } from 'src/layout/SimpleTable/SimpleTableSummary';
 import { validateDataModelBindingsAny } from 'src/utils/layout/generator/validation/hooks';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type { IDataModelBindings, NodeValidationProps } from 'src/layout/layout';
 import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
@@ -48,13 +48,13 @@ export class SimpleTable extends SimpleTableDef {
     return false;
   }
   renderSummary2(props: Summary2Props<'SimpleTable'>): React.JSX.Element | null {
-    const item = useNodeItem(props.target);
+    const { externalApi, dataModelBindings } = useItemWhenType(props.target.baseId, 'SimpleTable');
 
-    if (item.externalApi) {
+    if (externalApi) {
       return <ApiTableSummary componentNode={props.target} />;
     }
 
-    if (item.dataModelBindings) {
+    if (dataModelBindings) {
       return <SimpleTableSummary componentNode={props.target} />;
     }
 
@@ -62,21 +62,21 @@ export class SimpleTable extends SimpleTableDef {
   }
   render = forwardRef<HTMLElement, PropsFromGenericComponent<'SimpleTable'>>(
     function LayoutComponentTableRender(props, _): React.JSX.Element | null {
-      const item = useNodeItem(props.node);
-      if (item.dataModelBindings) {
+      const { dataModelBindings, externalApi } = useItemWhenType(props.node.baseId, 'SimpleTable');
+      if (dataModelBindings) {
         return (
           <SimpleTableComponent
             {...props}
-            dataModelBindings={item.dataModelBindings}
+            dataModelBindings={dataModelBindings}
           />
         );
       }
 
-      if (item.externalApi) {
+      if (externalApi) {
         return (
           <ApiTable
             {...props}
-            externalApi={item.externalApi}
+            externalApi={externalApi}
           />
         );
       }

--- a/src/layout/Subform/SubformComponent.tsx
+++ b/src/layout/Subform/SubformComponent.tsx
@@ -23,7 +23,7 @@ import { SubformCellContent } from 'src/layout/Subform/SubformCellContent';
 import classes from 'src/layout/Subform/SubformComponent.module.css';
 import { useExpressionDataSourcesForSubform, useSubformFormData } from 'src/layout/Subform/utils';
 import utilClasses from 'src/styles/utils.module.css';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type { IData } from 'src/types/shared';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
@@ -36,7 +36,7 @@ export function SubformComponent({ node }: PropsFromGenericComponent<'Subform'>)
     tableColumns = [],
     showAddButton = true,
     showDeleteButton = true,
-  } = useNodeItem(node);
+  } = useItemWhenType(node.baseId, 'Subform');
 
   const isSubformPage = useIsSubformPage();
   if (isSubformPage) {
@@ -192,7 +192,7 @@ function SubformTableRow({
   deleteEntryCallback: (dataElement: IData) => void;
 }) {
   const id = dataElement.id;
-  const { tableColumns = [] } = useNodeItem(node);
+  const { tableColumns = [] } = useItemWhenType(node.baseId, 'Subform');
   const { isSubformDataFetching, subformData, subformDataError } = useSubformFormData(dataElement.id);
   const subformDataSources = useExpressionDataSourcesForSubform(dataElement.dataType, subformData, tableColumns);
   const { langAsString } = useLanguage();

--- a/src/layout/Subform/SubformWrapper.tsx
+++ b/src/layout/Subform/SubformWrapper.tsx
@@ -10,7 +10,7 @@ import { useDataTypeFromLayoutSet } from 'src/features/form/layout/LayoutsContex
 import { useNavigationParam } from 'src/features/routing/AppRoutingContext';
 import { useNavigatePage } from 'src/hooks/useNavigatePage';
 import { ProcessTaskType } from 'src/types';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export function SubformWrapper({ node, children }: PropsWithChildren<{ node: LayoutNode<'Subform'> }>) {
@@ -73,7 +73,7 @@ export const useDoOverrideSummary = (dataElementId: string, layoutSet: string, d
 export const useDoOverride = (node: LayoutNode<'Subform'>, providedDataElementId?: string) => {
   const dataElementId = useNavigationParam('dataElementId');
   const actualDataElementId = providedDataElementId ? providedDataElementId : dataElementId;
-  const { layoutSet, id } = useNodeItem(node);
+  const { layoutSet, id } = useItemWhenType(node.baseId, 'Subform');
   const dataType = useDataTypeFromLayoutSet(layoutSet);
 
   if (!dataType) {

--- a/src/layout/Subform/Summary/SubformSummaryComponent.tsx
+++ b/src/layout/Subform/Summary/SubformSummaryComponent.tsx
@@ -10,7 +10,7 @@ import { useLanguage } from 'src/features/language/useLanguage';
 import { SubformCellContent } from 'src/layout/Subform/SubformCellContent';
 import classes from 'src/layout/Subform/Summary/SubformSummaryComponent.module.css';
 import { useExpressionDataSourcesForSubform, useSubformFormData } from 'src/layout/Subform/utils';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { IData } from 'src/types/shared';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
@@ -19,7 +19,7 @@ export interface ISubformSummaryComponent {
 }
 
 export function SubformSummaryComponent({ targetNode }: ISubformSummaryComponent): React.JSX.Element | null {
-  const { layoutSet, id } = useNodeItem(targetNode);
+  const { layoutSet, id } = useItemWhenType(targetNode.baseId, 'Subform');
   const dataType = useDataTypeFromLayoutSet(layoutSet);
   const dataElements = useStrictDataElements(dataType);
 
@@ -47,7 +47,7 @@ export function SubformSummaryComponent({ targetNode }: ISubformSummaryComponent
 
 function SubformSummaryRow({ dataElement, node }: { dataElement: IData; node: LayoutNode<'Subform'> }) {
   const id = dataElement.id;
-  const { tableColumns, summaryDelimiter = ' — ' } = useNodeItem(node);
+  const { tableColumns, summaryDelimiter = ' — ' } = useItemWhenType(node.baseId, 'Subform');
 
   const { isSubformDataFetching, subformData, subformDataError } = useSubformFormData(dataElement.id);
   const subformDataSources = useExpressionDataSourcesForSubform(dataElement.dataType, subformData, tableColumns);

--- a/src/layout/Subform/Summary/SubformSummaryComponent2.tsx
+++ b/src/layout/Subform/Summary/SubformSummaryComponent2.tsx
@@ -23,7 +23,7 @@ import { SummaryContains, SummaryFlex } from 'src/layout/Summary2/SummaryCompone
 import { LayoutSetSummary } from 'src/layout/Summary2/SummaryComponent2/LayoutSetSummary';
 import { useSummaryOverrides } from 'src/layout/Summary2/summaryStoreContext';
 import { useNode } from 'src/utils/layout/NodesContext';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import { typedBoolean } from 'src/utils/typing';
 import type { ExprVal, ExprValToActualOrExpr } from 'src/features/expressions/types';
 import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types';
@@ -32,7 +32,7 @@ import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 const SummarySubformWrapperInner = ({ nodeId }: PropsWithChildren<{ nodeId: string }>) => {
   const node = useNode(nodeId) as LayoutNode<'Subform'>;
-  const { layoutSet, id, textResourceBindings, entryDisplayName } = useNodeItem(node);
+  const { layoutSet, id, textResourceBindings, entryDisplayName } = useItemWhenType(node.baseId, 'Subform');
   const dataType = useDataTypeFromLayoutSet(layoutSet);
   const dataElements = useStrictDataElements(dataType);
 
@@ -88,7 +88,7 @@ const DoSummaryWrapper = ({
   title: string | undefined;
   node: LayoutNode<'Subform'>;
 }>) => {
-  const item = useNodeItem(node);
+  const item = useItemWhenType(node.baseId, 'Subform');
   const isDone = useDoOverrideSummary(dataElement.id, layoutSet, dataElement.dataType);
 
   const { isSubformDataFetching, subformData, subformDataError } = useSubformFormData(dataElement.id);
@@ -160,12 +160,12 @@ export function AllSubformSummaryComponent2() {
 
 export function SubformSummaryComponent2({ target }: Summary2Props<'Subform'>) {
   const displayType = useSummaryOverrides(target)?.display;
-  const layoutSet = useNodeItem(target, (i) => i.layoutSet);
+  const { layoutSet } = useItemWhenType(target.baseId, 'Subform');
   const dataType = useDataTypeFromLayoutSet(layoutSet);
   const dataElements = useStrictDataElements(dataType);
   const minCount = useApplicationMetadata().dataTypes.find((dt) => dt.id === dataType)?.minCount;
   const hasElements = !!(dataType && dataElements.length > 0);
-  const required = useNodeItem(target, (i) => i.required) || (minCount !== undefined && minCount > 0);
+  const required = useItemWhenType(target.baseId, 'Subform').required || (minCount !== undefined && minCount > 0);
 
   const inner =
     displayType === 'table' && target ? (

--- a/src/layout/Subform/Summary/SubformSummaryTable.tsx
+++ b/src/layout/Subform/Summary/SubformSummaryTable.tsx
@@ -21,7 +21,7 @@ import classes2 from 'src/layout/Subform/Summary/SubformSummaryComponent2.module
 import { useExpressionDataSourcesForSubform, useSubformFormData } from 'src/layout/Subform/utils';
 import { EditButton } from 'src/layout/Summary2/CommonSummaryComponents/EditButton';
 import utilClasses from 'src/styles/utils.module.css';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { ISubformSummaryComponent } from 'src/layout/Subform/Summary/SubformSummaryComponent';
 import type { IData } from 'src/types/shared';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
@@ -40,7 +40,7 @@ function SubformTableRow({
   pdfModeActive: boolean;
 }) {
   const id = dataElement.id;
-  const { tableColumns } = useNodeItem(targetNode);
+  const { tableColumns } = useItemWhenType(targetNode.baseId, 'Subform');
   const { instanceOwnerPartyId, instanceGuid, taskId } = useNavigationParams();
 
   const { isSubformDataFetching, subformData, subformDataError } = useSubformFormData(dataElement.id);
@@ -105,7 +105,7 @@ function SubformTableRow({
 }
 
 export function SubformSummaryTable({ targetNode }: ISubformSummaryComponent): React.JSX.Element | null {
-  const { id, layoutSet, textResourceBindings, tableColumns = [] } = useNodeItem(targetNode);
+  const { id, layoutSet, textResourceBindings, tableColumns = [] } = useItemWhenType(targetNode.baseId, 'Subform');
 
   const isSubformPage = useIsSubformPage();
   if (isSubformPage) {

--- a/src/layout/Summary/SummaryComponent.tsx
+++ b/src/layout/Summary/SummaryComponent.tsx
@@ -16,7 +16,7 @@ import classes from 'src/layout/Summary/SummaryComponent.module.css';
 import { SummaryContent } from 'src/layout/Summary/SummaryContent';
 import { pageBreakStyles } from 'src/utils/formComponentUtils';
 import { Hidden, useNode } from 'src/utils/layout/NodesContext';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemFor, useItemWhenType } from 'src/utils/layout/useNodeItem';
 import { useGetUniqueKeyFromObject } from 'src/utils/useGetKeyFromObject';
 import type { ExprResolved } from 'src/features/expressions/types';
 import type { IGrid, IPageBreak } from 'src/layout/common.generated';
@@ -43,7 +43,7 @@ export const SummaryComponentFor = React.forwardRef(function (
   { targetNode, overrides }: { targetNode: LayoutNode; overrides?: LegacySummaryOverrides },
   ref: React.Ref<HTMLDivElement>,
 ) {
-  const targetItem = useNodeItem(targetNode);
+  const targetItem = useItemWhenType(targetNode.baseId, 'Summary');
 
   return (
     <SummaryComponentInner
@@ -72,9 +72,9 @@ export const SummaryComponent = React.forwardRef(function (
   { summaryNode, overrides }: { summaryNode: LayoutNode<'Summary'>; overrides?: LegacySummaryOverrides },
   ref: React.Ref<HTMLDivElement>,
 ) {
-  const summaryItem = useNodeItem(summaryNode);
+  const summaryItem = useItemWhenType(summaryNode.baseId, 'Summary');
   const targetNode = useNode(summaryItem.componentRef);
-  const targetItem = useNodeItem(targetNode);
+  const { grid, pageBreak } = useItemWhenType(targetNode.baseId, 'Summary');
 
   if (!targetNode) {
     throw new Error(
@@ -94,10 +94,10 @@ export const SummaryComponent = React.forwardRef(function (
       display={overrides?.display ?? summaryItem?.display}
       grid={
         overrides?.display && overrides?.display.useComponentGrid
-          ? overrides?.grid || targetItem?.grid
+          ? overrides?.grid || grid
           : overrides?.grid || summaryItem?.grid
       }
-      pageBreak={overrides?.pageBreak ?? summaryItem?.pageBreak ?? targetItem?.pageBreak}
+      pageBreak={overrides?.pageBreak ?? summaryItem?.pageBreak ?? pageBreak}
       largeGroup={overrides?.largeGroup ?? summaryItem?.largeGroup}
       excludedChildren={overrides?.excludedChildren ?? summaryItem?.excludedChildren}
     />
@@ -129,7 +129,7 @@ const SummaryComponentInner = React.forwardRef(function (
   }: ISummaryProps,
   ref: React.Ref<HTMLDivElement>,
 ) {
-  const targetItem = useNodeItem(targetNode);
+  const targetItem = useItemFor(targetNode.baseId);
   const { langAsString } = useLanguage();
   const getUniqueKeyFromObject = useGetUniqueKeyFromObject();
   const currentPageId = useNavigationParam('pageKey');

--- a/src/layout/Summary/SummaryComponent.tsx
+++ b/src/layout/Summary/SummaryComponent.tsx
@@ -43,7 +43,7 @@ export const SummaryComponentFor = React.forwardRef(function (
   { targetNode, overrides }: { targetNode: LayoutNode; overrides?: LegacySummaryOverrides },
   ref: React.Ref<HTMLDivElement>,
 ) {
-  const targetItem = useItemWhenType(targetNode.baseId, 'Summary');
+  const targetItem = useItemFor(targetNode.baseId);
 
   return (
     <SummaryComponentInner

--- a/src/layout/Summary/SummaryComponent.tsx
+++ b/src/layout/Summary/SummaryComponent.tsx
@@ -74,7 +74,7 @@ export const SummaryComponent = React.forwardRef(function (
 ) {
   const summaryItem = useItemWhenType(summaryNode.baseId, 'Summary');
   const targetNode = useNode(summaryItem.componentRef);
-  const { grid, pageBreak } = useItemWhenType(targetNode.baseId, 'Summary');
+  const { grid, pageBreak } = useItemFor(targetNode.baseId);
 
   if (!targetNode) {
     throw new Error(

--- a/src/layout/Summary/SummaryContent.tsx
+++ b/src/layout/Summary/SummaryContent.tsx
@@ -8,7 +8,7 @@ import { useUnifiedValidationsForNode } from 'src/features/validation/selectors/
 import { hasValidationErrors } from 'src/features/validation/utils';
 import { EditButton } from 'src/layout/Summary/EditButton';
 import classes from 'src/layout/Summary/SummaryContent.module.css';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemFor } from 'src/utils/layout/useNodeItem';
 import type { CompTypes } from 'src/layout/layout';
 import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 
@@ -24,7 +24,7 @@ export function SummaryContent({
   RenderSummary,
 }: SummaryContentProps) {
   const { langAsString } = useLanguage();
-  const targetItem = useNodeItem(targetNode);
+  const targetItem = useItemFor(targetNode.baseId);
   const display = overrides?.display;
   const readOnlyComponent = 'readOnly' in targetItem && targetItem.readOnly === true;
   const validations = useUnifiedValidationsForNode(targetNode);

--- a/src/layout/Summary/SummaryItemCompact.tsx
+++ b/src/layout/Summary/SummaryItemCompact.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Lang } from 'src/features/language/Lang';
 import { useLanguage } from 'src/features/language/useLanguage';
 import classes from 'src/layout/Summary/SummaryItemCompact.module.css';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemFor } from 'src/utils/layout/useNodeItem';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 export interface ICompactSummaryItem {
@@ -12,7 +12,7 @@ export interface ICompactSummaryItem {
 }
 
 export function SummaryItemCompact({ targetNode, displayData }: ICompactSummaryItem) {
-  const targetItem = useNodeItem(targetNode);
+  const targetItem = useItemFor(targetNode.baseId);
   const textBindings = 'textResourceBindings' in targetItem ? targetItem.textResourceBindings : undefined;
   const summaryTitleTrb =
     textBindings && 'summaryTitle' in textBindings ? (textBindings.summaryTitle as string) : undefined;

--- a/src/layout/Summary2/CommonSummaryComponents/EditButton.tsx
+++ b/src/layout/Summary2/CommonSummaryComponents/EditButton.tsx
@@ -12,7 +12,7 @@ import { usePdfModeActive } from 'src/features/pdf/PDFWrapper';
 import { useIsMobile } from 'src/hooks/useDeviceWidths';
 import { useCurrentView } from 'src/hooks/useNavigatePage';
 import { Hidden, useNode } from 'src/utils/layout/NodesContext';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemFor } from 'src/utils/layout/useNodeItem';
 import type { NavigationResult } from 'src/features/form/layout/NavigateToNode';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
@@ -54,9 +54,8 @@ export function EditButton({
   const pdfModeActive = usePdfModeActive();
   const isMobile = useIsMobile();
 
-  const titleTrb = useNodeItem(componentNode, (i) =>
-    i.textResourceBindings && 'title' in i.textResourceBindings ? i.textResourceBindings.title : undefined,
-  );
+  const { textResourceBindings } = useItemFor(componentNode.baseId);
+  const titleTrb = textResourceBindings && 'title' in textResourceBindings ? textResourceBindings.title : undefined;
   const accessibleTitle = titleTrb ? langAsString(titleTrb) : '';
 
   const overriddenTaskId = useTaskStore((state) => state.overriddenTaskId);

--- a/src/layout/Summary2/CommonSummaryComponents/MultipleValueSummary.tsx
+++ b/src/layout/Summary2/CommonSummaryComponents/MultipleValueSummary.tsx
@@ -12,7 +12,8 @@ import { useUnifiedValidationsForNode } from 'src/features/validation/selectors/
 import { validationsOfSeverity } from 'src/features/validation/utils';
 import { EditButton } from 'src/layout/Summary2/CommonSummaryComponents/EditButton';
 import classes from 'src/layout/Summary2/CommonSummaryComponents/MultipleValueSummary.module.css';
-import { useNodeFormData, useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useDataModelBindingsFor } from 'src/utils/layout/hooks';
+import { useNodeFormData } from 'src/utils/layout/useNodeItem';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 type ValidTypes = 'MultipleSelect' | 'Checkboxes';
@@ -44,7 +45,10 @@ function getDisplayType(
 }
 
 export function useMultipleValuesForSummary(componentNode: ValidNodes) {
-  const { dataModelBindings } = useNodeItem(componentNode);
+  const dataModelBindings = useDataModelBindingsFor<'MultipleSelect' | 'Checkboxes'>(
+    componentNode.baseId,
+    (t) => t === 'MultipleSelect' || t === 'Checkboxes',
+  );
   const options = useOptionsFor(componentNode.baseId, 'multi').options;
   const rawFormData = useNodeFormData(componentNode);
   const { langAsString } = useLanguage();

--- a/src/layout/Summary2/SummaryComponent2/ComponentSummary.tsx
+++ b/src/layout/Summary2/SummaryComponent2/ComponentSummary.tsx
@@ -11,7 +11,7 @@ import classes from 'src/layout/Summary2/Summary2.module.css';
 import { useSummaryOverrides, useSummaryProp } from 'src/layout/Summary2/summaryStoreContext';
 import { pageBreakStyles } from 'src/utils/formComponentUtils';
 import { Hidden, useNode } from 'src/utils/layout/NodesContext';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemFor, useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { CompTypes } from 'src/layout/layout';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
@@ -81,8 +81,9 @@ function useIsHidden<T extends CompTypes>(node: LayoutNode<T>) {
 
 function useIsHiddenBecauseEmpty<T extends CompTypes>(node: LayoutNode<T>, content: SummaryContains) {
   const hideEmptyFields = useSummaryProp('hideEmptyFields');
-  const isRequired = useNodeItem(node, (i) => ('required' in i ? i.required : undefined));
-  const forceShowInSummary = useNodeItem(node, (i) => i['forceShowInSummary']);
+  const item = useItemWhenType(node.baseId, node.type);
+  const isRequired = 'required' in item ? item.required : undefined;
+  const forceShowInSummary = item['forceShowInSummary'];
 
   if (isRequired && content === SummaryContains.EmptyValueNotRequired) {
     window.logErrorOnce(`Node ${node.id} marked as required, but summary indicates EmptyValueNotRequired`);
@@ -100,8 +101,7 @@ interface SummaryFlexProps extends PropsWithChildren {
 }
 
 function SummaryFlexInternal({ target, children, className }: Omit<SummaryFlexProps, 'content'>) {
-  const pageBreak = useNodeItem(target, (i) => i.pageBreak);
-  const grid = useNodeItem(target, (i) => i.grid);
+  const { pageBreak, grid } = useItemFor(target.baseId);
 
   return (
     <Flex

--- a/src/layout/Summary2/SummaryComponent2/SummaryComponent2.tsx
+++ b/src/layout/Summary2/SummaryComponent2/SummaryComponent2.tsx
@@ -5,7 +5,7 @@ import { ComponentSummaryById } from 'src/layout/Summary2/SummaryComponent2/Comp
 import { LayoutSetSummary } from 'src/layout/Summary2/SummaryComponent2/LayoutSetSummary';
 import { TaskSummaryWrapper } from 'src/layout/Summary2/SummaryComponent2/TaskSummaryWrapper';
 import { Summary2StoreProvider } from 'src/layout/Summary2/summaryStoreContext';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useExternalItem } from 'src/utils/layout/hooks';
 import type { CompSummary2External } from 'src/layout/Summary2/config.generated';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
@@ -31,7 +31,7 @@ function SummaryBody({ target }: SummaryBodyProps) {
 }
 
 function SummaryComponent2Inner({ summaryNode }: ISummaryComponent2) {
-  const target = useNodeItem(summaryNode, (i) => i.target);
+  const target = useExternalItem(summaryNode.baseId, 'Summary2').target;
   return (
     <TaskStoreProvider>
       <Summary2StoreProvider node={summaryNode}>

--- a/src/layout/Summary2/isEmpty/isEmptyComponent.ts
+++ b/src/layout/Summary2/isEmpty/isEmptyComponent.ts
@@ -1,9 +1,9 @@
 import { FD } from 'src/features/formData/FormDataWrite';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useDataModelBindingsFor } from 'src/utils/layout/hooks';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 function useHasDataInBindings(node: LayoutNode) {
-  const dataModelBindings = useNodeItem(node, (i) => i.dataModelBindings);
+  const dataModelBindings = useDataModelBindingsFor(node.baseId);
   const formData = FD.useFreshBindings(dataModelBindings, 'raw');
 
   // Checks if there is data in any of the data model binding
@@ -15,6 +15,6 @@ export function useHasNoDataInBindings(node: LayoutNode) {
 }
 
 export function useHasBindingsAndNoData(node: LayoutNode) {
-  const hasBindings = useNodeItem(node, (i) => !!i.dataModelBindings);
+  const hasBindings = !!useDataModelBindingsFor(node.baseId);
   return useHasNoDataInBindings(node) && hasBindings;
 }

--- a/src/layout/Summary2/summaryStoreContext.tsx
+++ b/src/layout/Summary2/summaryStoreContext.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, useContext } from 'react';
 import type { PropsWithChildren } from 'react';
 
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { ISummaryOverridesCommon } from 'src/layout/common.generated';
 import type { CompSummaryOverrides, CompTypes } from 'src/layout/layout';
 import type { CompSummary2External } from 'src/layout/Summary2/config.generated';
@@ -11,10 +11,7 @@ type Summary2State = Pick<CompSummary2External, 'hideEmptyFields' | 'showPageInA
 const StoreContext = createContext<Summary2State | null>(null);
 
 export function Summary2StoreProvider({ children, node }: PropsWithChildren<{ node: LayoutNode<'Summary2'> }>) {
-  const hideEmptyFields = useNodeItem(node, (i) => i.hideEmptyFields);
-  const showPageInAccordion = useNodeItem(node, (i) => i.showPageInAccordion);
-  const overrides = useNodeItem(node, (i) => i.overrides);
-  const isCompact = useNodeItem(node, (i) => i.isCompact);
+  const { hideEmptyFields, showPageInAccordion, overrides, isCompact } = useItemWhenType(node.baseId, 'Summary2');
 
   return (
     <StoreContext.Provider value={{ hideEmptyFields, showPageInAccordion, overrides, isCompact }}>

--- a/src/layout/Tabs/Tabs.tsx
+++ b/src/layout/Tabs/Tabs.tsx
@@ -10,8 +10,8 @@ import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper'
 import { GenericComponentByBaseId } from 'src/layout/GenericComponent';
 import classes from 'src/layout/Tabs/Tabs.module.css';
 import { useComponentIdMutator } from 'src/utils/layout/DataModelLocation';
+import { useExternalItem } from 'src/utils/layout/hooks';
 import { LayoutNode } from 'src/utils/layout/LayoutNode';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
 import { typedBoolean } from 'src/utils/typing';
 import type { PropsFromGenericComponent } from 'src/layout';
 
@@ -22,9 +22,8 @@ const sizeMap: Record<string, 'sm' | 'md' | 'lg'> = {
 };
 
 export const Tabs = ({ node }: PropsFromGenericComponent<'Tabs'>) => {
-  const size = useNodeItem(node, (i) => i.size) ?? 'medium';
-  const defaultTab = useNodeItem(node, (i) => i.defaultTab);
-  const tabs = useNodeItem(node, (i) => i.tabs);
+  const { size: _size, defaultTab, tabs } = useExternalItem(node.baseId, 'Tabs');
+  const size = _size ?? 'medium';
   const idMutator = useComponentIdMutator();
   const [activeTab, setActiveTab] = useState<string | undefined>(defaultTab ?? tabs.at(0)?.id);
 

--- a/src/layout/Tabs/TabsSummary.tsx
+++ b/src/layout/Tabs/TabsSummary.tsx
@@ -9,7 +9,7 @@ import { useSummaryProp } from 'src/layout/Summary2/summaryStoreContext';
 import classes from 'src/layout/Tabs/TabsSummary.module.css';
 import { useHasCapability } from 'src/utils/layout/canRenderIn';
 import { useComponentIdMutator } from 'src/utils/layout/DataModelLocation';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useExternalItem } from 'src/utils/layout/hooks';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
 type TabsSummaryProps = {
@@ -19,7 +19,7 @@ type TabsSummaryProps = {
 export const TabsSummary = ({ componentNode }: TabsSummaryProps) => {
   const hideEmptyFields = useSummaryProp('hideEmptyFields');
   const idMutator = useComponentIdMutator();
-  const tabs = useNodeItem(componentNode, (i) => i.tabs);
+  const { tabs } = useExternalItem(componentNode.baseId, 'Tabs');
   const canRender = useHasCapability('renderInTabs');
 
   if (!tabs || tabs.length === 0) {

--- a/src/layout/Tabs/TabsSummaryComponent.tsx
+++ b/src/layout/Tabs/TabsSummaryComponent.tsx
@@ -4,14 +4,14 @@ import type { JSX } from 'react';
 import { SummaryComponentFor } from 'src/layout/Summary/SummaryComponent';
 import { useHasCapability } from 'src/utils/layout/canRenderIn';
 import { useIndexedId } from 'src/utils/layout/DataModelLocation';
+import { useExternalItem } from 'src/utils/layout/hooks';
 import { useNode } from 'src/utils/layout/NodesContext';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
 import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 
 type Props = Pick<SummaryRendererProps<'Tabs'>, 'targetNode' | 'overrides'>;
 
 export function TabsSummaryComponent({ targetNode, overrides }: Props): JSX.Element | null {
-  const tabs = useNodeItem(targetNode, (i) => i.tabs);
+  const { tabs } = useExternalItem(targetNode.baseId, 'Tabs');
   const childIds = tabs.map((card) => card.children).flat();
 
   return (

--- a/src/layout/Text/TextComponent.tsx
+++ b/src/layout/Text/TextComponent.tsx
@@ -7,14 +7,12 @@ import classes from 'src/app-components/Text/Text.module.css';
 import { getLabelId } from 'src/components/label/Label';
 import { useLanguage } from 'src/features/language/useLanguage';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export const TextComponent = ({ node }: PropsFromGenericComponent<'Text'>) => {
-  const textResourceBindings = useNodeItem(node, (i) => i.textResourceBindings);
-  const value = useNodeItem(node, (i) => i.value);
-  const icon = useNodeItem(node, (i) => i.icon);
-  const direction = useNodeItem(node, (i) => i.direction) ?? 'horizontal';
+  const { textResourceBindings, value, icon, direction: _direction } = useItemWhenType(node.baseId, 'Text');
+  const direction = _direction ?? 'horizontal';
   const { langAsString } = useLanguage();
 
   if (!textResourceBindings?.title) {

--- a/src/layout/Text/TextSummary.tsx
+++ b/src/layout/Text/TextSummary.tsx
@@ -7,7 +7,7 @@ import { validationsOfSeverity } from 'src/features/validation/utils';
 import { SingleValueSummary } from 'src/layout/Summary2/CommonSummaryComponents/SingleValueSummary';
 import { SummaryContains, SummaryFlex } from 'src/layout/Summary2/SummaryComponent2/ComponentSummary';
 import { useSummaryOverrides, useSummaryProp } from 'src/layout/Summary2/summaryStoreContext';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types';
 
 export const TextSummary = ({ target }: Summary2Props<'Text'>) => {
@@ -16,8 +16,8 @@ export const TextSummary = ({ target }: Summary2Props<'Text'>) => {
   const displayData = useDisplayData(target);
   const validations = useUnifiedValidationsForNode(target);
   const errors = validationsOfSeverity(validations, 'error');
-  const title = useNodeItem(target, (i) => i.textResourceBindings?.title);
-  const direction = useNodeItem(target, (i) => i.direction);
+  const { textResourceBindings, direction } = useItemWhenType(target.baseId, 'Text');
+  const title = textResourceBindings?.title;
 
   const compact = (direction === 'horizontal' && isCompact == undefined) || isCompact;
 

--- a/src/layout/Text/index.tsx
+++ b/src/layout/Text/index.tsx
@@ -4,7 +4,6 @@ import type { JSX } from 'react';
 import { TextDef } from 'src/layout/Text/config.def.generated';
 import { TextComponent } from 'src/layout/Text/TextComponent';
 import { TextSummary } from 'src/layout/Text/TextSummary';
-import { useIndexedId } from 'src/utils/layout/DataModelLocation';
 import { useNodeItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { DisplayData } from 'src/features/displayData';
 import type { PropsFromGenericComponent } from 'src/layout';
@@ -13,8 +12,7 @@ import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types'
 
 export class Text extends TextDef implements DisplayData {
   useDisplayData(baseComponentId: string): string {
-    const nodeId = useIndexedId(baseComponentId);
-    const item = useNodeItemWhenType(nodeId, 'Text');
+    const item = useNodeItemWhenType(baseComponentId, 'Text');
     const text = item?.value;
     if (!text) {
       return '';

--- a/src/layout/Text/index.tsx
+++ b/src/layout/Text/index.tsx
@@ -4,7 +4,7 @@ import type { JSX } from 'react';
 import { TextDef } from 'src/layout/Text/config.def.generated';
 import { TextComponent } from 'src/layout/Text/TextComponent';
 import { TextSummary } from 'src/layout/Text/TextSummary';
-import { useNodeItemWhenType } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { DisplayData } from 'src/features/displayData';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type { ExprResolver } from 'src/layout/LayoutComponent';
@@ -12,7 +12,7 @@ import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types'
 
 export class Text extends TextDef implements DisplayData {
   useDisplayData(baseComponentId: string): string {
-    const item = useNodeItemWhenType(baseComponentId, 'Text');
+    const item = useItemWhenType(baseComponentId, 'Text');
     const text = item?.value;
     if (!text) {
       return '';

--- a/src/layout/TextArea/TextAreaComponent.tsx
+++ b/src/layout/TextArea/TextAreaComponent.tsx
@@ -10,7 +10,7 @@ import { useIsValid } from 'src/features/validation/selectors/isValid';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
 import { useCharacterLimit } from 'src/utils/inputUtils';
 import { useLabel } from 'src/utils/layout/useLabel';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 import 'src/styles/shared.css';
@@ -30,7 +30,7 @@ export function TextAreaComponent({ node, overrideDisplay }: ITextAreaProps) {
     maxLength,
     grid,
     required,
-  } = useNodeItem(node);
+  } = useItemWhenType(node.baseId, 'TextArea');
   const characterLimit = useCharacterLimit(maxLength);
   const {
     formData: { simpleBinding: value },

--- a/src/layout/TextArea/TextAreaSummary.tsx
+++ b/src/layout/TextArea/TextAreaSummary.tsx
@@ -7,7 +7,7 @@ import { validationsOfSeverity } from 'src/features/validation/utils';
 import { SingleValueSummary } from 'src/layout/Summary2/CommonSummaryComponents/SingleValueSummary';
 import { SummaryContains, SummaryFlex } from 'src/layout/Summary2/SummaryComponent2/ComponentSummary';
 import { useSummaryOverrides, useSummaryProp } from 'src/layout/Summary2/summaryStoreContext';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types';
 
 export const TextAreaSummary = ({ target }: Summary2Props<'TextArea'>) => {
@@ -16,8 +16,8 @@ export const TextAreaSummary = ({ target }: Summary2Props<'TextArea'>) => {
   const displayData = useDisplayData(target);
   const validations = useUnifiedValidationsForNode(target);
   const errors = validationsOfSeverity(validations, 'error');
-  const title = useNodeItem(target, (i) => i.textResourceBindings?.title);
-  const required = useNodeItem(target, (i) => i.required);
+  const { textResourceBindings, required } = useItemWhenType(target.baseId, 'TextArea');
+  const title = textResourceBindings?.title;
 
   return (
     <SummaryFlex

--- a/src/layout/Video/Video.tsx
+++ b/src/layout/Video/Video.tsx
@@ -3,14 +3,14 @@ import React from 'react';
 import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
 import { useLanguage } from 'src/features/language/useLanguage';
 import { useParentCard } from 'src/layout/Cards/CardContext';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export type IVideoProps = PropsFromGenericComponent<'Video'>;
 
 export function VideoComponent({ node }: IVideoProps) {
   const { langAsString } = useLanguage();
-  const { id, video, textResourceBindings } = useNodeItem(node);
+  const { id, video, textResourceBindings } = useItemWhenType(node.baseId, 'Video');
   const languageKey = useCurrentLanguage();
   const altText = textResourceBindings?.altText ? langAsString(textResourceBindings.altText) : undefined;
   const videoSrc = video?.src?.[languageKey] || '';

--- a/src/layout/index.ts
+++ b/src/layout/index.ts
@@ -62,17 +62,15 @@ type TypeFromDef<Def extends CompDef> = Def extends CompDef<infer T> ? T : CompT
 
 export function implementsAnyValidation<Def extends CompDef>(
   def: Def,
-): def is Def & (ValidateEmptyField<TypeFromDef<Def>> | ValidateComponent<TypeFromDef<Def>>) {
+): def is Def & (ValidateEmptyField | ValidateComponent<TypeFromDef<Def>>) {
   return 'useEmptyFieldValidation' in def || 'useComponentValidation' in def;
 }
 
-export interface ValidateEmptyField<Type extends CompTypes> {
-  useEmptyFieldValidation: (node: LayoutNode<Type>) => ComponentValidation[];
+export interface ValidateEmptyField {
+  useEmptyFieldValidation: (baseComponentId: string) => ComponentValidation[];
 }
 
-export function implementsValidateEmptyField<Def extends CompDef>(
-  def: Def,
-): def is Def & ValidateEmptyField<TypeFromDef<Def>> {
+export function implementsValidateEmptyField<Def extends CompDef>(def: Def): def is Def & ValidateEmptyField {
   return 'useEmptyFieldValidation' in def;
 }
 

--- a/src/utils/layout/hooks.ts
+++ b/src/utils/layout/hooks.ts
@@ -13,7 +13,7 @@ import type { CompIntermediate, CompTypes, IDataModelBindings } from 'src/layout
  *  - The `dataModelBindings` property will never have any indexes for which row in a repeating group it is in.
  *  - The `mapping` property will never have any indexes for which row in a repeating group it is in.
  */
-export function useExternalItem<T extends CompTypes = CompTypes>(baseComponentId: string | undefined, type?: T) {
+export function useExternalItem<T extends CompTypes = CompTypes>(baseComponentId: string, type?: T) {
   const lookups = useLayoutLookups();
   return lookups.getComponent(baseComponentId, type);
 }
@@ -44,22 +44,19 @@ function useBindingParts() {
  * the current path inside the data model.
  */
 export function useIntermediateItem<T extends CompTypes = CompTypes>(
-  baseComponentId: string | undefined,
+  baseComponentId: string,
   type?: T,
-): CompIntermediate<T> | undefined {
+): CompIntermediate<T> {
   const component = useExternalItem(baseComponentId, type);
   const idMutator = useComponentIdMutator();
   const bindingParts = useBindingParts();
 
   return useMemo(() => {
-    if (!component) {
-      return undefined;
-    }
     const clone = structuredClone(component) as unknown as CompIntermediate<T>;
     if ('mapping' in clone) {
       clone.mapping = mutateMapping(clone.mapping, bindingParts);
     }
-    if ('dataModelBindings' in clone) {
+    if ('dataModelBindings' in clone && clone.dataModelBindings !== undefined) {
       clone.dataModelBindings = mutateDataModelBindings(clone.dataModelBindings, bindingParts);
     }
 
@@ -70,11 +67,11 @@ export function useIntermediateItem<T extends CompTypes = CompTypes>(
 }
 
 function mutateDataModelBindings<T extends CompTypes = CompTypes>(
-  bindings: IDataModelBindings<T> | undefined,
+  bindings: IDataModelBindings<T>,
   parts: ReturnType<typeof useBindingParts>,
-): IDataModelBindings<T> | undefined {
+): IDataModelBindings<T> {
   if (!bindings) {
-    return undefined;
+    return bindings;
   }
 
   const clone = structuredClone(bindings);
@@ -100,13 +97,13 @@ function mutateDataModelBindings<T extends CompTypes = CompTypes>(
 }
 
 export function useDataModelBindingsFor<T extends CompTypes = CompTypes>(
-  baseComponentId: string | undefined,
+  baseComponentId: string,
   type?: T,
-): IDataModelBindings<T> | undefined {
+): IDataModelBindings<T> {
   const component = useExternalItem<T>(baseComponentId, type);
   const parts = useBindingParts();
   return useMemo(
-    () => mutateDataModelBindings<T>(component?.dataModelBindings as IDataModelBindings<T> | undefined, parts),
+    () => mutateDataModelBindings<T>(component.dataModelBindings as IDataModelBindings<T>, parts),
     [component, parts],
   );
 }
@@ -128,7 +125,7 @@ function mutateMapping(mapping: IMapping | undefined, parts: ReturnType<typeof u
   return clone;
 }
 
-export function useMappingFor<T extends CompTypes = CompTypes>(baseComponentId: string | undefined, type?: T) {
+export function useMappingFor<T extends CompTypes = CompTypes>(baseComponentId: string, type?: T) {
   const component = useExternalItem<T>(baseComponentId, type);
   const parts = useBindingParts();
   return useMemo(

--- a/src/utils/layout/hooks.ts
+++ b/src/utils/layout/hooks.ts
@@ -13,7 +13,10 @@ import type { CompIntermediate, CompTypes, IDataModelBindings } from 'src/layout
  *  - The `dataModelBindings` property will never have any indexes for which row in a repeating group it is in.
  *  - The `mapping` property will never have any indexes for which row in a repeating group it is in.
  */
-export function useExternalItem<T extends CompTypes = CompTypes>(baseComponentId: string, type?: T) {
+export function useExternalItem<T extends CompTypes = CompTypes>(
+  baseComponentId: string,
+  type?: T | ((type: CompTypes) => boolean),
+) {
   const lookups = useLayoutLookups();
   return lookups.getComponent(baseComponentId, type);
 }
@@ -98,7 +101,7 @@ function mutateDataModelBindings<T extends CompTypes = CompTypes>(
 
 export function useDataModelBindingsFor<T extends CompTypes = CompTypes>(
   baseComponentId: string,
-  type?: T,
+  type?: T | ((type: CompTypes) => boolean),
 ): IDataModelBindings<T> {
   const component = useExternalItem<T>(baseComponentId, type);
   const parts = useBindingParts();

--- a/src/utils/layout/useLabel.tsx
+++ b/src/utils/layout/useLabel.tsx
@@ -6,7 +6,7 @@ import { OptionalIndicator } from 'src/components/form/OptionalIndicator';
 import { RequiredIndicator } from 'src/components/form/RequiredIndicator';
 import { Lang } from 'src/features/language/Lang';
 import { useLanguage } from 'src/features/language/useLanguage';
-import { useNodeItem } from 'src/utils/layout/useNodeItem';
+import { useItemFor } from 'src/utils/layout/useNodeItem';
 import type { GenericComponentOverrideDisplay } from 'src/layout/FormComponentContext';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
 
@@ -17,7 +17,7 @@ export function useLabel({
   node: LayoutNode;
   overrideDisplay: GenericComponentOverrideDisplay | undefined;
 }) {
-  const item = useNodeItem(node);
+  const item = useItemFor(node.baseId);
   const { readOnly, required, showOptionalMarking, textResourceBindings } = {
     readOnly: item['readOnly'],
     required: item['required'],

--- a/src/utils/layout/useNodeItem.ts
+++ b/src/utils/layout/useNodeItem.ts
@@ -1,11 +1,10 @@
 import { FD } from 'src/features/formData/FormDataWrite';
 import { getComponentDef } from 'src/layout';
-import { useDataModelLocationForNode } from 'src/utils/layout/DataModelLocation';
+import { useCurrentDataModelLocation, useDataModelLocationForNode } from 'src/utils/layout/DataModelLocation';
 import { useExpressionResolverProps } from 'src/utils/layout/generator/NodeGenerator';
 import { useDataModelBindingsFor, useIntermediateItem } from 'src/utils/layout/hooks';
 import { NodesInternal, useNodes } from 'src/utils/layout/NodesContext';
 import { useExpressionDataSources } from 'src/utils/layout/useExpressionDataSources';
-import { splitDashedKey } from 'src/utils/splitDashedKey';
 import { typedBoolean } from 'src/utils/typing';
 import type { FormDataSelector } from 'src/layout';
 import type { CompInternal, CompTypes, IDataModelBindings, TypeFromNode } from 'src/layout/layout';
@@ -25,9 +24,8 @@ export function useNodeItem(node: LayoutNode, selector: never): unknown {
   const intermediate = useIntermediateItem(node.baseId);
   const location = useDataModelLocationForNode(node.id);
   const dataSources = useExpressionDataSources(intermediate, { dataSources: { currentDataModelPath: () => location } });
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const props = useExpressionResolverProps(`Invalid expression for ${node?.id}`, intermediate, dataSources) as any;
-  const resolved = node?.def.evalExpressions(props);
+  const props = useExpressionResolverProps(`Invalid expression for ${node?.id}`, intermediate, dataSources);
+  const resolved = node?.def.evalExpressions(props as never);
 
   if (!resolved) {
     return undefined;
@@ -37,15 +35,13 @@ export function useNodeItem(node: LayoutNode, selector: never): unknown {
   return selector ? (selector as any)(resolved) : resolved;
 }
 
-export function useNodeItemWhenType<T extends CompTypes>(nodeId: string, type: T): CompInternal<T> {
-  const { baseComponentId } = nodeId ? splitDashedKey(nodeId) : { baseComponentId: undefined };
+export function useNodeItemWhenType<T extends CompTypes>(baseComponentId: string, type: T): CompInternal<T> {
   const intermediate = useIntermediateItem(baseComponentId);
-  const location = useDataModelLocationForNode(nodeId);
+  const location = useCurrentDataModelLocation();
   const dataSources = useExpressionDataSources(intermediate, { dataSources: { currentDataModelPath: () => location } });
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const props = useExpressionResolverProps(`Invalid expression for ${nodeId}`, intermediate, dataSources) as any;
+  const props = useExpressionResolverProps(`Invalid expression for ${baseComponentId}`, intermediate, dataSources);
   const def = getComponentDef(type);
-  return def.evalExpressions(props) as CompInternal<T>;
+  return def.evalExpressions(props as never) as CompInternal<T>;
 }
 
 const emptyArray: LayoutNode[] = [];

--- a/src/utils/layout/useNodeItem.ts
+++ b/src/utils/layout/useNodeItem.ts
@@ -39,7 +39,7 @@ export function useNodeItem(node: LayoutNode, selector: never): unknown {
  * This evaluates all expressions for a given component configuration. If the type is not correct, things will crash.
  * @see useNodeItemIfType Use this one if you only want to evaluate expressions _if_ the type is the expected one.
  */
-export function useNodeItemWhenType<T extends CompTypes>(
+export function useItemWhenType<T extends CompTypes>(
   baseComponentId: string,
   type: T | ((type: CompTypes) => boolean),
 ): CompInternal<T> {
@@ -49,7 +49,8 @@ export function useNodeItemWhenType<T extends CompTypes>(
     (typeof type === 'string' && intermediate.type !== type) ||
     (typeof type === 'function' && !type(intermediate.type))
   ) {
-    throw new Error(`Unexpected type for ${baseComponentId}: ${intermediate?.type} (expected ${type})`);
+    const suffix = typeof type === 'string' ? ` (expected ${type})` : '';
+    throw new Error(`Unexpected type for ${baseComponentId}: ${intermediate?.type}${suffix}`);
   }
   const location = useCurrentDataModelLocation();
   const dataSources = useExpressionDataSources(intermediate, { dataSources: { currentDataModelPath: () => location } });
@@ -61,8 +62,10 @@ export function useNodeItemWhenType<T extends CompTypes>(
 /**
  * This evaluates all expressions for a given component configuration, but only when the
  * target component is the given type.
+ * @see useItemWhenType
+ * @see useItemFor
  */
-export function useNodeItemIfType<T extends CompTypes>(
+export function useItemIfType<T extends CompTypes>(
   baseComponentId: string,
   type: T | ((type: CompTypes) => boolean),
 ): CompInternal<T> | undefined {
@@ -85,10 +88,12 @@ export function useNodeItemIfType<T extends CompTypes>(
 }
 
 /**
- * This evaluates all expressions for a given component configuration, but only when the
- * target component is the given type.
+ * This evaluates all expressions for a given component configuration. This should only be used when you don't know
+ * the target component type beforehand.
+ * @see useItemWhenType
+ * @see useItemIfType
  */
-export function useNodeItemFor<T extends CompTypes = CompTypes>(baseComponentId: string): CompInternal<T> {
+export function useItemFor<T extends CompTypes = CompTypes>(baseComponentId: string): CompInternal<T> {
   const intermediate = useIntermediateItem(baseComponentId);
   if (!intermediate) {
     throw new Error(`No component configuration found for ${baseComponentId}`);

--- a/src/utils/layout/useNodeItem.ts
+++ b/src/utils/layout/useNodeItem.ts
@@ -1,6 +1,6 @@
 import { FD } from 'src/features/formData/FormDataWrite';
 import { getComponentDef } from 'src/layout';
-import { useCurrentDataModelLocation, useDataModelLocationForNode } from 'src/utils/layout/DataModelLocation';
+import { useCurrentDataModelLocation } from 'src/utils/layout/DataModelLocation';
 import { useExpressionResolverProps } from 'src/utils/layout/generator/NodeGenerator';
 import { useDataModelBindingsFor, useIntermediateItem } from 'src/utils/layout/hooks';
 import { NodesInternal, useNodes } from 'src/utils/layout/NodesContext';
@@ -10,30 +10,6 @@ import type { FormDataSelector } from 'src/layout';
 import type { CompInternal, CompTypes, IDataModelBindings, TypeFromNode } from 'src/layout/layout';
 import type { IComponentFormData } from 'src/utils/formComponentUtils';
 import type { LayoutNode } from 'src/utils/layout/LayoutNode';
-import type { NodeItemFromNode } from 'src/utils/layout/types';
-
-/**
- * Use the item of a node. This re-renders when the item changes (or when the part of the item you select changes),
- * which doesn't happen if you use node.item directly.
- */
-export function useNodeItem<N extends LayoutNode, Out>(node: N, selector: (item: NodeItemFromNode<N>) => Out): Out;
-// eslint-disable-next-line no-redeclare
-export function useNodeItem<N extends LayoutNode>(node: N, selector?: undefined): NodeItemFromNode<N>;
-// eslint-disable-next-line no-redeclare
-export function useNodeItem(node: LayoutNode, selector: never): unknown {
-  const intermediate = useIntermediateItem(node.baseId);
-  const location = useDataModelLocationForNode(node.id);
-  const dataSources = useExpressionDataSources(intermediate, { dataSources: { currentDataModelPath: () => location } });
-  const props = useExpressionResolverProps(`Invalid expression for ${node?.id}`, intermediate, dataSources);
-  const resolved = node?.def.evalExpressions(props as never);
-
-  if (!resolved) {
-    return undefined;
-  }
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return selector ? (selector as any)(resolved) : resolved;
-}
 
 /**
  * This evaluates all expressions for a given component configuration. If the type is not correct, things will crash.


### PR DESCRIPTION
## Description

This was simply a chore. To get to a place where we don't need the `LayoutNode` objects anymore, we have to get rid of the places that pass them around. I would assume the most-used hook using taking that object in is the `useNodeItem()` hook that returns the layout config with expressions already evaluated.

I wanted to simply pass `baseComponentId` instead, but it's not possible to replace `useNodeItem()` with just one hook. Instead we get three:
- `useItemWhenType(baseComponentId, type)` is the one you'll most likely want to use. Given a component id (without indexes) and a component type, you'll get back the layout config for that component id, with expressions resolved, but only when the type matches. If the type doesn't match, things will crash. That's a good thing - it prevents sneaky bugs where you'll get config you didn't expect for another component type.
- `useItemIfType(baseComponentId, type)` is useful in a handful of cases where the previous hook crashing isn't optimal. If the type doesn't match the type you expect, this will instead just return `undefined`. This is useful when you don't know the type beforehand, but only need to evaluate expressions if the type is the one you're looking for. Rarely used in practice.
- `useItemFor(baseComponentId)` is for everything else. You don't know the type, and you don't care which type it is. You just want the evaluated expressions, and that's it. You'll get a `CompInternal` back, but nobody knows the exact type unless you check it afterwards.

In some cases I used `useExternalItem()` or other hooks instead, because the code wasn't really using any properties with possible expressions in them, so then there's no need to evaluate them either.

I do think these hooks will only be one stop along the way to a better solution, hopefully one where each property with an expression can be resolved individually, so that we don't get data sources for things we don't need in that context - and only re-render when the data we used is the data that changes. However, to get rid of `LayoutNode`, `LayoutPage` and `LayoutPages`, this is the obvious first thing to tackle.

## Related Issue(s)

- #3147

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [x] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->
