### PR TITLE
Minor performance optimizations for large repeating groups

### DIFF
--- a/src/features/datamodel/DataModelsProvider.tsx
+++ b/src/features/datamodel/DataModelsProvider.tsx
@@ -1,7 +1,7 @@
-import React, { useCallback, useEffect, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import type { PropsWithChildren } from 'react';
 
-import { useQueryClient } from '@tanstack/react-query';
+import { useMutationState, useQueryClient } from '@tanstack/react-query';
 import deepEqual from 'fast-deep-equal';
 import { createStore } from 'zustand';
 import type { JSONSchema7 } from 'json-schema';
@@ -256,17 +256,18 @@ function BlockUntilLoaded({ children }: PropsWithChildren) {
     useSelector((state) => state);
   const actualCurrentTask = useCurrentLayoutSetId();
   const isPDF = useIsPdf();
-  const mutations = useQueryClient()
-    .getMutationCache()
-    .findAll({ mutationKey: ['saveFormData'] });
 
-  if (mutations.some((m) => m.state.status === 'pending')) {
+  const currentMutations = useMutationState({ filters: { status: 'pending', mutationKey: ['saveFormData'] } });
+  const hasPassedMutationCheck = useRef(false);
+  if (currentMutations.length > 0 && !hasPassedMutationCheck.current) {
     // FormDataWrite automatically saves unsaved changes on unmount. If something happens above us in the render tree
     // that causes FormDataWrite to be unmounted (forcing it to save) and re-mounts everything (including us), we
     // should wait for that previously started save to complete. Otherwise, we'd end up saving outdated initial data
     // and cause a 409 when patching later.
     return <Loader reason='save-form-data' />;
   }
+
+  hasPassedMutationCheck.current = true;
 
   if (error) {
     // Error trying to fetch data, if missing rights we display relevant page

--- a/src/features/form/layout/LayoutsContext.tsx
+++ b/src/features/form/layout/LayoutsContext.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 
 import { skipToken, useQuery } from '@tanstack/react-query';
 
@@ -57,15 +57,18 @@ function useLayoutQuery() {
     utils.error && window.logError('Fetching form layout failed:\n', utils.error);
   }, [utils.error]);
 
-  return utils.data
-    ? {
-        ...utils,
-        data: {
-          ...utils.data,
-          lookups: makeLayoutLookups(utils.data.layouts),
-        },
-      }
-    : utils;
+  const data = useMemo(() => {
+    if (utils.data) {
+      return {
+        ...utils.data,
+        lookups: makeLayoutLookups(utils.data.layouts),
+      };
+    }
+
+    return utils.data;
+  }, [utils.data]);
+
+  return { ...utils, data };
 }
 const { Provider, useCtx, useLaxCtx } = delayedContext(() =>
   createQueryContext({

--- a/src/features/form/layoutSets/LayoutSetsProvider.tsx
+++ b/src/features/form/layoutSets/LayoutSetsProvider.tsx
@@ -15,6 +15,18 @@ export function useLayoutSetsQueryDef() {
   return {
     queryKey: ['fetchLayoutSets'],
     queryFn: fetchLayoutSets,
+    select: (layoutSets: ILayoutSets) => {
+      if (layoutSets?.uiSettings?.taskNavigation) {
+        return {
+          ...layoutSets,
+          uiSettings: {
+            ...layoutSets.uiSettings,
+            taskNavigation: layoutSets.uiSettings.taskNavigation.map((g) => ({ ...g, id: uuidv4() })),
+          },
+        };
+      }
+      return layoutSets;
+    },
   };
 }
 
@@ -33,18 +45,6 @@ const { Provider, useCtx, useLaxCtx } = delayedContext(() =>
     name: 'LayoutSets',
     required: true,
     query: useLayoutSetsQuery,
-    process: (layoutSets) => {
-      if (layoutSets?.uiSettings?.taskNavigation) {
-        return {
-          ...layoutSets,
-          uiSettings: {
-            ...layoutSets.uiSettings,
-            taskNavigation: layoutSets.uiSettings.taskNavigation.map((g) => ({ ...g, id: uuidv4() })),
-          },
-        };
-      }
-      return layoutSets;
-    },
   }),
 );
 

--- a/src/features/form/layoutSets/LayoutSetsProvider.tsx
+++ b/src/features/form/layoutSets/LayoutSetsProvider.tsx
@@ -14,8 +14,8 @@ export function useLayoutSetsQueryDef() {
   const { fetchLayoutSets } = useAppQueries();
   return {
     queryKey: ['fetchLayoutSets'],
-    queryFn: fetchLayoutSets,
-    select: (layoutSets: ILayoutSets) => {
+    queryFn: async () => {
+      const layoutSets = await fetchLayoutSets();
       if (layoutSets?.uiSettings?.taskNavigation) {
         return {
           ...layoutSets,

--- a/src/features/form/layoutSettings/LayoutSettingsContext.tsx
+++ b/src/features/form/layoutSettings/LayoutSettingsContext.tsx
@@ -14,11 +14,11 @@ import type { QueryDefinition } from 'src/core/queries/usePrefetchQuery';
 import type { GlobalPageSettings, ILayoutSettings, NavigationPageGroup } from 'src/layout/common.generated';
 
 // Also used for prefetching @see formPrefetcher.ts
-export function useLayoutSettingsQueryDef(layoutSetId?: string): QueryDefinition<ILayoutSettings | null> {
+export function useLayoutSettingsQueryDef(layoutSetId?: string): QueryDefinition<ProcessedLayoutSettings> {
   const { fetchLayoutSettings } = useAppQueries();
   return {
     queryKey: ['layoutSettings', layoutSetId],
-    queryFn: () => (layoutSetId ? fetchLayoutSettings(layoutSetId) : null),
+    queryFn: async () => processData(layoutSetId ? await fetchLayoutSettings(layoutSetId) : null),
   };
 }
 
@@ -33,50 +33,51 @@ function useLayoutSettingsQuery() {
   return query;
 }
 
+function processData(settings: ILayoutSettings | null): ProcessedLayoutSettings {
+  if (!settings) {
+    return {
+      order: [],
+      groups: [],
+      pageSettings: {},
+      pdfLayoutName: undefined,
+    };
+  }
+
+  if (!('order' in settings.pages) && !('groups' in settings.pages)) {
+    window.logError('Missing page order, specify one of `pages.order` or `pages.groups` in Settings.json');
+    throw 'Missing page order, specify one of `pages.order` or `pages.groups` in Settings.json';
+  }
+  if ('order' in settings.pages && 'groups' in settings.pages) {
+    window.logError('Both `pages.order` and `pages.groups` was set in Settings.json');
+    throw 'Both `pages.order` and `pages.groups` was set in Settings.json';
+  }
+
+  const order: string[] =
+    'order' in settings.pages
+      ? settings.pages.order
+      : settings.pages.groups.filter((group) => 'order' in group).flatMap((group) => group.order);
+
+  return {
+    order,
+    groups: 'groups' in settings.pages ? settings.pages.groups.map((g) => ({ ...g, id: uuidv4() })) : undefined,
+    pageSettings: omitUndefined({
+      autoSaveBehavior: settings.pages.autoSaveBehavior,
+      expandedWidth: settings.pages.expandedWidth,
+      hideCloseButton: settings.pages.hideCloseButton,
+      showExpandWidthButton: settings.pages.showExpandWidthButton,
+      showLanguageSelector: settings.pages.showLanguageSelector,
+      showProgress: settings.pages.showProgress,
+      taskNavigation: settings.pages.taskNavigation?.map((g) => ({ ...g, id: uuidv4() })),
+    }),
+    pdfLayoutName: settings.pages.pdfLayoutName,
+  };
+}
+
 const { Provider, useCtx, useLaxCtx } = delayedContext(() =>
-  createQueryContext<ILayoutSettings | null, true, ProcessedLayoutSettings>({
+  createQueryContext<ProcessedLayoutSettings, true>({
     name: 'LayoutSettings',
     required: true,
     query: useLayoutSettingsQuery,
-    process: (settings) => {
-      if (!settings) {
-        return {
-          order: [],
-          groups: [],
-          pageSettings: {},
-          pdfLayoutName: undefined,
-        };
-      }
-
-      if (!('order' in settings.pages) && !('groups' in settings.pages)) {
-        window.logError('Missing page order, specify one of `pages.order` or `pages.groups` in Settings.json');
-        throw 'Missing page order, specify one of `pages.order` or `pages.groups` in Settings.json';
-      }
-      if ('order' in settings.pages && 'groups' in settings.pages) {
-        window.logError('Both `pages.order` and `pages.groups` was set in Settings.json');
-        throw 'Both `pages.order` and `pages.groups` was set in Settings.json';
-      }
-
-      const order: string[] =
-        'order' in settings.pages
-          ? settings.pages.order
-          : settings.pages.groups.filter((group) => 'order' in group).flatMap((group) => group.order);
-
-      return {
-        order,
-        groups: 'groups' in settings.pages ? settings.pages.groups.map((g) => ({ ...g, id: uuidv4() })) : undefined,
-        pageSettings: omitUndefined({
-          autoSaveBehavior: settings.pages.autoSaveBehavior,
-          expandedWidth: settings.pages.expandedWidth,
-          hideCloseButton: settings.pages.hideCloseButton,
-          showExpandWidthButton: settings.pages.showExpandWidthButton,
-          showLanguageSelector: settings.pages.showLanguageSelector,
-          showProgress: settings.pages.showProgress,
-          taskNavigation: settings.pages.taskNavigation?.map((g) => ({ ...g, id: uuidv4() })),
-        }),
-        pdfLayoutName: settings.pages.pdfLayoutName,
-      };
-    },
   }),
 );
 

--- a/src/features/form/layoutSettings/LayoutSettingsContext.tsx
+++ b/src/features/form/layoutSettings/LayoutSettingsContext.tsx
@@ -44,12 +44,14 @@ function processData(settings: ILayoutSettings | null): ProcessedLayoutSettings 
   }
 
   if (!('order' in settings.pages) && !('groups' in settings.pages)) {
-    window.logError('Missing page order, specify one of `pages.order` or `pages.groups` in Settings.json');
-    throw 'Missing page order, specify one of `pages.order` or `pages.groups` in Settings.json';
+    const msg = 'Missing page order, specify one of `pages.order` or `pages.groups` in Settings.json';
+    window.logError(msg);
+    throw new Error(msg);
   }
   if ('order' in settings.pages && 'groups' in settings.pages) {
-    window.logError('Both `pages.order` and `pages.groups` was set in Settings.json');
-    throw 'Both `pages.order` and `pages.groups` was set in Settings.json';
+    const msg = 'Specify one of `pages.order` or `pages.groups` in Settings.json';
+    window.logError(msg);
+    throw new Error(msg);
   }
 
   const order: string[] =

--- a/src/features/language/textResources/TextResourcesProvider.tsx
+++ b/src/features/language/textResources/TextResourcesProvider.tsx
@@ -22,10 +22,10 @@ const useTextResourcesQuery = () => {
   const enabled = useIsCurrentLanguageResolved();
 
   const utils = {
-    ...useQueryWithStaleData<ITextResourceResult, HttpClientError>({
+    ...useQueryWithStaleData<TextResourceMap, HttpClientError>({
       enabled,
       queryKey: ['fetchTextResources', selectedLanguage],
-      queryFn: () => fetchTextResources(selectedLanguage),
+      queryFn: async () => convertResult(await fetchTextResources(selectedLanguage)),
     }),
     enabled,
   };
@@ -38,12 +38,11 @@ const useTextResourcesQuery = () => {
 };
 
 const { Provider, useCtx, useHasProvider } = delayedContext(() =>
-  createQueryContext<ITextResourceResult, false, TextResourceMap>({
+  createQueryContext<TextResourceMap, false>({
     name: 'TextResources',
     required: false,
     default: {},
     query: useTextResourcesQuery,
-    process: convertResult,
   }),
 );
 

--- a/src/layout/RepeatingGroup/Table/RepeatingGroupTable.tsx
+++ b/src/layout/RepeatingGroup/Table/RepeatingGroupTable.tsx
@@ -147,7 +147,8 @@ export function RepeatingGroupTable(): React.JSX.Element | null {
               key={`edit-container-${row.uuid}`}
               baseComponentId={baseComponentId}
               dataModelBindings={dataModelBindings}
-              row={row}
+              index={row.index}
+              uuid={row.uuid}
               displayDeleteColumn={displayDeleteColumn}
               displayEditColumn={displayEditColumn}
               tableIds={tableIds}
@@ -170,16 +171,16 @@ function RowToDisplay({
   dataModelBindings: { group },
   displayDeleteColumn,
   displayEditColumn,
-  row: { index, uuid },
+  index,
+  uuid,
   tableIds,
 }: {
   baseComponentId: string;
   dataModelBindings: IDataModelBindings<'RepeatingGroup'>;
-  row: BaseRow;
   displayDeleteColumn: boolean;
   displayEditColumn: boolean;
   tableIds: string[];
-}) {
+} & BaseRow) {
   const component = useExternalItem(baseComponentId, 'RepeatingGroup');
   const mobileView = useIsMobileOrTablet();
   const isEditingRow = RepGroupContext.useIsEditingRow(uuid);

--- a/src/layout/RepeatingGroup/useTableComponentIds.ts
+++ b/src/layout/RepeatingGroup/useTableComponentIds.ts
@@ -12,15 +12,18 @@ export function useTableComponentIds(baseComponentId: string) {
   const component = layoutLookups.getComponent(baseComponentId, 'RepeatingGroup');
   const tableHeaders = component.tableHeaders;
   const multiPage = component.edit?.multiPage ?? false;
-  const children =
-    component.children.map((id) => {
-      if (multiPage) {
-        const [, childId] = id.split(':', 2);
-        return layoutLookups.getComponent(childId);
-      }
+  const children = useMemo(
+    () =>
+      component.children.map((id) => {
+        if (multiPage) {
+          const [, childId] = id.split(':', 2);
+          return layoutLookups.getComponent(childId);
+        }
 
-      return layoutLookups.getComponent(id);
-    }) ?? emptyArray;
+        return layoutLookups.getComponent(id);
+      }) ?? emptyArray,
+    [component.children, layoutLookups, multiPage],
+  );
 
   return useMemo(() => {
     const ids = children

--- a/src/layout/RepeatingGroup/utils.ts
+++ b/src/layout/RepeatingGroup/utils.ts
@@ -4,6 +4,7 @@ import { evalExpr } from 'src/features/expressions';
 import { ExprVal } from 'src/features/expressions/types';
 import { ExprValidation } from 'src/features/expressions/validation';
 import { FD } from 'src/features/formData/FormDataWrite';
+import { useMemoDeepEqual } from 'src/hooks/useStateDeepEqual';
 import { useComponentIdMutator } from 'src/utils/layout/DataModelLocation';
 import { useIsHiddenMulti } from 'src/utils/layout/hidden';
 import { useDataModelBindingsFor, useExternalItem } from 'src/utils/layout/hooks';
@@ -145,7 +146,7 @@ export const RepGroupHooks = {
     const rows = RepGroupHooks.useAllBaseRows(baseComponentId);
     const row = _row === 'first' ? rows[0] : 'uuid' in _row ? rows.find((r) => r.uuid === _row.uuid) : rows[_row.index];
 
-    return useMemo(() => {
+    return useMemoDeepEqual(() => {
       if (!groupBinding || !row) {
         return undefined;
       }


### PR DESCRIPTION
## Description

- Removing `process()` from `createQueryContext()`, as this can be covered by functionality already in tanstack query, or the code could simply be added to the query function instead. This caused spooky stuff to happen, as I initially removed the `useMemo()` from the wrapper provider inside `createQueryContext()`, and I think that caused react compiler to optimize a bit too much. With a `useMemo()` it works fine, but without it the app would never load.
- Removing usages of `delayedSelector` in some utility functions for `RepeatingGroup`. These functions does not really need to be re-created every time some state changes - they can just get the fresh state every call. There's still an issue in `RepGroupHooks.useGetFreshRowsWithButtons()` which also could just get fresh state instead of re-rendering after it has been called, but that would mean I'd have to create a non-reactive variant of expression data sources - which will be much easier after we move to one big store.
- Preventing a forced child re-render in `RepeatingGroupTable.tsx` because an object was passed instead of just the `index` and `uuid` properties that rarely changes.
- Fixing memoization issues in `useTableComponentIds()`, as a dependency to `useMemo()` was not itself memoized.
- Preventing unnecessary work in `useRowWithExpressions()`. The result rarely changes, but since data sources may force a re-render when a new row is added, this memo would be re-generated a bit often, and would cause more work to be done downstream.

These are all minor stuff, but in sum they further boost the performance when testing the `ssb/ra0485-01` app. Along with pagination in that repeating group, I can _just about_ keep working with ~370 rows. 

## Related Issue(s)

- #3147

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Displays a “saving” loader while form data is being saved, preventing premature interaction.

- Bug Fixes
  - More consistent page ordering and task navigation items across forms.
  - Smoother loading/error handling for layouts and text resources.

- Refactor
  - Streamlined data fetching by moving post-fetch processing into query fetches.
  - Improved performance and stability for repeating groups via memoization and simpler props.

- Chores
  - Simplified context APIs to reduce configuration complexity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->