### PR TITLE
Move the image cropper into a card

### DIFF
--- a/src/app-components/Card/Card.tsx
+++ b/src/app-components/Card/Card.tsx
@@ -13,6 +13,7 @@ type AppCardProps = {
   color?: Parameters<typeof Card>[0]['color'];
   children?: React.ReactNode;
   variant?: 'tinted' | 'default';
+  className?: string;
 };
 
 export function AppCard({
@@ -24,11 +25,13 @@ export function AppCard({
   mediaPosition = 'top',
   children,
   variant = 'tinted',
+  className,
 }: AppCardProps) {
   return (
     <Card
       data-color={color}
       variant={variant}
+      className={className}
     >
       {media && mediaPosition === 'top' && <Card.Block className={classes.mediaCard}>{media}</Card.Block>}
       <Card.Block>

--- a/src/layout/ImageUpload/ImageControllers.tsx
+++ b/src/layout/ImageUpload/ImageControllers.tsx
@@ -9,7 +9,7 @@ import {
   ZoomPlusIcon as ZoomIn,
 } from '@navikt/aksel-icons';
 
-import styles from 'src/layout/ImageUpload/ImageControllers.module.css';
+import classes from 'src/layout/ImageUpload/ImageControllers.module.css';
 import { logToNormalZoom, normalToLogZoom } from 'src/layout/ImageUpload/imageUploadUtils';
 
 type ImageControllersProps = {
@@ -49,16 +49,16 @@ export function ImageControllers({
   };
 
   return (
-    <div className={styles.controlsContainer}>
-      <div className={styles.controlSection}>
+    <div className={classes.controlsContainer}>
+      <div className={classes.controlSection}>
         <label
           htmlFor='zoom'
-          className={styles.label}
+          className={classes.label}
         >
           Zoom
         </label>
-        <div className={styles.zoomControls}>
-          <ZoomOut className={styles.zoomIcon} />
+        <div className={classes.zoomControls}>
+          <ZoomOut className={classes.zoomIcon} />
           <input
             id='zoom'
             type='range'
@@ -68,23 +68,23 @@ export function ImageControllers({
             // value={zoomToSliderValue(zoom)}
             value={logToNormalZoom({ value: zoom, minZoom, maxZoom })}
             onChange={handleSliderZoom}
-            className={styles.zoomSlider}
+            className={classes.zoomSlider}
           />
-          <ZoomIn className={styles.zoomIcon} />
+          <ZoomIn className={classes.zoomIcon} />
         </div>
       </div>
-      <div className={styles.actionButtons}>
+      <div className={classes.actionButtons}>
         <button
           onClick={onReset}
-          className={`${styles.button} ${styles.resetButton}`}
+          className={`${classes.button} ${classes.resetButton}`}
         >
-          <RefreshCw className={styles.icon} /> Reset
+          <RefreshCw className={classes.icon} /> Reset
         </button>
         <button
           onClick={onCrop}
-          className={`${styles.button} ${styles.cropButton}`}
+          className={`${classes.button} ${classes.cropButton}`}
         >
-          <Scissors className={styles.icon} /> Crop
+          <Scissors className={classes.icon} /> Crop
         </button>
       </div>
 
@@ -104,7 +104,7 @@ export function ImageControllers({
       >
         <Label
           htmlFor='image-upload'
-          className={styles.changeImageLabel}
+          className={classes.changeImageLabel}
         >
           <ArrowsSquarepathIcon />
           Bytt bilde

--- a/src/layout/ImageUpload/ImageUpload.module.css
+++ b/src/layout/ImageUpload/ImageUpload.module.css
@@ -20,6 +20,12 @@
   }
 }
 
+/* New wrapper for sizing the canvas */
+.canvasSizingWrapper {
+  width: 100%;
+  position: relative;
+}
+
 /* Canvas Column */
 .canvasContainerWrapper {
   width: 100%;
@@ -33,6 +39,8 @@
 
 .canvas {
   display: block;
+  width: 100%;
+  height: 100%;
   background-color: #e5e7eb;
   overflow: hidden;
   cursor: grab;
@@ -43,7 +51,8 @@
 .placeholder {
   background-color: #e5e7eb;
   width: 100%;
-  height: 300px;
+  /* Removed fixed height, using aspect-ratio to match canvas */
+  aspect-ratio: 8 / 3;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/layout/ImageUpload/ImageUpload.module.css
+++ b/src/layout/ImageUpload/ImageUpload.module.css
@@ -32,11 +32,8 @@
 }
 
 .canvas {
-  width: 100%;
-  height: auto;
   display: block;
   background-color: #e5e7eb;
-  border-radius: 0.5rem;
   overflow: hidden;
   cursor: grab;
   touch-action: none;
@@ -45,14 +42,21 @@
 /* Placeholder for when no image is loaded */
 .placeholder {
   background-color: #e5e7eb;
-  border-radius: 0.5rem;
   width: 100%;
-  height: 500px;
+  height: 300px;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   color: #6b7280;
+}
+
+div:has(.placeholder) {
+  margin-bottom: 0;
+}
+
+div:has(.canvas) {
+  margin-bottom: 0;
 }
 
 .placeholderIcon {
@@ -139,31 +143,6 @@
   flex-direction: row;
   align-items: center;
 }
-
-.shapeButton {
-  flex: 1 1 0%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.5rem;
-  border-radius: 0.375rem;
-  transition:
-    color 150ms ease-in-out,
-    background-color 150ms ease-in-out;
-  background-color: #e5e7eb;
-  color: #374151;
-  border: none;
-  cursor: pointer;
-}
-
-.shapeButton.active {
-  background-color: #2563eb;
-  color: white;
-  box-shadow:
-    0 1px 3px 0 rgb(0 0 0 / 0.1),
-    0 1px 2px -1px rgb(0 0 0 / 0.1);
-}
-
 .resetButton {
   background-color: #e5e7eb;
   color: #1f2937;

--- a/src/layout/ImageUpload/ImageUpload.tsx
+++ b/src/layout/ImageUpload/ImageUpload.tsx
@@ -8,7 +8,8 @@ import {
   ZoomPlusIcon as ZoomIn,
 } from '@navikt/aksel-icons';
 
-import styles from 'src/layout/ImageUpload/ImageUpload.module.css';
+import { AppCard } from 'src/app-components/Card/Card';
+import classes from 'src/layout/ImageUpload/ImageUpload.module.css';
 import {
   calculatePositions,
   constrainToArea,
@@ -296,35 +297,37 @@ export function ImageCropper({ onCrop, cropAsCircle = false, viewport }: ImageCr
   };
 
   return (
-    <div className={styles.cropperContainer}>
-      {/* Right side: Canvas */}
-      <div className={styles.canvasContainerWrapper}>
-        {imageSrc ? (
+    <AppCard
+      variant='default'
+      mediaPosition='top'
+      className={classes.imageUploadCard}
+      media={
+        imageSrc ? (
           <canvas
             onPointerDown={handlePointerDown}
             onKeyDown={handleKeyDown}
             tabIndex={0}
             ref={canvasRef}
-            width={500}
-            height={500}
-            className={styles.canvas}
+            width={800}
+            height={300}
+            className={classes.canvas}
             aria-label='Image cropping area'
           />
         ) : (
-          <div className={styles.placeholder}>
-            <Upload className={styles.placeholderIcon} />
-            <p className={styles.placeholderText}>Upload an image to start cropping</p>
+          <div className={classes.placeholder}>
+            <Upload className={classes.placeholderIcon} />
+            <p className={classes.placeholderText}>Upload an image to start cropping</p>
           </div>
-        )}
-      </div>
-      {/* Left side: Controls */}
-      <div className={styles.controlsContainer}>
+        )
+      }
+    >
+      <div className={classes.controlsContainer}>
         <label
           htmlFor='image-upload'
-          className={styles.uploadLabel}
+          className={classes.uploadLabel}
         >
-          <div className={styles.uploadButton}>
-            <Upload className={styles.icon} />
+          <div className={classes.uploadButton}>
+            <Upload className={classes.icon} />
             {imageSrc ? 'Change Image' : 'Upload Image'}
           </div>
           <input
@@ -332,21 +335,21 @@ export function ImageCropper({ onCrop, cropAsCircle = false, viewport }: ImageCr
             type='file'
             accept='image/*'
             onChange={handleFileChange}
-            className={styles.hiddenInput}
+            className={classes.hiddenInput}
           />
         </label>
 
         {imageSrc && (
-          <div className={styles.controlsContainer}>
-            <div className={styles.controlSection}>
+          <div className={classes.controlsContainer}>
+            <div className={classes.controlSection}>
               <label
                 htmlFor='zoom'
-                className={styles.label}
+                className={classes.label}
               >
                 Zoom
               </label>
-              <div className={styles.zoomControls}>
-                <ZoomOut className={styles.zoomIcon} />
+              <div className={classes.zoomControls}>
+                <ZoomOut className={classes.zoomIcon} />
                 <input
                   id='zoom'
                   type='range'
@@ -355,29 +358,29 @@ export function ImageCropper({ onCrop, cropAsCircle = false, viewport }: ImageCr
                   step='0.1'
                   value={logToNormalZoom({ value: zoom, minZoom: minAllowedZoom, maxZoom: MAX_ZOOM })}
                   onChange={handleSliderZoom}
-                  className={styles.zoomSlider}
+                  className={classes.zoomSlider}
                 />
-                <ZoomIn className={styles.zoomIcon} />
+                <ZoomIn className={classes.zoomIcon} />
               </div>
             </div>
 
-            <div className={styles.actionButtons}>
+            <div className={classes.actionButtons}>
               <button
                 onClick={handleReset}
-                className={`${styles.button} ${styles.resetButton}`}
+                className={`${classes.button} ${classes.resetButton}`}
               >
-                <RefreshCw className={styles.icon} /> Reset
+                <RefreshCw className={classes.icon} /> Reset
               </button>
               <button
                 onClick={handleCrop}
-                className={`${styles.button} ${styles.cropButton}`}
+                className={`${classes.button} ${classes.cropButton}`}
               >
-                <Scissors className={styles.icon} /> Crop
+                <Scissors className={classes.icon} /> Crop
               </button>
             </div>
           </div>
         )}
       </div>
-    </div>
+    </AppCard>
   );
 }

--- a/src/layout/ImageUpload/imageUploadUtils.ts
+++ b/src/layout/ImageUpload/imageUploadUtils.ts
@@ -7,7 +7,7 @@ export const getViewport = (viewport?: string) => {
     case '16:9':
       return { width: 320, height: 180 };
     default:
-      return { width: 300, height: 300 };
+      return { width: 280, height: 280 };
   }
 };
 


### PR DESCRIPTION
## Description

Moves the canvas and its controls into a card component, using their respective blocks.

Also adds a Resize observer in order to keep the canvas responsive to page width after it broke when moving it into the card.

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->
