### PR TITLE
Restore loading state for server action in custom button

### DIFF
--- a/src/layout/CustomButton/CustomButtonComponent.tsx
+++ b/src/layout/CustomButton/CustomButtonComponent.tsx
@@ -263,7 +263,11 @@ export const CustomButtonComponent = ({ baseComponentId }: PropsFromGenericCompo
         if (isClientAction(action)) {
           await handleClientActions([action]);
         } else if (isServerAction(action)) {
-          await handleServerAction({ action, buttonId: id });
+          try {
+            await handleServerAction({ action, buttonId: id });
+          } catch {
+            // Error is handled elsewhere
+          }
         }
       }
     });

--- a/src/layout/CustomButton/CustomButtonComponent.tsx
+++ b/src/layout/CustomButton/CustomButtonComponent.tsx
@@ -202,7 +202,7 @@ export const CustomButtonComponent = ({ baseComponentId }: PropsFromGenericCompo
   const acquireLock = FD.useLocking(id);
   const isAuthorized = useIsAuthorized();
   const { handleClientActions } = useHandleClientActions();
-  const { mutate: handleServerAction, error } = useMutation({
+  const { mutateAsync: handleServerAction, error } = useMutation({
     mutationFn: useHandleServerActionMutationFn(acquireLock),
   });
 
@@ -263,7 +263,7 @@ export const CustomButtonComponent = ({ baseComponentId }: PropsFromGenericCompo
         if (isClientAction(action)) {
           await handleClientActions([action]);
         } else if (isServerAction(action)) {
-          handleServerAction({ action, buttonId: id });
+          await handleServerAction({ action, buttonId: id });
         }
       }
     });

--- a/test/e2e/integration/frontend-test/custom-button.ts
+++ b/test/e2e/integration/frontend-test/custom-button.ts
@@ -7,6 +7,8 @@ describe('Custom Button', () => {
     cy.goto('changename');
 
     cy.findByRole('button', { name: 'Fyll ut skjema' }).click();
+    cy.findByRole('button', { name: 'Fyll ut skjema' }).should('be.disabled'); // Disabled while loading
+    cy.findByRole('button', { name: 'Fyll ut skjema' }).should('not.be.disabled'); // Enabled when finished
     cy.findByRole('textbox', { name: 'Denne oppdateres av custom button' }).should(
       'have.value',
       'Her kommer det data fra backend',

--- a/test/e2e/integration/frontend-test/custom-button.ts
+++ b/test/e2e/integration/frontend-test/custom-button.ts
@@ -4,10 +4,17 @@ const appFrontend = new AppFrontend();
 
 describe('Custom Button', () => {
   it('Should perform action and update the frontend with the updated datamodel', () => {
+    cy.intercept({ url: '**/instances/**/actions*' }, (req) => {
+      req.reply((res) => {
+        res.setDelay(500);
+      });
+    }).as('actionWithDelay');
+
     cy.goto('changename');
 
     cy.findByRole('button', { name: 'Fyll ut skjema' }).click();
     cy.findByRole('button', { name: 'Fyll ut skjema' }).should('be.disabled'); // Disabled while loading
+    cy.wait('@actionWithDelay');
     cy.findByRole('button', { name: 'Fyll ut skjema' }).should('not.be.disabled'); // Enabled when finished
     cy.findByRole('textbox', { name: 'Denne oppdateres av custom button' }).should(
       'have.value',


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

Restore loading state when a server action is pending in custom button

## Related Issue(s)

- https://digdir-samarbeid.slack.com/archives/C02EJ9HKQA3/p1759396784110369
- https://github.com/Altinn/app-frontend-react/pull/3512

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Actions triggered by buttons are now properly awaited so the UI waits for completion, preventing premature updates or duplicate triggers.
  - Improved local error handling to avoid unhandled failures while preserving external error flows.
  - Loading/disabled states are more consistent during long-running operations.

- Tests
  - Added end-to-end checks verifying the button is disabled while processing and re-enabled after completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->