### PR TITLE
Added tableTitle and tertiary to custom button

### DIFF
--- a/src/layout/CustomButton/CustomButtonComponent.test.tsx
+++ b/src/layout/CustomButton/CustomButtonComponent.test.tsx
@@ -6,7 +6,6 @@ import { screen } from '@testing-library/react';
 import { CustomButtonComponent } from 'src/layout/CustomButton/CustomButtonComponent';
 import { fetchProcessState } from 'src/queries/queries';
 import { renderGenericComponentTest } from 'src/test/renderWithProviders';
-import type { PropsFromGenericComponent } from 'src/layout';
 import type { CustomAction } from 'src/layout/CustomButton/config.generated';
 import type { IUserAction } from 'src/types/shared';
 
@@ -118,46 +117,14 @@ describe('CustomButtonComponent', () => {
 
     expect(screen.getByRole('button')).not.toBeDisabled();
   });
-
-  it('uses tableTitle when rendered in a table', async () => {
-    await render({
-      actions: [{ id: 'nextPage', type: 'ClientAction' }],
-      textResourceBindingsOverride: {
-        title: 'Custom button',
-        tableTitle: 'Custom table button',
-      },
-      overrideDisplay: { renderedInTable: true },
-    });
-    expect(screen.getByRole('button', { name: 'Custom table button' })).toBeInTheDocument();
-  });
-
-  it('falls back to title when tableTitle is missing in a table', async () => {
-    await render({
-      actions: [{ id: 'nextPage', type: 'ClientAction' }],
-      textResourceBindingsOverride: {
-        title: 'Custom button',
-      },
-      overrideDisplay: { renderedInTable: true },
-    });
-    expect(screen.getByRole('button', { name: 'Custom button' })).toBeInTheDocument();
-  });
 });
 
 type RenderProps = {
   actions?: CustomAction[];
   actionAuthorization?: IUserAction[];
-  textResourceBindingsOverride?: {
-    title?: string;
-    tableTitle?: string;
-  };
-  overrideDisplay?: PropsFromGenericComponent<'CustomButton'>['overrideDisplay'];
 };
 
-async function render(
-  { actions, actionAuthorization, textResourceBindingsOverride, overrideDisplay }: RenderProps = {
-    actionAuthorization: [],
-  },
-) {
+async function render({ actions, actionAuthorization }: RenderProps = { actionAuthorization: [] }) {
   jest.mocked(fetchProcessState).mockImplementation(async () => ({
     started: '2024-01-03T06:52:49.716640678Z',
     ended: null,
@@ -202,12 +169,8 @@ async function render(
     component: {
       textResourceBindings: {
         title: 'Custom button',
-        ...textResourceBindingsOverride,
       },
-      actions: actions ?? [],
-    },
-    genericProps: {
-      overrideDisplay,
+      actions,
     },
   });
 }

--- a/src/layout/CustomButton/CustomButtonComponent.tsx
+++ b/src/layout/CustomButton/CustomButtonComponent.tsx
@@ -194,10 +194,7 @@ function toShorthandSize(size?: CBTypes.CustomButtonSize): 'sm' | 'md' | 'lg' {
   }
 }
 
-export const CustomButtonComponent = ({
-  baseComponentId,
-  overrideDisplay,
-}: PropsFromGenericComponent<'CustomButton'>) => {
+export const CustomButtonComponent = ({ baseComponentId }: PropsFromGenericComponent<'CustomButton'>) => {
   const { textResourceBindings, actions, id, buttonColor, buttonSize, buttonStyle } = useItemWhenType(
     baseComponentId,
     'CustomButton',
@@ -232,11 +229,7 @@ export const CustomButtonComponent = ({
     interceptedButtonStyle = 'primary';
   }
 
-  const isInTable = overrideDisplay?.renderedInTable === true;
-
-  let buttonText = isInTable
-    ? (textResourceBindings?.tableTitle ?? textResourceBindings?.title)
-    : textResourceBindings?.title;
+  let buttonText = textResourceBindings?.title;
   if (isSubformCloseButton && !buttonText) {
     buttonText = 'general.done';
   }


### PR DESCRIPTION
## Description


  - Added `tertiary` property to custom button in a repeating group -table to give the user one more option for styling of the custom button and to to match with other buttons like edit and delete buttons. 
  - Added also `titelTabel` to custom button to have a descriptive text as the column title.
 
 NOTE-1: 
 After discussion we decided to not work on adding support for custom button icons in this PR.  This step can be fixed later because custom button can have may different icons and we need to think about this solution in a good way. 

NOTE-2:
I have tested for `tertiary` but we need also to test for `titelTabel`
## Related Issue(s)

- closes #2354 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new tertiary button style, providing an additional design option alongside primary and secondary styles
  * Added support for custom title text configuration for buttons rendered in table contexts

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->