### PR TITLE
always includeRowId when reading form

### DIFF
--- a/src/features/formData/FormDataReaders.test.tsx
+++ b/src/features/formData/FormDataReaders.test.tsx
@@ -97,8 +97,7 @@ async function render(props: TestProps) {
   function urlFor(dataModelName: string) {
     for (const [uuid, name] of Object.entries(idToNameMap)) {
       if (name === dataModelName) {
-        const isDefault = dataModelName === props.defaultDataModel;
-        return `https://local.altinn.cloud/ttd/test/instances/${instanceId}/data/${uuid}?includeRowId=${isDefault.toString()}&language=nb`;
+        return `https://local.altinn.cloud/ttd/test/instances/${instanceId}/data/${uuid}?includeRowId=true&language=nb`;
       }
     }
     return false;

--- a/src/features/formData/FormDataReaders.tsx
+++ b/src/features/formData/FormDataReaders.tsx
@@ -198,7 +198,7 @@ function SpecificDataModelFetcher({ reader, isAvailable }: { reader: DataModelRe
   const dataType = reader.getName();
   const dataElements = useInstanceDataElements(dataType);
   const dataElementId = getFirstDataElementId(dataElements, dataType);
-  const url = useDataModelUrl({ includeRowIds: false, dataType, dataElementId, language: useCurrentLanguage() });
+  const url = useDataModelUrl({ includeRowIds: true, dataType, dataElementId, language: useCurrentLanguage() });
   const enabled = isAvailable && reader.isLoading();
   const { data, error } = useFormDataQuery(enabled ? url : undefined);
   const { updateModel } = useCtx();


### PR DESCRIPTION
## Description

Challenge with AltinnRowId for hidden logic in stateless app. We have a support case where a regression bug has led to hidden logic being prioritized below required AltinnRowId, so that the user experience is that the hidden logic has now stopped working. Based on this, [we updated the backend](https://github.com/Altinn/app-lib-dotnet/pull/1415) to accept IncludeRowId for the relevant endpoints (initializes rowId if it doesn't have a value), but further investigation shows that the frontend sends IncludeRowId = false for the relevant query.

Send includeRowId = true from the frontend.

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [x] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->
