### PR TITLE
Incident rowsAfter hotfix

### DIFF
--- a/src/layout/RepeatingGroup/index.tsx
+++ b/src/layout/RepeatingGroup/index.tsx
@@ -165,11 +165,10 @@ export class RepeatingGroup extends RepeatingGroupDef implements ValidateCompone
     const item = props.externalItem as CompExternal<'RepeatingGroup'>;
     const repeatingClaims: ChildClaims = new Set(props.childClaims?.values() ?? []);
     const gridRowClaims: ChildClaims = new Set();
-
     for (const row of [...(item.rowsBefore || []), ...(item.rowsAfter || [])]) {
       for (const cell of row.cells.values()) {
         if (cell && 'component' in cell && cell.component && repeatingClaims.has(cell.component)) {
-          gridRowClaims.add(repeatingClaims[cell.component]);
+          gridRowClaims.add(cell.component);
           repeatingClaims.delete(cell.component);
         }
       }

--- a/src/utils/layout/hidden.ts
+++ b/src/utils/layout/hidden.ts
@@ -282,7 +282,11 @@ function findHiddenSources(
       const callback = () => parentDef.isChildHidden(tmpParentId, tmpChildId, layoutLookups);
       out.push({ type: 'callback', callback, id: parent.id });
     }
-    if (parentComponent.type === 'RepeatingGroup' && parentComponent.hiddenRow !== undefined) {
+    if (
+      parentComponent.type === 'RepeatingGroup' &&
+      parentComponent.hiddenRow !== undefined &&
+      parentComponent.children.includes(childId)
+    ) {
       out.push({ type: 'hiddenRow', expr: parentComponent.hiddenRow, id: parent.id });
     }
     if (parentComponent.hidden !== undefined) {


### PR DESCRIPTION
## Description

See: https://digdir-samarbeid.slack.com/archives/C02EVE4RU82/p1761660965878459


## Related Issue(s)

- closes #3825
- closes #3814

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed component identifier handling within repeating groups for more accurate data storage
  * Refined hidden row detection logic in repeating groups to properly evaluate group membership

<!-- end of auto-generated comment: release notes by coderabbit.ai -->