### PR TITLE
Update applicationmetadata schema with disallowUserCreate and Delete

### DIFF
--- a/schemas/json/application/application-metadata.schema.v1.json
+++ b/schemas/json/application/application-metadata.schema.v1.json
@@ -462,13 +462,12 @@
         "shadowFields": {
           "$ref": "#/definitions/shadowFields"
         },
-        "disallowUserCreate":{
+        "disallowUserCreate": {
           "type": "boolean",
           "title": "Disallow user create",
           "description": "A property indicating if users are disallowed from creating this data type through the public http apis."
         },
-        "disallowUserDelete":
-        {
+        "disallowUserDelete": {
           "type": "boolean",
           "title": "Disallow user delete",
           "description": "A property indicating if users are disallowed from deleting this data type through the public http apis."


### PR DESCRIPTION
These properties were used, but is missing from the schema

<img width="359" height="107" alt="image" src="https://github.com/user-attachments/assets/259a0667-1cf7-4189-b71c-58ae914efb05" />

Also reported by @xmrsa

- Fixes https://github.com/Altinn/app-frontend-react/issues/3860



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two new public configuration flags to restrict user-initiated create and delete actions on a per-data-type basis, allowing finer control over who can create or remove resources via public APIs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->