### PR TITLE
Sync some configuration to applicationmetadata JSON schema

### DIFF
--- a/schemas/json/application/application-metadata.schema.v1.json
+++ b/schemas/json/application/application-metadata.schema.v1.json
@@ -126,6 +126,11 @@
     },
     "logo": {
       "$ref": "#/definitions/logo"
+    },
+    "preventInstanceDeletionForDays": {
+      "type": "integer",
+      "title": "Prevent instance deletion for days",
+      "description": "Prevents the deletion of an instance for the specified number of days. This property takes precedence over the autoDeleteOnProcessEnd property."
     }
   },
   "definitions": {
@@ -399,6 +404,16 @@
           "items": {
             "type": "string"
           }
+        },
+        "actionRequiredToRead": {
+          "type": "string",
+          "title": "Action required to read",
+          "description": "When this is set, it overrides what action is required to read the blob of data elements of this data type."
+        },
+        "actionRequiredToWrite": {
+          "type": "string",
+          "title": "Action required to write",
+          "description": "When this is set, it overrides what action is required to write to the blob of data elements of this data type."
         }
       }
     },
@@ -489,6 +504,11 @@
           "items": {
             "type": "string"
           }
+        },
+        "includeAttachments": {
+          "type": "boolean",
+          "title": "Include attachments",
+          "description": "Gets or sets a boolean indicating if copying of attachments is enabled."
         }
       }
     },


### PR DESCRIPTION
## Description
Syncs some of our newer configuration options into appmetadata JSON schema
* `preventInstanceDeletionForDays` - https://github.com/Altinn/altinn-storage/pull/627
* `actionRequiredToRead`/`actionRequiredToWrite` - https://github.com/Altinn/altinn-storage/pull/741
* `includeAttachments` - https://github.com/Altinn/altinn-storage/pull/732

Does it make sense to backport these?

## Related Issue(s)

- PRs above

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a setting to delay instance deletion for a specified number of days, taking precedence over automatic deletion at process end.
  * Added per–data-type controls to define the required action to read or write associated blobs, enabling more granular access management.
  * Added an option to include attachments when copying an instance, allowing more complete duplication when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->