### PR TITLE
Refactor: Making TaskStore a regular context

### DIFF
--- a/src/core/contexts/TaskOverrides.tsx
+++ b/src/core/contexts/TaskOverrides.tsx
@@ -6,10 +6,9 @@ interface TaskOverridesContext {
   dataModelType?: string;
   dataModelElementId?: string;
   layoutSetId?: string;
-  depth: number;
 }
 
-const Context = createContext<TaskOverridesContext>({ depth: 1 });
+const Context = createContext<TaskOverridesContext>({});
 
 type Props = PropsWithChildren & Omit<TaskOverridesContext, 'depth'>;
 export function TaskOverrides({ children, ...overrides }: Props) {
@@ -22,7 +21,6 @@ export function TaskOverrides({ children, ...overrides }: Props) {
         dataModelType: overrides.dataModelType ?? parentContext.dataModelType,
         dataModelElementId: overrides.dataModelElementId ?? parentContext.dataModelElementId,
         layoutSetId: overrides.layoutSetId ?? parentContext.layoutSetId,
-        depth: parentContext.depth + 1,
       }}
     >
       {children}

--- a/src/core/contexts/TaskOverrides.tsx
+++ b/src/core/contexts/TaskOverrides.tsx
@@ -4,7 +4,7 @@ import type { PropsWithChildren } from 'react';
 interface TaskOverridesContext {
   taskId?: string;
   dataModelType?: string;
-  dataElementId?: string;
+  dataModelElementId?: string;
   layoutSetId?: string;
   depth: number;
 }
@@ -20,7 +20,7 @@ export function TaskOverrides({ children, ...overrides }: Props) {
       value={{
         taskId: overrides.taskId ?? parentContext.taskId,
         dataModelType: overrides.dataModelType ?? parentContext.dataModelType,
-        dataElementId: overrides.dataElementId ?? parentContext.dataElementId,
+        dataModelElementId: overrides.dataModelElementId ?? parentContext.dataModelElementId,
         layoutSetId: overrides.layoutSetId ?? parentContext.layoutSetId,
         depth: parentContext.depth + 1,
       }}

--- a/src/features/attachments/StoreAttachmentsInNode.tsx
+++ b/src/features/attachments/StoreAttachmentsInNode.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 
 import deepEqual from 'fast-deep-equal';
 
-import { useTaskStore } from 'src/core/contexts/taskStoreContext';
+import { useTaskOverrides } from 'src/core/contexts/taskStoreContext';
 import { useApplicationMetadata } from 'src/features/applicationMetadata/ApplicationMetadataProvider';
 import { isAttachmentUploaded } from 'src/features/attachments/index';
 import { DEFAULT_DEBOUNCE_TIMEOUT } from 'src/features/formData/types';
@@ -89,7 +89,7 @@ function useNodeAttachments(): AttachmentRecord {
   const { indexedId, baseId } = parent;
   const nodeData = useFormDataFor(baseId) as IComponentFormData<CompWithBehavior<'canHaveAttachments'>>;
 
-  const overriddenTaskId = useTaskStore((state) => state.overriddenTaskId);
+  const overriddenTaskId = useTaskOverrides()?.taskId;
 
   const application = useApplicationMetadata();
   const currentTask = useProcessQuery().data?.currentTask?.elementId;

--- a/src/features/attachments/StoreAttachmentsInNode.tsx
+++ b/src/features/attachments/StoreAttachmentsInNode.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 
 import deepEqual from 'fast-deep-equal';
 
-import { useTaskOverrides } from 'src/core/contexts/taskStoreContext';
+import { useTaskOverrides } from 'src/core/contexts/TaskOverrides';
 import { useApplicationMetadata } from 'src/features/applicationMetadata/ApplicationMetadataProvider';
 import { isAttachmentUploaded } from 'src/features/attachments/index';
 import { DEFAULT_DEBOUNCE_TIMEOUT } from 'src/features/formData/types';

--- a/src/features/datamodel/DataModelsProvider.tsx
+++ b/src/features/datamodel/DataModelsProvider.tsx
@@ -6,7 +6,7 @@ import deepEqual from 'fast-deep-equal';
 import { createStore } from 'zustand';
 import type { JSONSchema7 } from 'json-schema';
 
-import { useTaskOverrides } from 'src/core/contexts/taskStoreContext';
+import { useTaskOverrides } from 'src/core/contexts/TaskOverrides';
 import { createZustandContext } from 'src/core/contexts/zustandContext';
 import { DisplayError } from 'src/core/errorHandling/DisplayError';
 import { Loader } from 'src/core/loading/Loader';
@@ -171,7 +171,7 @@ function DataModelsLoader() {
 
   // Subform
   const overrides = useTaskOverrides();
-  const overriddenDataElementId = overrides?.dataElementId;
+  const overriddenDataElementId = overrides?.dataModelElementId;
   const overriddenDataType = overrides?.dataModelType;
 
   // Find all data types referenced in dataModelBindings in the layout

--- a/src/features/datamodel/DataModelsProvider.tsx
+++ b/src/features/datamodel/DataModelsProvider.tsx
@@ -6,7 +6,7 @@ import deepEqual from 'fast-deep-equal';
 import { createStore } from 'zustand';
 import type { JSONSchema7 } from 'json-schema';
 
-import { useTaskStore } from 'src/core/contexts/taskStoreContext';
+import { useTaskOverrides } from 'src/core/contexts/taskStoreContext';
 import { createZustandContext } from 'src/core/contexts/zustandContext';
 import { DisplayError } from 'src/core/errorHandling/DisplayError';
 import { Loader } from 'src/core/loading/Loader';
@@ -170,8 +170,9 @@ function DataModelsLoader() {
   const layoutSetId = useCurrentLayoutSetId();
 
   // Subform
-  const overriddenDataElementId = useTaskStore((state) => state.overriddenDataElementId);
-  const overriddenDataType = useTaskStore((state) => state.overriddenDataModelType);
+  const overrides = useTaskOverrides();
+  const overriddenDataElementId = overrides?.dataElementId;
+  const overriddenDataType = overrides?.dataModelType;
 
   // Find all data types referenced in dataModelBindings in the layout
   useEffect(() => {

--- a/src/features/datamodel/useBindingSchema.tsx
+++ b/src/features/datamodel/useBindingSchema.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo } from 'react';
 
 import type { JSONSchema7 } from 'json-schema';
 
-import { useTaskOverrides } from 'src/core/contexts/taskStoreContext';
+import { useTaskOverrides } from 'src/core/contexts/TaskOverrides';
 import { useApplicationMetadata } from 'src/features/applicationMetadata/ApplicationMetadataProvider';
 import {
   getCurrentDataTypeForApplication,
@@ -34,7 +34,7 @@ export function useCurrentDataModelDataElementId() {
   const layoutSets = useLayoutSets();
   const taskId = useProcessTaskId();
 
-  const overriddenDataElementId = useTaskOverrides()?.dataElementId;
+  const overriddenDataElementId = useTaskOverrides()?.dataModelElementId;
 
   // Instance data elements will update often (after each save), so we have to use a selector to make
   // sure components don't re-render too often.

--- a/src/features/datamodel/useBindingSchema.tsx
+++ b/src/features/datamodel/useBindingSchema.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo } from 'react';
 
 import type { JSONSchema7 } from 'json-schema';
 
-import { useTaskStore } from 'src/core/contexts/taskStoreContext';
+import { useTaskOverrides } from 'src/core/contexts/taskStoreContext';
 import { useApplicationMetadata } from 'src/features/applicationMetadata/ApplicationMetadataProvider';
 import {
   getCurrentDataTypeForApplication,
@@ -34,7 +34,7 @@ export function useCurrentDataModelDataElementId() {
   const layoutSets = useLayoutSets();
   const taskId = useProcessTaskId();
 
-  const overriddenDataElementId = useTaskStore((s) => s.overriddenDataElementId);
+  const overriddenDataElementId = useTaskOverrides()?.dataElementId;
 
   // Instance data elements will update often (after each save), so we have to use a selector to make
   // sure components don't re-render too often.
@@ -130,7 +130,7 @@ export function useDataModelUrl({ dataType, dataElementId, language, prefillFrom
 }
 
 export function useCurrentDataModelName() {
-  const overriddenDataModelType = useTaskStore((state) => state.overriddenDataModelType);
+  const overriddenDataModelType = useTaskOverrides()?.dataModelType;
 
   const application = useApplicationMetadata();
   const layoutSets = useLayoutSets();

--- a/src/features/form/layout/LayoutsContext.tsx
+++ b/src/features/form/layout/LayoutsContext.tsx
@@ -6,7 +6,7 @@ import { useAppQueries } from 'src/core/contexts/AppQueriesProvider';
 import { ContextNotProvided } from 'src/core/contexts/context';
 import { delayedContext } from 'src/core/contexts/delayedContext';
 import { createQueryContext } from 'src/core/contexts/queryContext';
-import { useTaskStore } from 'src/core/contexts/taskStoreContext';
+import { useTaskOverrides } from 'src/core/contexts/taskStoreContext';
 import { useCurrentDataModelName } from 'src/features/datamodel/useBindingSchema';
 import { cleanLayout } from 'src/features/form/layout/cleanLayout';
 import { makeLayoutLookups } from 'src/features/form/layout/makeLayoutLookups';
@@ -83,7 +83,7 @@ export function useLayoutSetId() {
   const currentProcessLayoutSetId = useCurrentLayoutSetId();
   const taskId = useNavigationParam('taskId');
 
-  const overriddenLayoutSetId = useTaskStore((state) => state.overriddenLayoutSetId);
+  const overriddenLayoutSetId = useTaskOverrides()?.layoutSetId;
 
   if (overriddenLayoutSetId) {
     return overriddenLayoutSetId;

--- a/src/features/form/layout/LayoutsContext.tsx
+++ b/src/features/form/layout/LayoutsContext.tsx
@@ -6,7 +6,7 @@ import { useAppQueries } from 'src/core/contexts/AppQueriesProvider';
 import { ContextNotProvided } from 'src/core/contexts/context';
 import { delayedContext } from 'src/core/contexts/delayedContext';
 import { createQueryContext } from 'src/core/contexts/queryContext';
-import { useTaskOverrides } from 'src/core/contexts/taskStoreContext';
+import { useTaskOverrides } from 'src/core/contexts/TaskOverrides';
 import { useCurrentDataModelName } from 'src/features/datamodel/useBindingSchema';
 import { cleanLayout } from 'src/features/form/layout/cleanLayout';
 import { makeLayoutLookups } from 'src/features/form/layout/makeLayoutLookups';

--- a/src/features/form/layoutSets/useCurrentLayoutSet.ts
+++ b/src/features/form/layoutSets/useCurrentLayoutSet.ts
@@ -1,5 +1,5 @@
 import { ContextNotProvided } from 'src/core/contexts/context';
-import { useTaskStore } from 'src/core/contexts/taskStoreContext';
+import { useTaskOverrides } from 'src/core/contexts/taskStoreContext';
 import { useLaxApplicationMetadata } from 'src/features/applicationMetadata/ApplicationMetadataProvider';
 import { getCurrentLayoutSet } from 'src/features/applicationMetadata/appMetadataUtils';
 import { useLaxLayoutSets } from 'src/features/form/layoutSets/LayoutSetsProvider';
@@ -13,7 +13,7 @@ export function useCurrentLayoutSet() {
   const application = useLaxApplicationMetadata();
   const layoutSets = useLaxLayoutSets();
   const taskId = useProcessTaskId();
-  const overriddenLayoutSetId = useTaskStore((state) => state.overriddenLayoutSetId);
+  const overriddenLayoutSetId = useTaskOverrides()?.layoutSetId;
 
   if (application === ContextNotProvided || layoutSets === ContextNotProvided) {
     return undefined;

--- a/src/features/form/layoutSets/useCurrentLayoutSet.ts
+++ b/src/features/form/layoutSets/useCurrentLayoutSet.ts
@@ -1,5 +1,5 @@
 import { ContextNotProvided } from 'src/core/contexts/context';
-import { useTaskOverrides } from 'src/core/contexts/taskStoreContext';
+import { useTaskOverrides } from 'src/core/contexts/TaskOverrides';
 import { useLaxApplicationMetadata } from 'src/features/applicationMetadata/ApplicationMetadataProvider';
 import { getCurrentLayoutSet } from 'src/features/applicationMetadata/appMetadataUtils';
 import { useLaxLayoutSets } from 'src/features/form/layoutSets/LayoutSetsProvider';

--- a/src/features/instance/useProcessTaskId.ts
+++ b/src/features/instance/useProcessTaskId.ts
@@ -1,4 +1,4 @@
-import { useTaskOverrides } from 'src/core/contexts/taskStoreContext';
+import { useTaskOverrides } from 'src/core/contexts/TaskOverrides';
 import { useProcessQuery } from 'src/features/instance/useProcessQuery';
 import { useNavigationParam } from 'src/hooks/navigation';
 

--- a/src/features/instance/useProcessTaskId.ts
+++ b/src/features/instance/useProcessTaskId.ts
@@ -1,9 +1,9 @@
-import { useTaskStore } from 'src/core/contexts/taskStoreContext';
+import { useTaskOverrides } from 'src/core/contexts/taskStoreContext';
 import { useProcessQuery } from 'src/features/instance/useProcessQuery';
 import { useNavigationParam } from 'src/hooks/navigation';
 
 export function useProcessTaskId() {
-  const overriddenTaskId = useTaskStore((state) => state.overriddenTaskId);
+  const overriddenTaskId = useTaskOverrides()?.taskId;
   const processTaskId = useProcessQuery().data?.currentTask?.elementId;
   const urlTaskId = useNavigationParam('taskId');
   return overriddenTaskId ?? processTaskId ?? urlTaskId;

--- a/src/features/instantiate/containers/InstantiationContainer.tsx
+++ b/src/features/instantiate/containers/InstantiationContainer.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import { ReadyForPrint } from 'src/components/ReadyForPrint';
-import { TaskStoreProvider } from 'src/core/contexts/taskStoreContext';
 import { RenderStart } from 'src/core/ui/RenderStart';
 import { Footer } from 'src/features/footer/Footer';
 import classes from 'src/features/instantiate/containers/InstantiationContainer.module.css';
@@ -19,15 +18,13 @@ export function InstantiationContainer({ children }: IInstantiateContainerProps)
   const profile = useProfile();
 
   return (
-    <TaskStoreProvider>
-      <RenderStart>
-        <div className={classes.container}>
-          <InstantiateHeader profile={profile} />
-          <main id='main-content'>{children}</main>
-          <Footer />
-          <ReadyForPrint type='load' />
-        </div>
-      </RenderStart>
-    </TaskStoreProvider>
+    <RenderStart>
+      <div className={classes.container}>
+        <InstantiateHeader profile={profile} />
+        <main id='main-content'>{children}</main>
+        <Footer />
+        <ReadyForPrint type='load' />
+      </div>
+    </RenderStart>
   );
 }

--- a/src/features/instantiate/selection/InstanceSelection.tsx
+++ b/src/features/instantiate/selection/InstanceSelection.tsx
@@ -10,7 +10,6 @@ import { ErrorListFromInstantiation, ErrorReport } from 'src/components/message/
 import { PresentationComponent } from 'src/components/presentation/Presentation';
 import { ReadyForPrint } from 'src/components/ReadyForPrint';
 import { useIsProcessing } from 'src/core/contexts/processingContext';
-import { TaskStoreProvider } from 'src/core/contexts/taskStoreContext';
 import { useAppName, useAppOwner } from 'src/core/texts/appTexts';
 import { useApplicationMetadata } from 'src/features/applicationMetadata/ApplicationMetadataProvider';
 import {
@@ -44,16 +43,14 @@ function getDateDisplayString(timeStamp: string) {
 }
 
 export const InstanceSelectionWrapper = () => (
-  <TaskStoreProvider>
-    <ActiveInstancesProvider>
-      <PresentationComponent
-        type={ProcessTaskType.Unknown}
-        showNavigation={false}
-      >
-        <InstanceSelection />
-      </PresentationComponent>
-    </ActiveInstancesProvider>
-  </TaskStoreProvider>
+  <ActiveInstancesProvider>
+    <PresentationComponent
+      type={ProcessTaskType.Unknown}
+      showNavigation={false}
+    >
+      <InstanceSelection />
+    </PresentationComponent>
+  </ActiveInstancesProvider>
 );
 
 function InstanceSelection() {
@@ -237,7 +234,7 @@ function InstanceSelection() {
   );
 
   return (
-    <TaskStoreProvider>
+    <>
       <title>{`${getPageTitle(appName, langAsString('instance_selection.left_of'), appOwner)}`}</title>
       <div id='instance-selection-container'>
         <div>
@@ -289,7 +286,7 @@ function InstanceSelection() {
         </div>
       </div>
       <ReadyForPrint type='load' />
-    </TaskStoreProvider>
+    </>
   );
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -22,7 +22,6 @@ import { ViewportWrapper } from 'src/components/ViewportWrapper';
 import { KeepAliveProvider } from 'src/core/auth/KeepAliveProvider';
 import { AppQueriesProvider } from 'src/core/contexts/AppQueriesProvider';
 import { ProcessingProvider } from 'src/core/contexts/processingContext';
-import { TaskStoreProvider } from 'src/core/contexts/taskStoreContext';
 import { DisplayErrorProvider } from 'src/core/errorHandling/DisplayErrorProvider';
 import { ApplicationMetadataProvider } from 'src/features/applicationMetadata/ApplicationMetadataProvider';
 import { ApplicationSettingsProvider } from 'src/features/applicationSettings/ApplicationSettingsProvider';
@@ -93,41 +92,37 @@ function Root() {
   return (
     <>
       <InstantiationUrlReset />
-      <TaskStoreProvider>
-        <ApplicationMetadataProvider>
-          <GlobalFormDataReadersProvider>
-            <LayoutSetsProvider>
-              <SetShouldFetchAppLanguages />
-              <ProfileProvider>
-                <TextResourcesProvider>
-                  <OrgsProvider>
-                    <ApplicationSettingsProvider>
-                      <PartyProvider>
-                        <KeepAliveProvider>
-                          <TaskStoreProvider>
-                            <DisplayErrorProvider>
-                              <ProcessingProvider>
-                                <App />
-                              </ProcessingProvider>
-                            </DisplayErrorProvider>
-                          </TaskStoreProvider>
-                          <ToastContainer
-                            position='top-center'
-                            theme='colored'
-                            transition={Slide}
-                            draggable={false}
-                          />
-                        </KeepAliveProvider>
-                      </PartyProvider>
-                    </ApplicationSettingsProvider>
-                  </OrgsProvider>
-                </TextResourcesProvider>
-              </ProfileProvider>
-              <PartyPrefetcher />
-            </LayoutSetsProvider>
-          </GlobalFormDataReadersProvider>
-        </ApplicationMetadataProvider>
-      </TaskStoreProvider>
+      <ApplicationMetadataProvider>
+        <GlobalFormDataReadersProvider>
+          <LayoutSetsProvider>
+            <SetShouldFetchAppLanguages />
+            <ProfileProvider>
+              <TextResourcesProvider>
+                <OrgsProvider>
+                  <ApplicationSettingsProvider>
+                    <PartyProvider>
+                      <KeepAliveProvider>
+                        <DisplayErrorProvider>
+                          <ProcessingProvider>
+                            <App />
+                          </ProcessingProvider>
+                        </DisplayErrorProvider>
+                        <ToastContainer
+                          position='top-center'
+                          theme='colored'
+                          transition={Slide}
+                          draggable={false}
+                        />
+                      </KeepAliveProvider>
+                    </PartyProvider>
+                  </ApplicationSettingsProvider>
+                </OrgsProvider>
+              </TextResourcesProvider>
+            </ProfileProvider>
+            <PartyPrefetcher />
+          </LayoutSetsProvider>
+        </GlobalFormDataReadersProvider>
+      </ApplicationMetadataProvider>
     </>
   );
 }

--- a/src/layout/FileUpload/FileUploadTable/FileTableRow.tsx
+++ b/src/layout/FileUpload/FileUploadTable/FileTableRow.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import classNames from 'classnames';
 
 import { AltinnLoader } from 'src/components/AltinnLoader';
-import { useTaskStore } from 'src/core/contexts/taskStoreContext';
+import { useTaskOverrides } from 'src/core/contexts/taskStoreContext';
 import { isAttachmentUploaded } from 'src/features/attachments';
 import { FileScanResults } from 'src/features/attachments/types';
 import { Lang } from 'src/features/language/Lang';
@@ -40,7 +40,7 @@ export function FileTableRow({
   const pdfModeActive = usePdfModeActive();
   const readableSize = getSizeWithUnit(attachment.data.size, 2);
 
-  const overriddenTaskId = useTaskStore((state) => state.overriddenTaskId);
+  const overriddenTaskId = useTaskOverrides()?.taskId;
 
   const hasOverridenTaskId = !!overriddenTaskId;
 

--- a/src/layout/FileUpload/FileUploadTable/FileTableRow.tsx
+++ b/src/layout/FileUpload/FileUploadTable/FileTableRow.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import classNames from 'classnames';
 
 import { AltinnLoader } from 'src/components/AltinnLoader';
-import { useTaskOverrides } from 'src/core/contexts/taskStoreContext';
+import { useTaskOverrides } from 'src/core/contexts/TaskOverrides';
 import { isAttachmentUploaded } from 'src/features/attachments';
 import { FileScanResults } from 'src/features/attachments/types';
 import { Lang } from 'src/features/language/Lang';

--- a/src/layout/Subform/SubformWrapper.tsx
+++ b/src/layout/Subform/SubformWrapper.tsx
@@ -3,7 +3,7 @@ import type { PropsWithChildren } from 'react';
 
 import { Form } from 'src/components/form/Form';
 import { PresentationComponent } from 'src/components/presentation/Presentation';
-import { TaskOverrides } from 'src/core/contexts/taskStoreContext';
+import { TaskOverrides } from 'src/core/contexts/TaskOverrides';
 import { Loader } from 'src/core/loading/Loader';
 import { FormProvider } from 'src/features/form/FormContext';
 import { useDataTypeFromLayoutSet } from 'src/features/form/layout/LayoutsContext';
@@ -62,7 +62,7 @@ export function SubformOverrideWrapper({
   return (
     <TaskOverrides
       dataModelType={dataType}
-      dataElementId={actualDataElementId}
+      dataModelElementId={actualDataElementId}
       layoutSetId={layoutSet}
     >
       {children}

--- a/src/layout/Subform/SubformWrapper.tsx
+++ b/src/layout/Subform/SubformWrapper.tsx
@@ -3,7 +3,7 @@ import type { PropsWithChildren } from 'react';
 
 import { Form } from 'src/components/form/Form';
 import { PresentationComponent } from 'src/components/presentation/Presentation';
-import { useTaskStore } from 'src/core/contexts/taskStoreContext';
+import { TaskOverrides } from 'src/core/contexts/taskStoreContext';
 import { Loader } from 'src/core/loading/Loader';
 import { FormProvider } from 'src/features/form/FormContext';
 import { useDataTypeFromLayoutSet } from 'src/features/form/layout/LayoutsContext';
@@ -14,13 +14,11 @@ import { ProcessTaskType } from 'src/types';
 import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 
 export function SubformWrapper({ baseComponentId, children }: PropsWithChildren<{ baseComponentId: string }>) {
-  const isDone = useDoOverride(baseComponentId);
-
-  if (!isDone) {
-    return <Loader reason='subform-taskstore' />;
-  }
-
-  return <FormProvider>{children}</FormProvider>;
+  return (
+    <SubformOverrideWrapper baseComponentId={baseComponentId}>
+      <FormProvider>{children}</FormProvider>
+    </SubformOverrideWrapper>
+  );
 }
 
 export function SubformForm() {
@@ -44,35 +42,14 @@ export const RedirectBackToMainForm = () => {
   return <Loader reason='navigate-to-mainform' />;
 };
 
-export const useDoOverrideSummary = (dataElementId: string, layoutSet: string, dataType: string) => {
-  const setOverriddenLayoutSetId = useTaskStore((state) => state.setOverriddenLayoutSetId);
-  const setOverriddenDataModelType = useTaskStore((state) => state.setOverriddenDataModelType);
-  const setOverriddenDataModelDataElementId = useTaskStore((state) => state.setOverriddenDataModelDataElementId);
-
-  const isDone = useTaskStore(
-    (s) =>
-      s.overriddenDataModelType === dataType &&
-      s.overriddenDataElementId === dataElementId &&
-      s.overriddenLayoutSetId === layoutSet,
-  );
-
-  useEffect(() => {
-    setOverriddenLayoutSetId?.(layoutSet);
-    setOverriddenDataModelType?.(dataType);
-    setOverriddenDataModelDataElementId?.(dataElementId!);
-  }, [
-    dataElementId,
-    dataType,
-    layoutSet,
-    setOverriddenDataModelType,
-    setOverriddenDataModelDataElementId,
-    setOverriddenLayoutSetId,
-  ]);
-
-  return isDone;
-};
-
-export const useDoOverride = (baseComponentId: string, providedDataElementId?: string) => {
+export function SubformOverrideWrapper({
+  baseComponentId,
+  providedDataElementId,
+  children,
+}: PropsWithChildren<{
+  baseComponentId: string;
+  providedDataElementId?: string;
+}>) {
   const dataElementId = useNavigationParam('dataElementId');
   const actualDataElementId = providedDataElementId ? providedDataElementId : dataElementId;
   const { layoutSet, id } = useItemWhenType(baseComponentId, 'Subform');
@@ -82,28 +59,13 @@ export const useDoOverride = (baseComponentId: string, providedDataElementId?: s
     throw new Error(`Unable to find data type for subform with id ${id}`);
   }
 
-  const setOverriddenLayoutSetId = useTaskStore((state) => state.setOverriddenLayoutSetId);
-  const setOverriddenDataModelType = useTaskStore((state) => state.setOverriddenDataModelType);
-  const setOverriddenDataModelDataElementId = useTaskStore((state) => state.setOverriddenDataModelDataElementId);
-  const isDone = useTaskStore(
-    (s) =>
-      s.overriddenDataModelType === dataType &&
-      s.overriddenDataElementId === actualDataElementId &&
-      s.overriddenLayoutSetId === layoutSet,
+  return (
+    <TaskOverrides
+      dataModelType={dataType}
+      dataElementId={actualDataElementId}
+      layoutSetId={layoutSet}
+    >
+      {children}
+    </TaskOverrides>
   );
-
-  useEffect(() => {
-    setOverriddenLayoutSetId?.(layoutSet);
-    setOverriddenDataModelType?.(dataType);
-    setOverriddenDataModelDataElementId?.(actualDataElementId!);
-  }, [
-    actualDataElementId,
-    dataType,
-    layoutSet,
-    setOverriddenDataModelType,
-    setOverriddenDataModelDataElementId,
-    setOverriddenLayoutSetId,
-  ]);
-
-  return isDone;
-};
+}

--- a/src/layout/Subform/Summary/SubformSummaryComponent2.tsx
+++ b/src/layout/Subform/Summary/SubformSummaryComponent2.tsx
@@ -4,7 +4,7 @@ import { Heading, Paragraph } from '@digdir/designsystemet-react';
 
 import { Flex } from 'src/app-components/Flex/Flex';
 import { Label, LabelInner } from 'src/components/label/Label';
-import { TaskOverrides } from 'src/core/contexts/taskStoreContext';
+import { TaskOverrides } from 'src/core/contexts/TaskOverrides';
 import { useApplicationMetadata } from 'src/features/applicationMetadata/ApplicationMetadataProvider';
 import { FormProvider } from 'src/features/form/FormContext';
 import { useDataTypeFromLayoutSet, useLayoutLookups } from 'src/features/form/layout/LayoutsContext';
@@ -103,7 +103,7 @@ const DoSummaryWrapper = ({
   return (
     <div className={classes.summaryWrapperMargin}>
       <TaskOverrides
-        dataElementId={dataElement.id}
+        dataModelElementId={dataElement.id}
         dataModelType={dataElement.dataType}
         layoutSetId={layoutSet}
       >

--- a/src/layout/Subform/Summary/SubformSummaryComponent2.tsx
+++ b/src/layout/Subform/Summary/SubformSummaryComponent2.tsx
@@ -1,16 +1,15 @@
-import React, { type PropsWithChildren } from 'react';
+import React, { Fragment, type PropsWithChildren } from 'react';
 
 import { Heading, Paragraph } from '@digdir/designsystemet-react';
 
 import { Flex } from 'src/app-components/Flex/Flex';
 import { Label, LabelInner } from 'src/components/label/Label';
-import { TaskStoreProvider } from 'src/core/contexts/taskStoreContext';
+import { TaskOverrides } from 'src/core/contexts/taskStoreContext';
 import { useApplicationMetadata } from 'src/features/applicationMetadata/ApplicationMetadataProvider';
 import { FormProvider } from 'src/features/form/FormContext';
 import { useDataTypeFromLayoutSet, useLayoutLookups } from 'src/features/form/layout/LayoutsContext';
 import { useInstanceDataElements } from 'src/features/instance/InstanceContext';
 import { Lang } from 'src/features/language/Lang';
-import { useDoOverrideSummary } from 'src/layout/Subform/SubformWrapper';
 import classes from 'src/layout/Subform/Summary/SubformSummaryComponent2.module.css';
 import { SubformSummaryTable } from 'src/layout/Subform/Summary/SubformSummaryTable';
 import {
@@ -56,7 +55,7 @@ const SummarySubformWrapperInner = ({
         </>
       )}
       {dataElements?.map((element, idx) => (
-        <TaskStoreProvider key={element.id + idx}>
+        <Fragment key={idx}>
           <div className={classes.pageBreak} />
           <DoSummaryWrapper
             dataElement={element}
@@ -65,7 +64,7 @@ const SummarySubformWrapperInner = ({
             entryDisplayName={entryDisplayName}
             title={textResourceBindings?.title}
           />
-        </TaskStoreProvider>
+        </Fragment>
       ))}
     </>
   );
@@ -88,12 +87,11 @@ const DoSummaryWrapper = ({
   baseComponentId: string;
 }>) => {
   const item = useItemWhenType(baseComponentId, 'Subform');
-  const isDone = useDoOverrideSummary(dataElement.id, layoutSet, dataElement.dataType);
 
   const { isSubformDataFetching, subformData, subformDataError } = useSubformFormData(dataElement.id);
   const subformDataSources = useExpressionDataSourcesForSubform(dataElement.dataType, subformData, entryDisplayName);
 
-  if (!isDone || isSubformDataFetching) {
+  if (isSubformDataFetching) {
     return null;
   }
 
@@ -104,36 +102,42 @@ const DoSummaryWrapper = ({
 
   return (
     <div className={classes.summaryWrapperMargin}>
-      <FormProvider readOnly={true}>
-        <Flex
-          container
-          spacing={6}
-          alignItems='flex-start'
-        >
-          <Flex item>
-            <div className={classes_singlevaluesummary.labelValueWrapper}>
-              <LabelInner
-                item={item}
-                baseComponentId={baseComponentId}
-                id={`subform-summary2-${dataElement.id}`}
-                renderLabelAs='span'
-                weight='regular'
-                textResourceBindings={{ title }}
-              />
-              {subformEntryName && (
-                <Heading
-                  className='no-visual-testing'
-                  data-size='sm'
-                  level={2}
-                >
-                  {subformEntryName}
-                </Heading>
-              )}
-            </div>
+      <TaskOverrides
+        dataElementId={dataElement.id}
+        dataModelType={dataElement.dataType}
+        layoutSetId={layoutSet}
+      >
+        <FormProvider readOnly={true}>
+          <Flex
+            container
+            spacing={6}
+            alignItems='flex-start'
+          >
+            <Flex item>
+              <div className={classes_singlevaluesummary.labelValueWrapper}>
+                <LabelInner
+                  item={item}
+                  baseComponentId={baseComponentId}
+                  id={`subform-summary2-${dataElement.id}`}
+                  renderLabelAs='span'
+                  weight='regular'
+                  textResourceBindings={{ title }}
+                />
+                {subformEntryName && (
+                  <Heading
+                    className='no-visual-testing'
+                    data-size='sm'
+                    level={2}
+                  >
+                    {subformEntryName}
+                  </Heading>
+                )}
+              </div>
+            </Flex>
+            <LayoutSetSummary />
           </Flex>
-          <LayoutSetSummary />
-        </Flex>
-      </FormProvider>
+        </FormProvider>
+      </TaskOverrides>
     </div>
   );
 };

--- a/src/layout/Subform/index.tsx
+++ b/src/layout/Subform/index.tsx
@@ -2,7 +2,6 @@ import React, { forwardRef } from 'react';
 import { Route, Routes } from 'react-router-dom';
 import type { JSX, ReactNode } from 'react';
 
-import { TaskStoreProvider } from 'src/core/contexts/taskStoreContext';
 import { type ComponentValidation } from 'src/features/validation';
 import { type SummaryRendererProps } from 'src/layout/LayoutComponent';
 import { SubformDef } from 'src/layout/Subform/config.def.generated';
@@ -25,22 +24,20 @@ export class Subform extends SubformDef implements ValidateComponent, SubRouting
 
   subRouting({ baseComponentId }: { baseComponentId: string }): ReactNode {
     return (
-      <TaskStoreProvider>
-        <Routes>
-          <Route
-            path=':dataElementId/:subformPage?'
-            element={
-              <SubformWrapper baseComponentId={baseComponentId}>
-                <SubformForm />
-              </SubformWrapper>
-            }
-          />
-          <Route
-            path='*'
-            element={<RedirectBackToMainForm />}
-          />
-        </Routes>
-      </TaskStoreProvider>
+      <Routes>
+        <Route
+          path=':dataElementId/:subformPage?'
+          element={
+            <SubformWrapper baseComponentId={baseComponentId}>
+              <SubformForm />
+            </SubformWrapper>
+          }
+        />
+        <Route
+          path='*'
+          element={<RedirectBackToMainForm />}
+        />
+      </Routes>
     );
   }
 

--- a/src/layout/Summary2/CommonSummaryComponents/EditButton.tsx
+++ b/src/layout/Summary2/CommonSummaryComponents/EditButton.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { PencilIcon } from '@navikt/aksel-icons';
 
 import { Button } from 'src/app-components/Button/Button';
-import { useTaskStore } from 'src/core/contexts/taskStoreContext';
+import { useTaskOverrides } from 'src/core/contexts/taskStoreContext';
 import { useSetReturnToView, useSetSummaryNodeOfOrigin } from 'src/features/form/layout/PageNavigationContext';
 import { Lang } from 'src/features/language/Lang';
 import { useLanguage } from 'src/features/language/useLanguage';
@@ -66,8 +66,9 @@ export function EditButton({
   const titleTrb = textResourceBindings && 'title' in textResourceBindings ? textResourceBindings.title : undefined;
   const accessibleTitle = titleTrb ? langAsString(titleTrb) : '';
 
-  const overriddenTaskId = useTaskStore((state) => state.overriddenTaskId);
-  const overriddenDataElementId = useTaskStore((state) => state.overriddenDataElementId);
+  const overrides = useTaskOverrides();
+  const overriddenTaskId = overrides?.taskId;
+  const overriddenDataElementId = overrides?.dataElementId;
   const indexedId = useIndexedId(targetBaseComponentId, skipLastIdMutator);
   const summary2Id = useSummaryProp('id');
 

--- a/src/layout/Summary2/CommonSummaryComponents/EditButton.tsx
+++ b/src/layout/Summary2/CommonSummaryComponents/EditButton.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { PencilIcon } from '@navikt/aksel-icons';
 
 import { Button } from 'src/app-components/Button/Button';
-import { useTaskOverrides } from 'src/core/contexts/taskStoreContext';
+import { useTaskOverrides } from 'src/core/contexts/TaskOverrides';
 import { useSetReturnToView, useSetSummaryNodeOfOrigin } from 'src/features/form/layout/PageNavigationContext';
 import { Lang } from 'src/features/language/Lang';
 import { useLanguage } from 'src/features/language/useLanguage';
@@ -68,7 +68,7 @@ export function EditButton({
 
   const overrides = useTaskOverrides();
   const overriddenTaskId = overrides?.taskId;
-  const overriddenDataElementId = overrides?.dataElementId;
+  const overriddenDataElementId = overrides?.dataModelElementId;
   const indexedId = useIndexedId(targetBaseComponentId, skipLastIdMutator);
   const summary2Id = useSummaryProp('id');
 

--- a/src/layout/Summary2/SummaryComponent2/SummaryComponent2.tsx
+++ b/src/layout/Summary2/SummaryComponent2/SummaryComponent2.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import { TaskStoreProvider } from 'src/core/contexts/taskStoreContext';
 import { ComponentSummary } from 'src/layout/Summary2/SummaryComponent2/ComponentSummary';
 import { LayoutSetSummary } from 'src/layout/Summary2/SummaryComponent2/LayoutSetSummary';
 import { TaskSummaryWrapper } from 'src/layout/Summary2/SummaryComponent2/TaskSummaryWrapper';
@@ -29,13 +28,11 @@ function SummaryBody({ target }: SummaryBodyProps) {
 function SummaryComponent2Inner({ baseComponentId }: Pick<PropsFromGenericComponent<'Summary2'>, 'baseComponentId'>) {
   const target = useExternalItem(baseComponentId, 'Summary2').target;
   return (
-    <TaskStoreProvider>
-      <Summary2StoreProvider baseComponentId={baseComponentId}>
-        <TaskSummaryWrapper taskId={target?.taskId}>
-          <SummaryBody target={target} />
-        </TaskSummaryWrapper>
-      </Summary2StoreProvider>
-    </TaskStoreProvider>
+    <Summary2StoreProvider baseComponentId={baseComponentId}>
+      <TaskSummaryWrapper taskId={target?.taskId}>
+        <SummaryBody target={target} />
+      </TaskSummaryWrapper>
+    </Summary2StoreProvider>
   );
 }
 

--- a/src/layout/Summary2/SummaryComponent2/TaskSummaryWrapper.tsx
+++ b/src/layout/Summary2/SummaryComponent2/TaskSummaryWrapper.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { TaskOverrides } from 'src/core/contexts/taskStoreContext';
+import { TaskOverrides } from 'src/core/contexts/TaskOverrides';
 import { FormProvider } from 'src/features/form/FormContext';
 import { useLayoutSets } from 'src/features/form/layoutSets/LayoutSetsProvider';
 import { useNavigationParam } from 'src/hooks/navigation';

--- a/src/layout/Summary2/SummaryComponent2/TaskSummaryWrapper.tsx
+++ b/src/layout/Summary2/SummaryComponent2/TaskSummaryWrapper.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 
-import { useTaskStore } from 'src/core/contexts/taskStoreContext';
+import { TaskOverrides } from 'src/core/contexts/taskStoreContext';
 import { FormProvider } from 'src/features/form/FormContext';
 import { useLayoutSets } from 'src/features/form/layoutSets/LayoutSetsProvider';
 import { useNavigationParam } from 'src/hooks/navigation';
@@ -12,43 +12,17 @@ interface TaskSummaryProps {
 }
 
 export function TaskSummaryWrapper({ taskId, children }: React.PropsWithChildren<TaskSummaryProps>) {
-  const setTaskId = useTaskStore((state) => state.setTaskId);
-  const setOverriddenDataModelType = useTaskStore((state) => state.setOverriddenDataModelType);
-  const setOverriddenDataModelDataElementId = useTaskStore((state) => state.setOverriddenDataModelDataElementId);
-  const setOverriddenLayoutSetId = useTaskStore((state) => state.setOverriddenLayoutSetId);
-
   const currentTaskId = useNavigationParam('taskId');
-  const overriddenTaskId = useTaskStore((state) => state.overriddenTaskId);
-  const notCurrentTask = overriddenTaskId && overriddenTaskId !== currentTaskId;
-
   const layoutSets = useLayoutSets();
+  const layoutSetForTask = taskId ? layoutSets.find((set) => set.tasks?.includes(taskId)) : undefined;
 
-  useEffect(() => {
-    if (taskId) {
-      const layoutSetForTask = layoutSets.find((set) => set.tasks?.includes(taskId));
-      setTaskId && setTaskId(taskId);
-      if (layoutSetForTask) {
-        setOverriddenDataModelType && setOverriddenDataModelType(layoutSetForTask.dataType);
-        setOverriddenLayoutSetId && setOverriddenLayoutSetId(layoutSetForTask.id);
-      }
-    }
-  }, [
-    layoutSets,
-    setOverriddenDataModelType,
-    setOverriddenDataModelDataElementId,
-    setOverriddenLayoutSetId,
-    setTaskId,
-    taskId,
-  ]);
-
-  if (taskId && overriddenTaskId !== taskId) {
-    // Wait for the task to be set correctly
-    return null;
-  }
-
-  if (notCurrentTask) {
-    return <FormProvider readOnly={true}>{children}</FormProvider>;
-  }
-
-  return children;
+  return (
+    <TaskOverrides
+      taskId={taskId}
+      dataModelType={layoutSetForTask?.dataType}
+      layoutSetId={layoutSetForTask?.id}
+    >
+      {taskId && taskId !== currentTaskId ? <FormProvider readOnly={true}>{children}</FormProvider> : children}
+    </TaskOverrides>
+  );
 }

--- a/src/test/renderWithProviders.tsx
+++ b/src/test/renderWithProviders.tsx
@@ -20,7 +20,6 @@ import { getPartyMock } from 'src/__mocks__/getPartyMock';
 import { paymentResponsePayload } from 'src/__mocks__/getPaymentPayloadMock';
 import { getTextResourcesMock } from 'src/__mocks__/getTextResourcesMock';
 import { AppQueriesProvider } from 'src/core/contexts/AppQueriesProvider';
-import { TaskStoreProvider } from 'src/core/contexts/taskStoreContext';
 import { RenderStart } from 'src/core/ui/RenderStart';
 import { ApplicationMetadataProvider } from 'src/features/applicationMetadata/ApplicationMetadataProvider';
 import { ApplicationSettingsProvider } from 'src/features/applicationSettings/ApplicationSettingsProvider';
@@ -330,34 +329,32 @@ function DefaultProviders({ children, queries, queryClient, Router = DefaultRout
       queryClient={queryClient}
     >
       <LanguageProvider>
-        <TaskStoreProvider>
-          <LangToolsStoreProvider>
-            <UiConfigProvider>
-              <PageNavigationProvider>
-                <Router>
-                  <NavigationEffectProvider>
-                    <ApplicationMetadataProvider>
-                      <GlobalFormDataReadersProvider>
-                        <OrgsProvider>
-                          <ApplicationSettingsProvider>
-                            <LayoutSetsProvider>
-                              <SetShouldFetchAppLanguages />
-                              <ProfileProvider>
-                                <PartyProvider>
-                                  <TextResourcesProvider>{children}</TextResourcesProvider>
-                                </PartyProvider>
-                              </ProfileProvider>
-                            </LayoutSetsProvider>
-                          </ApplicationSettingsProvider>
-                        </OrgsProvider>
-                      </GlobalFormDataReadersProvider>
-                    </ApplicationMetadataProvider>
-                  </NavigationEffectProvider>
-                </Router>
-              </PageNavigationProvider>
-            </UiConfigProvider>
-          </LangToolsStoreProvider>
-        </TaskStoreProvider>
+        <LangToolsStoreProvider>
+          <UiConfigProvider>
+            <PageNavigationProvider>
+              <Router>
+                <NavigationEffectProvider>
+                  <ApplicationMetadataProvider>
+                    <GlobalFormDataReadersProvider>
+                      <OrgsProvider>
+                        <ApplicationSettingsProvider>
+                          <LayoutSetsProvider>
+                            <SetShouldFetchAppLanguages />
+                            <ProfileProvider>
+                              <PartyProvider>
+                                <TextResourcesProvider>{children}</TextResourcesProvider>
+                              </PartyProvider>
+                            </ProfileProvider>
+                          </LayoutSetsProvider>
+                        </ApplicationSettingsProvider>
+                      </OrgsProvider>
+                    </GlobalFormDataReadersProvider>
+                  </ApplicationMetadataProvider>
+                </NavigationEffectProvider>
+              </Router>
+            </PageNavigationProvider>
+          </UiConfigProvider>
+        </LangToolsStoreProvider>
       </LanguageProvider>
     </AppQueriesProvider>
   );
@@ -383,13 +380,11 @@ function MinimalProviders({ children, queries, queryClient, Router = DefaultRout
       {...queries}
       queryClient={queryClient}
     >
-      <TaskStoreProvider>
-        <LangToolsStoreProvider>
-          <Router>
-            <NavigationEffectProvider>{children}</NavigationEffectProvider>
-          </Router>
-        </LangToolsStoreProvider>
-      </TaskStoreProvider>
+      <LangToolsStoreProvider>
+        <Router>
+          <NavigationEffectProvider>{children}</NavigationEffectProvider>
+        </Router>
+      </LangToolsStoreProvider>
     </AppQueriesProvider>
   );
 }

--- a/src/utils/layout/all.test.tsx
+++ b/src/utils/layout/all.test.tsx
@@ -9,7 +9,6 @@ import type { JSONSchema7 } from 'json-schema';
 
 import { ignoredConsoleMessages } from 'test/e2e/support/fail-on-console-log';
 
-import { TaskStoreProvider } from 'src/core/contexts/taskStoreContext';
 import { quirks } from 'src/features/form/layout/quirks';
 import { GenericComponent } from 'src/layout/GenericComponent';
 import { SubformWrapper } from 'src/layout/Subform/SubformWrapper';
@@ -80,11 +79,7 @@ function RenderAllComponents() {
  * Makes sure we go one level deeper into the subform context when testing subforms
  */
 function SubformTestWrapper({ baseId, children }: PropsWithChildren<{ baseId: string }>) {
-  return (
-    <TaskStoreProvider>
-      <SubformWrapper baseComponentId={baseId}>{children}</SubformWrapper>
-    </TaskStoreProvider>
-  );
+  return <SubformWrapper baseComponentId={baseId}>{children}</SubformWrapper>;
 }
 
 const windowLoggers = ['logError', 'logErrorOnce', 'logWarn', 'logWarnOnce', 'logInfo', 'logInfoOnce'];


### PR DESCRIPTION
## Description

Currently, taskStore is a context that is provided pretty much all around, and some places we set data in it (and then wait until that data is set in the zustand store before continuing rendering). This seemed overly complicated, as what we really need here (as far as i can tell) is just to provide some overrides to components below us - so a regular context will suffice and be easier to follow.

This PR cherry-picks such a refactor from #3731, where I really needed to provide multiple different sets of overrides side-by-side for rendering automatic PDFs for different tasks.

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->
