### PR TITLE
Implementing `textOverflow.lineWrap` in RepeatingGroup

### DIFF
--- a/src/layout/RepeatingGroup/RepeatingGroup.module.css
+++ b/src/layout/RepeatingGroup/RepeatingGroup.module.css
@@ -117,9 +117,10 @@ table > tbody > tr.editingRow:hover {
 
 .contentFormatting {
   --cell-text-alignment: left;
+  --cell-word-break: break-word;
   overflow: hidden;
   text-overflow: ellipsis;
-  word-break: break-word;
+  word-break: var(--cell-word-break);
   display: -webkit-box;
   -webkit-box-orient: vertical;
   text-align: var(--cell-text-alignment);

--- a/src/utils/formComponentUtils.test.ts
+++ b/src/utils/formComponentUtils.test.ts
@@ -44,6 +44,7 @@ describe('formComponentUtils', () => {
         '--cell-max-number-of-lines': 3,
         '--cell-text-alignment': 'center',
         '--cell-width': '100px',
+        '--cell-word-break': 'break-word',
       });
     });
 
@@ -55,6 +56,7 @@ describe('formComponentUtils', () => {
       };
       const columnStyles = getColumnStyles(columnSettings);
       expect(columnStyles['--cell-max-number-of-lines']).toEqual(0);
+      expect(columnStyles['--cell-word-break']).toEqual('normal');
     });
   });
 });

--- a/src/utils/formComponentUtils.ts
+++ b/src/utils/formComponentUtils.ts
@@ -167,6 +167,7 @@ export function getColumnStyles(columnSettings: ITableColumnProperties) {
     '--cell-max-number-of-lines': (columnSettings.textOverflow?.maxHeight ?? 2) * lineClampToggle,
     '--cell-text-alignment': columnSettings.alignText,
     '--cell-width': width,
+    '--cell-word-break': columnSettings.textOverflow?.lineWrap ? 'break-word' : 'normal',
   };
 
   return columnStyleVariables as React.CSSProperties;

--- a/src/utils/formComponentUtils.ts
+++ b/src/utils/formComponentUtils.ts
@@ -151,8 +151,8 @@ export function useColumnStylesRepeatingGroups(
 }
 
 export function getColumnStyles(columnSettings: ITableColumnProperties) {
-  const lineClampToggle =
-    columnSettings.textOverflow?.lineWrap || columnSettings.textOverflow?.lineWrap === undefined ? 1 : 0;
+  const lineWrap = columnSettings.textOverflow?.lineWrap || columnSettings.textOverflow?.lineWrap === undefined;
+  const lineClampToggle = lineWrap ? 1 : 0;
 
   let width: string | number | undefined = columnSettings.width ?? 'auto';
   const widthPercentage = Number(width.substring(0, width.length - 1));
@@ -167,7 +167,7 @@ export function getColumnStyles(columnSettings: ITableColumnProperties) {
     '--cell-max-number-of-lines': (columnSettings.textOverflow?.maxHeight ?? 2) * lineClampToggle,
     '--cell-text-alignment': columnSettings.alignText,
     '--cell-width': width,
-    '--cell-word-break': columnSettings.textOverflow?.lineWrap ? 'break-word' : 'normal',
+    '--cell-word-break': lineWrap ? 'break-word' : 'normal',
   };
 
   return columnStyleVariables as React.CSSProperties;


### PR DESCRIPTION
## Description

This property was not supported in `RepeatingGroup` table cells

## Related Issue(s)

- https://digdir-samarbeid.slack.com/archives/C02EJ9HKQA3/p1758712564983439

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added configurable text wrapping for Repeating Group cells via a new setting that toggles word-break between breaking long words and normal wrapping, giving better control over column text layout.

- Style
  - Standardized word-break behavior across the app for more consistent, theme-friendly rendering and improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->