### PR TITLE
Using profile directly from query instead of complex provider chains

### DIFF
--- a/src/features/entrypoint/Entrypoint.tsx
+++ b/src/features/entrypoint/Entrypoint.tsx
@@ -12,7 +12,7 @@ import {
   useValidParties,
 } from 'src/features/party/PartiesProvider';
 import { useProfile } from 'src/features/profile/ProfileProvider';
-import { useAllowAnonymousIs } from 'src/features/stateless/getAllowAnonymous';
+import { useIsAllowAnonymous } from 'src/features/stateless/getAllowAnonymous';
 import type { ShowTypes } from 'src/features/applicationMetadata/types';
 
 const ShowOrInstantiate: React.FC<{ show: ShowTypes }> = ({ show }) => {
@@ -47,7 +47,7 @@ export const Entrypoint = () => {
   const validParties = useValidParties();
   const partyIsValid = useSelectedPartyIsValid();
   const userHasSelectedParty = useHasSelectedParty();
-  const allowAnonymous = useAllowAnonymousIs(true);
+  const allowAnonymous = useIsAllowAnonymous(true);
   const party = useSelectedParty();
 
   if (isStateless && allowAnonymous && !party) {

--- a/src/features/expressions/shared-functions.test.tsx
+++ b/src/features/expressions/shared-functions.test.tsx
@@ -20,7 +20,7 @@ import {
   isRepeatingComponent,
   RepeatingComponents,
 } from 'src/features/form/layout/utils/repeating';
-import { fetchApplicationMetadata, fetchProcessState } from 'src/queries/queries';
+import { fetchApplicationMetadata, fetchProcessState, fetchUserProfile } from 'src/queries/queries';
 import { renderWithInstanceAndLayout, renderWithoutInstanceAndLayout } from 'src/test/renderWithProviders';
 import { DataModelLocationProvider } from 'src/utils/layout/DataModelLocation';
 import { useEvalExpression } from 'src/utils/layout/generator/useEvalExpression';
@@ -327,6 +327,7 @@ describe('Expressions shared function tests', () => {
       jest.mocked(fetchApplicationMetadata).mockResolvedValue(applicationMetadata);
       jest.mocked(useExternalApis).mockReturnValue(externalApis as ExternalApisResult);
       jest.mocked(fetchProcessState).mockImplementation(async () => process ?? getProcessDataMock());
+      jest.mocked(fetchUserProfile).mockImplementation(async () => profile);
 
       const renderFunc = stateless ? renderWithoutInstanceAndLayout : renderWithInstanceAndLayout;
       const { rerender } = await renderFunc({
@@ -346,7 +347,6 @@ describe('Expressions shared function tests', () => {
           fetchFormData,
           fetchInstanceData,
           ...(frontendSettings ? { fetchApplicationSettings: async () => frontendSettings } : {}),
-          fetchUserProfile: async () => profile,
           fetchTextResources: async () => ({
             language: 'nb',
             resources: textResources || [],

--- a/src/features/form/layoutSets/LayoutSetsProvider.tsx
+++ b/src/features/form/layoutSets/LayoutSetsProvider.tsx
@@ -18,7 +18,7 @@ export function useLayoutSetsQueryDef() {
   };
 }
 
-const useLayoutSetsQuery = () => {
+export const useLayoutSetsQuery = () => {
   const utils = useQuery(useLayoutSetsQueryDef());
 
   useEffect(() => {

--- a/src/features/instantiate/instantiateHeader/InstantiateHeader.tsx
+++ b/src/features/instantiate/instantiateHeader/InstantiateHeader.tsx
@@ -11,7 +11,7 @@ import { getMessageBoxUrl, returnUrlToAllForms, returnUrlToProfile } from 'src/u
 import type { IProfile } from 'src/types/shared';
 
 export interface InstantiateHeaderProps {
-  profile: IProfile | undefined;
+  profile: IProfile | null;
 }
 
 export const InstantiateHeader = ({ profile }: InstantiateHeaderProps) => {

--- a/src/features/language/Lang.test.tsx
+++ b/src/features/language/Lang.test.tsx
@@ -3,8 +3,10 @@ import React from 'react';
 import { afterAll, beforeAll, jest } from '@jest/globals';
 import { screen } from '@testing-library/react';
 
+import { getProfileMock } from 'src/__mocks__/getProfileMock';
 import { Lang } from 'src/features/language/Lang';
 import { LanguageProvider } from 'src/features/language/LanguageProvider';
+import { fetchUserProfile } from 'src/queries/queries';
 import { renderWithMinimalProviders } from 'src/test/renderWithProviders';
 
 function TestSubject() {
@@ -18,6 +20,9 @@ function TestSubject() {
 describe('Lang', () => {
   beforeAll(() => {
     jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  beforeEach(() => {
+    jest.mocked(fetchUserProfile).mockImplementation(async () => getProfileMock());
   });
   afterEach(() => {
     jest.resetAllMocks();

--- a/src/features/profile/ProfileProvider.tsx
+++ b/src/features/profile/ProfileProvider.tsx
@@ -1,24 +1,21 @@
-import { useEffect } from 'react';
-
-import { useQuery } from '@tanstack/react-query';
+import { queryOptions, useQuery } from '@tanstack/react-query';
 import type { UseQueryResult } from '@tanstack/react-query';
 
-import { useAppQueries } from 'src/core/contexts/AppQueriesProvider';
 import { delayedContext } from 'src/core/contexts/delayedContext';
 import { createQueryContext } from 'src/core/contexts/queryContext';
-import { useSetProfileForLanguage } from 'src/features/language/LanguageProvider';
-import { useAllowAnonymousIs } from 'src/features/stateless/getAllowAnonymous';
+import { useIsAllowAnonymous } from 'src/features/stateless/getAllowAnonymous';
+import { fetchUserProfile } from 'src/queries/queries';
 import { isAxiosError } from 'src/utils/isAxiosError';
 import type { IProfile } from 'src/types/shared';
 
 // Also used for prefetching @see appPrefetcher.ts
-export function useProfileQueryDef(enabled: boolean) {
-  const { fetchUserProfile } = useAppQueries();
-  return {
+export function profileQueryDef(enabled: boolean) {
+  return queryOptions<IProfile | null>({
     queryKey: ['fetchUserProfile', enabled],
     queryFn: fetchUserProfile,
     enabled,
-  };
+    placeholderData: null,
+  });
 }
 
 const canHandleProfileQueryError = (error: UseQueryResult<IProfile | undefined>['error']) =>
@@ -26,46 +23,24 @@ const canHandleProfileQueryError = (error: UseQueryResult<IProfile | undefined>[
   // Altinn users have profiles, but organisations, service owners and system users do not, so this is expected
   isAxiosError(error) && error.response?.status === 400;
 
-const useProfileQuery = () => {
+export const useProfileQuery = () => {
   const enabled = useShouldFetchProfile();
-  const setProfileForLanguage = useSetProfileForLanguage();
+  const query = useQuery(profileQueryDef(enabled));
 
-  const utils = useQuery(useProfileQueryDef(enabled));
-
-  useEffect(() => {
-    if (utils.error) {
-      if (canHandleProfileQueryError(utils.error)) {
-        setProfileForLanguage(null);
-        return;
-      }
-
-      window.logError('Fetching user profile failed:\n', utils.error);
-    }
-  }, [setProfileForLanguage, utils.error]);
-
-  useEffect(() => {
-    if (utils.data) {
-      setProfileForLanguage(utils.data);
-    }
-  }, [setProfileForLanguage, utils.data]);
-
-  useEffect(() => {
-    if (!enabled) {
-      setProfileForLanguage(null);
-    }
-  }, [setProfileForLanguage, enabled]);
+  const shouldReturnNull = !enabled || (query.isError && canHandleProfileQueryError(query.error));
 
   return {
-    ...utils,
+    ...query,
+    data: shouldReturnNull ? null : query.data,
     enabled,
   };
 };
 
 const { Provider, useCtx } = delayedContext(() =>
-  createQueryContext<IProfile | undefined, false>({
+  createQueryContext<IProfile | null, false>({
     name: 'Profile',
     required: false,
-    default: undefined,
+    default: null,
     shouldDisplayError: (error) => !canHandleProfileQueryError(error),
     query: useProfileQuery,
   }),
@@ -73,4 +48,4 @@ const { Provider, useCtx } = delayedContext(() =>
 
 export const ProfileProvider = Provider;
 export const useProfile = () => useCtx();
-export const useShouldFetchProfile = () => useAllowAnonymousIs(false);
+export const useShouldFetchProfile = () => useIsAllowAnonymous(false);

--- a/src/features/profile/ProfileProvider.tsx
+++ b/src/features/profile/ProfileProvider.tsx
@@ -8,8 +8,7 @@ import { fetchUserProfile } from 'src/queries/queries';
 import { isAxiosError } from 'src/utils/isAxiosError';
 import type { IProfile } from 'src/types/shared';
 
-// Also used for prefetching @see appPrefetcher.ts
-export function profileQueryDef(enabled: boolean) {
+function profileQueryOptions(enabled: boolean) {
   return queryOptions<IProfile | null>({
     queryKey: ['fetchUserProfile', enabled],
     queryFn: fetchUserProfile,
@@ -25,7 +24,7 @@ const canHandleProfileQueryError = (error: UseQueryResult<IProfile | undefined>[
 
 export const useProfileQuery = () => {
   const enabled = useShouldFetchProfile();
-  const query = useQuery(profileQueryDef(enabled));
+  const query = useQuery(profileQueryOptions(enabled));
 
   const shouldReturnNull = !enabled || (query.isError && canHandleProfileQueryError(query.error));
 

--- a/src/features/stateless/getAllowAnonymous.ts
+++ b/src/features/stateless/getAllowAnonymous.ts
@@ -1,23 +1,19 @@
 import { ContextNotProvided } from 'src/core/contexts/context';
 import { useLaxApplicationMetadata } from 'src/features/applicationMetadata/ApplicationMetadataProvider';
 import { getDataTypeByLayoutSetId } from 'src/features/applicationMetadata/appMetadataUtils';
-import { useLayoutSets } from 'src/features/form/layoutSets/LayoutSetsProvider';
+import { useLayoutSetsQuery } from 'src/features/form/layoutSets/LayoutSetsProvider';
 
 export const useAllowAnonymous = () => {
   const application = useLaxApplicationMetadata();
-  const layoutSets = useLayoutSets();
+  const { data: layoutSets } = useLayoutSetsQuery();
 
-  if (application === ContextNotProvided) {
-    return false;
-  }
-
-  if (!application.isStatelessApp) {
+  if (!layoutSets || application === ContextNotProvided || !application.isStatelessApp) {
     return false;
   }
 
   const dataTypeId = getDataTypeByLayoutSetId({
     layoutSetId: application.onEntry.show,
-    layoutSets,
+    layoutSets: layoutSets.sets,
     appMetaData: application,
   });
   const dataType = application.dataTypes.find((d) => d.id === dataTypeId);
@@ -29,7 +25,7 @@ export const useAllowAnonymous = () => {
   return false;
 };
 
-export const useAllowAnonymousIs = (compareWith: boolean) => {
+export const useIsAllowAnonymous = (compareWith: boolean) => {
   const allowAnonymous = useAllowAnonymous();
   return allowAnonymous === compareWith;
 };

--- a/src/layout/FileUpload/DropZone/DropzoneComponent.test.tsx
+++ b/src/layout/FileUpload/DropZone/DropzoneComponent.test.tsx
@@ -5,7 +5,7 @@ import { screen } from '@testing-library/react';
 
 import { getDescriptionId, getLabelId } from 'src/components/label/Label';
 import { DropzoneComponent } from 'src/layout/FileUpload/DropZone/DropzoneComponent';
-import { renderWithoutInstanceAndLayout } from 'src/test/renderWithProviders';
+import { renderWithMinimalProviders } from 'src/test/renderWithProviders';
 import type { IDropzoneComponentProps } from 'src/layout/FileUpload/DropZone/DropzoneComponent';
 
 describe('DropzoneComponent', () => {
@@ -32,7 +32,7 @@ describe('DropzoneComponent', () => {
   };
 
   it('should include aria-describedby for description if textResourceBindings.description is present', async () => {
-    await renderWithoutInstanceAndLayout({
+    await renderWithMinimalProviders({
       renderer: () => (
         <>
           <label id={getLabelId(id)}>Enkel filopplasting</label>
@@ -53,7 +53,7 @@ describe('DropzoneComponent', () => {
   });
 
   it('should not include aria-describedby for description if textResourceBindings.description is not present', async () => {
-    await renderWithoutInstanceAndLayout({
+    await renderWithMinimalProviders({
       renderer: () => <DropzoneComponent {...defaultProps} />,
     });
 

--- a/src/queries/appPrefetcher.ts
+++ b/src/queries/appPrefetcher.ts
@@ -8,7 +8,6 @@ import { useInstanceDataQueryDef } from 'src/features/instance/InstanceContext';
 import { processQueries } from 'src/features/instance/useProcessQuery';
 import { useOrgsQueryDef } from 'src/features/orgs/OrgsProvider';
 import { usePartiesQueryDef, useSelectedPartyQueryDef } from 'src/features/party/PartiesProvider';
-import { profileQueryDef } from 'src/features/profile/ProfileProvider';
 
 /**
  * Prefetches requests that require no processed data to determine the url
@@ -22,7 +21,6 @@ export function AppPrefetcher() {
 
   usePrefetchQuery(getApplicationMetadataQueryDef(instanceGuid));
   usePrefetchQuery(useLayoutSetsQueryDef());
-  usePrefetchQuery(profileQueryDef(true), Boolean(instanceOwnerPartyId));
   usePrefetchQuery(useOrgsQueryDef());
   usePrefetchQuery(useApplicationSettingsQueryDef());
   usePrefetchQuery(usePartiesQueryDef(true), Boolean(instanceOwnerPartyId));

--- a/src/queries/appPrefetcher.ts
+++ b/src/queries/appPrefetcher.ts
@@ -8,7 +8,7 @@ import { useInstanceDataQueryDef } from 'src/features/instance/InstanceContext';
 import { processQueries } from 'src/features/instance/useProcessQuery';
 import { useOrgsQueryDef } from 'src/features/orgs/OrgsProvider';
 import { usePartiesQueryDef, useSelectedPartyQueryDef } from 'src/features/party/PartiesProvider';
-import { useProfileQueryDef } from 'src/features/profile/ProfileProvider';
+import { profileQueryDef } from 'src/features/profile/ProfileProvider';
 
 /**
  * Prefetches requests that require no processed data to determine the url
@@ -22,7 +22,7 @@ export function AppPrefetcher() {
 
   usePrefetchQuery(getApplicationMetadataQueryDef(instanceGuid));
   usePrefetchQuery(useLayoutSetsQueryDef());
-  usePrefetchQuery(useProfileQueryDef(true), Boolean(instanceOwnerPartyId));
+  usePrefetchQuery(profileQueryDef(true), Boolean(instanceOwnerPartyId));
   usePrefetchQuery(useOrgsQueryDef());
   usePrefetchQuery(useApplicationSettingsQueryDef());
   usePrefetchQuery(usePartiesQueryDef(true), Boolean(instanceOwnerPartyId));

--- a/src/queries/types.ts
+++ b/src/queries/types.ts
@@ -2,7 +2,7 @@ import type * as queries from 'src/queries/queries';
 
 type IgnoredQueriesAndMutations = keyof Pick<
   typeof queries,
-  'fetchApplicationMetadata' | 'fetchExternalApi' | 'fetchProcessState' | 'doProcessNext'
+  'fetchApplicationMetadata' | 'fetchExternalApi' | 'fetchProcessState' | 'doProcessNext' | 'fetchUserProfile'
 >;
 
 type KeysStartingWith<T, U extends string> = {

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -14,7 +14,8 @@ import { TextDecoder, TextEncoder } from 'util';
 
 import { getIncomingApplicationMetadataMock } from 'src/__mocks__/getApplicationMetadataMock';
 import { getProcessDataMock } from 'src/__mocks__/getProcessDataMock';
-import type { doProcessNext, fetchApplicationMetadata, fetchProcessState } from 'src/queries/queries';
+import { getProfileMock } from 'src/__mocks__/getProfileMock';
+import type { doProcessNext, fetchApplicationMetadata, fetchProcessState, fetchUserProfile } from 'src/queries/queries';
 import type { AppQueries } from 'src/queries/types';
 
 // Importing CSS for jest-preview to look nicer
@@ -109,4 +110,5 @@ jest.mock('src/queries/queries', () => ({
     .mockImplementation(async () => getIncomingApplicationMetadataMock()),
   fetchProcessState: jest.fn<typeof fetchProcessState>(async () => getProcessDataMock()),
   doProcessNext: jest.fn<typeof doProcessNext>(async () => getProcessDataMock()),
+  fetchUserProfile: jest.fn<typeof fetchUserProfile>(async () => getProfileMock()),
 }));

--- a/src/test/renderWithProviders.tsx
+++ b/src/test/renderWithProviders.tsx
@@ -19,7 +19,6 @@ import { orderDetailsResponsePayload } from 'src/__mocks__/getOrderDetailsPayloa
 import { getOrgsMock } from 'src/__mocks__/getOrgsMock';
 import { getPartyMock } from 'src/__mocks__/getPartyMock';
 import { paymentResponsePayload } from 'src/__mocks__/getPaymentPayloadMock';
-import { getProfileMock } from 'src/__mocks__/getProfileMock';
 import { getTextResourcesMock } from 'src/__mocks__/getTextResourcesMock';
 import { AppQueriesProvider } from 'src/core/contexts/AppQueriesProvider';
 import { TaskStoreProvider } from 'src/core/contexts/taskStoreContext';
@@ -138,7 +137,6 @@ const defaultQueryMocks: AppQueries = {
   fetchFooterLayout: async () => ({ footer: [] }) as IFooterLayout,
   fetchLayoutSets: async () => getLayoutSetsMock(),
   fetchOrgs: async () => ({ orgs: getOrgsMock() }),
-  fetchUserProfile: async () => getProfileMock(),
   fetchReturnUrl: async () => Promise.reject(),
   fetchDataModelSchema: async () => ({}),
   fetchPartiesAllowedToInstantiate: async () => [getPartyMock()],


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->
