### PR TITLE
fix: fixed contrast between border and backgrund

### DIFF
--- a/src/app-components/Dropzone/Dropzone.module.css
+++ b/src/app-components/Dropzone/Dropzone.module.css
@@ -10,7 +10,7 @@
   justify-content: center;
   padding: var(--ds-size-7);
   border-width: 2px;
-  border-color: var(--colors-primary-blue);
+  border-color: var(--ds-color-border-strong);
   border-style: dotted;
   cursor: pointer;
   background: transparent;
@@ -18,8 +18,8 @@
 
 .fileUploadInvalid:focus {
   border-style: solid !important;
-  outline-color: #e23b53 !important;
-  border-color: #e23b53 !important;
+  outline-color: var(--ds-color-danger-border-default) !important;
+  border-color: var(--ds-color-danger-border-default) !important;
 }
 
 .fileUpload:hover {

--- a/src/layout/FileUpload/FileUploadComponent.tsx
+++ b/src/layout/FileUpload/FileUploadComponent.tsx
@@ -153,7 +153,9 @@ export function FileUploadComponent({
 
                 <b id={dragLabelId}>
                   {mobileView ? (
-                    <Lang id='form_filler.file_uploader_upload' />
+                    <span className={cn(classes.blueUnderLine)}>
+                      <Lang id='form_filler.file_uploader_upload' />
+                    </span>
                   ) : (
                     <>
                       <Lang id='form_filler.file_uploader_drag' />

--- a/src/layout/ImageUpload/ImageDropzone.tsx
+++ b/src/layout/ImageUpload/ImageDropzone.tsx
@@ -40,7 +40,9 @@ export function ImageDropzone({ baseComponentId, hasErrors, readOnly, onDrop, dr
       <div className={classes.dropZone}>
         <b id={dragLabelId}>
           {isMobile ? (
-            <Lang id='form_filler.file_uploader_upload' />
+            <span className={classes.underLine}>
+              <Lang id='form_filler.file_uploader_upload' />
+            </span>
           ) : (
             <>
               <Lang id='form_filler.file_uploader_drag' />


### PR DESCRIPTION
## Description

<img width="1519" height="585" alt="Screenshot 2026-04-14 at 14 46 55" src="https://github.com/user-attachments/assets/78887b14-bcc3-41bc-8298-d40e7d26386a" />


## Related Issue(s)

- closes #4004 

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Switched file upload borders and invalid-focus colors to design system variables for consistent theming and improved accessibility.
  * Ensured upload action text is underlined on mobile/tablet for clearer tappable affordance and consistent visual behavior with desktop.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->