### PR TITLE
Fixes attachment list title disappearing

### DIFF
--- a/src/components/atoms/AltinnAttachments.test.tsx
+++ b/src/components/atoms/AltinnAttachments.test.tsx
@@ -48,6 +48,10 @@ jest.mock('src/features/language/useLanguage', () => ({
   })),
 }));
 
+jest.mock('src/features/language/Lang', () => ({
+  Lang: ({ id }) => <span data-testid='lang-component'>{id}</span>,
+}));
+
 jest.mock('src/layout/FileUpload/FileUploadTable/AttachmentFileName', () => ({
   FileExtensionIcon: jest.fn(({ fileEnding, className }) => (
     <span

--- a/src/components/atoms/AltinnAttachments.tsx
+++ b/src/components/atoms/AltinnAttachments.tsx
@@ -41,7 +41,7 @@ export function AltinnAttachments({
       {title && (
         <Heading
           level={2}
-          data-size='xs'
+          data-size='sm'
         >
           {title}
         </Heading>

--- a/src/components/atoms/AltinnAttachments.tsx
+++ b/src/components/atoms/AltinnAttachments.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import type { PropsWithChildren } from 'react';
 
-import { Heading, Link, List } from '@digdir/designsystemet-react';
+import { Link, List } from '@digdir/designsystemet-react';
 import cn from 'classnames';
 
 import classes from 'src/components/atoms/AltinnAttachment.module.css';
+import { MainAttachmentHeader } from 'src/components/atoms/AttachmentHeader';
 import { Lang } from 'src/features/language/Lang';
 import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
 import { useLanguage } from 'src/features/language/useLanguage';
@@ -38,14 +39,7 @@ export function AltinnAttachments({
       id={id}
       data-testid='attachment-list'
     >
-      {title && (
-        <Heading
-          level={2}
-          data-size='sm'
-        >
-          {title}
-        </Heading>
-      )}
+      <MainAttachmentHeader title={title} />
       <List.Unordered
         className={classes.attachmentList}
         data-size='sm'

--- a/src/components/atoms/AltinnAttachments.tsx
+++ b/src/components/atoms/AltinnAttachments.tsx
@@ -5,6 +5,7 @@ import { Heading, Link, List } from '@digdir/designsystemet-react';
 import cn from 'classnames';
 
 import classes from 'src/components/atoms/AltinnAttachment.module.css';
+import { Lang } from 'src/features/language/Lang';
 import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
 import { useLanguage } from 'src/features/language/useLanguage';
 import { FileExtensionIcon } from 'src/layout/FileUpload/FileUploadTable/AttachmentFileName';
@@ -85,7 +86,7 @@ function Attachment({ attachment, showLink, showDescription }: IAltinnAttachment
           <div className={classes.attachmentText}>
             {showDescription && attachment.description?.[currentLanguage] && (
               <div className={classes.description}>
-                {attachment.description[currentLanguage]}
+                <Lang id={attachment.description[currentLanguage]} />
                 <span>&nbsp;&ndash;&ndash;&nbsp;</span>
               </div>
             )}
@@ -114,7 +115,7 @@ function AttachmentFileName({
         href={attachment.url && makeUrlRelativeIfSameDomain(attachment.url)}
         className={cn(classes.attachment, classes.attachmentLink)}
         aria-label={langAsString('general.download', [`${attachment.name}`])}
-        aria-description={attachment.description?.[currentLanguage]}
+        aria-description={langAsString(attachment.description?.[currentLanguage])}
       >
         {children}
       </Link>

--- a/src/components/atoms/AttachmentHeader.tsx
+++ b/src/components/atoms/AttachmentHeader.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+import { Heading } from '@digdir/designsystemet-react';
+
+export function MainAttachmentHeader({ title, className }: { title: React.ReactNode; className?: string }) {
+  if (!title) {
+    return null;
+  }
+
+  return (
+    <Heading
+      level={2}
+      data-size='sm'
+      className={className}
+    >
+      {title}
+    </Heading>
+  );
+}
+
+export function SubAttachmentHeader({ title }: { title: React.ReactNode }) {
+  return (
+    <Heading
+      level={3}
+      data-size='xs'
+    >
+      {title}
+    </Heading>
+  );
+}

--- a/src/components/molecules/AltinnCollapsibleAttachments.test.tsx
+++ b/src/components/molecules/AltinnCollapsibleAttachments.test.tsx
@@ -1,0 +1,308 @@
+import React from 'react';
+
+import { jest } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { AltinnCollapsibleAttachments } from 'src/components/molecules/AltinnCollapsibleAttachments';
+import type { IDisplayAttachment } from 'src/types/shared';
+
+const mockAttachments = [
+  {
+    name: 'file1.pdf',
+    url: 'https://example.com/file1.pdf',
+    description: {
+      nb: 'Beskrivelse av fil 1',
+      en: 'Description of file 1',
+    },
+  },
+  {
+    name: 'file2.docx',
+    url: 'https://example.com/file2.docx',
+    description: {
+      nb: 'Beskrivelse av fil 2',
+      en: 'Description of file 2',
+    },
+  },
+  {
+    name: 'file3.xlsx',
+    url: 'https://example.com/file3.xlsx',
+    description: undefined,
+  },
+  {
+    name: 'file4.txt',
+    url: 'https://example.com/file4.txt',
+    description: undefined,
+  },
+  {
+    name: 'file5.png',
+    url: 'https://example.com/file5.png',
+    description: undefined,
+  },
+] as unknown as IDisplayAttachment[];
+
+// Mock the AltinnAttachments component
+jest.mock('src/components/atoms/AltinnAttachments', () => ({
+  AltinnAttachments: jest.fn(({ id, title, attachments }) => (
+    <div data-testid='attachment-list'>
+      {id && <div data-testid='list-id'>{id}</div>}
+      {title && <div data-testid='list-title'>{title}</div>}
+      {attachments?.map((attachment: IDisplayAttachment, index: number) => (
+        <div
+          key={index}
+          data-testid='attachment-item'
+        >
+          {attachment.name}
+        </div>
+      ))}
+    </div>
+  )),
+}));
+
+// Mock the AltinnCollapsible component
+jest.mock('src/components/AltinnCollapsible', () => ({
+  AltinnCollapsible: jest.fn(({ open, children }) => (
+    <div
+      data-testid='collapsible-content'
+      style={{ display: open ? 'block' : 'none' }}
+    >
+      {children}
+    </div>
+  )),
+}));
+
+// Mock CSS modules
+jest.mock('src/components/molecules/AltinnCollapsibleAttachments.module.css', () => ({
+  container: 'container',
+  transformArrowRight: 'transform-arrow-right',
+  transition: 'transition',
+}));
+
+describe('AltinnCollapsibleAttachments', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Reset window.matchMedia mock
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn().mockImplementation(() => ({
+        matches: false,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+      })),
+    });
+  });
+
+  describe('when there are no attachments', () => {
+    it('displays attachments list without collapsible functionality', () => {
+      render(
+        <AltinnCollapsibleAttachments
+          attachments={[]}
+          title='Test Title'
+          showLinks={true}
+          showDescription={false}
+        />,
+      );
+
+      expect(screen.getByTestId('attachment-list')).toBeInTheDocument();
+      expect(screen.getByTestId('list-id')).toHaveTextContent('attachment-list');
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
+
+    it('displays attachments list when attachments is undefined', () => {
+      render(
+        <AltinnCollapsibleAttachments
+          attachments={undefined}
+          title='Test Title'
+          showLinks={true}
+          showDescription={false}
+        />,
+      );
+
+      expect(screen.getByTestId('attachment-list')).toBeInTheDocument();
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('when there are attachments', () => {
+    it('displays a collapsible button with the title', () => {
+      render(
+        <AltinnCollapsibleAttachments
+          attachments={mockAttachments}
+          title='My Attachments'
+          showLinks={true}
+          showDescription={false}
+        />,
+      );
+
+      expect(screen.getByRole('button')).toBeInTheDocument();
+      expect(screen.getByText('My Attachments')).toBeInTheDocument();
+    });
+
+    it('shows attachments by default', () => {
+      render(
+        <AltinnCollapsibleAttachments
+          attachments={mockAttachments}
+          title='My Attachments'
+          showLinks={true}
+          showDescription={false}
+        />,
+      );
+
+      expect(screen.getByTestId('collapsible-content')).toHaveStyle({ display: 'block' });
+      expect(screen.getByTestId('attachment-list')).toBeInTheDocument();
+    });
+
+    it('hides and shows attachments when user clicks the collapse button', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <AltinnCollapsibleAttachments
+          attachments={mockAttachments}
+          title='My Attachments'
+          showLinks={true}
+          showDescription={false}
+        />,
+      );
+
+      const button = screen.getByRole('button');
+
+      // Collapse
+      await user.click(button);
+      expect(screen.getByTestId('collapsible-content')).toHaveStyle({
+        display: 'none',
+      });
+
+      // Expand
+      await user.click(button);
+      expect(screen.getByTestId('collapsible-content')).toHaveStyle({
+        display: 'block',
+      });
+    });
+
+    it('toggles when user presses Enter key', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <AltinnCollapsibleAttachments
+          attachments={mockAttachments}
+          title='My Attachments'
+          showLinks={true}
+          showDescription={false}
+        />,
+      );
+
+      const button = screen.getByRole('button');
+
+      // Initially expanded
+      expect(screen.getByTestId('collapsible-content')).toHaveStyle({ display: 'block' });
+
+      // Focus the button and press Enter to collapse
+      button.focus();
+      await user.keyboard('{Enter}');
+      expect(screen.getByTestId('collapsible-content')).toHaveStyle({ display: 'none' });
+    });
+
+    it('is keyboard accessible with proper tabindex', () => {
+      render(
+        <AltinnCollapsibleAttachments
+          attachments={mockAttachments}
+          title='My Attachments'
+          showLinks={true}
+          showDescription={false}
+        />,
+      );
+
+      const button = screen.getByRole('button');
+      expect(button).toHaveAttribute('tabIndex', '0');
+    });
+
+    it('displays all attachment names', () => {
+      render(
+        <AltinnCollapsibleAttachments
+          attachments={mockAttachments}
+          title='My Attachments'
+          showLinks={true}
+          showDescription={false}
+        />,
+      );
+
+      expect(screen.getByText('file1.pdf')).toBeInTheDocument();
+      expect(screen.getByText('file2.docx')).toBeInTheDocument();
+      expect(screen.getByText('file3.xlsx')).toBeInTheDocument();
+      expect(screen.getByText('file4.txt')).toBeInTheDocument();
+      expect(screen.getByText('file5.png')).toBeInTheDocument();
+    });
+
+    it('handles complex title elements', () => {
+      const ComplexTitle = () => (
+        <div>
+          <span>Documents</span>
+          <strong> (5)</strong>
+        </div>
+      );
+
+      render(
+        <AltinnCollapsibleAttachments
+          attachments={mockAttachments}
+          title={<ComplexTitle />}
+          showLinks={true}
+          showDescription={false}
+        />,
+      );
+
+      expect(screen.getByText('Documents')).toBeInTheDocument();
+      expect(screen.getByText('(5)')).toBeInTheDocument();
+    });
+  });
+
+  describe('when printing', () => {
+    it('displays attachments without collapsible functionality', () => {
+      // Mock print media query
+      Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: jest.fn().mockImplementation(() => ({
+          matches: true,
+          addListener: jest.fn(),
+          removeListener: jest.fn(),
+          addEventListener: jest.fn(),
+          removeEventListener: jest.fn(),
+        })),
+      });
+
+      render(
+        <AltinnCollapsibleAttachments
+          attachments={mockAttachments}
+          title='Print Title'
+          showLinks={true}
+          showDescription={false}
+        />,
+      );
+
+      expect(screen.getByTestId('attachment-list')).toBeInTheDocument();
+      expect(screen.getByTestId('list-title')).toHaveTextContent('Print Title');
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('accessibility', () => {
+    it('maintains focus on the button after interaction', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <AltinnCollapsibleAttachments
+          attachments={mockAttachments}
+          title='My Attachments'
+          showLinks={true}
+          showDescription={false}
+        />,
+      );
+
+      const button = screen.getByRole('button');
+      await user.click(button);
+
+      expect(button).toHaveFocus();
+    });
+  });
+});

--- a/src/components/molecules/AltinnCollapsibleAttachments.tsx
+++ b/src/components/molecules/AltinnCollapsibleAttachments.tsx
@@ -21,7 +21,7 @@ export function AltinnCollapsibleAttachments({
   showLinks = true,
   showDescription,
 }: IAltinnCollapsibleAttachmentsProps) {
-  const isCollapsible = useIsPrint() ? false : Boolean(attachments && attachments.length > 0);
+  const isCollapsible = useIsPrint() ? false : Boolean(attachments && attachments.length > 4);
   const [open, setOpen] = React.useState(true);
 
   function handleOpenClose() {

--- a/src/components/molecules/AltinnCollapsibleAttachments.tsx
+++ b/src/components/molecules/AltinnCollapsibleAttachments.tsx
@@ -48,7 +48,10 @@ export function AltinnCollapsibleAttachments({
             fontSize='1.5rem'
             className={cn({ [classes.transformArrowRight]: !open }, classes.transition)}
           />
-          <Heading data-size='xs'>
+          <Heading
+            level={3}
+            data-size='xs'
+          >
             {title} {attachmentCount}
           </Heading>
         </div>

--- a/src/components/molecules/AltinnCollapsibleAttachments.tsx
+++ b/src/components/molecules/AltinnCollapsibleAttachments.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 
-import { Heading } from '@digdir/designsystemet-react';
 import { CaretDownFillIcon } from '@navikt/aksel-icons';
 import cn from 'classnames';
 
@@ -12,7 +11,6 @@ import type { IDisplayAttachment } from 'src/types/shared';
 interface IAltinnCollapsibleAttachmentsProps {
   attachments: IDisplayAttachment[] | undefined;
   title: React.ReactNode | undefined;
-  hideCount?: boolean;
   showLinks: boolean | undefined;
   showDescription: boolean;
 }
@@ -20,18 +18,15 @@ interface IAltinnCollapsibleAttachmentsProps {
 export function AltinnCollapsibleAttachments({
   attachments,
   title,
-  hideCount,
   showLinks = true,
   showDescription,
 }: IAltinnCollapsibleAttachmentsProps) {
-  const isCollapsible = useIsPrint() ? false : Boolean(attachments && attachments.length > 4);
+  const isCollapsible = useIsPrint() ? false : Boolean(attachments && attachments.length > 0);
   const [open, setOpen] = React.useState(true);
 
   function handleOpenClose() {
     setOpen(!open);
   }
-
-  const attachmentCount = hideCount ? '' : `(${attachments && attachments.length})`;
 
   if (isCollapsible) {
     return (
@@ -48,12 +43,7 @@ export function AltinnCollapsibleAttachments({
             fontSize='1.5rem'
             className={cn({ [classes.transformArrowRight]: !open }, classes.transition)}
           />
-          <Heading
-            level={3}
-            data-size='xs'
-          >
-            {title} {attachmentCount}
-          </Heading>
+          {title}
         </div>
         <AltinnCollapsible open={open}>
           <AltinnAttachments
@@ -69,11 +59,7 @@ export function AltinnCollapsibleAttachments({
   return (
     <AltinnAttachments
       id='attachment-list'
-      title={
-        <>
-          {title} {attachmentCount}
-        </>
-      }
+      title={title}
       attachments={attachments}
       showLinks={showLinks}
       showDescription={showDescription}

--- a/src/components/organisms/AltinnReceipt.test.tsx
+++ b/src/components/organisms/AltinnReceipt.test.tsx
@@ -10,7 +10,7 @@ const render = async (props: Partial<IReceiptComponentProps> = {}) => {
   const allProps = {
     attachments: undefined,
     body: 'body',
-    collapsibleTitle: 'collapsibleTitle',
+    collapsibleTitle: <>collapsibleTitle</>,
     instanceMetaDataObject: {},
     title: 'title',
     titleSubmitted: 'titleSubmitted',
@@ -98,7 +98,7 @@ describe('AltinnReceipt', () => {
   it('should show 2 attachments in default group when group name is not set', async () => {
     await render({
       attachments: [attachment1, attachment2],
-      collapsibleTitle: 'collapsibleTitle',
+      collapsibleTitle: <>collapsibleTitle</>,
       hideCollapsibleCount: false,
     });
 
@@ -110,7 +110,7 @@ describe('AltinnReceipt', () => {
   it('should not show collapsible count when hideCollapsibleCount is true', async () => {
     await render({
       attachments: [attachment1, attachment2],
-      collapsibleTitle: 'collapsibleTitle',
+      collapsibleTitle: <>collapsibleTitle</>,
       hideCollapsibleCount: true,
     });
 
@@ -124,7 +124,7 @@ describe('AltinnReceipt', () => {
         { ...attachment1, grouping: 'group1' },
         { ...attachment2, grouping: 'group2' },
       ],
-      collapsibleTitle: 'collapsibleTitle',
+      collapsibleTitle: <>collapsibleTitle</>,
       hideCollapsibleCount: false,
     });
 

--- a/src/components/organisms/AltinnReceipt.tsx
+++ b/src/components/organisms/AltinnReceipt.tsx
@@ -13,7 +13,7 @@ import type { IDisplayAttachment } from 'src/types/shared';
 export interface IReceiptComponentProps {
   attachments: IDisplayAttachment[] | undefined;
   body: React.ReactNode;
-  collapsibleTitle: React.ReactNode;
+  collapsibleTitle: JSX.Element | undefined;
   hideCollapsibleCount?: boolean;
   instanceMetaDataObject: SummaryDataObject;
   pdf: IDisplayAttachment[];
@@ -88,7 +88,7 @@ export function ReceiptComponent({
       {attachments && (
         <AttachmentGroupings
           attachments={attachments}
-          collapsibleTitle={collapsibleTitle}
+          title={collapsibleTitle}
           hideCollapsibleCount={hideCollapsibleCount}
           showLinks={true}
         />

--- a/src/components/organisms/AttachmentGroupings.module.css
+++ b/src/components/organisms/AttachmentGroupings.module.css
@@ -1,0 +1,11 @@
+.paddingBottom {
+  padding-bottom: var(--ds-size-2);
+}
+
+.groupList {
+  padding: 0;
+}
+
+.groupList li {
+  list-style: none;
+}

--- a/src/components/organisms/AttachmentGroupings.test.tsx
+++ b/src/components/organisms/AttachmentGroupings.test.tsx
@@ -1,0 +1,247 @@
+import React from 'react';
+
+import { jest } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+
+import { AttachmentGroupings } from 'src/components/organisms/AttachmentGroupings';
+import type { IDisplayAttachment } from 'src/types/shared';
+
+const mockAttachments: IDisplayAttachment[] = [
+  {
+    name: 'file1.pdf',
+    url: 'https://example.com/file1.pdf',
+    grouping: 'Documents',
+    description: { nb: 'Beskrivelse 1' },
+  },
+  {
+    name: 'file2.docx',
+    url: 'https://example.com/file2.docx',
+    grouping: 'Documents',
+    description: { nb: 'Beskrivelse 2' },
+  },
+  {
+    name: 'image1.jpg',
+    url: 'https://example.com/image1.jpg',
+    grouping: 'Images',
+    description: { nb: 'Bilde 1' },
+  },
+  {
+    name: 'file3.txt',
+    url: 'https://example.com/file3.txt',
+    grouping: undefined, // No grouping
+    description: { nb: 'Fil uten gruppering' },
+  },
+] as unknown as IDisplayAttachment[];
+
+// Mock the AltinnCollapsibleAttachments component
+jest.mock('src/components/molecules/AltinnCollapsibleAttachments', () => ({
+  AltinnCollapsibleAttachments: jest.fn(({ attachments, title }) => (
+    <div data-testid='collapsible-attachments'>
+      <div data-testid='collapsible-title'>{title}</div>
+      <div data-testid='attachment-count'>{attachments?.length || 0}</div>
+      {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+      {attachments?.map((attachment: any, index: number) => (
+        <div
+          key={index}
+          data-testid='attachment-item'
+        >
+          {attachment.name}
+        </div>
+      ))}
+    </div>
+  )),
+}));
+
+// Mock the language hook
+jest.mock('src/features/language/useLanguage', () => ({
+  useLanguage: jest.fn(() => ({
+    langAsString: jest.fn((key) => key),
+  })),
+}));
+
+// Mock CSS modules
+jest.mock('src/components/organisms/AttachmentGroupings.module.css', () => ({
+  groupList: 'group-list',
+  paddingBottom: 'padding-bottom',
+}));
+
+describe('AttachmentGroupings', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('when there are no attachments', () => {
+    it.each([[], undefined])(
+      'displays only the main title when attachments array is empty or undefined',
+      (attachments) => {
+        render(
+          <AttachmentGroupings
+            attachments={attachments}
+            title={<span>My Documents</span>}
+            showLinks={true}
+          />,
+        );
+
+        expect(screen.getByText('My Documents')).toBeInTheDocument();
+        expect(screen.getByRole('heading', { level: 2 })).toBeInTheDocument();
+        expect(screen.queryByRole('list')).not.toBeInTheDocument();
+      },
+    );
+
+    it('renders nothing when no attachments and no title', () => {
+      const { container } = render(
+        <AttachmentGroupings
+          attachments={[]}
+          title={undefined}
+          showLinks={true}
+        />,
+      );
+
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('hides count when hideCollapsibleCount is true and no attachments', () => {
+      render(
+        <AttachmentGroupings
+          attachments={[]}
+          title={<span>Empty List</span>}
+          hideCollapsibleCount={true}
+          showLinks={true}
+        />,
+      );
+
+      const heading = screen.getByRole('heading', { level: 2 });
+      expect(heading).toHaveTextContent('Empty List');
+      expect(heading).not.toHaveTextContent('(0)');
+    });
+  });
+
+  describe('when there are attachments', () => {
+    it('displays all grouped attachments in collapsible sections', () => {
+      render(
+        <AttachmentGroupings
+          attachments={mockAttachments}
+          title={<span>All Files</span>}
+          showLinks={true}
+        />,
+      );
+
+      expect(screen.getByRole('list')).toBeInTheDocument();
+      expect(screen.getAllByRole('listitem')).toHaveLength(3);
+      expect(screen.getAllByTestId('collapsible-attachments')).toHaveLength(3);
+    });
+
+    it('shows correct attachment counts per group', () => {
+      render(
+        <AttachmentGroupings
+          attachments={mockAttachments}
+          title={<span>All Files</span>}
+          showLinks={true}
+        />,
+      );
+
+      const counts = screen.getAllByTestId('attachment-count');
+      expect(counts).toHaveLength(3);
+
+      // Check that counts are correct (order depends on sorting)
+      const countValues = counts.map((el) => el.textContent);
+      expect(countValues).toContain('1'); // ungrouped
+      expect(countValues).toContain('2'); // Documents
+      expect(countValues).toContain('1'); // Images
+    });
+
+    it('sorts ungrouped attachments first', () => {
+      render(
+        <AttachmentGroupings
+          attachments={mockAttachments}
+          title={<span>All Files</span>}
+          showLinks={true}
+        />,
+      );
+
+      const listItems = screen.getAllByRole('listitem');
+      const firstItem = listItems[0];
+
+      // First item should contain the ungrouped attachment
+      expect(firstItem).toContainElement(screen.getByText('file3.txt'));
+    });
+  });
+
+  describe('title display logic', () => {
+    it('displays main title when all attachments have grouping', () => {
+      const groupedAttachments = mockAttachments.filter((att) => att.grouping);
+
+      render(
+        <AttachmentGroupings
+          attachments={groupedAttachments}
+          title={<span>Grouped Files</span>}
+          showLinks={true}
+        />,
+      );
+
+      expect(screen.getByText('Grouped Files')).toBeInTheDocument();
+      expect(screen.getByRole('heading', { level: 2 })).toBeInTheDocument();
+    });
+
+    it('does not display main title separately when ungrouped attachments exist', () => {
+      render(
+        <AttachmentGroupings
+          attachments={mockAttachments}
+          title={<span>Mixed Files</span>}
+          showLinks={true}
+        />,
+      );
+
+      // Main title should be within the ungrouped section, not separately
+      expect(screen.getByText('Mixed Files')).toBeInTheDocument();
+
+      // Should only have group titles as separate headings
+      const headings = screen.getAllByRole('heading');
+      expect(headings).toHaveLength(3); // One for each group
+    });
+
+    it('shows group names with attachment counts', () => {
+      render(
+        <AttachmentGroupings
+          attachments={mockAttachments}
+          title={<span>All Files</span>}
+          showLinks={true}
+        />,
+      );
+
+      expect(screen.getByText('Documents (2)')).toBeInTheDocument();
+      expect(screen.getByText('Images (1)')).toBeInTheDocument();
+    });
+
+    it('hides attachment counts when hideCollapsibleCount is true', () => {
+      render(
+        <AttachmentGroupings
+          attachments={mockAttachments}
+          title={<span>All Files</span>}
+          hideCollapsibleCount={true}
+          showLinks={true}
+        />,
+      );
+
+      expect(screen.getByText('Documents')).toBeInTheDocument();
+      expect(screen.getByText('Images')).toBeInTheDocument();
+      expect(screen.queryByText('Documents (2)')).not.toBeInTheDocument();
+      expect(screen.queryByText('Images (1)')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('accessibility', () => {
+    it('uses proper list structure', () => {
+      render(
+        <AttachmentGroupings
+          attachments={mockAttachments}
+          title={<span>All Files</span>}
+          showLinks={true}
+        />,
+      );
+
+      expect(screen.getByRole('list')).toBeInTheDocument();
+      expect(screen.getAllByRole('listitem')).toHaveLength(3);
+    });
+  });
+});

--- a/src/components/organisms/AttachmentGroupings.tsx
+++ b/src/components/organisms/AttachmentGroupings.tsx
@@ -1,12 +1,17 @@
 import React from 'react';
+import type { JSX } from 'react';
+
+import { Heading } from '@digdir/designsystemet-react';
+import cn from 'classnames';
 
 import { AltinnCollapsibleAttachments } from 'src/components/molecules/AltinnCollapsibleAttachments';
+import classes from 'src/components/organisms/AttachmentGroupings.module.css';
 import { useLanguage } from 'src/features/language/useLanguage';
 import type { IDisplayAttachment } from 'src/types/shared';
 
 interface IRenderAttachmentGroupings {
   attachments: IDisplayAttachment[] | undefined;
-  collapsibleTitle: React.ReactNode;
+  title: JSX.Element | undefined;
   hideCollapsibleCount?: boolean;
   showLinks: boolean | undefined;
   showDescription?: boolean;
@@ -16,7 +21,7 @@ const defaultGroupingKey = 'null';
 
 export const AttachmentGroupings = ({
   attachments = [],
-  collapsibleTitle,
+  title,
   hideCollapsibleCount,
   showLinks = true,
   showDescription = false,
@@ -43,24 +48,40 @@ export const AttachmentGroupings = ({
     return 0;
   }
 
-  if (!groupings) {
+  if (!Object.entries(groupings).length) {
     return null;
   }
+  const attachmentsWithoutGrouping = groupings[defaultGroupingKey] ?? [];
+  const hasAnyDocumentsWithoutGrouping = attachmentsWithoutGrouping.length > 0;
+  const noGroupingAttachmentCount =
+    !hideCollapsibleCount && attachmentsWithoutGrouping.length > 0 ? `(${attachmentsWithoutGrouping.length})` : '';
 
   return (
     <>
-      {Object.keys(groupings)
-        .sort(sortDefaultGroupingFirst)
-        .map((groupTitle, index) => (
-          <AltinnCollapsibleAttachments
-            key={index}
-            attachments={groupings[groupTitle]}
-            title={groupTitle === 'null' ? collapsibleTitle : groupTitle}
-            hideCount={hideCollapsibleCount}
-            showLinks={showLinks}
-            showDescription={showDescription}
-          />
-        ))}
+      {title && (
+        <Heading
+          level={2}
+          data-size='sm'
+          className={cn({ [classes.paddingBottom]: !hasAnyDocumentsWithoutGrouping })}
+        >
+          {title}&nbsp;{noGroupingAttachmentCount}
+        </Heading>
+      )}
+      <ul className={classes.groupList}>
+        {Object.keys(groupings)
+          .sort(sortDefaultGroupingFirst)
+          .map((groupTitle) => (
+            <li key={groupTitle}>
+              <AltinnCollapsibleAttachments
+                attachments={groupings[groupTitle]}
+                title={groupTitle === defaultGroupingKey ? undefined : groupTitle}
+                hideCount={hideCollapsibleCount}
+                showLinks={showLinks}
+                showDescription={showDescription}
+              />
+            </li>
+          ))}
+      </ul>
     </>
   );
 };

--- a/src/components/organisms/AttachmentGroupings.tsx
+++ b/src/components/organisms/AttachmentGroupings.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import type { JSX } from 'react';
 
-import { Heading } from '@digdir/designsystemet-react';
 import cn from 'classnames';
 
+import { MainAttachmentHeader, SubAttachmentHeader } from 'src/components/atoms/AttachmentHeader';
 import { AltinnCollapsibleAttachments } from 'src/components/molecules/AltinnCollapsibleAttachments';
 import classes from 'src/components/organisms/AttachmentGroupings.module.css';
 import { useLanguage } from 'src/features/language/useLanguage';
@@ -100,23 +100,25 @@ function GroupingTitle({ groupTitle, hideCollapsibleCount, groupings, mainTitle 
 
   if (groupTitle === defaultGroupingKey) {
     return (
-      <Heading
-        level={2}
-        data-size='sm'
+      <MainAttachmentHeader
+        title={
+          <>
+            {mainTitle}&nbsp;{numAttachmentsInGroup}
+          </>
+        }
         className={cn({ [classes.paddingBottom]: !hasAnyAttachmentsWithoutGrouping })}
-      >
-        {mainTitle}&nbsp;{numAttachmentsInGroup}
-      </Heading>
+      />
     );
   }
 
   return (
-    <Heading
-      level={3}
-      data-size='xs'
-    >
-      {groupTitle}&nbsp;{numAttachmentsInGroup}
-    </Heading>
+    <SubAttachmentHeader
+      title={
+        <>
+          {groupTitle}&nbsp;{numAttachmentsInGroup}
+        </>
+      }
+    />
   );
 }
 

--- a/src/components/organisms/AttachmentGroupings.tsx
+++ b/src/components/organisms/AttachmentGroupings.tsx
@@ -9,23 +9,23 @@ import classes from 'src/components/organisms/AttachmentGroupings.module.css';
 import { useLanguage } from 'src/features/language/useLanguage';
 import type { IDisplayAttachment } from 'src/types/shared';
 
-interface IRenderAttachmentGroupings {
+const defaultGroupingKey = 'null';
+
+type AttachmentGroupingsProps = {
   attachments: IDisplayAttachment[] | undefined;
   title: JSX.Element | undefined;
   hideCollapsibleCount?: boolean;
   showLinks: boolean | undefined;
   showDescription?: boolean;
-}
+};
 
-const defaultGroupingKey = 'null';
-
-export const AttachmentGroupings = ({
+export function AttachmentGroupings({
   attachments = [],
   title,
   hideCollapsibleCount,
   showLinks = true,
   showDescription = false,
-}: IRenderAttachmentGroupings) => {
+}: AttachmentGroupingsProps) {
   const langTools = useLanguage();
 
   const groupings = attachments?.reduce<Record<string, IDisplayAttachment[]>>((acc, attachment) => {
@@ -38,34 +38,28 @@ export const AttachmentGroupings = ({
     return acc;
   }, {});
 
-  function sortDefaultGroupingFirst(a: string, b: string) {
-    if (a === defaultGroupingKey) {
-      return -1;
-    }
-    if (b === defaultGroupingKey) {
-      return 1;
-    }
-    return 0;
-  }
-
   if (!Object.entries(groupings).length) {
-    return null;
+    return title ? (
+      <GroupingTitle
+        groupTitle={defaultGroupingKey}
+        hideCollapsibleCount={!!hideCollapsibleCount}
+        groupings={groupings}
+        mainTitle={title}
+      />
+    ) : null;
   }
   const attachmentsWithoutGrouping = groupings[defaultGroupingKey] ?? [];
-  const hasAnyDocumentsWithoutGrouping = attachmentsWithoutGrouping.length > 0;
-  const noGroupingAttachmentCount =
-    !hideCollapsibleCount && attachmentsWithoutGrouping.length > 0 ? `(${attachmentsWithoutGrouping.length})` : '';
+  const hasAnyAttachmentsWithoutGrouping = attachmentsWithoutGrouping.length > 0;
 
   return (
     <>
-      {title && (
-        <Heading
-          level={2}
-          data-size='sm'
-          className={cn({ [classes.paddingBottom]: !hasAnyDocumentsWithoutGrouping })}
-        >
-          {title}&nbsp;{noGroupingAttachmentCount}
-        </Heading>
+      {!hasAnyAttachmentsWithoutGrouping && title && (
+        <GroupingTitle
+          groupTitle={defaultGroupingKey}
+          hideCollapsibleCount={!!hideCollapsibleCount}
+          groupings={groupings}
+          mainTitle={title}
+        />
       )}
       <ul className={classes.groupList}>
         {Object.keys(groupings)
@@ -74,8 +68,14 @@ export const AttachmentGroupings = ({
             <li key={groupTitle}>
               <AltinnCollapsibleAttachments
                 attachments={groupings[groupTitle]}
-                title={groupTitle === defaultGroupingKey ? undefined : groupTitle}
-                hideCount={hideCollapsibleCount}
+                title={
+                  <GroupingTitle
+                    groupTitle={groupTitle}
+                    hideCollapsibleCount={!!hideCollapsibleCount}
+                    groupings={groupings}
+                    mainTitle={title}
+                  />
+                }
                 showLinks={showLinks}
                 showDescription={showDescription}
               />
@@ -84,4 +84,48 @@ export const AttachmentGroupings = ({
       </ul>
     </>
   );
+}
+
+type GroupingTitleProps = {
+  groupTitle: string;
+  hideCollapsibleCount: boolean;
+  groupings: Record<string, IDisplayAttachment[]>;
+  mainTitle: JSX.Element | undefined;
 };
+
+function GroupingTitle({ groupTitle, hideCollapsibleCount, groupings, mainTitle }: GroupingTitleProps) {
+  const numAttachmentsInGroup = hideCollapsibleCount ? '' : `(${groupings[groupTitle]?.length ?? 0})`;
+  const attachmentsWithoutGrouping = groupings[defaultGroupingKey] ?? [];
+  const hasAnyAttachmentsWithoutGrouping = attachmentsWithoutGrouping.length > 0;
+
+  if (groupTitle === defaultGroupingKey) {
+    return (
+      <Heading
+        level={2}
+        data-size='sm'
+        className={cn({ [classes.paddingBottom]: !hasAnyAttachmentsWithoutGrouping })}
+      >
+        {mainTitle}&nbsp;{numAttachmentsInGroup}
+      </Heading>
+    );
+  }
+
+  return (
+    <Heading
+      level={3}
+      data-size='xs'
+    >
+      {groupTitle}&nbsp;{numAttachmentsInGroup}
+    </Heading>
+  );
+}
+
+function sortDefaultGroupingFirst(a: string, b: string) {
+  if (a === defaultGroupingKey) {
+    return -1;
+  }
+  if (b === defaultGroupingKey) {
+    return 1;
+  }
+  return 0;
+}

--- a/src/layout/AttachmentList/AttachmentListComponent.tsx
+++ b/src/layout/AttachmentList/AttachmentListComponent.tsx
@@ -69,12 +69,14 @@ export function AttachmentListComponent({ node }: IAttachmentListProps) {
 
   const displayAttachments = toDisplayAttachments([...pdfAttachments, ...filteredAttachments]);
 
+  const title = textResourceBindings?.title ? <Lang id={textResourceBindings?.title} /> : undefined;
+
   return (
     <ComponentStructureWrapper node={node}>
       {groupAttachments ? (
         <AttachmentGroupings
           attachments={displayAttachments}
-          title={<Lang id={textResourceBindings?.title} />}
+          title={title}
           hideCollapsibleCount={true}
           showLinks={showLinks}
           showDescription={showDescription}
@@ -82,7 +84,7 @@ export function AttachmentListComponent({ node }: IAttachmentListProps) {
       ) : (
         <AltinnAttachments
           attachments={displayAttachments}
-          title={<Lang id={textResourceBindings?.title} />}
+          title={title}
           showLinks={showLinks}
           showDescription={showDescription}
         />

--- a/src/layout/AttachmentList/AttachmentListComponent.tsx
+++ b/src/layout/AttachmentList/AttachmentListComponent.tsx
@@ -74,7 +74,7 @@ export function AttachmentListComponent({ node }: IAttachmentListProps) {
       {groupAttachments ? (
         <AttachmentGroupings
           attachments={displayAttachments}
-          collapsibleTitle={<Lang id={textResourceBindings?.title} />}
+          title={<Lang id={textResourceBindings?.title} />}
           hideCollapsibleCount={true}
           showLinks={showLinks}
           showDescription={showDescription}


### PR DESCRIPTION
## Description
Fixes title set on attachment list disappearing if `groupByDataTypeGrouping` is `true` and all attachments have a corresponding data type grouping. 

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [x] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->
