### PR TITLE
hotfix for the double payment action call.

### DIFF
--- a/src/features/payment/PaymentProvider.tsx
+++ b/src/features/payment/PaymentProvider.tsx
@@ -72,11 +72,15 @@ function PaymentNavigation() {
         paymentInitiatedForInstance.set(instanceGuid, true);
         performPayment();
       }
-    } else if (instanceGuid && !paymentDoesNotExist) {
-      // Clean up the flag once payment is no longer uninitialized
+    } else if (
+      instanceGuid &&
+      paymentInfo?.status !== undefined &&
+      paymentInfo.status !== PaymentStatus.Uninitialized
+    ) {
+      // Clean up the flag once payment status is known and no longer Uninitialized
       paymentInitiatedForInstance.delete(instanceGuid);
     }
-  }, [isPaymentProcess, paymentDoesNotExist, performPayment, isPdf, instanceGuid]);
+  }, [isPaymentProcess, paymentDoesNotExist, performPayment, isPdf, instanceGuid, paymentInfo?.status]);
 
   const paymentCompleted = paymentInfo?.status === PaymentStatus.Paid || paymentInfo?.status === PaymentStatus.Skipped;
 


### PR DESCRIPTION

## Description

  Problem:
  Since release v4.21.4, performPayment() was being called twice when navigating to a
  payment task, creating duplicate payment instances. The calls occurred:
  1. Once before the route change from the signing  route completes
  2. Once after the route changed to the payment task

  Root Cause:
  The issue was introduced in commit 7bb7ec3c9 ("Refactor InstanceContext (#3575)") from
  August 4, 2025. The refactor changed InstanceContext from a Zustand store pattern to
  React Query + Context, which inadvertently caused provider components to remount during
  navigation.

  When PaymentProvider remounted during the route transition, the useEffect in
  PaymentNavigation would re-execute with the same conditions (isPaymentProcess=true,
  paymentDoesNotExist=true), triggering a second call to performPayment().

  Solution:
  Implemented a module-level Map that tracks which instances have already had payment
  initiated. This prevents duplicate calls even when the component remounts during
  navigation:

  1. Guard check: Before calling performPayment(), check if payment has already been
  initiated for this instanceGuid
  2. Module-level persistence: Using a Map at module scope ensures the tracking survives
  component remounts (unlike React refs which reset)
  3. Cleanup: Remove instances from the Map once payment status is no longer
  "Uninitialized" to prevent memory leaks

  Changes:
  - Added paymentInitiatedForInstance Map to track payment initiation state across remounts
  - Modified PaymentNavigation useEffect to check the Map before calling performPayment()
  - Added cleanup logic to remove completed instances from the Map

  Testing:
  Manual testing confirmed the debugger on line 73 is now only hit once per payment task
  navigation, resolving the duplicate instance creation issue.


## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate payment starts when navigating or remounting components, ensuring each payment is initiated only once and related temporary state is cleared when a payment is established.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->