### PR TITLE
support summary2

### DIFF
--- a/src/layout/FileUpload/FileUploadTable/FileTable.tsx
+++ b/src/layout/FileUpload/FileUploadTable/FileTable.tsx
@@ -30,9 +30,9 @@ export function FileTable({
   isSummary,
   isFetching,
 }: FileTableProps): React.JSX.Element | null {
-  const { textResourceBindings, type, readOnly } = useItemWhenType<'FileUpload' | 'FileUploadWithTag'>(
+  const { textResourceBindings, type, readOnly } = useItemWhenType<'FileUpload' | 'FileUploadWithTag' | 'ImageUpload'>(
     baseComponentId,
-    (t) => t === 'FileUpload' || t === 'FileUploadWithTag',
+    (t) => t === 'FileUpload' || t === 'FileUploadWithTag' || t === 'ImageUpload',
   );
   const hasTag = type === 'FileUploadWithTag';
   const pdfModeActive = usePdfModeActive();

--- a/src/layout/ImageUpload/ImageDropzone.tsx
+++ b/src/layout/ImageUpload/ImageDropzone.tsx
@@ -9,7 +9,6 @@ import classes from 'src/layout/ImageUpload/ImageDropzone.module.css';
 import { VALID_FILE_ENDINGS } from 'src/layout/ImageUpload/imageUploadUtils';
 import type { IDropzoneProps } from 'src/app-components/Dropzone/Dropzone';
 
-// interface ImageDropzoneProps extends IDropzoneComponentProps {}
 type ImageDropzoneProps = {
   componentId: string;
   hasErrors: boolean;

--- a/src/layout/ImageUpload/ImageUploadComponent.tsx
+++ b/src/layout/ImageUpload/ImageUploadComponent.tsx
@@ -13,7 +13,6 @@ export function ImageUploadComponent({ baseComponentId, overrideDisplay }: Props
   const { id, cropHeight, cropShape, cropWidth, grid, required } = useItemWhenType(baseComponentId, 'ImageUpload');
   const { labelText, getRequiredComponent, getOptionalComponent, getHelpTextComponent, getDescriptionComponent } =
     useLabel({ baseComponentId, overrideDisplay });
-  const cropArea = { width: cropWidth, height: cropHeight, type: cropShape } as CropArea;
 
   return (
     <Label
@@ -28,7 +27,7 @@ export function ImageUploadComponent({ baseComponentId, overrideDisplay }: Props
     >
       <ComponentStructureWrapper baseComponentId={baseComponentId}>
         <ImageCropper
-          cropArea={getCropArea(cropArea)}
+          cropArea={getCropArea({ width: cropWidth, height: cropHeight, type: cropShape } as CropArea)}
           baseComponentId={baseComponentId}
         />
       </ComponentStructureWrapper>

--- a/src/layout/ImageUpload/ImageUploadSummary2.tsx
+++ b/src/layout/ImageUpload/ImageUploadSummary2.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+
+import { Paragraph } from '@digdir/designsystemet-react';
+
+import { Label } from 'src/components/label/Label';
+import { Lang } from 'src/features/language/Lang';
+import { useOptionsFor } from 'src/features/options/useOptionsFor';
+import { usePdfModeActive } from 'src/features/pdf/PDFWrapper';
+import { useIsMobileOrTablet } from 'src/hooks/useDeviceWidths';
+import { FileTable } from 'src/layout/FileUpload/FileUploadTable/FileTable';
+import { useUploaderSummaryData } from 'src/layout/FileUpload/Summary/summary';
+import { SummaryContains, SummaryFlex } from 'src/layout/Summary2/SummaryComponent2/ComponentSummary';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
+import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types';
+
+export function ImageUploadSummary2({ targetBaseComponentId }: Summary2Props) {
+  const attachment = useUploaderSummaryData(targetBaseComponentId);
+  const { required } = useItemWhenType(targetBaseComponentId, 'ImageUpload');
+  const { options, isFetching } = useOptionsFor(targetBaseComponentId, 'single');
+  const mobileView = useIsMobileOrTablet();
+  const pdfModeActive = usePdfModeActive();
+  const isSmall = mobileView && !pdfModeActive;
+  const isEmpty = attachment.length === 0;
+
+  return (
+    <SummaryFlex
+      targetBaseId={targetBaseComponentId}
+      content={
+        isEmpty
+          ? required
+            ? SummaryContains.EmptyValueRequired
+            : SummaryContains.EmptyValueNotRequired
+          : SummaryContains.SomeUserContent
+      }
+    >
+      <Label
+        baseComponentId={targetBaseComponentId}
+        overrideId={`imageUpload-summary2-${targetBaseComponentId}`}
+        renderLabelAs='span'
+        weight='regular'
+      />
+      {attachment.length === 0 ? (
+        <Paragraph asChild>
+          <span>
+            <Lang id='general.empty_summary' />
+          </span>
+        </Paragraph>
+      ) : (
+        <FileTable
+          baseComponentId={targetBaseComponentId}
+          mobileView={isSmall}
+          attachments={attachment}
+          options={options}
+          isSummary={true}
+          isFetching={isFetching}
+        />
+      )}
+    </SummaryFlex>
+  );
+}

--- a/src/layout/ImageUpload/ImageUploadSummary2.tsx
+++ b/src/layout/ImageUpload/ImageUploadSummary2.tsx
@@ -22,16 +22,16 @@ export function ImageUploadSummary2({ targetBaseComponentId }: Summary2Props) {
   const isSmall = mobileView && !pdfModeActive;
   const isEmpty = attachment.length === 0;
 
+  const contentLogic = isEmpty
+    ? required
+      ? SummaryContains.EmptyValueRequired
+      : SummaryContains.EmptyValueNotRequired
+    : SummaryContains.SomeUserContent;
+
   return (
     <SummaryFlex
       targetBaseId={targetBaseComponentId}
-      content={
-        isEmpty
-          ? required
-            ? SummaryContains.EmptyValueRequired
-            : SummaryContains.EmptyValueNotRequired
-          : SummaryContains.SomeUserContent
-      }
+      content={contentLogic}
     >
       <Label
         baseComponentId={targetBaseComponentId}
@@ -39,7 +39,7 @@ export function ImageUploadSummary2({ targetBaseComponentId }: Summary2Props) {
         renderLabelAs='span'
         weight='regular'
       />
-      {attachment.length === 0 ? (
+      {isEmpty ? (
         <Paragraph asChild>
           <span>
             <Lang id='general.empty_summary' />

--- a/src/layout/ImageUpload/imageUploadUtils.ts
+++ b/src/layout/ImageUpload/imageUploadUtils.ts
@@ -10,7 +10,7 @@ export type CropAreaParams = { width?: number; height?: number; type?: CropForm.
 export type CropArea = { width: number; height: number; type: CropForm.Square | CropForm.Circle };
 
 export const getCropArea = (cropArea?: CropAreaParams): CropArea => {
-  const defaultSize = 300;
+  const defaultSize = 250;
 
   let width = cropArea?.width ?? defaultSize;
   let height = cropArea?.height ?? defaultSize;

--- a/src/layout/ImageUpload/index.tsx
+++ b/src/layout/ImageUpload/index.tsx
@@ -5,10 +5,12 @@ import { useAttachmentsFor } from 'src/features/attachments/hooks';
 import { useFileUploaderDataBindingsValidation } from 'src/layout/FileUpload/utils/useFileUploaderDataBindingsValidation';
 import { ImageUploadDef } from 'src/layout/ImageUpload/config.def.generated';
 import { ImageUploadComponent } from 'src/layout/ImageUpload/ImageUploadComponent';
+import { ImageUploadSummary2 } from 'src/layout/ImageUpload/ImageUploadSummary2';
 import type { LayoutLookups } from 'src/features/form/layout/makeLayoutLookups';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type { IDataModelBindings } from 'src/layout/layout';
 import type { ExprResolver, SummaryRendererProps } from 'src/layout/LayoutComponent';
+import type { Summary2Props } from 'src/layout/Summary2/SummaryComponent2/types';
 
 export class ImageUpload extends ImageUploadDef {
   useDisplayData(baseComponentId: string): string {
@@ -37,8 +39,8 @@ export class ImageUpload extends ImageUploadDef {
     throw new Error('Method not implemented.'); // TODO
   }
 
-  renderSummary2(): JSX.Element | null {
-    return <div>test</div>;
+  renderSummary2(props: Summary2Props): JSX.Element | null {
+    return <ImageUploadSummary2 {...props} />;
   }
 
   evalExpressions(props: ExprResolver<'ImageUpload'>) {


### PR DESCRIPTION
## Description

This PR utilize the logic for file upload in summary 2 so that image upload can also be presented in the summary.
Also changed the default size of cropper to 250.


<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->
