### PR TITLE
feat: implement cropAsConfig prop into viewport config

### DIFF
--- a/src/layout/ImageUpload/ImageUpload.tsx
+++ b/src/layout/ImageUpload/ImageUpload.tsx
@@ -15,6 +15,7 @@ import {
   drawViewport,
   getViewport,
 } from 'src/layout/ImageUpload/imageUploadUtils';
+import type { ViewportType } from 'src/layout/ImageUpload/imageUploadUtils';
 
 // Define types for state and props
 type Position = {
@@ -23,13 +24,12 @@ type Position = {
 };
 
 interface ImageCropperProps {
+  viewport?: ViewportType;
   onCrop: (image: string) => void;
-  cropAsCircle?: boolean;
-  viewport?: string;
 }
 
 // ImageCropper Component
-export function ImageCropper({ onCrop, cropAsCircle = false, viewport }: ImageCropperProps) {
+export function ImageCropper({ onCrop, viewport }: ImageCropperProps) {
   // Refs for canvas and image
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const imageRef = useRef<HTMLImageElement | null>(null);
@@ -83,19 +83,19 @@ export function ImageCropper({ onCrop, cropAsCircle = false, viewport }: ImageCr
     const viewportX = (canvas.width - selectedViewport.width) / 2;
     const viewportY = (canvas.height - selectedViewport.height) / 2;
 
-    drawViewport({ ctx, cropAsCircle, x: viewportX, y: viewportY, selectedViewport });
+    drawViewport({ ctx, x: viewportX, y: viewportY, selectedViewport });
     ctx.clip();
     ctx.drawImage(img, imgX, imgY, scaledWidth, scaledHeight);
     ctx.restore();
 
     // 4. Draw the dashed border
-    drawViewport({ ctx, cropAsCircle, x: viewportX, y: viewportY, selectedViewport });
+    drawViewport({ ctx, x: viewportX, y: viewportY, selectedViewport });
     ctx.strokeStyle = 'white';
     ctx.lineWidth = 2;
     ctx.setLineDash([5, 5]);
     ctx.stroke();
     ctx.setLineDash([]);
-  }, [zoom, position, cropAsCircle, selectedViewport]);
+  }, [zoom, position, selectedViewport]);
 
   // useEffect to draw when state changes
   useEffect(() => {
@@ -290,7 +290,7 @@ export function ImageCropper({ onCrop, cropAsCircle = false, viewport }: ImageCr
     const viewportX = (canvas.width - selectedViewport.width) / 2;
     const viewportY = (canvas.height - selectedViewport.height) / 2;
 
-    drawViewport({ ctx: cropCtx, cropAsCircle, selectedViewport });
+    drawViewport({ ctx: cropCtx, selectedViewport });
     cropCtx.clip();
 
     cropCtx.drawImage(img, imgX - viewportX, imgY - viewportY, scaledWidth, scaledHeight);

--- a/src/layout/ImageUpload/ImageUploadComponent.tsx
+++ b/src/layout/ImageUpload/ImageUploadComponent.tsx
@@ -6,16 +6,17 @@ import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper'
 import { ImageCropper } from 'src/layout/ImageUpload/ImageUpload';
 import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
+import type { ViewportType } from 'src/layout/ImageUpload/imageUploadUtils';
 
 export function ImageUploadComponent({ baseComponentId }: PropsFromGenericComponent<'ImageUpload'>) {
   const [croppedImage, setCroppedImage] = useState<string | null>(null);
-  const { cropAsCircle } = useItemWhenType(baseComponentId, 'ImageUpload');
+  const { viewport } = useItemWhenType(baseComponentId, 'ImageUpload');
 
   return (
     <ComponentStructureWrapper baseComponentId={baseComponentId}>
       <ImageCropper
         onCrop={setCroppedImage}
-        cropAsCircle={cropAsCircle}
+        viewport={viewport as ViewportType}
       />
       {croppedImage && (
         <div>

--- a/src/layout/ImageUpload/config.ts
+++ b/src/layout/ImageUpload/config.ts
@@ -20,13 +20,11 @@ export const Config = new CG.component({
   .extendTextResources(CG.common('TRBLabel'))
   .addProperty(
     new CG.prop(
-      'cropAsCircle',
-      new CG.bool()
-        .optional({ default: false })
-        .setTitle('Crop as a circle')
-        .setDescription(
-          'If enabled, the cropping area will be a circle. The resulting image will still be a square with transparent corners.',
-        ),
+      'viewport',
+      new CG.enum('1:1', '4:3', '16:9', 'circle')
+        .optional({ default: 'circle' })
+        .setTitle('Viewport')
+        .setDescription('The aspect ratio of the cropping area'),
     ),
   )
   .addSummaryOverrides();

--- a/src/layout/ImageUpload/imageUploadUtils.ts
+++ b/src/layout/ImageUpload/imageUploadUtils.ts
@@ -1,13 +1,23 @@
-export const getViewport = (viewport?: string) => {
+export type Viewport = { width: number; height: number; circle?: boolean };
+
+export enum ViewportType {
+  Square = '1:1',
+  Rectangle4_3 = '4:3',
+  Rectangle16_9 = '16:9',
+  Circle = 'circle',
+}
+
+export const getViewport = (viewport?: ViewportType): Viewport => {
   switch (viewport) {
-    case '1:1':
-      return { width: 100, height: 100 };
-    case '4:3':
-      return { width: 400, height: 300 };
-    case '16:9':
-      return { width: 320, height: 180 };
+    case ViewportType.Square:
+      return { width: 300, height: 300, circle: false };
+    case ViewportType.Rectangle4_3:
+      return { width: 400, height: 300, circle: false };
+    case ViewportType.Rectangle16_9:
+      return { width: 480, height: 270, circle: false };
+    case ViewportType.Circle:
     default:
-      return { width: 300, height: 300 };
+      return { width: 300, height: 300, circle: true };
   }
 };
 
@@ -39,7 +49,6 @@ interface CalculatePositionsParams {
   img: HTMLImageElement;
   zoom: number;
   position: { x: number; y: number };
-  viewport?: { width: number; height: number };
 }
 
 export const calculatePositions = ({ canvas, img, zoom, position }: CalculatePositionsParams) => {
@@ -53,16 +62,15 @@ export const calculatePositions = ({ canvas, img, zoom, position }: CalculatePos
 
 interface DrawViewportParams {
   ctx: CanvasRenderingContext2D;
-  cropAsCircle: boolean;
+  selectedViewport: Viewport;
   x?: number;
   y?: number;
-  selectedViewport: { width: number; height: number };
 }
 
-export function drawViewport({ ctx, cropAsCircle, x = 0, y = 0, selectedViewport }: DrawViewportParams) {
-  const { width, height } = selectedViewport;
+export function drawViewport({ ctx, x = 0, y = 0, selectedViewport }: DrawViewportParams) {
+  const { width, height, circle } = selectedViewport;
   ctx.beginPath();
-  if (cropAsCircle) {
+  if (circle) {
     ctx.arc(x + width / 2, y + height / 2, width / 2, 0, Math.PI * 2);
   } else {
     ctx.rect(x, y, width, height);


### PR DESCRIPTION
## Description

Implementerer `viewport config`, hvor også `circle` er inkludert istedenfor å være en egen egenskap i konfigen. 

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->
