### PR TITLE
Fix for `pageBreak` bug in repeating groups

### DIFF
--- a/src/layout/Summary/SummaryComponent.tsx
+++ b/src/layout/Summary/SummaryComponent.tsx
@@ -189,7 +189,10 @@ const SummaryComponentInner = React.forwardRef(function (
             onChangeClick={onChangeClick}
             changeText={langAsString('form_filler.summary_item_change')}
             targetBaseComponentId={targetBaseComponentId}
-            overrides={{ largeGroup, display, pageBreak, grid, excludedChildren }}
+            // Intentionally not passing the pageBreak override here, as that will cause the property to
+            // be inherited forever in repeating groups, causing every component inside to be on a separate page.
+            // Passing `grid` here would make every Summary render use the grid settings for the topmost component
+            overrides={{ largeGroup, display, excludedChildren }}
             RenderSummary={RenderSummary}
           />
         ) : (

--- a/test/e2e/integration/multiple-datamodels-test/saving.ts
+++ b/test/e2e/integration/multiple-datamodels-test/saving.ts
@@ -11,7 +11,7 @@ describe('saving multiple data models', () => {
     // same time.
     cy.intercept('PATCH', '**/data*').as('saveFormData');
     cy.startAppInstance(appFrontend.apps.multipleDatamodelsTest);
-    cy.setCookie('FEATURE_saveOnBlur', 'false');
+    cy.setFeatureToggle('saveOnBlur', false);
   });
 
   it('Calls save on individual data models', () => {

--- a/test/e2e/support/custom.ts
+++ b/test/e2e/support/custom.ts
@@ -684,6 +684,7 @@ Cypress.Commands.add(
         // Set viewport to A4 paper
         cy.viewport(794, 1123);
         cy.get('body').invoke('css', 'margin', '0.75in');
+        cy.getPrintPageCount().as('pageCount');
 
         // Stops timers which helps in 'freezing' the page in its current state, makes it easier to see when data is missing
         cy.clock();
@@ -986,4 +987,16 @@ Cypress.Commands.add('openNavGroup', (groupName, pageName, subformName) => {
       }
     });
   }
+});
+
+Cypress.Commands.add('getPrintPageCount', () => {
+  cy.window().then((win) => {
+    if (!win.matchMedia('print').matches) {
+      throw new Error('getPrintPageCount can only be called when media is in print mode');
+    }
+    const allElements = Array.from(win.document.querySelectorAll('*'));
+    const breakBeforeCount = allElements.filter((e) => win.getComputedStyle(e).breakBefore === 'page').length;
+    const breakAfterCount = allElements.filter((e) => win.getComputedStyle(e).breakAfter === 'page').length;
+    return breakBeforeCount + breakAfterCount;
+  });
 });

--- a/test/e2e/support/custom.ts
+++ b/test/e2e/support/custom.ts
@@ -12,6 +12,7 @@ import type { ResponseFuzzing, Size, SnapshotOptions, SnapshotViewport } from 't
 import { breakpoints } from 'src/hooks/useDeviceWidths';
 import { getInstanceIdRegExp } from 'src/utils/instanceIdRegExp';
 import type { LayoutContextValue } from 'src/features/form/layout/LayoutsContext';
+import type { IFeatureToggles } from 'src/features/toggles';
 import type { ILayoutFile } from 'src/layout/common.generated';
 import JQueryWithSelector = Cypress.JQueryWithSelector;
 
@@ -635,6 +636,7 @@ Cypress.Commands.add(
     snapshotName = false,
     beforeReload,
     callback,
+    freeze = true,
     returnToForm = false,
     enableResponseFuzzing = false,
     buildUrl = buildPdfUrl,
@@ -684,21 +686,25 @@ Cypress.Commands.add(
         // Set viewport to A4 paper
         cy.viewport(794, 1123);
         cy.get('body').invoke('css', 'margin', '0.75in');
-        cy.getPrintPageCount().as('pageCount');
 
-        // Stops timers which helps in 'freezing' the page in its current state, makes it easier to see when data is missing
-        cy.clock();
+        if (freeze) {
+          // Stops timers which helps in 'freezing' the page in its current state, makes it easier to see when data is missing
+          cy.clock();
 
-        cy.then(() => {
-          const timeout = setTimeout(() => {
-            throw 'PDF callback failed, print was not ready when #readyForPrint appeared';
-          }, 0);
-          // Verify that generic elements that should be hidden are not present
+          cy.then(() => {
+            const timeout = setTimeout(() => {
+              throw 'PDF callback failed, print was not ready when #readyForPrint appeared';
+            }, 0);
+            // Verify that generic elements that should be hidden are not present
+            cy.findAllByRole('button').should('not.exist');
+            // Run tests from callback
+            callback();
+            cy.then(() => clearTimeout(timeout));
+          });
+        } else {
           cy.findAllByRole('button').should('not.exist');
-          // Run tests from callback
           callback();
-          cy.then(() => clearTimeout(timeout));
-        });
+        }
 
         // Disable response fuzzing and re-enable caching
         cy.get<ResponseFuzzing>('@responseFuzzing').invoke('disable');
@@ -989,14 +995,19 @@ Cypress.Commands.add('openNavGroup', (groupName, pageName, subformName) => {
   }
 });
 
-Cypress.Commands.add('getPrintPageCount', () => {
-  cy.window().then((win) => {
+Cypress.Commands.add('expectPageBreaks', (expectedCount: number) => {
+  cy.window().should((win) => {
     if (!win.matchMedia('print').matches) {
-      throw new Error('getPrintPageCount can only be called when media is in print mode');
+      throw new Error('expectPageBreaks can only be called when media is in print mode');
     }
     const allElements = Array.from(win.document.querySelectorAll('*'));
     const breakBeforeCount = allElements.filter((e) => win.getComputedStyle(e).breakBefore === 'page').length;
     const breakAfterCount = allElements.filter((e) => win.getComputedStyle(e).breakAfter === 'page').length;
-    return breakBeforeCount + breakAfterCount;
+    const pageCount = breakBeforeCount + breakAfterCount;
+    expect(pageCount).to.equal(expectedCount);
   });
+});
+
+Cypress.Commands.add('setFeatureToggle', (toggleName: IFeatureToggles, value: boolean) => {
+  cy.setCookie(`FEATURE_${toggleName}`, value.toString());
 });

--- a/test/e2e/support/global.ts
+++ b/test/e2e/support/global.ts
@@ -4,6 +4,7 @@ import type { ConsoleMessage } from 'cypress-fail-on-console-error';
 
 import type { CyUser, TenorUser } from 'test/e2e/support/auth';
 
+import type { IFeatureToggles } from 'src/features/toggles';
 import type { BackendValidationIssue, BackendValidationIssuesWithSource } from 'src/features/validation';
 import type { ILayoutSets } from 'src/layout/common.generated';
 import type { CompExternal, ILayoutCollection, ILayouts } from 'src/layout/layout';
@@ -33,6 +34,7 @@ export type StartAppInstanceOptions = {
 export interface TestPdfOptions {
   snapshotName?: string;
   beforeReload?: () => void;
+  freeze?: boolean;
   callback: () => void;
   returnToForm?: boolean;
   enableResponseFuzzing?: boolean;
@@ -326,9 +328,14 @@ declare global {
       openNavGroup(groupName: RegExp, pageName?: RegExp, subformName?: RegExp): Chainable<null>;
 
       /**
-       * Get the approximate number of pages in a printout by counting CSS break-before and break-after page properties
+       * Assert the approximate number of pages in a printout by counting CSS break-before and break-after page properties
        */
-      getPrintPageCount(): Chainable<number>;
+      expectPageBreaks(expectedCount: number): Chainable<null>;
+
+      /**
+       * Set a feature toggle value via cookie
+       */
+      setFeatureToggle(toggleName: IFeatureToggles, value: boolean): Chainable<null>;
 
       ignoreConsoleMessages(consoleMessages: ConsoleMessage[]): Chainable<null>;
     }

--- a/test/e2e/support/global.ts
+++ b/test/e2e/support/global.ts
@@ -325,6 +325,11 @@ declare global {
 
       openNavGroup(groupName: RegExp, pageName?: RegExp, subformName?: RegExp): Chainable<null>;
 
+      /**
+       * Get the approximate number of pages in a printout by counting CSS break-before and break-after page properties
+       */
+      getPrintPageCount(): Chainable<number>;
+
       ignoreConsoleMessages(consoleMessages: ConsoleMessage[]): Chainable<null>;
     }
   }


### PR DESCRIPTION
## Description

This should fix #3745, which seemed to happen after refactoring in #3462

## Related Issue(s)

- closes #3745
- https://digdir-samarbeid.slack.com/archives/C02EJ9HKQA3/p1758789108689589

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed summary rendering to prevent unintended page breaks in repeating groups and stop outer layout settings from affecting nested components, improving PDF layout consistency and page counts.

* **Tests**
  * Added two end-to-end PDF tests covering different summary layouts and page-break behaviors.
  * Updated tests to use a feature-toggle helper instead of raw cookie-setting.

* **New Features**
  * Added testing utilities: a controllable PDF freeze option, a page-break assertion helper, and a feature-toggle setter for test flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->