### PR TITLE
Expression validation: Keep running when values are `undefined` or `null`

### DIFF
--- a/src/features/formData/FormDataWrite.test.ts
+++ b/src/features/formData/FormDataWrite.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { selectAllPaths } from 'src/features/formData/FormDataWrite';
+import type { FormDataContext } from 'src/features/formData/FormDataWriteStateMachine';
+
+const dataType = 'default';
+
+function makeContext(formData?: object): FormDataContext {
+  return {
+    dataModels: formData
+      ? {
+          [dataType]: {
+            debouncedCurrentData: formData,
+          },
+        }
+      : {},
+  } as FormDataContext;
+}
+
+describe('selectAllPaths', () => {
+  function testSelectAllPaths(field: string, noRepGroup: boolean, formData: object) {
+    return selectAllPaths({ dataType, field }, noRepGroup)(makeContext(formData));
+  }
+
+  it('returns an empty array when there is no reference', () => {
+    expect(selectAllPaths(undefined, false)(makeContext({ person: { name: 'Ada' } }))).toEqual([]);
+  });
+
+  it('returns the raw field when noRepGroup is set', () => {
+    expect(testSelectAllPaths('person.name', true, {})).toEqual(['person.name']);
+  });
+
+  it('finds a path in a regular nested object', () => {
+    const formData = {
+      person: {
+        address: {
+          street: 'Karl Johans gate',
+        },
+      },
+    };
+
+    expect(testSelectAllPaths('person.address.street', false, formData)).toEqual(['person.address.street']);
+  });
+
+  it('finds all matching paths across repeating groups', () => {
+    const formData = {
+      person: [{ name: 'Ada' }, { name: 'Bob' }, { name: 'Cleo' }],
+    };
+
+    expect(testSelectAllPaths('person.name', false, formData)).toEqual([
+      'person[0].name',
+      'person[1].name',
+      'person[2].name',
+    ]);
+  });
+
+  it('finds matching paths in nested repeating groups and includes missing values', () => {
+    const formData = {
+      groups: [
+        { members: [{ id: 'a' }, { id: 'b' }] },
+        { members: null },
+        {},
+        { members: [{}, { id: null }, { id: 'c' }] },
+      ],
+    };
+
+    expect(testSelectAllPaths('groups.members.id', false, formData)).toEqual([
+      'groups[0].members[0].id',
+      'groups[0].members[1].id',
+      'groups[3].members[0].id',
+      'groups[3].members[1].id',
+      'groups[3].members[2].id',
+    ]);
+  });
+
+  it('returns an empty array when the data model is missing', () => {
+    expect(testSelectAllPaths('person.name', false, {})).toEqual([]);
+  });
+});

--- a/src/features/formData/FormDataWrite.tsx
+++ b/src/features/formData/FormDataWrite.tsx
@@ -685,7 +685,7 @@ function collectMatchingFieldPaths(
   }
 
   const part = fieldParts[partIndex];
-  if (typeof data !== 'object' || data === null || data[part] === undefined || data[part] === null) {
+  if (typeof data !== 'object' || data === null) {
     return;
   }
 
@@ -699,6 +699,29 @@ function collectMatchingFieldPaths(
   } else {
     collectMatchingFieldPaths(nextData, fieldParts, nextPath, partIndex + 1, results);
   }
+}
+
+export function selectAllPaths(reference: IDataModelReference | undefined, noRepGroup: boolean | undefined) {
+  return (v: FormDataContext) => {
+    if (!reference) {
+      return emptyArray;
+    }
+
+    if (noRepGroup) {
+      return [reference.field];
+    }
+
+    // If lookupTool is not available (e.g., in tests), or if there's a missingRepeatingGroup error,
+    // we need to check the actual data to find all matching paths.
+    const formData = v.dataModels[reference.dataType]?.debouncedCurrentData;
+    if (!formData) {
+      return [];
+    }
+
+    const paths: string[] = [];
+    collectMatchingFieldPaths(formData, reference.field.split('.'), '', 0, paths);
+    return paths.sort();
+  };
 }
 
 const currentSelector = (reference: IDataModelReference) => (state: FormDataContext) =>
@@ -831,29 +854,14 @@ export const FD = {
     const lookupTool = DataModels.useLookupBinding();
     const [, lookupErr] = (reference ? lookupTool?.(reference) : undefined) ?? [undefined, undefined];
 
-    return useShallowSelector((v) => {
-      if (!reference) {
-        return emptyArray;
-      }
+    // When lookupTool is available and doesn't report a missing repeating group error, we know there's no
+    // repeating group structure in this path, so we can return the field as-is.
+    const noRepGroup =
+      lookupTool &&
+      (!lookupErr || lookupErr.error !== 'missingProperty') &&
+      (!lookupErr || lookupErr.error !== 'missingRepeatingGroup');
 
-      // When lookupTool is available and doesn't report a missing repeating group error, we know there's no
-      // repeating group structure in this path, so we can return the field as-is.
-      const foundInDataModel = lookupTool && (!lookupErr || lookupErr.error !== 'missingProperty');
-      if (foundInDataModel && lookupErr?.error !== 'missingRepeatingGroup') {
-        return [reference?.field];
-      }
-
-      // If lookupTool is not available (e.g., in tests), or if there's a missingRepeatingGroup error,
-      // we need to check the actual data to find all matching paths.
-      const formData = v.dataModels[reference.dataType]?.debouncedCurrentData;
-      if (!formData) {
-        return [];
-      }
-
-      const paths: string[] = [];
-      collectMatchingFieldPaths(formData, reference.field.split('.'), '', 0, paths);
-      return paths.sort();
-    });
+    return useShallowSelector(selectAllPaths(reference, noRepGroup));
   },
 
   /**


### PR DESCRIPTION
## Description

In #3735 the expression validation system was refactored and introduced a way to find all the valid/specific paths for a data model binding, i.e. find every row in repeating group structures and outputting all the valid full paths inside. This included a check for null/undefined which seemed smart, but it caused problems as expression validation would simply not run when a value was cleared by the user - so older expression validations would linger. See the referenced thread for a reproduction.

## Related Issue(s)

- https://digdir-samarbeid.slack.com/archives/C02EJ9HKQA3/p1773822005363639

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for form field path selection across nested structures, repeating groups, and edge cases with missing values.

* **Chores**
  * Refactored internal form data path resolution logic to reduce duplication and centralize decision-making for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->