### PR TITLE
fix: checkbox loses focus when changing state

### DIFF
--- a/src/features/alertOnChange/DeleteWarningPopover.tsx
+++ b/src/features/alertOnChange/DeleteWarningPopover.tsx
@@ -16,6 +16,7 @@ export interface IDeleteWarningPopover {
   popoverId?: string;
   setOpen: (open: boolean) => void;
   placement?: 'bottom' | 'left' | 'right' | 'top';
+  withTrigger?: boolean;
 }
 
 export function DeleteWarningPopover({
@@ -28,15 +29,20 @@ export function DeleteWarningPopover({
   popoverId,
   open,
   setOpen,
+  withTrigger = true,
 }: IDeleteWarningPopover) {
   return (
     <Popover.TriggerContext>
-      <Popover.Trigger
-        asChild
-        onClick={() => setOpen(!open)}
-      >
-        {children}
-      </Popover.Trigger>
+      {withTrigger ? (
+        <Popover.Trigger
+          asChild
+          onClick={() => setOpen(!open)}
+        >
+          {children}
+        </Popover.Trigger>
+      ) : (
+        children
+      )}
       <Popover
         data-testid='delete-warning-popover'
         id={popoverId}

--- a/src/layout/Checkboxes/CheckboxesContainerComponent.tsx
+++ b/src/layout/Checkboxes/CheckboxesContainerComponent.tsx
@@ -116,8 +116,7 @@ export const CheckboxContainerComponent = ({
             >
               {calculatedOptions.map((option) => (
                 <WrappedCheckbox
-                  // Force remount to ensure checkbox reflects correct checked state
-                  key={`checkbox-${option.value}-${selectedValues.includes(option.value)}`}
+                  key={`checkbox-${option.value}`}
                   id={id}
                   option={option}
                   hideLabel={hideLabel}

--- a/src/layout/Checkboxes/WrappedCheckbox.tsx
+++ b/src/layout/Checkboxes/WrappedCheckbox.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useId } from 'react';
 
 import { Checkbox } from '@digdir/designsystemet-react';
 import cn from 'classnames';
@@ -34,6 +34,8 @@ export const WrappedCheckbox = forwardRef<HTMLInputElement, IWrappedCheckboxProp
     (isChecked) => !isChecked,
   );
 
+  const popoverId = useId();
+
   return (
     <ConditionalWrapper
       key={option.value}
@@ -46,6 +48,8 @@ export const WrappedCheckbox = forwardRef<HTMLInputElement, IWrappedCheckboxProp
           onPopoverDeleteClick={confirmChange}
           open={alertOpen}
           setOpen={setAlertOpen}
+          popoverId={popoverId}
+          withTrigger={false}
         >
           {children}
         </DeleteWarningPopover>
@@ -57,7 +61,10 @@ export const WrappedCheckbox = forwardRef<HTMLInputElement, IWrappedCheckboxProp
         value={option.value}
         readOnly={readOnly}
         label={
-          <span className={cn({ 'sr-only': hideLabel }, classes.checkboxLabelContainer)}>
+          <span
+            popoverTarget={popoverId}
+            className={cn({ 'sr-only': hideLabel }, classes.checkboxLabelContainer)}
+          >
             {langAsString(option.label)}
             {option.helpText && (
               <HelpText


### PR DESCRIPTION
## Description

- Changed `key` causing re-mount of checkbox when changing state. Causing loss of focus e.g. when toggling with keyboard `space`.

The above change worked for every case except when used with `DeleteWarningPopover`. When wrapped in the popover, changes were not reflected correctly, the `checked` react state changed, but the actual Checkbox-component did not update. 
The only non-intrusive solutions i found were:
- Adding a dummy `useEffect` that did nothing except update an unused state (probably causing a double-render, which somehow solves the issue), 
- Making the popover target the label of the checkbox instead of the checkbox itself. 

## Related Issue(s)

- closes #16416

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->
