### PR TITLE
Chore: Add environment to pr-actions workflow

### DIFF
--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -6,6 +6,7 @@ jobs:
   publish:
     name: Publish PR packages
     runs-on: ubuntu-latest
+    environment: test
     if: github.event.issue.pull_request && contains(github.event.comment.body, '/publish')
     permissions:
       id-token: write


### PR DESCRIPTION
Adding environment `test` to pr-actions workflow.

Vemund informed me that they will stop using SAS token for altinn-cdn, these changes will come soon, but the new authentication method will require a specific environment to have access.
