### PR TITLE
clean up css and style closer to figma design

### DIFF
--- a/src/layout/FileUpload/DropZone/DropzoneComponent.module.css
+++ b/src/layout/FileUpload/DropZone/DropzoneComponent.module.css
@@ -19,6 +19,13 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  height: 9.75rem;
+  border-width: 2px;
+  border-color: var(--colors-primary-blue);
+  border-style: dotted;
+  cursor: pointer;
+  background: transparent;
+  width: 100%;
 }
 
 .fileUploadInvalid:focus {
@@ -39,4 +46,13 @@
 
 .uploadIcon {
   font-size: 2.5rem;
+}
+
+.active {
+  border-style: solid;
+}
+
+.validationError {
+  border-style: dotted;
+  border-color: var(--colors-danger);
 }

--- a/src/layout/FileUpload/DropZone/DropzoneComponent.tsx
+++ b/src/layout/FileUpload/DropZone/DropzoneComponent.tsx
@@ -9,13 +9,12 @@ import { Lang } from 'src/features/language/Lang';
 import { useLanguage } from 'src/features/language/useLanguage';
 import classes from 'src/layout/FileUpload/DropZone/DropzoneComponent.module.css';
 import { mapExtensionToAcceptMime } from 'src/layout/FileUpload/DropZone/mapExtensionToAcceptMime';
-import { AltinnPalette } from 'src/theme/altinnAppTheme';
 import type { CompInternal } from 'src/layout/layout';
 
 export interface IDropzoneComponentProps {
   id: string;
   isMobile: boolean;
-  maxFileSizeInMB: number;
+  maxFileSizeInMB?: number;
   readOnly: boolean;
   onClick: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
   onDrop: (acceptedFiles: File[], rejectedFiles: FileRejection[]) => void;
@@ -24,30 +23,10 @@ export interface IDropzoneComponentProps {
   validFileEndings?: CompInternal<'FileUpload'>['validFileEndings'];
   labelId?: string;
   descriptionId?: string;
+  className?: string;
 }
 
-export const bytesInOneMB = 1048576;
-
-const fileUploadButtonStyle = {
-  background: 'transparent',
-  width: '100%',
-};
-
-export const baseStyle = {
-  width: 'auto',
-  height: '9.75rem',
-  borderWidth: '2px',
-  borderColor: AltinnPalette.blueMedium,
-  borderStyle: 'dotted',
-  cursor: 'pointer',
-};
-export const activeStyle = {
-  borderStyle: 'solid',
-};
-export const validationErrorStyle = {
-  borderStyle: 'dotted',
-  borderColor: AltinnPalette.red,
-};
+const bytesInOneMB = 1048576;
 
 export function DropzoneComponent({
   id,
@@ -61,6 +40,7 @@ export function DropzoneComponent({
   validFileEndings,
   labelId,
   descriptionId,
+  className,
 }: IDropzoneComponentProps): React.JSX.Element {
   const maxSizeLabelId = `file-upload-max-size-${id}`;
   const { langAsString } = useLanguage();
@@ -70,14 +50,16 @@ export function DropzoneComponent({
         className={classes.fileUploadTextBoldSmall}
         id={maxSizeLabelId}
       >
-        <Lang
-          id='form_filler.file_uploader_max_size_mb'
-          params={[maxFileSizeInMB]}
-        />
+        {maxFileSizeInMB && (
+          <Lang
+            id='form_filler.file_uploader_max_size_mb'
+            params={[maxFileSizeInMB]}
+          />
+        )}
       </div>
       <DropZone
         onDrop={onDrop}
-        maxSize={maxFileSizeInMB * bytesInOneMB} // mb to bytes
+        maxSize={maxFileSizeInMB && maxFileSizeInMB * bytesInOneMB} // mb to bytes
         disabled={readOnly}
         accept={
           hasCustomFileEndings && validFileEndings !== undefined
@@ -86,10 +68,6 @@ export function DropzoneComponent({
         }
       >
         {({ getRootProps, getInputProps, isDragActive }) => {
-          let styles = { ...baseStyle, ...fileUploadButtonStyle };
-          styles = isDragActive ? { ...styles, ...activeStyle } : styles;
-          styles = hasValidationMessages ? { ...styles, ...validationErrorStyle } : styles;
-
           const dragLabelId = `file-upload-drag-${id}`;
           const formatLabelId = `file-upload-format-${id}`;
           const ariaDescribedBy = descriptionId
@@ -101,9 +79,14 @@ export function DropzoneComponent({
               {...getRootProps({
                 onClick,
               })}
-              style={styles}
               id={`altinn-drop-zone-${id}`}
-              className={`${classes.fileUpload}${hasValidationMessages ? classes.fileUploadInvalid : ''}`}
+              className={cn(
+                classes.fileUpload,
+                { [classes.active]: isDragActive },
+                { [classes.validationError]: hasValidationMessages },
+                { [classes.fileUploadInvalid]: hasValidationMessages },
+                className,
+              )}
               aria-labelledby={labelId}
               aria-describedby={ariaDescribedBy}
             >

--- a/src/layout/ImageUpload/ImageUpload.module.css
+++ b/src/layout/ImageUpload/ImageUpload.module.css
@@ -66,10 +66,8 @@ div:has(.canvas) {
   width: 1.25rem;
 }
 
-.dropZoneWrapper {
-  width: 100%;
-}
-
-.dropZoneWrapper :global(#altinn-drop-zone-image-upload) {
+.dropZone {
   border-radius: var(--ds-border-radius-lg);
+  border-style: dashed;
+  border: 2px dashed var(--ds-color-border-default);
 }

--- a/src/layout/ImageUpload/ImageUpload.tsx
+++ b/src/layout/ImageUpload/ImageUpload.tsx
@@ -353,18 +353,16 @@ export function ImageCropper({ onCrop, viewport }: ImageCropperProps) {
           onCrop={handleCrop}
         />
       ) : (
-        <div className={classes.dropZoneWrapper}>
-          <DropzoneComponent
-            id='image-upload'
-            isMobile={mobileView}
-            maxFileSizeInMB={10}
-            readOnly={false}
-            onClick={(e) => e.preventDefault()}
-            onDrop={(files) => handleFileUpload(files[0])}
-            hasValidationMessages={false}
-            validFileEndings={['.jpg', '.jpeg', '.png', '.gif']}
-          />
-        </div>
+        <DropzoneComponent
+          id='image-upload'
+          isMobile={mobileView}
+          readOnly={false}
+          onClick={(e) => e.preventDefault()}
+          onDrop={(files) => handleFileUpload(files[0])}
+          hasValidationMessages={false}
+          validFileEndings={['.jpg', '.jpeg', '.png', '.gif']}
+          className={classes.dropZone}
+        />
       )}
     </AppCard>
   );


### PR DESCRIPTION
## Description

- Moves the inline styles into css module for dropzone component.
- Also makes the components css to be modified with classNames.
- Adds css to image upload implementation of teh dropzone component to make it look more like the figma design

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->
