### PR TITLE
[Backport] release workflow changes

### DIFF
--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -17,11 +17,6 @@ while [[ $# -gt 0 ]]; do
       shift # pop option
       shift # pop option
       ;;
-    --azure-sa-token)
-      AZURE_STORAGE_ACCOUNT_TOKEN="$2"
-      shift # pop option
-      shift # pop option
-      ;;
     --azure-sync-cdn )
       SYNC_AZURE_CDN=yes
       shift #pop option
@@ -128,7 +123,7 @@ else
     else
       echo "Publishing files to azure cdn"
     fi
-    azcopy sync "$TARGET" "$AZURE_TARGET_URI/toolkits${AZURE_STORAGE_ACCOUNT_TOKEN}" "${AZCOPY_TOOLKITS_OPTS[@]}" "${AZCOPY_ADDITIONAL_OPTS[@]}"
+    azcopy sync "$TARGET" "$AZURE_TARGET_URI/toolkits" "${AZCOPY_TOOLKITS_OPTS[@]}" "${AZCOPY_ADDITIONAL_OPTS[@]}"
     echo "-------------------------------------"
     if [[ "$SYNC_AZURE_CDN" == "yes" && "$PRE_RELEASE" == "no" ]]; then
       bash ".github/scripts/purge-frontdoor-cache.sh" --path "/toolkits/altinn-app-frontend/$APP_MAJOR/*" --path "/toolkits/altinn-app-frontend/$APP_MAJOR_MINOR/*"

--- a/.github/scripts/revert.sh
+++ b/.github/scripts/revert.sh
@@ -68,8 +68,8 @@ else
   else
     echo "Publishing files to azure cdn"
   fi
-  azcopy sync "$AZURE_TARGET_URI/toolkits/$APP_FULL/" "$AZURE_TARGET_URI/toolkits/$APP_MAJOR/${AZURE_STORAGE_ACCOUNT_TOKEN}" "${AZCOPY_OPTS[@]}"
-  azcopy sync "$AZURE_TARGET_URI/toolkits/$APP_FULL/" "$AZURE_TARGET_URI/toolkits/$APP_MAJOR_MINOR/${AZURE_STORAGE_ACCOUNT_TOKEN}" "${AZCOPY_OPTS[@]}"
+  azcopy sync "$AZURE_TARGET_URI/toolkits/$APP_FULL/" "$AZURE_TARGET_URI/toolkits/$APP_MAJOR/" "${AZCOPY_OPTS[@]}"
+  azcopy sync "$AZURE_TARGET_URI/toolkits/$APP_FULL/" "$AZURE_TARGET_URI/toolkits/$APP_MAJOR_MINOR/" "${AZCOPY_OPTS[@]}"
   echo "-------------------------------------"
   if [[ "$SYNC_AZURE_CDN" != "no" ]]; then
     bash ".github/scripts/purge-frontdoor-cache.sh" --path "/toolkits/altinn-app-frontend/$APP_MAJOR/*" --path "/toolkits/altinn-app-frontend/$APP_MAJOR_MINOR/*"

--- a/.github/scripts/revert.sh
+++ b/.github/scripts/revert.sh
@@ -17,11 +17,6 @@ while [[ $# -gt 0 ]]; do
       shift # pop option
       shift # pop option
       ;;
-    --azure-sa-token)
-      AZURE_STORAGE_ACCOUNT_TOKEN="$2"
-      shift # pop option
-      shift # pop option
-      ;;
     --azure-sync-cdn )
       SYNC_AZURE_CDN=yes
       shift #pop option
@@ -73,8 +68,8 @@ else
   else
     echo "Publishing files to azure cdn"
   fi
-  azcopy sync "$AZURE_TARGET_URI/toolkits/$APP_FULL/${AZURE_STORAGE_ACCOUNT_TOKEN}" "$AZURE_TARGET_URI/toolkits/$APP_MAJOR/${AZURE_STORAGE_ACCOUNT_TOKEN}" "${AZCOPY_OPTS[@]}"
-  azcopy sync "$AZURE_TARGET_URI/toolkits/$APP_FULL/${AZURE_STORAGE_ACCOUNT_TOKEN}" "$AZURE_TARGET_URI/toolkits/$APP_MAJOR_MINOR/${AZURE_STORAGE_ACCOUNT_TOKEN}" "${AZCOPY_OPTS[@]}"
+  azcopy sync "$AZURE_TARGET_URI/toolkits/$APP_FULL/" "$AZURE_TARGET_URI/toolkits/$APP_MAJOR/${AZURE_STORAGE_ACCOUNT_TOKEN}" "${AZCOPY_OPTS[@]}"
+  azcopy sync "$AZURE_TARGET_URI/toolkits/$APP_FULL/" "$AZURE_TARGET_URI/toolkits/$APP_MAJOR_MINOR/${AZURE_STORAGE_ACCOUNT_TOKEN}" "${AZCOPY_OPTS[@]}"
   echo "-------------------------------------"
   if [[ "$SYNC_AZURE_CDN" != "no" ]]; then
     bash ".github/scripts/purge-frontdoor-cache.sh" --path "/toolkits/altinn-app-frontend/$APP_MAJOR/*" --path "/toolkits/altinn-app-frontend/$APP_MAJOR_MINOR/*"

--- a/.github/scripts/sync-index.sh
+++ b/.github/scripts/sync-index.sh
@@ -12,11 +12,6 @@ while [[ $# -gt 0 ]]; do
       shift # pop option
       shift # pop option
       ;;
-    --azure-sa-token)
-      AZURE_STORAGE_ACCOUNT_TOKEN="$2"
-      shift # pop option
-      shift # pop option
-      ;;
     --azure-sync-cdn )
       SYNC_AZURE_CDN=yes
       shift #pop option
@@ -39,7 +34,7 @@ VERSION_REGEX="^[\d\.]+((?:-|.)[a-z0-9.\-]+)?$"
 mkdir -p "$TARGET"
 
 echo "Updating index.json"
-azcopy ls "$AZURE_TARGET_URI/toolkits/${AZURE_STORAGE_ACCOUNT_TOKEN}" | \
+azcopy ls "$AZURE_TARGET_URI/toolkits/" | \
   cut -d/ -f 1 | \
   grep --perl-regexp "$VERSION_REGEX" | \
   sort --version-sort | \
@@ -53,7 +48,7 @@ if [[ "$SYNC_AZURE_CDN" == "no" ]]; then
 else
   echo "Publishing index to azure cdn"
 fi
-azcopy sync "$TARGET/index.json" "$AZURE_TARGET_URI/toolkits/index.json${AZURE_STORAGE_ACCOUNT_TOKEN}" "${AZCOPY_OPTS[@]}"
+azcopy sync "$TARGET/index.json" "$AZURE_TARGET_URI/toolkits/index.json" "${AZCOPY_OPTS[@]}"
 if [[ "$SYNC_AZURE_CDN" == "yes" ]]; then
   bash ".github/scripts/purge-frontdoor-cache.sh" --path "/toolkits/altinn-app-frontend/index.json"
 fi

--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -6,6 +6,7 @@ jobs:
   publish:
     name: Publish PR packages
     runs-on: ubuntu-latest
+    environment: test
     if: github.event.issue.pull_request && contains(github.event.comment.body, '/publish')
     permissions:
       id-token: write

--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -94,6 +94,8 @@ jobs:
         working-directory: app-frontend
         if: '!env.ACT'
         env:
+          AZCOPY_AUTO_LOGIN_TYPE: AZCLI
+          AZCOPY_TENANT_ID: ${{ secrets.AZURE_TENANT_ID_FC }}
           FD_DOMAIN: ${{ vars.AZURE_DOMAIN_FC }}
           FD_ENDPOINT: ${{ vars.AZURE_ENDPOINT_FC }}
           FD_PROFILE: ${{ vars.AZURE_PROFILE_FC }}
@@ -103,12 +105,13 @@ jobs:
             --pre-release \
             --azure-sync-cdn \
             --azure-sa-name "${{ secrets.PRODUCTION_STORAGEACCOUNT_NAME }}" \
-            --azure-sa-token "${{ secrets.PRODUCTION_ALTINN_CDN_SAS_TOKEN }}"
 
       - name: Run sync-index script
         working-directory: app-frontend
         if: '!env.ACT'
         env:
+          AZCOPY_AUTO_LOGIN_TYPE: AZCLI
+          AZCOPY_TENANT_ID: ${{ secrets.AZURE_TENANT_ID_FC }}
           FD_DOMAIN: ${{ vars.AZURE_DOMAIN_FC }}
           FD_ENDPOINT: ${{ vars.AZURE_ENDPOINT_FC }}
           FD_PROFILE: ${{ vars.AZURE_PROFILE_FC }}
@@ -117,7 +120,6 @@ jobs:
           bash .github/scripts/sync-index.sh \
            --azure-sync-cdn \
            --azure-sa-name "${{ secrets.PRODUCTION_STORAGEACCOUNT_NAME }}" \
-           --azure-sa-token "${{ secrets.PRODUCTION_ALTINN_CDN_SAS_TOKEN }}"
 
       - name: Update PR comment - failure
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,8 @@ jobs:
         working-directory: app-frontend
         if: '!env.ACT && !github.event.release.prerelease'
         env:
+          AZCOPY_AUTO_LOGIN_TYPE: AZCLI
+          AZCOPY_TENANT_ID: ${{ secrets.AZURE_TENANT_ID_FC }}
           FD_DOMAIN: ${{ vars.AZURE_DOMAIN_FC }}
           FD_ENDPOINT: ${{ vars.AZURE_ENDPOINT_FC }}
           FD_PROFILE: ${{ vars.AZURE_PROFILE_FC }}
@@ -63,12 +65,13 @@ jobs:
           bash .github/scripts/release.sh \
            --azure-sync-cdn \
            --azure-sa-name "${{ secrets.PRODUCTION_STORAGEACCOUNT_NAME }}" \
-           --azure-sa-token "${{ secrets.PRODUCTION_ALTINN_CDN_SAS_TOKEN }}"
 
       - name: Run release script (pre-release)
         working-directory: app-frontend
         if: '!env.ACT && github.event.release.prerelease'
         env:
+          AZCOPY_AUTO_LOGIN_TYPE: AZCLI
+          AZCOPY_TENANT_ID: ${{ secrets.AZURE_TENANT_ID_FC }}
           FD_DOMAIN: ${{ vars.AZURE_DOMAIN_FC }}
           FD_ENDPOINT: ${{ vars.AZURE_ENDPOINT_FC }}
           FD_PROFILE: ${{ vars.AZURE_PROFILE_FC }}
@@ -78,12 +81,13 @@ jobs:
             --pre-release \
             --azure-sync-cdn \
             --azure-sa-name "${{ secrets.PRODUCTION_STORAGEACCOUNT_NAME }}" \
-            --azure-sa-token "${{ secrets.PRODUCTION_ALTINN_CDN_SAS_TOKEN }}"
 
       - name: Run sync-index script
         working-directory: app-frontend
         if: '!env.ACT'
         env:
+          AZCOPY_AUTO_LOGIN_TYPE: AZCLI
+          AZCOPY_TENANT_ID: ${{ secrets.AZURE_TENANT_ID_FC }}
           FD_DOMAIN: ${{ vars.AZURE_DOMAIN_FC }}
           FD_ENDPOINT: ${{ vars.AZURE_ENDPOINT_FC }}
           FD_PROFILE: ${{ vars.AZURE_PROFILE_FC }}
@@ -92,4 +96,3 @@ jobs:
           bash .github/scripts/sync-index.sh \
            --azure-sync-cdn \
            --azure-sa-name "${{ secrets.PRODUCTION_STORAGEACCOUNT_NAME }}" \
-           --azure-sa-token "${{ secrets.PRODUCTION_ALTINN_CDN_SAS_TOKEN }}"

--- a/.github/workflows/revert.yml
+++ b/.github/workflows/revert.yml
@@ -43,6 +43,8 @@ jobs:
       - name: Run roll back script
         working-directory: app-frontend
         env:
+          AZCOPY_AUTO_LOGIN_TYPE: AZCLI
+          AZCOPY_TENANT_ID: ${{ secrets.AZURE_TENANT_ID_FC }}
           FD_DOMAIN: ${{ vars.AZURE_DOMAIN_FC }}
           FD_ENDPOINT: ${{ vars.AZURE_ENDPOINT_FC }}
           FD_PROFILE: ${{ vars.AZURE_PROFILE_FC }}
@@ -52,4 +54,3 @@ jobs:
            --tag "${{ inputs.tag }}" \
            --azure-sync-cdn \
            --azure-sa-name "${{ secrets.PRODUCTION_STORAGEACCOUNT_NAME }}" \
-           --azure-sa-token "${{ secrets.PRODUCTION_ALTINN_CDN_SAS_TOKEN }}"


### PR DESCRIPTION
Release with SAS-token no longer works as the token is expired. To continue releasing patches in v4.21 we need to update the workflow