### PR TITLE
fix: Remove implicit hidden state for onlyTable when editInTable is false

### DIFF
--- a/src/layout/RepeatingGroup/index.tsx
+++ b/src/layout/RepeatingGroup/index.tsx
@@ -147,16 +147,11 @@ export class RepeatingGroup extends RepeatingGroupDef implements ValidateCompone
     // It's most likely done by mistake, but we still need to respect it when checking if the component is hidden,
     // because it doesn't make sense to validate a component that is hidden in the UI and the
     // user cannot interact with.
-    let hiddenImplicitly =
+    const hiddenImplicitly =
       tableColSetup?.showInExpandedEdit === false &&
       !tableColSetup?.editInTable &&
       mode !== 'onlyTable' &&
       mode !== 'showAll';
-
-    if (mode === 'onlyTable' && tableColSetup?.editInTable === false) {
-      // This is also a way to hide a component implicitly
-      hiddenImplicitly = true;
-    }
 
     // TODO: Comment this in. It will be a breaking change, and may break some
     // apps (for example the PDF view in ssb/ra0760-01) which rely on this.

--- a/test/e2e/integration/frontend-test/validation.ts
+++ b/test/e2e/integration/frontend-test/validation.ts
@@ -497,7 +497,7 @@ describe('Validation', () => {
 
     cy.changeLayout((component) => {
       if (component.type === 'RepeatingGroup' && component.id === 'mainGroup' && component.tableColumns) {
-        // Components that are not editable in the table, when using the 'onlyTable' mode, are implicitly hidden
+        // Components with editInTable: false in onlyTable mode are shown as read-only cells are still visible and validated.
         component.tableColumns.currentValue.editInTable = false;
       }
     });
@@ -509,7 +509,7 @@ describe('Validation', () => {
     cy.get(appFrontend.group.row(2).currentValue).should('not.exist');
     cy.findByRole('button', { name: /Neste/ }).click();
     cy.navPage('repeating').should('have.attr', 'aria-current', 'page');
-    cy.get(appFrontend.errorReport).findAllByRole('listitem').should('have.length', 1);
+    cy.get(appFrontend.errorReport).findAllByRole('listitem').should('have.length', 2);
     cy.get(appFrontend.errorReport).findByText('Du må fylle ut 2. endre verdi til').click();
     cy.get(appFrontend.group.row(2).newValue).should('be.focused');
 


### PR DESCRIPTION
## Description
Summary and Summary2 now show uneditable columns in repeating group with the mode "onlyTable".

The only side effect of removing this if statement is that these components will now be validated. This is the correct behavior since they are visible. If a field is marked as `"required": true` but the user cannot edit it, a validation error will occur if no value is provided. This is expected behavior, as it indicates a misconfiguration. 
We should consider wether this could be a breaking change for any apps?

Related issue: #4073 
<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected item visibility logic in repeating group components to properly respect configuration settings in certain editing modes, ensuring items display as intended rather than being unnecessarily hidden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->