### PR TITLE
PersonLookup: Inform user about lock-out duration

### DIFF
--- a/src/language/texts/en.ts
+++ b/src/language/texts/en.ts
@@ -340,7 +340,7 @@ export function en() {
     'person_lookup.validation_error_name_too_short': "The name can't be empty.",
     'person_lookup.validation_error_ssn': 'The national ID number/D-number is invalid.',
     'person_lookup.validation_error_not_found':
-      'No person is registered with this combination of national ID number/D-number and name. Please check the fields and try again. <br> Note: After 3 failed attempts, the search functionality will be temporarily locked.',
+      'No person is registered with this combination of national ID number/D-number and name. Please check the fields and try again. <br> Note: After 3 failed attempts, the search functionality may be temporarily locked.',
     'person_lookup.validation_error_too_many_requests':
       'Too many requests. You have been locked out of the search functionality for one hour. Please try again later.',
     'person_lookup.validation_error_forbidden':

--- a/src/language/texts/nb.ts
+++ b/src/language/texts/nb.ts
@@ -344,7 +344,7 @@ export function nb() {
     'person_lookup.validation_error_name_too_short': 'Etternavn kan ikke være tomt.',
     'person_lookup.validation_error_ssn': 'Fødselsnummeret/D-nummeret er ugyldig.',
     'person_lookup.validation_error_not_found':
-      'Ingen person er registrert med denne kombinasjonen av fødselsnummer/D-nummer og navn. Vennligst kontroller feltene og prøv igjen. <br> Merk: Etter 3 feilforsøk blir søkemuligheten midlertidig sperret.',
+      'Ingen person er registrert med denne kombinasjonen av fødselsnummer/D-nummer og navn. Vennligst kontroller feltene og prøv igjen. <br> Merk: Etter 3 feilforsøk kan søkemuligheten bli midlertidig sperret.',
     'person_lookup.validation_error_too_many_requests':
       'Du har nådd grensen for antall søk. Du har blitt utestengt fra søkefunksjonaliteten i en time. Vennligst prøv igjen senere.',
     'person_lookup.validation_error_forbidden':

--- a/src/language/texts/nn.ts
+++ b/src/language/texts/nn.ts
@@ -342,7 +342,7 @@ export function nn() {
     'person_lookup.validation_error_name_too_short': 'Etternamn kan ikkje vere tomt.',
     'person_lookup.validation_error_ssn': 'Fødselsnummeret/D-nummeret er ugyldig.',
     'person_lookup.validation_error_not_found':
-      'Ingen person er registrert med denne kombinasjonen av fødselsnummer/D-nummer og namn. Ver venleg og kontroller felta og prøv igjen. <br> Merk: Etter 3 feilforsøk blir søkemoglegheita mellombels sperra.',
+      'Ingen person er registrert med denne kombinasjonen av fødselsnummer/D-nummer og namn. Ver venleg og kontroller felta og prøv igjen. <br> Merk: Etter 3 feilforsøk kan søkemoglegheita bli mellombels sperra.',
     'person_lookup.validation_error_too_many_requests':
       'Du har gjort for mange søk. Du har blitt utestengt frå søkefunksjonaliteten i ein time. Ver venleg, prøv igjen seinare.',
     'person_lookup.validation_error_forbidden':

--- a/test/e2e/integration/component-library/personlookup.ts
+++ b/test/e2e/integration/component-library/personlookup.ts
@@ -72,7 +72,7 @@ describe('Person lookup component', () => {
       /Ingen person er registrert med denne kombinasjonen av fødselsnummer\/D-nummer og navn. Vennligst kontroller feltene og prøv igjen./i,
     ).should('exist');
 
-    cy.findByText(/Merk: Etter 3 feilforsøk blir søkemuligheten midlertidig sperret./i).should('exist');
+    cy.findByText(/Merk: Etter 3 feilforsøk kan søkemuligheten bli midlertidig sperret./i).should('exist');
 
     // Must be updated when backend returns better http status codes
     cy.intercept('POST', '/ttd/component-library/api/v1/lookup/person', {


### PR DESCRIPTION
## Description

Update the error messages to be more informative. 
Hard code as fetching from souce is over-engineering as these are not dynamic values. 

Docs is a screenshot of the component, which is why the doc issue is connected here.

## Related Issue(s)

- closes https://github.com/Altinn/altinn-studio-docs/issues/2643

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Revised person-lookup validation messages in supported languages: failed-attempt threshold lowered from 5 to 3 and wording changed to indicate the search may be temporarily locked.
  * Clarified lockout message to state a 1-hour temporary block.

* **Tests**
  * Updated end-to-end expectation to reflect the new 3-attempt threshold.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->