### PR TITLE
Bug: Failed to wait for task validations

### DIFF
--- a/test/e2e/integration/frontend-test/process-next.ts
+++ b/test/e2e/integration/frontend-test/process-next.ts
@@ -1,7 +1,5 @@
 import { AppFrontend } from 'test/e2e/pageobjects/app-frontend';
 
-import type { IncomingApplicationMetadata } from 'src/features/applicationMetadata/types';
-
 const appFrontend = new AppFrontend();
 
 describe('Process/next', () => {
@@ -41,72 +39,5 @@ describe('Process/next', () => {
     cy.findByRole('button', { name: 'Send inn' }).click();
     cy.get(appFrontend.toast).should('contain.text', 'Noe gikk galt under innsendingen, prøv igjen om noen minutter');
     cy.findByRole('heading', { name: 'Ukjent feil' }).should('not.exist');
-  });
-
-  it('Task validations returned from process/next should be visible immediately', () => {
-    // Regression test: previously, UpdateShowAllErrors could turn off showAllBackendErrors immediately
-    // on its first render (when taskValidations was still empty in the zustand store), causing the
-    // error report to disappear before the task validations were actually rendered..
-    //
-    // This bug seemingly relied on two things:
-    // 1. That no data models are writable. A trick to achieve this is to make it seem there are no data models at all:
-    cy.intercept('GET', '**/applicationmetadata', (req) =>
-      req.reply((res) => {
-        const body = res.body as IncomingApplicationMetadata;
-        body.dataTypes = body.dataTypes.map((dt) => ({ ...dt, appLogic: undefined }));
-        res.send();
-      }),
-    );
-
-    // 2. That no components support validation. This is achieved by only having Button components in the layout.
-    cy.interceptLayout('message', undefined, (layoutSet) => {
-      layoutSet['neverDisplayed'] = { data: { layout: [] } };
-      layoutSet['taskChooser'] = { data: { layout: [] } };
-      layoutSet['formLayout'] = {
-        data: {
-          layout: [
-            {
-              id: 'submit',
-              type: 'Button',
-              textResourceBindings: {
-                title: 'Send inn',
-              },
-            },
-          ],
-        },
-      };
-
-      // Verify our assumptions about the layout, in case a new page is added later on
-      for (const pageKey of Object.keys(layoutSet)) {
-        const numOthers = layoutSet[pageKey].data.layout.filter((component) => component.type !== 'Button').length;
-        if (numOthers > 0) {
-          throw new Error(`Unexpected components on page ${pageKey}: ${numOthers}`);
-        }
-      }
-    });
-
-    cy.goto('message');
-
-    cy.intercept(
-      { method: 'PUT', url: '**/process/next*', times: 1 },
-      {
-        statusCode: 409,
-        body: {
-          validationIssues: [
-            {
-              severity: 1,
-              code: 'error',
-              description: 'task validation from process next',
-              source: 'Whatever',
-            },
-          ],
-        },
-      },
-    );
-
-    cy.findByRole('button', { name: 'Send inn' }).click();
-
-    // Error report should appear immediately, showing the task validation
-    cy.get(appFrontend.errorReport).should('contain.text', 'task validation from process next');
   });
 });

--- a/test/e2e/integration/signing-test/validation.ts
+++ b/test/e2e/integration/signing-test/validation.ts
@@ -1,0 +1,51 @@
+import { AppFrontend } from 'test/e2e/pageobjects/app-frontend';
+import { signingTestLogin } from 'test/e2e/support/apps/signing-test/signing-login';
+
+const appFrontend = new AppFrontend();
+
+describe('Validation', () => {
+  beforeEach(() => {
+    cy.intercept('**/active', []).as('noActiveInstances');
+  });
+
+  it('Task validations returned from process/next should be visible immediately', () => {
+    // Regression test for: waitForValidation() must ensure task validations are processed before
+    // returning. The manager's signing step is a natural test case because it has no writable data
+    // models and no components that support component-level validation, which are the conditions
+    // required to trigger the bug without any mocking of application metadata or layouts.
+
+    // Fill the form as accountant and submit to advance to the signing step
+    signingTestLogin('accountant');
+    cy.get(appFrontend.signingTest.incomeField).type('4567');
+    cy.get(appFrontend.signingTest.submitButton).click();
+    cy.get(appFrontend.signingTest.noAccessPanel).should('be.visible');
+
+    // Log in as manager, who lands on the signing step
+    signingTestLogin('manager');
+    cy.get(appFrontend.signingTest.managerConfirmPanel).should('be.visible');
+
+    // Intercept the signing process/next call to return a task validation error. This bug was specific to a signing
+    // task, as it did not happen when you have writable data models and/or components that support validation.
+    cy.intercept(
+      { method: 'PUT', url: '**/process/next*', times: 1 },
+      {
+        statusCode: 409,
+        body: {
+          validationIssues: [
+            {
+              severity: 1,
+              code: 'error',
+              description: 'task validation from process next',
+              source: 'Whatever',
+            },
+          ],
+        },
+      },
+    );
+
+    cy.get(appFrontend.signingTest.signingButton).click();
+
+    // Error report should appear immediately, showing the task validation
+    cy.get(appFrontend.errorReport).should('contain.text', 'task validation from process next');
+  });
+});


### PR DESCRIPTION
## Description

When submitting a form that has no writable data types at the current task step (e.g. a signing task), task-level validation errors returned by a 409 from `process/next` would never become visible to the user (or, the user would have to click twice to make them show up).

### Root cause

The submit flow calls `setShowAllBackendErrors()`, which first awaits `waitForValidation()` as a guard to ensure validation state is settled before turning on error visibility. However, `waitForValidation` has an early return when `useShouldValidateInitial()` is `false` (which is the case for any step without writable data types). This caused it to resolve immediately — before `BackendValidation` had a chance to react to the query cache update from `updateInitialValidations()` and write the task validations into the validation zustand store.

As a result, `UpdateShowAllErrors` would render with `showAllBackendErrors = true` but an empty `state.task`, conclude there were no errors, and immediately flip `showAllBackendErrors` back to `false` — all before the actual task validations arrived in the store.

### Fix

Even on the early-return path, `waitForValidation` now waits for `processedLast.initial` (the zustand store's record of what it last processed) to match `cachedInitialValidations` (the current React Query cache). This ensures `BackendValidation`'s effect has run and state.task is populated before `setShowAllBackendErrors(true)` is called — regardless of whether the app actively runs initial validation.

_(Note from a human: I'll leave in this snarky comment from Claude Code regarding my naiive attempt to work around this issue with a `setTimeout()` early on:)_ The previous workaround (a 1-second debounce on `setShowAllErrors(false)` in `UpdateShowAllErrors`) has been reverted since the race condition is now prevented at the source.

## Related Issue(s)

- https://digdir-samarbeid.slack.com/archives/C02EJ9HKQA3/p1773143677790279

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved validation processing reliability by ensuring backend validations are fully processed before the system proceeds, particularly in signing workflows and when validation is disabled.

* **Tests**
  * Added comprehensive end-to-end tests for validation behavior during signing workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->