### PR TITLE
Supporting the Sámi name for Oslo

### DIFF
--- a/test/e2e/integration/expression-validation-test/expression-validation.ts
+++ b/test/e2e/integration/expression-validation-test/expression-validation.ts
@@ -50,7 +50,7 @@ describe('Expression validation', () => {
     cy.findByRole('textbox', { name: /telefonnummer/i }).type('98765432');
     cy.get(appFrontend.errorReport).should('not.exist');
 
-    cy.dsSelect(appFrontend.expressionValidationTest.bosted, 'Oslo');
+    cy.dsSelect(appFrontend.expressionValidationTest.bosted, /Oslo/);
 
     cy.findByRole('button', { name: /neste/i }).click();
     cy.navPage('Skjul felter').should('have.attr', 'aria-current', 'page');

--- a/test/e2e/integration/expression-validation-test/tags-validation.ts
+++ b/test/e2e/integration/expression-validation-test/tags-validation.ts
@@ -73,7 +73,7 @@ describe('Attachment tags validation', () => {
     cy.dsSelect(appFrontend.expressionValidationTest.kjønn, 'Mann');
     cy.findByRole('textbox', { name: /e-post/i }).type('test@altinn.no');
     cy.findByRole('textbox', { name: /telefonnummer/i }).type('98765432');
-    cy.dsSelect(appFrontend.expressionValidationTest.bosted, 'Oslo');
+    cy.dsSelect(appFrontend.expressionValidationTest.bosted, /Oslo/);
 
     cy.findByRole('button', { name: /neste/i }).click();
     cy.findByRole('button', { name: /send inn/i }).click();

--- a/test/e2e/integration/frontend-test/options.ts
+++ b/test/e2e/integration/frontend-test/options.ts
@@ -143,7 +143,7 @@ describe('Options', () => {
     cy.goto('changename');
     cy.wait('@optionsMunicipality');
 
-    cy.dsSelect(appFrontend.changeOfName.municipality, 'Oslo');
+    cy.dsSelect(appFrontend.changeOfName.municipality, /Oslo/);
 
     cy.get(appFrontend.changeOfName.municipalityMetadata)
       .should('have.prop', 'value')

--- a/test/e2e/support/global.ts
+++ b/test/e2e/support/global.ts
@@ -205,7 +205,7 @@ declare global {
       /**
        * Select from a dropdown in the design system
        */
-      dsSelect(selector: string, value: string, debounce?: boolean): Chainable<null>;
+      dsSelect(selector: string, value: string | RegExp, debounce?: boolean): Chainable<null>;
 
       /**
        * Shortcut for clicking an element and waiting for it to disappear


### PR DESCRIPTION
## Description

SSB seems to have added 'Oslove' to the name for Oslo in the 'kommuner' shared code list, which broke some of our automated tests. This is the official Sámi spelling. With this change we select using a regex instead, which should be more compatible.

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Updated integration and validation tests to utilize pattern-based option selection for improved test robustness.

* **New Features**
  * Enhanced dropdown selection to support both exact string matching and regex pattern matching for more flexible option selection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->