### PR TITLE
feat: add common utils for draw and handlecrop functions + variable viewport

### DIFF
--- a/src/layout/ImageUpload/imageUploadUtils.ts
+++ b/src/layout/ImageUpload/imageUploadUtils.ts
@@ -1,3 +1,16 @@
+export const getViewport = (viewport?: string) => {
+  switch (viewport) {
+    case '1:1':
+      return { width: 100, height: 100 };
+    case '4:3':
+      return { width: 400, height: 300 };
+    case '16:9':
+      return { width: 320, height: 180 };
+    default:
+      return { width: 300, height: 300 };
+  }
+};
+
 interface ConstrainToAreaParams {
   image: HTMLImageElement;
   zoom: number;
@@ -19,4 +32,39 @@ export function constrainToArea({ image, zoom, position, viewport }: ConstrainTo
   const newY = Math.max(-clampY, Math.min(position.y, clampY));
 
   return { x: newX, y: newY };
+}
+
+interface CalculatePositionsParams {
+  canvas: HTMLCanvasElement;
+  img: HTMLImageElement;
+  zoom: number;
+  position: { x: number; y: number };
+  viewport?: { width: number; height: number };
+}
+
+export const calculatePositions = ({ canvas, img, zoom, position }: CalculatePositionsParams) => {
+  const scaledWidth = img.width * zoom;
+  const scaledHeight = img.height * zoom;
+  const imgX = (canvas.width - scaledWidth) / 2 + position.x;
+  const imgY = (canvas.height - scaledHeight) / 2 + position.y;
+
+  return { imgX, imgY, scaledWidth, scaledHeight };
+};
+
+interface DrawViewportParams {
+  ctx: CanvasRenderingContext2D;
+  cropAsCircle: boolean;
+  x?: number;
+  y?: number;
+  selectedViewport: { width: number; height: number };
+}
+
+export function drawViewport({ ctx, cropAsCircle, x = 0, y = 0, selectedViewport }: DrawViewportParams) {
+  const { width, height } = selectedViewport;
+  ctx.beginPath();
+  if (cropAsCircle) {
+    ctx.arc(x + width / 2, y + height / 2, width / 2, 0, Math.PI * 2);
+  } else {
+    ctx.rect(x, y, width, height);
+  }
 }


### PR DESCRIPTION
## Description

Målet med denne PR'en var å forsøke å gjenbruke deler av logikken til funksjonene `draw` og `handleCrop` slik at de blir enklere å håndtere og forhåpentligvis enklere å lese. 

Jeg flyttet til utils logikk som å kalkulere posisjonen til viewport og tegne innholdet til viewport.

Jeg husker ikke konkret årsaken til at jeg også kom over viewport størrelser i denne PR'en, men tenker vi kan beholde disse endringene for nå, hvis du ikke har noen innvendelser, Magnus. Viewport er nå en variabel som kan styres med konfig gitt de ulike størrelsene '1:1', '4:3' og '16:9' som er vilkårlig px størrelser som copilot foreslo. Dette antar jeg vi endrer på senere, også annen logikk som at den ikke kalles hvis det er satt `cropAsCircel` til `true`.
 


<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->
