### PR TITLE
Feat/unifiy events (reduce amount of states) and support touch

### DIFF
--- a/src/layout/ImageUpload/ImageUpload.module.css
+++ b/src/layout/ImageUpload/ImageUpload.module.css
@@ -39,6 +39,7 @@
   border-radius: 0.5rem;
   overflow: hidden;
   cursor: grab;
+  touch-action: none;
 }
 
 /* Placeholder for when no image is loaded */


### PR DESCRIPTION
## Description

Tanken bak denne PR-en var å redusere antall event-håndteringer og tilhørende state.
Tidligere håndterte vi separat `onMouseDown`, `onMouseMove`, `onMouseUp` og `onMouseLeave` og måtte ha 2 stater for å styre viewport-bevegelse knyttet til disse eventene. Med `onPointerDown` samler den eventene og styrer logikken videre.
Dette resulterer i at vi kan fjerne statene `isDragging` og `startDrag`, som forbedrer ytelsen ved å redusere re-renders og statehåndtering. 
Den håndterer også touch-screens. For å sikre forventet oppførsel der, settes `touch-action: none` i css for å hindre uønsket standard touch-adferd som påvirker canvas eventene når jeg har testet. 


Docs: https://developer.mozilla.org/en-US/docs/Web/API/Element/pointerdown_event

`onPointerDown` støtter safari 13 og nyere. Jeg undersøkte litt og det viser seg at under 1% bruker eldre versjon enn det. Det er først og fremst knyttet til mobilbruk, noe jeg antar vil inntreffe svært sjeldent eller aldri i dette tilfellet. Derfor konkluderte jeg med at det er ok å ta i bruk. Gjerne gi beskjed hvis du har innspill til det.









<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->
