### PR TITLE
`Group` label and description alignment

### DIFF
--- a/src/layout/Group/GroupComponent.module.css
+++ b/src/layout/Group/GroupComponent.module.css
@@ -3,9 +3,13 @@
   padding-bottom: var(--ds-size-9);
   width: 100%;
 
-  .legend,
+  .legend {
+    padding: 0 12px;
+  }
+
   .description {
     padding: 0 var(--ds-size-3);
+    display: inline-block;
   }
 }
 


### PR DESCRIPTION
## Description

After the design system changes, multi-line descriptions in `Group` had their second line display out-of-line with other components, and the legend/label had a 16px padding instead of 12px (which makes sense since `--ds-size-3` is relative to the font size).

This gif shows before/after:

![bugfix-group-label](https://github.com/user-attachments/assets/ee2490b1-45de-446a-9354-5972120fe3da)

## Related Issue(s)

- https://digdir-samarbeid.slack.com/archives/C02EJ9HKQA3/p1758195016189619

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->
