### PR TITLE
Adds script for running specified cypress tests until failure and save logs (for flaky tests)

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -11,6 +11,7 @@ const CYPRESS_WINDOW_HEIGHT = env.parsed?.CYPRESS_WINDOW_HEIGHT || 1080;
 module.exports = defineConfig({
   e2e: {
     setupNodeEvents(on, config) {
+      require('cypress-terminal-report/src/installLogsPrinter')(on, { printLogsToConsole: 'always' });
       on('before:browser:launch', (browser, launchOptions) => {
         if (browser.name === 'electron') {
           launchOptions.preferences.width = CYPRESS_WINDOW_WIDTH;

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "cypress-multi-reporters": "2.0.5",
     "cypress-network-idle": "1.15.0",
     "cypress-plugin-tab": "1.0.5",
+    "cypress-terminal-report": "^7.2.1",
     "cypress-wait-until": "3.0.2",
     "dotenv": "17.2.1",
     "esbuild-loader": "4.3.0",

--- a/scripts/debug-flaky-cypress.sh
+++ b/scripts/debug-flaky-cypress.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+# Script to run specified Cypress test a certain number of times (defaults to 50) or until failure.
+# Writes logs to the $logs_folder
+
+spec_arg=${1:-""}  # Optional spec argument- defaults to running all tests if not specified
+max_runs=${2:-50}  # Default to 50 if no argument provided
+counter=1
+logs_folder=scripts/debug-flaky-cypress-logs
+
+# Handle Ctrl+C gracefully
+cleanup() {
+    echo ""
+    echo "Interrupted by user after $((counter-1)) runs"
+    # Kill any running cypress processes
+    pkill -f "cypress"
+    exit 0
+}
+
+trap cleanup INT TERM
+
+if [ -n "$spec_arg" ]; then
+  echo "Running test up to $max_runs times with spec: $spec_arg"
+else
+  echo "Running test up to $max_runs times..."
+fi
+
+# If logs_folder doesn't exist, create it
+mkdir -p $logs_folder;
+
+while [ $counter -le $max_runs ]; do
+  echo "=== Run #$counter/$max_runs ==="
+
+  # Run the command and capture output
+  if [ -n "$spec_arg" ]; then
+    yarn cy:run --spec "$spec_arg" 2>&1 | tee "$logs_folder/run-$counter.log"
+  else
+    yarn cy:run 2>&1 | tee "$logs_folder/run-$counter.log"
+  fi
+  exit_code=$?
+  echo "Exit code for run #$counter: $exit_code"
+
+  # Check for test failures in the output
+  if grep -q "Failing:.*[1-9]" "$logs_folder/run-$counter.log" || \
+     grep -q "✖.*failed" "$logs_folder/run-$counter.log" || \
+     grep -q "failed (100%)" "$logs_folder/run-$counter.log"; then
+    echo ""
+    echo "==================================="
+    echo "FAILURE DETECTED ON RUN #$counter"
+    echo "==================================="
+    echo "Test failed after $counter attempts"
+    echo "Check $logs_folder/run-$counter.log for details"
+    echo ""
+    exit 0
+  fi
+
+  # Also check exit code as backup
+  if [ $exit_code -ne 0 ]; then
+    echo ""
+    echo "==================================="
+    echo "FAILURE DETECTED ON RUN #$counter"
+    echo "==================================="
+    echo "Test failed with exit code $exit_code on the $counter attempt"
+    echo "Check $logs_folder/run-$counter.log for details"
+    echo ""
+    exit 0  # Exit the function, not the script
+  fi
+
+  echo "Run #$counter passed"
+  counter=$((counter + 1))
+done
+
+echo "All $max_runs runs passed!"
+return 0

--- a/test/e2e/support/index.ts
+++ b/test/e2e/support/index.ts
@@ -12,6 +12,7 @@ import '@percy/cypress';
 
 import { register as registerSnapshot } from '@cypress/snapshot';
 import failOnConsoleError from 'cypress-fail-on-console-error';
+import installLogsCollector from 'cypress-terminal-report/src/installLogsCollector';
 import type { ConsoleMessage } from 'cypress-fail-on-console-error';
 
 import { AppFrontend } from 'test/e2e/pageobjects/app-frontend';
@@ -58,3 +59,5 @@ Cypress.Commands.add('ignoreConsoleMessages', (consoleMessages: ConsoleMessage[]
     consoleMessages: config?.consoleMessages ? [...config.consoleMessages, ...consoleMessages] : consoleMessages,
   });
 });
+
+installLogsCollector();

--- a/yarn.lock
+++ b/yarn.lock
@@ -5473,6 +5473,7 @@ __metadata:
     cypress-network-idle: "npm:1.15.0"
     cypress-parallel: "npm:0.15.0"
     cypress-plugin-tab: "npm:1.0.5"
+    cypress-terminal-report: "npm:^7.2.1"
     cypress-wait-until: "npm:3.0.2"
     date-fns: "npm:4.1.0"
     dompurify: "npm:3.2.6"
@@ -6948,6 +6949,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"compare-versions@npm:^6.1.1":
+  version: 6.1.1
+  resolution: "compare-versions@npm:6.1.1"
+  checksum: 10c0/415205c7627f9e4f358f571266422980c9fe2d99086be0c9a48008ef7c771f32b0fbe8e97a441ffedc3910872f917a0675fe0fe3c3b6d331cda6d8690be06338
+  languageName: node
+  linkType: hard
+
 "compressible@npm:~2.0.18":
   version: 2.0.18
   resolution: "compressible@npm:2.0.18"
@@ -7418,6 +7426,19 @@ __metadata:
   dependencies:
     ally.js: "npm:^1.4.1"
   checksum: 10c0/2f2f339b87e66da62401b124cf0b06796e755d4220de648bed5eea2dad10f18968b594335c22c09300c0719c5b54e5196e8a545dfab3ec23b87819a7af61d1fc
+  languageName: node
+  linkType: hard
+
+"cypress-terminal-report@npm:^7.2.1":
+  version: 7.2.1
+  resolution: "cypress-terminal-report@npm:7.2.1"
+  dependencies:
+    chalk: "npm:^4.0.0"
+    compare-versions: "npm:^6.1.1"
+    superstruct: "npm:0.14.2"
+  peerDependencies:
+    cypress: ">=10.0.0"
+  checksum: 10c0/8396407f0fc5d8300c71e9026973fa38f370c22a28b08d1b53fa35a4595f7d626d975c304ac9f88c6bb4a239cdc42da163684fb8560ba7bc3bd43bcfce416515
   languageName: node
   linkType: hard
 
@@ -16718,6 +16739,13 @@ __metadata:
   bin:
     stylus: bin/stylus
   checksum: 10c0/62afe3a6d781f66d7d283e8218dc1a15530d7d89fc2f09457a723975b2073e96e0d32c61d7f0dd1bd2686aae4ab6cc6933dc85e1b72eebab8aa30167bd16962b
+  languageName: node
+  linkType: hard
+
+"superstruct@npm:0.14.2":
+  version: 0.14.2
+  resolution: "superstruct@npm:0.14.2"
+  checksum: 10c0/e5518f6701524fb8cbae504a84dc9c304bf3fe01616230a5eb4e14af9bfc4e3518b94bfe457e57a5d1b99a2b54f82881b4a39e0b266caa6053f84aa294613b94
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description
What the title says ☝️ 

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->
