### PR TITLE
Only prefetch pdf format for the main form

### DIFF
--- a/src/queries/formPrefetcher.ts
+++ b/src/queries/formPrefetcher.ts
@@ -1,6 +1,7 @@
 import { usePrefetchQuery } from 'src/core/queries/usePrefetchQuery';
 import { useCurrentDataModelDataElementId, useCurrentDataModelName } from 'src/features/datamodel/useBindingSchema';
 import { useDynamicsQueryDef } from 'src/features/form/dynamics/DynamicsContext';
+import { useIsInFormContext } from 'src/features/form/FormContext';
 import { useLayoutQueryDef } from 'src/features/form/layout/LayoutsContext';
 import { useLayoutSetIdFromUrl } from 'src/features/form/layoutSets/useCurrentLayoutSet';
 import { useLayoutSettingsQueryDef } from 'src/features/form/layoutSettings/LayoutSettingsContext';
@@ -24,8 +25,6 @@ export function FormPrefetcher() {
   // Prefetch layouts
   usePrefetchQuery(useLayoutQueryDef(true, dataTypeId, layoutSetId));
 
-  const dataElementId = useCurrentDataModelDataElementId();
-
   // Prefetch other layout related files
   usePrefetchQuery(useLayoutSettingsQueryDef(layoutSetId));
   usePrefetchQuery(useDynamicsQueryDef(layoutSetId));
@@ -35,8 +34,10 @@ export function FormPrefetcher() {
   usePrefetchQuery(usePaymentInformationQueryDef(useIsPayment(), instanceId));
   usePrefetchQuery(useOrderDetailsQueryDef(useHasPayment(), instanceId));
 
-  // Prefetch PDF format only if we are in PDF mode
-  usePrefetchQuery(usePdfFormatQueryDef(true, instanceId, dataElementId), isPDF);
+  // Prefetch PDF format only if we are in PDF mode and loading the main form
+  const dataElementId = useCurrentDataModelDataElementId();
+  const isEmbedded = useIsInFormContext();
+  usePrefetchQuery(usePdfFormatQueryDef(true, instanceId, dataElementId), isPDF && !isEmbedded);
 
   return null;
 }


### PR DESCRIPTION
## Description

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

I hope we can remove pdf/format entirely in the next major, but for now, we don't need to prefetch pdf/format for subforms, as it only gets used by the main form anyway (in AutoGeneratePdfFromLayout).

<img width="783" height="231" alt="bilde" src="https://github.com/user-attachments/assets/1cabf4e0-4032-49db-8e0a-0be1e4b8b4bf" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized PDF resource prefetching to load more selectively. Resources are now prefetched only when viewing main forms in PDF mode, eliminating unnecessary loading for embedded forms and other scenarios, improving overall application performance and responsiveness.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->