### PR TITLE
Fixes datepicker cy test relying on specific current date

### DIFF
--- a/test/e2e/integration/component-library/date-picker.ts
+++ b/test/e2e/integration/component-library/date-picker.ts
@@ -10,7 +10,6 @@ describe('Datepicker component', () => {
     const minDatePicker = '[id=DatepickerMinDateExample1]';
     const maxDatePicker = '[id=DatepickerMaxDateExample1]';
     const datePicker = '[data-componentid=DatepickerExample1]';
-    const openDatePickerPopover = 'div[aria-hidden=false]';
 
     cy.get(minDatePicker);
     cy.get(minDatePicker).type('02.07.2025');
@@ -20,18 +19,14 @@ describe('Datepicker component', () => {
     cy.get(maxDatePicker).blur();
 
     cy.get(datePicker).contains('button', 'Åpne datovelger').click();
-    cy.get(openDatePickerPopover)
-      .findByRole('button', { name: /tirsdag 1. juli 2025/i })
-      .should('be.disabled');
-    cy.get(openDatePickerPopover)
-      .findByRole('button', { name: /torsdag 31. juli 2025/i })
-      .should('be.disabled');
-    cy.get(openDatePickerPopover)
-      .findByRole('button', { name: /fredag 4. juli 2025/i })
-      .should('not.be.disabled');
-    cy.get(openDatePickerPopover)
-      .findByRole('button', { name: /fredag 4. juli 2025/i })
-      .click();
+
+    cy.findByRole('combobox', { name: /velg måned/i }).select('juli');
+    cy.findByRole('combobox', { name: /velg år/i }).select('2025');
+
+    cy.findByRole('button', { name: /tirsdag 1. juli 2025/i }).should('be.disabled');
+    cy.findByRole('button', { name: /torsdag 31. juli 2025/i }).should('be.disabled');
+    cy.findByRole('button', { name: /fredag 4. juli 2025/i }).should('not.be.disabled');
+    cy.findByRole('button', { name: /fredag 4. juli 2025/i }).click();
     cy.get(datePicker).findByRole('textbox').should('have.value', '04/07/2025');
   });
 });


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->
