### PR TITLE
Add displaydata expression test

### DIFF
--- a/src/features/expressions/shared-tests/functions/displayValue/type-ImageUpload.json
+++ b/src/features/expressions/shared-tests/functions/displayValue/type-ImageUpload.json
@@ -1,0 +1,42 @@
+{
+  "name": "Display value of FileUpload component",
+  "expression": [
+    "displayValue",
+    "image"
+  ],
+  "context": {
+    "component": "image",
+    "currentLayout": "Page"
+  },
+  "expects": "my-image.jpg",
+  "layouts": {
+    "Page": {
+      "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+      "data": {
+        "layout": [
+          {
+            "id": "image",
+            "type": "ImageUpload"
+          }
+        ]
+      }
+    }
+  },
+  "instanceDataElements": [
+    {
+        "id": "bb2b2222-2b22-2b22-222b-222222222222",
+        "instanceGuid": "aa1a1111-1a11-1a11-111a-111111111111",
+        "dataType": "image",
+        "filename": "my-image.jpg",
+        "contentType": "image/jpeg",
+        "blobStoragePath": "",
+        "size": 100,
+        "locked": false,
+        "refs": [],
+        "created": "2021-01-01T00:00:00.000Z",
+        "createdBy": "testUser",
+        "lastChanged": "2021-01-01T00:00:00.000Z",
+        "lastChangedBy": "testUser"
+    }
+  ]
+}

--- a/src/layout/ImageUpload/index.tsx
+++ b/src/layout/ImageUpload/index.tsx
@@ -1,6 +1,7 @@
 import React, { forwardRef } from 'react';
 import type { JSX } from 'react';
 
+import { useAttachmentsFor } from 'src/features/attachments/hooks';
 import { useFileUploaderDataBindingsValidation } from 'src/layout/FileUpload/utils/useFileUploaderDataBindingsValidation';
 import { ImageUploadDef } from 'src/layout/ImageUpload/config.def.generated';
 import { ImageUploadComponent } from 'src/layout/ImageUpload/ImageUploadComponent';
@@ -10,8 +11,9 @@ import type { IDataModelBindings } from 'src/layout/layout';
 import type { ExprResolver, SummaryRendererProps } from 'src/layout/LayoutComponent';
 
 export class ImageUpload extends ImageUploadDef {
-  useDisplayData(): string {
-    return '';
+  useDisplayData(baseComponentId: string): string {
+    const attachments = useAttachmentsFor(baseComponentId);
+    return attachments.map((a) => a.data.filename).join(', ');
   }
 
   render = forwardRef<HTMLElement, PropsFromGenericComponent<'ImageUpload'>>(


### PR DESCRIPTION
## Description

Adds displaydata implementation and expression test for displaydata.

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->
