### PR TITLE
Moved validationOnNavigation to globalPageSettings

### DIFF
--- a/src/codegen/Common.ts
+++ b/src/codegen/Common.ts
@@ -763,6 +763,7 @@ const common = {
           .setTitle('Task navigation settings')
           .setDescription('Shows the listed tasks in the sidebar navigation menu'),
       ),
+      new CG.prop('validationOnNavigation', CG.common('PageValidation').optional()),
     ),
   IPagesBaseSettings: () =>
     new CG.obj(
@@ -853,7 +854,6 @@ const common = {
           .setTitle('Layout sets')
           .setDescription('List of layout sets for different data types'),
       ),
-      new CG.prop('validationOnNavigation', CG.common('PageValidation').optional()),
       new CG.prop('uiSettings', CG.common('GlobalPageSettings').optional()),
     )
       .setTitle('Layout sets')

--- a/src/features/form/layoutSets/LayoutSetsProvider.tsx
+++ b/src/features/form/layoutSets/LayoutSetsProvider.tsx
@@ -64,8 +64,3 @@ export const useLaxGlobalUISettings = () => {
   const layoutSets = useLaxCtx();
   return layoutSets !== ContextNotProvided ? layoutSets.uiSettings : ContextNotProvided;
 };
-
-export const useLaxLayoutSetsPageValidation = () => {
-  const layoutSets = useLaxCtx();
-  return layoutSets !== ContextNotProvided ? layoutSets.validationOnNavigation : ContextNotProvided;
-};

--- a/src/features/form/layoutSettings/LayoutSettingsContext.tsx
+++ b/src/features/form/layoutSettings/LayoutSettingsContext.tsx
@@ -7,19 +7,11 @@ import { useAppQueries } from 'src/core/contexts/AppQueriesProvider';
 import { ContextNotProvided } from 'src/core/contexts/context';
 import { delayedContext } from 'src/core/contexts/delayedContext';
 import { createQueryContext } from 'src/core/contexts/queryContext';
-import {
-  useLaxGlobalUISettings,
-  useLaxLayoutSetsPageValidation,
-} from 'src/features/form/layoutSets/LayoutSetsProvider';
+import { useLaxGlobalUISettings } from 'src/features/form/layoutSets/LayoutSetsProvider';
 import { useLayoutSetIdFromUrl } from 'src/features/form/layoutSets/useCurrentLayoutSet';
 import { useShallowMemo } from 'src/hooks/useShallowMemo';
 import type { QueryDefinition } from 'src/core/queries/usePrefetchQuery';
-import type {
-  GlobalPageSettings,
-  ILayoutSettings,
-  NavigationPageGroup,
-  PageValidation,
-} from 'src/layout/common.generated';
+import type { GlobalPageSettings, ILayoutSettings, NavigationPageGroup } from 'src/layout/common.generated';
 
 // Also used for prefetching @see formPrefetcher.ts
 export function useLayoutSettingsQueryDef(layoutSetId?: string): QueryDefinition<ProcessedLayoutSettings> {
@@ -78,8 +70,8 @@ function processData(settings: ILayoutSettings | null): ProcessedLayoutSettings 
       showLanguageSelector: settings.pages.showLanguageSelector,
       showProgress: settings.pages.showProgress,
       taskNavigation: settings.pages.taskNavigation?.map((g) => ({ ...g, id: uuidv4() })),
+      validationOnNavigation: settings.pages.validationOnNavigation,
     }),
-    validationOnNavigation: settings.pages.validationOnNavigation,
     pdfLayoutName: settings.pages.pdfLayoutName,
   };
 }
@@ -105,7 +97,6 @@ interface ProcessedLayoutSettings {
   order: string[];
   groups?: NavigationPageGroup[];
   pageSettings: GlobalPageSettings;
-  validationOnNavigation?: PageValidation;
   pdfLayoutName?: string;
 }
 
@@ -131,7 +122,7 @@ export const usePageGroups = () => {
 
 const emptyArray = [];
 
-const defaults: Required<GlobalPageSettings> = {
+const defaults: Omit<Required<GlobalPageSettings>, 'validationOnNavigation'> = {
   hideCloseButton: false,
   showLanguageSelector: false,
   showProgress: false,
@@ -141,17 +132,8 @@ const defaults: Required<GlobalPageSettings> = {
   taskNavigation: [],
 };
 
-export const useValidationOnNavigation = (): PageValidation | undefined => {
-  const layoutSettings = useLaxCtx();
-  const layoutSetsPageValidation = useLaxLayoutSetsPageValidation();
-
-  const settingsValidation = layoutSettings !== ContextNotProvided ? layoutSettings.validationOnNavigation : undefined;
-  const layoutSetsValidation = layoutSetsPageValidation !== ContextNotProvided ? layoutSetsPageValidation : undefined;
-
-  return layoutSetsValidation ?? settingsValidation;
-};
-
-export const usePageSettings = (): Required<GlobalPageSettings> => {
+export const usePageSettings = (): Required<Omit<GlobalPageSettings, 'validationOnNavigation'>> &
+  Pick<GlobalPageSettings, 'validationOnNavigation'> => {
   const globalUISettings = useLaxGlobalUISettings();
   const layoutSettings = useLaxCtx();
 

--- a/src/features/navigation/utils.ts
+++ b/src/features/navigation/utils.ts
@@ -12,11 +12,7 @@ import {
 import { ContextNotProvided } from 'src/core/contexts/context';
 import { useIsReceiptPage } from 'src/core/routing/useIsReceiptPage';
 import { useLayoutCollection } from 'src/features/form/layout/LayoutsContext';
-import {
-  usePageGroups,
-  usePageSettings,
-  useValidationOnNavigation,
-} from 'src/features/form/layoutSettings/LayoutSettingsContext';
+import { usePageGroups, usePageSettings } from 'src/features/form/layoutSettings/LayoutSettingsContext';
 import { useGetAltinnTaskType } from 'src/features/instance/useProcessQuery';
 import { ValidationMask } from 'src/features/validation';
 import { getVisibilityMask } from 'src/features/validation/utils';
@@ -24,7 +20,7 @@ import { useNavigationParam } from 'src/hooks/navigation';
 import { useNavigatePage, useVisitedPages } from 'src/hooks/useNavigatePage';
 import { useHiddenPages } from 'src/utils/layout/hidden';
 import { NodesInternal } from 'src/utils/layout/NodesContext';
-import type { NavigationReceipt, NavigationTask, PageValidation } from 'src/layout/common.generated';
+import type { NavigationReceipt, NavigationTask } from 'src/layout/common.generated';
 
 export function useHasGroupedNavigation() {
   const pageGroups = usePageGroups();
@@ -162,7 +158,7 @@ export function useValidationsForPages(order: string[], shouldMarkWhenCompleted 
 export function useGetNavigationIsPrevented() {
   const currentPageId = useNavigationParam('pageKey') ?? '';
   const layoutCollection = useLayoutCollection();
-  const globalValidationOnNavigation = useValidationOnNavigation();
+  const globalValidationOnNavigation = usePageSettings().validationOnNavigation;
   const { order } = useNavigatePage();
   const validationsSelector = NodesInternal.useLaxValidationsSelector();
   const allNodeIds = NodesInternal.useLaxMemoSelector((state) => {
@@ -184,15 +180,14 @@ export function useGetNavigationIsPrevented() {
     }
 
     return order.slice(currentIndex + 1, targetIndex).some((pageId) => {
-      const config =
-        globalValidationOnNavigation ??
-        (layoutCollection[pageId]?.data?.validationOnNavigation as PageValidation | undefined);
+      const validationOnNavigation =
+        layoutCollection[pageId]?.data?.validationOnNavigation ?? globalValidationOnNavigation;
 
-      if (!config) {
+      if (!validationOnNavigation) {
         return false;
       }
 
-      const mask = getVisibilityMask(config.show);
+      const mask = getVisibilityMask(validationOnNavigation.show);
       return (allNodeIds[pageId] ?? []).some((nodeId) => {
         const validations = validationsSelector(nodeId, mask, 'error');
         return validations !== ContextNotProvided && validations.length > 0;

--- a/src/hooks/usePageValidation.ts
+++ b/src/hooks/usePageValidation.ts
@@ -1,14 +1,14 @@
 import { useMemo } from 'react';
 
 import { useLayoutCollection, useLayoutLookups } from 'src/features/form/layout/LayoutsContext';
-import { useValidationOnNavigation } from 'src/features/form/layoutSettings/LayoutSettingsContext';
+import { usePageSettings } from 'src/features/form/layoutSettings/LayoutSettingsContext';
 import type { ILayoutFile, PageValidation } from 'src/layout/common.generated';
 
 export function useEffectivePageValidation(pageKey: string): {
   getPageValidation: () => PageValidation | undefined;
 } {
   const layoutCollection = useLayoutCollection();
-  const effectivePageValidation = useValidationOnNavigation();
+  const effectivePageValidation = usePageSettings().validationOnNavigation;
 
   return useMemo(() => {
     if (!pageKey) {
@@ -18,7 +18,7 @@ export function useEffectivePageValidation(pageKey: string): {
     const pageValidation = currentPageLayout?.data
       ?.validationOnNavigation as ILayoutFile['data']['validationOnNavigation'];
 
-    const validationOnNavigation = effectivePageValidation ?? pageValidation;
+    const validationOnNavigation = pageValidation ?? effectivePageValidation;
 
     return {
       getPageValidation: () => validationOnNavigation,


### PR DESCRIPTION
## Description
Moved validationOnNavigation into GlobalPageSettings in Common.ts. This means it is now part of the standard page settings hierarchy and will be automatically supported in NEXT, where uiSettings from layout-sets.json moves to App/ui/Settings.json).

By being part of GlobalPageSettings, the setting is automatically handled by usePageSettings(): layout-set-specific Settings.json overrides the global layout-sets.json uiSettings.

Fixed the override priority for validationOnNavigation in useGetNavigationIsPrevented — page-specific configuration now correctly takes precedence over the global setting, instead of the other way around.

Override hierarchy (highest to lowest priority)
Individual page layout file (data.validationOnNavigation)
Layout-set Settings.json (pages.validationOnNavigation)
Global layout-sets.json uiSettings (validationOnNavigation)

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [x] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->
