### PR TITLE
Improve shared expression tests

### DIFF
--- a/src/features/expressions/shared-functions.test.tsx
+++ b/src/features/expressions/shared-functions.test.tsx
@@ -162,7 +162,7 @@ function getAllTestCases(test: FunctionTest): FunctionTestBase[] {
 }
 
 function extractMainTestCase({ expression, expects, expectsFailure }: FunctionTest): FunctionTestBase | null {
-  return expression ? { expression, expects, expectsFailure } : null;
+  return expression === undefined ? null : { expression, expects, expectsFailure };
 }
 
 function clearGlobals(): void {


### PR DESCRIPTION
## Description
When the `testCases` property in the shared expression tests is set, all of the tests are run within the same `it` block. As a consequence, when one of them fails, it is not possible to see which one it is and why it fails. This pull request fixes that, so that each test case is run separately. It also moves some code into separate functions to make it more readable. Most of the changed lines in the diff are indeed just moved from another place.

We will need this when implementing the arithmetic operation functions.

## Related Issue(s)
- #1179

## Verification/QA
- Manual functionality testing
  - [x] I have tested these changes manually
- Automated tests
  - [x] No automatic tests are needed here (no functional changes/additions)
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [x] No testing done/necessary (no DOM/visual changes)
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [x] No functionality has been changed/added, so no documentation is needed
- Support in Altinn Studio
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Reworked the expressions test harness to be data-driven and modular, centralizing mock/setup helpers and test rendering orchestration to improve maintainability and clarity.
  * Adjusted TypeScript type imports and organization within tests (no runtime API changes).

---

Note: Internal test and typing improvements only; no changes to end-user functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->