### PR TITLE
hiding progress bar before pages is properly loaded

### DIFF
--- a/src/components/presentation/Progress.tsx
+++ b/src/components/presentation/Progress.tsx
@@ -11,6 +11,10 @@ export const Progress = () => {
   const { order } = useNavigatePage();
   const { langAsString } = useLanguage();
 
+  if (!currentPageId) {
+    return null;
+  }
+
   const currentPageIndex = order?.findIndex((page) => page === currentPageId) || 0;
   const currentPageNum = currentPageIndex + 1;
 


### PR DESCRIPTION
## Description

When going from a stateless to a statefull step, this flashes for a second before the correct page is shown:

<img width="1204" height="698" alt="Screenshot 2025-08-11 at 10 37 19" src="https://github.com/user-attachments/assets/a3d380b9-2c11-476c-bd55-8ebf70ad0af9" />

then the correct progress is shown:
<img width="1213" height="695" alt="Screenshot 2025-08-11 at 10 37 27" src="https://github.com/user-attachments/assets/0a08b669-95f3-499f-8fa6-1faf95d259f3" />

This PR hides the progress bar until the data is loaded properly.


## Related Issue(s)

- closes #2177

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->
