### PR TITLE
Extract canvas and effects into its own component

### DIFF
--- a/src/layout/ImageUpload/ImageCanvas.tsx
+++ b/src/layout/ImageUpload/ImageCanvas.tsx
@@ -1,0 +1,209 @@
+import React, { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react';
+
+import classes from 'src/layout/ImageUpload/ImageUpload.module.css';
+import { calculatePositions, drawViewport } from 'src/layout/ImageUpload/imageUploadUtils';
+import type { Position, Viewport } from 'src/layout/ImageUpload/imageUploadUtils';
+
+// Props for the ImageCanvas component
+interface ImageCanvasProps {
+  imageRef: React.RefObject<HTMLImageElement | null>;
+  zoom: number;
+  position: Position;
+  viewport: Viewport;
+  onPositionChange: (newPosition: Position) => void;
+  onZoomChange: (newZoom: number) => void;
+}
+
+// The handle exposed to the parent component via ref
+export interface ImageCanvasHandle {
+  crop: () => string | null;
+}
+
+const CANVAS_HEIGHT = 320;
+
+export const ImageCanvas = forwardRef<ImageCanvasHandle, ImageCanvasProps>(
+  ({ imageRef, zoom, position, viewport, onPositionChange, onZoomChange }, ref) => {
+    const canvasRef = useRef<HTMLCanvasElement>(null);
+    const containerRef = useRef<HTMLDivElement>(null);
+    const [canvasWidth, setCanvasWidth] = useState(800);
+
+    // Expose the crop function to the parent component
+    useImperativeHandle(ref, () => ({
+      crop: () => {
+        const canvas = canvasRef.current;
+        const img = imageRef.current;
+        const cropCanvas = document.createElement('canvas');
+        const cropCtx = cropCanvas.getContext('2d');
+
+        if (!canvas || !img || !cropCtx) {
+          return null;
+        }
+
+        cropCanvas.width = viewport.width;
+        cropCanvas.height = viewport.height;
+
+        const { imgX, imgY, scaledWidth, scaledHeight } = calculatePositions({
+          canvas,
+          img,
+          zoom,
+          position,
+        });
+
+        const viewportX = (canvas.width - viewport.width) / 2;
+        const viewportY = (canvas.height - viewport.height) / 2;
+
+        drawViewport({ ctx: cropCtx, selectedViewport: viewport });
+        cropCtx.clip();
+        cropCtx.drawImage(img, imgX - viewportX, imgY - viewportY, scaledWidth, scaledHeight);
+
+        return cropCanvas.toDataURL('image/png');
+      },
+    }));
+
+    // Handles all drawing operations on the canvas
+    const draw = useCallback(() => {
+      const canvas = canvasRef.current;
+      const ctx = canvas?.getContext('2d');
+      const img = imageRef.current;
+
+      if (!canvas || !img?.complete || !ctx) {
+        return;
+      }
+
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      const { imgX, imgY, scaledWidth, scaledHeight } = calculatePositions({
+        canvas,
+        img,
+        zoom,
+        position,
+      });
+
+      ctx.drawImage(img, imgX, imgY, scaledWidth, scaledHeight);
+      ctx.fillStyle = 'rgba(0, 0, 0, 0.5)';
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      ctx.save();
+
+      const viewportX = (canvas.width - viewport.width) / 2;
+      const viewportY = (canvas.height - viewport.height) / 2;
+
+      drawViewport({ ctx, x: viewportX, y: viewportY, selectedViewport: viewport });
+      ctx.clip();
+      ctx.drawImage(img, imgX, imgY, scaledWidth, scaledHeight);
+      ctx.restore();
+
+      drawViewport({ ctx, x: viewportX, y: viewportY, selectedViewport: viewport });
+      ctx.strokeStyle = 'white';
+      ctx.lineWidth = 2;
+      ctx.setLineDash([5, 5]);
+      ctx.stroke();
+      ctx.setLineDash([]);
+    }, [zoom, position, viewport, imageRef]);
+
+    useEffect(() => {
+      draw();
+    }, [draw, canvasWidth]);
+
+    // Observes the container size to make the canvas responsive
+    useEffect(() => {
+      const container = containerRef.current;
+      if (!container) {
+        return;
+      }
+      let animationFrameId: number | null = null;
+      const resizeObserver = new ResizeObserver((entries) => {
+        animationFrameId = window.requestAnimationFrame(() => {
+          if (entries[0]) {
+            setCanvasWidth(entries[0].contentRect.width);
+          }
+        });
+      });
+      resizeObserver.observe(container);
+      return () => {
+        if (animationFrameId) {
+          window.cancelAnimationFrame(animationFrameId);
+        }
+        resizeObserver.disconnect();
+      };
+    }, []);
+
+    // Handles panning via pointer events (mouse/touch)
+    const handlePointerDown = (e: React.PointerEvent<HTMLCanvasElement>) => {
+      e.preventDefault();
+      const canvas = canvasRef.current;
+      if (!canvas) {
+        return;
+      }
+      canvas.setPointerCapture(e.pointerId);
+      const startDrag = { x: e.clientX - position.x, y: e.clientY - position.y };
+
+      const handlePointerMove = (moveEvent: PointerEvent) => {
+        onPositionChange({
+          x: moveEvent.clientX - startDrag.x,
+          y: moveEvent.clientY - startDrag.y,
+        });
+      };
+      const handlePointerUp = () => {
+        canvas.releasePointerCapture(e.pointerId);
+        document.removeEventListener('pointermove', handlePointerMove);
+        document.removeEventListener('pointerup', handlePointerUp);
+      };
+      document.addEventListener('pointermove', handlePointerMove);
+      document.addEventListener('pointerup', handlePointerUp);
+    };
+
+    // Handles zooming via the mouse wheel
+    const handleWheel = useCallback(
+      (e: WheelEvent) => {
+        e.preventDefault();
+        onZoomChange(zoom - e.deltaY * 0.001);
+      },
+      [zoom, onZoomChange],
+    );
+
+    useEffect(() => {
+      const canvas = canvasRef.current;
+      if (canvas) {
+        canvas.addEventListener('wheel', handleWheel, { passive: false });
+      }
+      return () => {
+        canvas?.removeEventListener('wheel', handleWheel);
+      };
+    }, [handleWheel]);
+
+    // Handles panning via keyboard arrow keys
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLCanvasElement>) => {
+      const moveAmount = 10;
+      const keyMap: Record<string, () => void> = {
+        ArrowUp: () => onPositionChange({ ...position, y: position.y - moveAmount }),
+        ArrowDown: () => onPositionChange({ ...position, y: position.y + moveAmount }),
+        ArrowLeft: () => onPositionChange({ ...position, x: position.x - moveAmount }),
+        ArrowRight: () => onPositionChange({ ...position, x: position.x + moveAmount }),
+      };
+
+      if (keyMap[e.key]) {
+        e.preventDefault();
+        keyMap[e.key]();
+      }
+    };
+
+    return (
+      <div
+        ref={containerRef}
+        className={classes.canvasSizingWrapper}
+      >
+        <canvas
+          onPointerDown={handlePointerDown}
+          onKeyDown={handleKeyDown}
+          tabIndex={0}
+          ref={canvasRef}
+          width={canvasWidth}
+          height={CANVAS_HEIGHT}
+          className={classes.canvas}
+          aria-label='Image cropping area'
+        />
+      </div>
+    );
+  },
+);
+
+ImageCanvas.displayName = 'ImageCanvas';

--- a/src/layout/ImageUpload/ImageUpload.tsx
+++ b/src/layout/ImageUpload/ImageUpload.tsx
@@ -6,7 +6,7 @@ import { AppCard } from 'src/app-components/Card/Card';
 import { useAttachmentsUploader } from 'src/features/attachments/hooks';
 import { useIsMobileOrTablet } from 'src/hooks/useDeviceWidths';
 import { DropzoneComponent } from 'src/layout/FileUpload/DropZone/DropzoneComponent';
-import { ImageCanvas } from 'src/layout/ImageUpload/ImageCanvas'; // Adjust path as needed
+import { ImageCanvas } from 'src/layout/ImageUpload/ImageCanvas';
 import { ImageControllers } from 'src/layout/ImageUpload/ImageControllers';
 import classes from 'src/layout/ImageUpload/ImageUpload.module.css';
 import {

--- a/src/layout/ImageUpload/ImageUpload.tsx
+++ b/src/layout/ImageUpload/ImageUpload.tsx
@@ -37,7 +37,7 @@ export function ImageCropper({ baseComponentId, viewport, dataModelBindings }: I
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const imageRef = useRef<HTMLImageElement | null>(null);
 
-  // State
+  // State management
   const [zoom, setZoom] = useState<number>(1);
   const [position, setPosition] = useState<Position>({ x: 0, y: 0 });
   const [imageSrc, setImageSrc] = useState<File | null>(null);

--- a/src/layout/ImageUpload/imageUploadUtils.ts
+++ b/src/layout/ImageUpload/imageUploadUtils.ts
@@ -1,5 +1,7 @@
 export type Viewport = { width: number; height: number; circle?: boolean };
 
+export type Position = { x: number; y: number };
+
 export enum ViewportType {
   Square = '1:1',
   Rectangle4_3 = '4:3',
@@ -28,10 +30,7 @@ interface ConstrainToAreaParams {
   viewport: { width: number; height: number };
 }
 
-export function constrainToArea({ image, zoom, position, viewport }: ConstrainToAreaParams): {
-  x: number;
-  y: number;
-} {
+export function constrainToArea({ image, zoom, position, viewport }: ConstrainToAreaParams): Position {
   const scaledWidth = image.width * zoom;
   const scaledHeight = image.height * zoom;
 
@@ -48,7 +47,7 @@ interface CalculatePositionsParams {
   canvas: HTMLCanvasElement;
   img: HTMLImageElement;
   zoom: number;
-  position: { x: number; y: number };
+  position: Position;
 }
 
 export const calculatePositions = ({ canvas, img, zoom, position }: CalculatePositionsParams) => {


### PR DESCRIPTION
## Description

- Moves the canvas element into its own component along with its relevant useEffects and handlers. 
- Added a `handleZoomChange` that is used by both the scrollwheel on the canvas and the slider in imagecontrolls to update the zoom value
- Added a `handlePositionChange` that is used to update the images position state when the user moves the image with mouse or keyboard

For further development, maybe we could move the handlePositionChange into the canvas component. Or we could try to merge it with the handlePositionChange, seeing that the two handlers are fairly similar.


<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->
