### PR TITLE
Fixing auto-backport to use v4.25.0 as latest release

### DIFF
--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -26,7 +26,7 @@ jobs:
         id: find-release-branch
         run: |
           # Get the latest release from GitHub
-          LATEST_RELEASE_TAG=$(gh release list --limit 1 --exclude-pre-releases --exclude-drafts --json tagName --jq '.[0].tagName')
+          LATEST_RELEASE_TAG=$(gh release list --limit 10 --exclude-pre-releases --exclude-drafts --json tagName,publishedAt --jq 'sort_by(.publishedAt) | reverse | .[0].tagName')
 
           if [ -z "$LATEST_RELEASE_TAG" ]; then
             echo "No releases found"


### PR DESCRIPTION
## Description

The `gh release list` command sorts by when a release was created, not when it was published. This caused it to backport fixes to `v4.24.x` right now, instead of `v4.25.x`.

Example output from running `gh release list --limit 3 --exclude-pre-releases --exclude-drafts --json tagName,publishedAt,createdAt`:
```json
[
  {
    "createdAt": "2026-01-14T13:56:25Z",
    "publishedAt": "2026-01-14T13:59:00Z",
    "tagName": "v4.24.2"
  },
  {
    "createdAt": "2026-01-14T13:26:34Z",
    "publishedAt": "2026-01-15T13:28:55Z",
    "tagName": "v4.25.0"
  },
  {
    "createdAt": "2025-12-15T06:31:31Z",
    "publishedAt": "2025-12-15T08:03:08Z",
    "tagName": "v4.24.1"
  }
]
```

This problem happened because v4.24.2 was released after the draft-release for v4.25.0 was created.

This fix gets the last 10 releases and sorts them by published date first.

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release tag selection logic in automated workflows for better accuracy when managing multiple releases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->