### PR TITLE
Fixing help text rendered in bold by default

### DIFF
--- a/src/app-components/HelpText/Helptext.module.css
+++ b/src/app-components/HelpText/Helptext.module.css
@@ -37,6 +37,10 @@
   max-width: 700px;
 }
 
+.helpTextContent span {
+  font-weight: 400;
+}
+
 .helpText-focus:focus-visible {
   outline: var(--ds-border-width-focus) solid var(--ds-color-neutral-text-default);
   outline-offset: var(--ds-border-width-focus);

--- a/test/e2e/integration/frontend-test/components.ts
+++ b/test/e2e/integration/frontend-test/components.ts
@@ -372,7 +372,15 @@ describe('UI Components', () => {
     cy.visualTesting('components:read-only');
   });
 
-  it('description and helptext for options in radio and checkbox groups', () => {
+  it('description and helptext for components and options in radio and checkboxes', () => {
+    cy.interceptLayout('changename', (component) => {
+      if (component.type === 'RadioButtons' && component.id === 'reason') {
+        component.textResourceBindings!.help = 'Denne står på reason-komponenten';
+      }
+      if (component.type === 'Checkboxes' && component.id === 'confirmChangeName') {
+        component.textResourceBindings!.help = 'Denne står på confirmChangeName-komponenten';
+      }
+    });
     cy.goto('changename');
     cy.get(appFrontend.changeOfName.newFirstName).type('Per');
     cy.get(appFrontend.changeOfName.newFirstName).blur();
@@ -382,16 +390,37 @@ describe('UI Components', () => {
     cy.get(appFrontend.changeOfName.newLastName).blur();
 
     cy.get(appFrontend.changeOfName.confirmChangeName).findByText('Dette er en beskrivelse.').should('be.visible');
-    cy.get(appFrontend.helpText.alert).eq(1).should('not.be.visible');
-    cy.get(appFrontend.changeOfName.confirmChangeName).findByRole('button').click();
-    cy.get(appFrontend.helpText.alert).eq(1).should('be.visible');
+    cy.get(appFrontend.helpText.alertOpen).should('have.length', 0);
+    cy.get(appFrontend.changeOfName.confirmChangeName).findAllByRole('button').should('have.length', 2);
+    cy.get(appFrontend.changeOfName.confirmChangeName).findAllByRole('button').eq(0).click();
+    cy.get(appFrontend.helpText.alertOpen).should('have.length', 1);
+    cy.get(appFrontend.helpText.alertOpen).should('contain.text', 'Denne står på confirmChangeName-komponenten');
+    cy.get(appFrontend.helpText.alertOpen)
+      .find('span')
+      .should((helpText) => expect(helpText).to.have.css('font-weight', '400'));
+    cy.get(appFrontend.changeOfName.confirmChangeName).findAllByRole('button').eq(1).click();
+    cy.get(appFrontend.helpText.alertOpen).should('have.length', 1);
+    cy.get(appFrontend.helpText.alertOpen).should('contain.text', 'Dette er en hjelpetekst');
+    cy.get(appFrontend.helpText.alertOpen)
+      .find('span')
+      .should((helpText) => expect(helpText).to.have.css('font-weight', '400'));
 
     cy.get(appFrontend.changeOfName.confirmChangeName).find('label').click();
-    cy.get(appFrontend.changeOfName.reasons).should('be.visible');
+    cy.get(appFrontend.helpText.alertOpen).should('have.length', 0);
 
     cy.get(appFrontend.changeOfName.reasons).findByText('Dette er en beskrivelse.').should('be.visible');
-    cy.get(appFrontend.changeOfName.reasons).findByRole('button').click();
-    cy.get(appFrontend.helpText.alert).eq(2).should('be.visible');
+    cy.get(appFrontend.changeOfName.reasons).findAllByRole('button').eq(0).click();
+    cy.get(appFrontend.helpText.alertOpen).should('have.length', 1);
+    cy.get(appFrontend.helpText.alertOpen).should('contain.text', 'Denne står på reason-komponenten');
+    cy.get(appFrontend.helpText.alertOpen)
+      .find('span')
+      .should((helpText) => expect(helpText).to.have.css('font-weight', '400'));
+    cy.get(appFrontend.changeOfName.reasons).findAllByRole('button').eq(1).click();
+    cy.get(appFrontend.helpText.alertOpen).should('have.length', 1);
+    cy.get(appFrontend.helpText.alertOpen).should('contain.text', 'Dette er en hjelpetekst');
+    cy.get(appFrontend.helpText.alertOpen)
+      .find('span')
+      .should((helpText) => expect(helpText).to.have.css('font-weight', '400'));
   });
 
   it('should display alert on changing radio button', () => {

--- a/test/e2e/pageobjects/app-frontend.ts
+++ b/test/e2e/pageobjects/app-frontend.ts
@@ -63,6 +63,7 @@ export class AppFrontend {
   public helpText = {
     button: 'button[class^="ds-helptext"]',
     alert: 'div[data-testid="helptext"]',
+    alertOpen: 'div[data-testid="helptext"]:popover-open',
   };
 
   public deleteWarningPopover = 'div[data-testid="delete-warning-popover"]';


### PR DESCRIPTION
## Description

This forces the help text to use `font-weight: 400`. It turns out the label styling overrides the default font weight in some components, and it all seems to depend on the render hierarchy. Labels are still a bit complex, so instead of rewriting this to something easier, I guess this override (with a test) can do the trick as well.

## Related Issue(s)

- closes #728

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Help text now supports toggling between component-specific and general help through an improved interface.

* **Style**
  * Enhanced help text typography with refined font styling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->