### PR TITLE
Commit hook: Warn about files with significant changes in next

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,5 @@
 
 cd "$(dirname -- "$0")"
 cd ../
+sh .husky/pre-commit-check-monorepo-paths
 npx lint-staged

--- a/.husky/pre-commit-check-monorepo-paths
+++ b/.husky/pre-commit-check-monorepo-paths
@@ -13,28 +13,51 @@ fi
 
 [ -z "$MONOREPO_PATHS" ] && exit 0
 
-# Get staged files
-STAGED_FILES=$(git diff --cached --name-only)
+# Get staged files, excluding yarn.lock
+STAGED_FILES=$(git diff --cached --name-only | grep -v 'yarn\.lock')
 [ -z "$STAGED_FILES" ] && exit 0
 
 # Check staged files against each monorepo path (substring match)
-MATCHING_FILE=""
+MATCHING_FILES=""
 
 while IFS= read -r monorepo_path; do
   [ -z "$monorepo_path" ] && continue
 
-  match=$(printf '%s\n' "$STAGED_FILES" | grep -F "$monorepo_path" | head -1)
-  if [ -n "$match" ]; then
-    MATCHING_FILE="$match"
-    break
+  matches=$(printf '%s\n' "$STAGED_FILES" | grep -F "$monorepo_path")
+  if [ -n "$matches" ]; then
+    while IFS= read -r match; do
+      case "$MATCHING_FILES" in
+        *"$match"*) ;;
+        *) MATCHING_FILES="${MATCHING_FILES}${match}
+"
+        ;;
+      esac
+    done << MATCHES
+$matches
+MATCHES
   fi
 done << EOF
 $MONOREPO_PATHS
 EOF
 
-if [ -n "$MATCHING_FILE" ]; then
+if [ -n "$MATCHING_FILES" ]; then
   echo ""
-  echo "ERROR: You're changing a file ($MATCHING_FILE) that has been significantly changed/refactored in the monorepo (our next major version). Make sure you have a plan for how to integrate these changes in the next major version, always add tests for the functionality you are changing, and ask in #task-force-frontend-next on Slack if unsure. Try committing again without running git hooks to skip this error message."
+  echo "ERROR: You're changing files that have been significantly changed/refactored"
+  echo "in the monorepo (our next major version):"
+  echo ""
+  while IFS= read -r file; do
+    [ -z "$file" ] && continue
+    echo "  $file"
+  done << FILES
+$MATCHING_FILES
+FILES
+  echo ""
+  echo "Make sure you have a plan for how to integrate these changes in the next major version,"
+  echo "always add tests for the functionality you are changing, and ask in"
+  echo "#task-force-frontend-next on Slack if unsure."
+  echo ""
+  echo "To skip this check, commit without hooks:"
+  echo "  git commit --no-verify"
   echo ""
   exit 1
 fi

--- a/.husky/pre-commit-check-monorepo-paths
+++ b/.husky/pre-commit-check-monorepo-paths
@@ -1,0 +1,42 @@
+#!/usr/bin/env sh
+
+MONOREPO_PATHS_URL="https://raw.githubusercontent.com/Altinn/altinn-studio/refs/heads/main/src/App/frontend/monorepo-changed-paths.txt"
+
+# Try to fetch the file (5 second timeout, fail silently if unavailable)
+if command -v curl > /dev/null 2>&1; then
+  MONOREPO_PATHS=$(curl -sf --max-time 5 "$MONOREPO_PATHS_URL" 2>/dev/null)
+elif command -v wget > /dev/null 2>&1; then
+  MONOREPO_PATHS=$(wget -qO- --timeout=5 "$MONOREPO_PATHS_URL" 2>/dev/null)
+else
+  exit 0
+fi
+
+[ -z "$MONOREPO_PATHS" ] && exit 0
+
+# Get staged files
+STAGED_FILES=$(git diff --cached --name-only)
+[ -z "$STAGED_FILES" ] && exit 0
+
+# Check staged files against each monorepo path (substring match)
+MATCHING_FILE=""
+
+while IFS= read -r monorepo_path; do
+  [ -z "$monorepo_path" ] && continue
+
+  match=$(printf '%s\n' "$STAGED_FILES" | grep -F "$monorepo_path" | head -1)
+  if [ -n "$match" ]; then
+    MATCHING_FILE="$match"
+    break
+  fi
+done << EOF
+$MONOREPO_PATHS
+EOF
+
+if [ -n "$MATCHING_FILE" ]; then
+  echo ""
+  echo "ERROR: You're changing a file ($MATCHING_FILE) that has been significantly changed/refactored in the monorepo (our next major version). Make sure you have a plan for how to integrate these changes in the next major version, always add tests for the functionality you are changing, and ask in #task-force-frontend-next on Slack if unsure. Try committing again without running git hooks to skip this error message."
+  echo ""
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Description

This adds a commit hook that prevents commits/warns about commits that touch files we know has been changed significantly in the monorepo. Changes in places like this should be coordinated properly, as we'll otherwise just get merge conflicts that will become more difficult to resolve the longer we've been working on the code in 'next'.

## Related Issue(s)

- closes https://github.com/Altinn/altinn-studio/issues/17637

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced pre-commit validation to enforce monorepo path constraints, ensuring code changes align with repository structure guidelines before allowing commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->