### PR TITLE
Fix broken aria references in table

### DIFF
--- a/src/layout/Checkboxes/CheckboxesContainerComponent.tsx
+++ b/src/layout/Checkboxes/CheckboxesContainerComponent.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { Fieldset, useCheckboxGroup } from '@digdir/designsystemet-react';
+import cn from 'classnames';
 
 import { ConditionalWrapper } from 'src/app-components/ConditionalWrapper/ConditionalWrapper';
 import { AltinnSpinner } from 'src/components/AltinnSpinner';
@@ -13,6 +14,7 @@ import { useIsValid } from 'src/features/validation/selectors/isValid';
 import classes from 'src/layout/Checkboxes/CheckboxesContainerComponent.module.css';
 import { WrappedCheckbox } from 'src/layout/Checkboxes/WrappedCheckbox';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
+import utilClasses from 'src/styles/utils.module.css';
 import { shouldUseRowLayout } from 'src/utils/layout';
 import { useIndexedId } from 'src/utils/layout/DataModelLocation';
 import { useItemWhenType } from 'src/utils/layout/useNodeItem';
@@ -95,7 +97,9 @@ export const CheckboxContainerComponent = ({
               <Fieldset.Legend className={classes.legend}>{labelTextGroup}</Fieldset.Legend>
             )}
             {textResourceBindings?.description && (
-              <Fieldset.Description>
+              <Fieldset.Description
+                className={cn({ [utilClasses.visuallyHidden]: overrideDisplay?.renderLegend === false })}
+              >
                 <Lang id={textResourceBindings?.description} />
               </Fieldset.Description>
             )}

--- a/src/layout/Input/InputComponent.tsx
+++ b/src/layout/Input/InputComponent.tsx
@@ -133,7 +133,9 @@ export const InputVariant = ({
     id,
     'aria-label': langAsString(textResourceBindings?.title),
     'aria-describedby':
-      textResourceBindings?.title && textResourceBindings?.description ? getDescriptionId(id) : undefined,
+      overrideDisplay?.renderedInTable !== true && textResourceBindings?.title && textResourceBindings?.description
+        ? getDescriptionId(id)
+        : undefined,
     autoComplete: autocomplete,
     className: formatting?.align ? classes[`text-align-${formatting.align}`] : '',
     readOnly,

--- a/src/layout/RadioButtons/ControlledRadioGroup.tsx
+++ b/src/layout/RadioButtons/ControlledRadioGroup.tsx
@@ -100,7 +100,9 @@ export const ControlledRadioGroup = (props: PropsFromGenericComponent<'RadioButt
             {labelText}
           </Fieldset.Legend>
           {textResourceBindings?.description && (
-            <Fieldset.Description>
+            <Fieldset.Description
+              className={cn({ [utilClasses.visuallyHidden]: overrideDisplay?.renderLegend === false })}
+            >
               <Lang id={textResourceBindings?.description} />
             </Fieldset.Description>
           )}


### PR DESCRIPTION
## Description

Resolves broken aria reference by not adding it when using tables. 

Note: Descriptions could maybe be made usable in tables for both regular users and screenreaders later, but would be a breaking change for apps that contain components with descripitons that are displayed in a table today, since text and components would have to be pushed around to fit new content.

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes #1629


## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [x] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->
