### PR TITLE
Fixing claim error output after claims was converted to a `Set`

### DIFF
--- a/src/features/form/layout/makeLayoutLookups.ts
+++ b/src/features/form/layout/makeLayoutLookups.ts
@@ -206,7 +206,7 @@ function canClaimChild(childId: string, parentId: string, lookup: PlainLayoutLoo
   }
   const otherClaims: string[] = [];
   for (const otherParentId in claims) {
-    if (claims[otherParentId]?.[childId]) {
+    if (claims[otherParentId]?.has(childId) && otherParentId !== parentId) {
       otherClaims.push(otherParentId);
     }
   }


### PR DESCRIPTION
## Description

The refactoring in #3673 brought a subtle bug. After the `claims` was converted to use `new Set()`, this check for double-claimed component IDs broke. This should fix it again, bringing back error messages for this class of misconfiguration.

## Related Issue(s)

- https://digdir-samarbeid.slack.com/archives/C02EJ9HKQA3/p1760528377565999

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of child component claims in form layouts to avoid false self-conflicts and only flag genuine conflicts.
  * Ensures clearer, consistent error messages by preserving the error path when conflicts are detected.
  * Results in more accurate layout validation with fewer false positives, improving reliability when configuring or editing forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->