### PR TITLE
Empty/null cells were ignored in Summary2 and broke the table layout

### DIFF
--- a/src/layout/Grid/GridSummary.tsx
+++ b/src/layout/Grid/GridSummary.tsx
@@ -38,7 +38,6 @@ import { useHasCapability } from 'src/utils/layout/canRenderIn';
 import { useIndexedId } from 'src/utils/layout/DataModelLocation';
 import { useIsHidden } from 'src/utils/layout/hidden';
 import { useItemFor, useItemWhenType } from 'src/utils/layout/useNodeItem';
-import { typedBoolean } from 'src/utils/typing';
 import type {
   GridCell,
   GridCellLabelFrom,
@@ -197,7 +196,7 @@ function SummaryGridRowRenderer(props: GridRowProps) {
       hideWhen={hideEmptyRows}
       render={(className) => (
         <Table.Row className={cn(className, extraClassName)}>
-          {row.cells.filter(typedBoolean).map((cell, cellIdx) => (
+          {row.cells.map((cell, cellIdx) => (
             <SummaryCell
               key={cellIdx}
               cell={cell}

--- a/test/e2e/integration/component-library/grid.ts
+++ b/test/e2e/integration/component-library/grid.ts
@@ -21,4 +21,32 @@ describe('Grid summary test', () => {
 
     cy.visualTesting('grid-summary');
   });
+
+  it('Summary2 should render null-cells as empty strings', () => {
+    cy.gotoNavPage('Grid');
+
+    cy.changeLayout((component) => {
+      if (component.type === 'Grid' && component.id === 'grid-example-common-fields') {
+        let counter = 0;
+        for (const row of component.rows) {
+          for (const cellIdx in row.cells) {
+            const original = row.cells[cellIdx];
+            row.cells[cellIdx] = counter++ % 3 === 0 ? original : null;
+          }
+        }
+      }
+    });
+
+    // Asserts that all rows have the same amount of cells. There used to be a bug where the Summary2 table
+    // would just skip these cells when null, but that breaks the table visual.
+    const rows = [0, 1, 2, 3, 4];
+    cy.findByTestId('summary-grid-example-common-fields').find('tr').should('have.length', rows.length);
+    for (const rowIdx of rows) {
+      cy.findByTestId('summary-grid-example-common-fields')
+        .find('tr')
+        .eq(rowIdx)
+        .find('td,th')
+        .should('have.length', 5);
+    }
+  });
 });


### PR DESCRIPTION
## Description

Problem described here: https://digdir.slack.com/archives/C0760NPT2BE/p1769781823143779?thread_ts=1769779325.056329&cid=C0760NPT2BE

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Grid summary now renders all cells, including those with null or empty values, ensuring complete row display.

* **Tests**
  * Added end-to-end test validation for proper rendering of null cells in summary grids.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->