### PR TITLE
Fix/devtools-3524

### DIFF
--- a/src/features/devtools/DevTools.module.css
+++ b/src/features/devtools/DevTools.module.css
@@ -95,6 +95,13 @@
   padding: 0;
 }
 
+.tabPanel {
+  padding: 0;
+  box-sizing: border-box;
+  overflow-y: auto;
+  height: 100%;
+}
+
 .page {
   box-sizing: border-box;
   overflow-y: auto;

--- a/src/features/devtools/DevToolsControls.tsx
+++ b/src/features/devtools/DevToolsControls.tsx
@@ -52,7 +52,10 @@ export const DevToolsControls = () => {
         {isInForm && <Tabs.Tab value={DevToolsTab.Expressions}>{DevToolsTab.Expressions}</Tabs.Tab>}
         {/* <Tabs.Tab value={DevToolsTab.FeatureToggles}>{DevToolsTab.FeatureToggles}</Tabs.Tab> */}
       </Tabs.List>
-      <Tabs.Panel value={DevToolsTab.General}>
+      <Tabs.Panel
+        className={classes.tabPanel}
+        value={DevToolsTab.General}
+      >
         <div className={classes.page}>
           <PDFPreviewButton />
           <DevNavigationButtons />
@@ -64,21 +67,33 @@ export const DevToolsControls = () => {
           <ReactQueryDevtools initialIsOpen={false} />
         </div>
       </Tabs.Panel>
-      <Tabs.Panel value={DevToolsTab.Logs}>
+      <Tabs.Panel
+        className={classes.tabPanel}
+        value={DevToolsTab.Logs}
+      >
         <DevToolsLogs />
       </Tabs.Panel>
       {isInForm && (
-        <Tabs.Panel value={DevToolsTab.Layout}>
+        <Tabs.Panel
+          className={classes.tabPanel}
+          value={DevToolsTab.Layout}
+        >
           <LayoutInspector />
         </Tabs.Panel>
       )}
       {isInForm && (
-        <Tabs.Panel value={DevToolsTab.Components}>
+        <Tabs.Panel
+          className={classes.tabPanel}
+          value={DevToolsTab.Components}
+        >
           <NodeInspector />
         </Tabs.Panel>
       )}
       {isInForm && (
-        <Tabs.Panel value={DevToolsTab.Expressions}>
+        <Tabs.Panel
+          className={classes.tabPanel}
+          value={DevToolsTab.Expressions}
+        >
           <ExpressionPlayground />
         </Tabs.Panel>
       )}

--- a/src/features/devtools/components/ExpressionPlayground/ExpressionPlayground.module.css
+++ b/src/features/devtools/components/ExpressionPlayground/ExpressionPlayground.module.css
@@ -2,6 +2,7 @@
   box-sizing: border-box;
   height: 100%;
   width: 100%;
+  padding: 0;
 }
 
 .textbox {

--- a/src/features/devtools/components/NodeInspector/NodeInspector.module.css
+++ b/src/features/devtools/components/NodeInspector/NodeInspector.module.css
@@ -83,3 +83,10 @@ dd.typeUnknown {
   top: 6px;
   right: 6px;
 }
+
+.tabPanel {
+  padding: 0;
+  box-sizing: border-box;
+  overflow-y: auto;
+  height: 100%;
+}

--- a/src/features/devtools/components/NodeInspector/NodeInspector.tsx
+++ b/src/features/devtools/components/NodeInspector/NodeInspector.tsx
@@ -7,6 +7,7 @@ import { XMarkIcon } from '@navikt/aksel-icons';
 import { Button } from 'src/app-components/Button/Button';
 import reusedClasses from 'src/features/devtools/components/LayoutInspector/LayoutInspector.module.css';
 import { NodeHierarchy } from 'src/features/devtools/components/NodeInspector/NodeHierarchy';
+import classes from 'src/features/devtools/components/NodeInspector/NodeInspector.module.css';
 import { NodeInspectorContextProvider } from 'src/features/devtools/components/NodeInspector/NodeInspectorContext';
 import { ValidationInspector } from 'src/features/devtools/components/NodeInspector/ValidationInspector';
 import { SplitView } from 'src/features/devtools/components/SplitView/SplitView';
@@ -75,7 +76,10 @@ export const NodeInspector = () => {
                   <Tabs.Tab value='properties'>Egenskaper</Tabs.Tab>
                   {implementsAnyValidation(def) && <Tabs.Tab value='validation'>Validering</Tabs.Tab>}
                 </Tabs.List>
-                <Tabs.Panel value='properties'>
+                <Tabs.Panel
+                  className={classes.tabPanel}
+                  value='properties'
+                >
                   <div className={reusedClasses.properties}>
                     <div className={reusedClasses.headerLink}>
                       <a
@@ -93,7 +97,10 @@ export const NodeInspector = () => {
                     </DataModelLocationProviderFromNode>
                   </div>
                 </Tabs.Panel>
-                <Tabs.Panel value='validation'>
+                <Tabs.Panel
+                  className={classes.tabPanel}
+                  value='validation'
+                >
                   <div className={reusedClasses.scrollable}>
                     <ValidationInspector baseComponentId={baseComponentId} />
                   </div>

--- a/src/features/devtools/components/PDFPreviewButton/PDFPreview.module.css
+++ b/src/features/devtools/components/PDFPreviewButton/PDFPreview.module.css
@@ -15,6 +15,7 @@
   max-width: 1200px;
   height: 90vh;
   overflow: hidden;
+  padding: 0;
 }
 .loading {
   width: 100%;
@@ -26,6 +27,6 @@
 
 .iframe {
   width: 100%;
-  height: 100%;
+  height: 90%;
   border: none;
 }

--- a/src/features/devtools/components/PermissionsEditor/PermissionsEditor.module.css
+++ b/src/features/devtools/components/PermissionsEditor/PermissionsEditor.module.css
@@ -1,4 +1,5 @@
-.checkboxWrapper > div > div {
-  display: inline-grid;
-  margin-right: 1rem;
+.checkboxesWrapper {
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
 }

--- a/src/features/devtools/components/PermissionsEditor/PermissionsEditor.tsx
+++ b/src/features/devtools/components/PermissionsEditor/PermissionsEditor.tsx
@@ -25,56 +25,58 @@ export const PermissionsEditor = () => {
   }
 
   return (
-    <Fieldset className={classes.checkboxWrapper}>
+    <Fieldset>
       <Fieldset.Legend>Policy</Fieldset.Legend>
-      <Checkbox
-        data-size='sm'
-        checked={Boolean(write)}
-        onChange={(e) =>
-          handleChange((obj) => {
-            obj.write = e.target.checked;
-            return obj;
-          })
-        }
-        value='nothing'
-        label='Write'
-      />
-      <Checkbox
-        data-size='sm'
-        checked={Boolean(actions?.confirm)}
-        onChange={(e) =>
-          handleChange((obj) => {
-            obj.actions = { ...obj.actions, confirm: e.target.checked };
-            return obj;
-          })
-        }
-        value='nothing'
-        label='Confirm'
-      />
-      <Checkbox
-        data-size='sm'
-        checked={Boolean(actions?.sign)}
-        onChange={(e) =>
-          handleChange((obj) => {
-            obj.actions = { ...obj.actions, sign: e.target.checked };
-            return obj;
-          })
-        }
-        value='nothing'
-        label='Sign'
-      />
-      <Checkbox
-        data-size='sm'
-        checked={Boolean(actions?.reject)}
-        onChange={(e) =>
-          handleChange((obj) => {
-            obj.actions = { ...obj.actions, reject: e.target.checked };
-            return obj;
-          })
-        }
-        value='nothing'
-        label='Reject'
-      />
+      <div className={classes.checkboxesWrapper}>
+        <Checkbox
+          data-size='sm'
+          checked={Boolean(write)}
+          onChange={(e) =>
+            handleChange((obj) => {
+              obj.write = e.target.checked;
+              return obj;
+            })
+          }
+          value='nothing'
+          label='Write'
+        />
+        <Checkbox
+          data-size='sm'
+          checked={Boolean(actions?.confirm)}
+          onChange={(e) =>
+            handleChange((obj) => {
+              obj.actions = { ...obj.actions, confirm: e.target.checked };
+              return obj;
+            })
+          }
+          value='nothing'
+          label='Confirm'
+        />
+        <Checkbox
+          data-size='sm'
+          checked={Boolean(actions?.sign)}
+          onChange={(e) =>
+            handleChange((obj) => {
+              obj.actions = { ...obj.actions, sign: e.target.checked };
+              return obj;
+            })
+          }
+          value='nothing'
+          label='Sign'
+        />
+        <Checkbox
+          data-size='sm'
+          checked={Boolean(actions?.reject)}
+          onChange={(e) =>
+            handleChange((obj) => {
+              obj.actions = { ...obj.actions, reject: e.target.checked };
+              return obj;
+            })
+          }
+          value='nothing'
+          label='Reject'
+        />
+      </div>
     </Fieldset>
   );
 };


### PR DESCRIPTION
## Description

Fixes several bugs in devtools and restores some of the design to its original layout as before the Designsystem update which unintentionally introduced some bugs and visual changes. 

- Scrolling should now work again
- Removed an extra padding around tabcontent
- Fixed placement of generated pdf within the dialog popup to be able to see the end edge of the pdf
- Changed the alignment of the "Policy" checkboxes back to row from column.

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->
