### PR TITLE
Dropdown does not rerender when changing value to empty array from other sources

### DIFF
--- a/src/layout/Dropdown/DropdownComponent.tsx
+++ b/src/layout/Dropdown/DropdownComponent.tsx
@@ -108,6 +108,8 @@ export function DropdownComponent({ baseComponentId, overrideDisplay }: PropsFro
           filter={(args) => optionFilter(args, selectedLabels)}
           data-size='sm'
           selected={formatSelectedValues(selectedValues, options)}
+          //TODO: Remove the "key" prop when designsystemet have fixed the update https://github.com/digdir/designsystemet/issues/4109
+          key={selectedValues.toString()}
           onSelectedChange={(options) => handleChange(options.map((o) => o.value))}
           onBlur={() => debounce}
           name={overrideDisplay?.renderedInTable ? langAsString(textResourceBindings?.title) : undefined}


### PR DESCRIPTION

## Description

Added a temporary workaround for fix while waiting for https://github.com/Altinn/app-frontend-react/issues/3104


<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)
[Designsystemet - 4109](https://github.com/digdir/designsystemet/issues/4109)
- closes #3104 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of dropdown suggestions, reducing occasional UI flicker and preventing focus jumps when updating selections.
* **Performance**
  * Reduced unnecessary re-renders in dropdown suggestions for smoother, more consistent interactions.
  * Enhances perceived responsiveness without altering existing behavior or settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->