### PR TITLE
Fixes for `ttd/service-task` tests

### DIFF
--- a/test/e2e/integration/service-task/service-task.ts
+++ b/test/e2e/integration/service-task/service-task.ts
@@ -41,7 +41,7 @@ describe('Service task', () => {
         // a service task, so we can remove the custom layout-set here to simulate what happens in the PDF generator
         // for a PDF-generating service-task.
         const layoutSets: ILayoutSets = JSON.parse(res.body);
-        layoutSets.sets = layoutSets.sets.filter((set) => set.id !== 'Fail');
+        layoutSets.sets = layoutSets.sets.filter((set) => set.id !== 'SimulatedFailure');
         res.send(layoutSets);
       });
     }).as('LayoutSets');
@@ -86,7 +86,7 @@ function startAppAndFillToFailure() {
 
   cy.get('#subform-Subform-z8we7d-add-button').click();
   cy.get('#finishedLoading').should('exist');
-  cy.findByRole('textbox', { name: 'Subform tekstfelt' }).type('Lykkeønsker fra et underskjema');
+  cy.findByRole('textbox', { name: 'Test 1' }).type('Lykkeønsker fra et underskjema');
   cy.findByRole('button', { name: 'Ferdig' }).click();
 
   cy.findByRole('textbox', { name: 'En tekst i Task_Utfylling1' }).should(
@@ -135,7 +135,8 @@ function goBackAndAchieveSuccess() {
   cy.findByRole('button', { name: 'Neste' }).click();
 
   cy.findByText('Skjemaet er sendt inn').should('be.visible');
-  cy.findAllByRole('link', { name: /\.pdf$/ }).should('have.length', 2);
+  cy.findAllByRole('link', { name: /\.pdf$/ }).should('have.length', 3);
   cy.findByRole('link', { name: /Autogenerert PDF av Task_Utfylling1 og Task_Utfylling2\.pdf$/ }).should('be.visible');
   cy.findByRole('link', { name: /PDF basert på layout-set\.pdf$/ }).should('be.visible');
+  cy.findByRole('link', { name: /Subform pdf Lykkeønsker fra et underskjema\.pdf$/ }).should('be.visible');
 }


### PR DESCRIPTION
## Description

This updates e2e/Cypress tests to work with the changes in: https://altinn.studio/repos/ttd/service-task/pulls/1

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [x] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced end-to-end test coverage for service task workflows, including validation of PDF generation for subforms.
  * Updated test data and assertions to reflect current functionality and improve test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->