### PR TITLE
fix: fixed disappeared table title

### DIFF
--- a/src/layout/RepeatingGroup/Table/RepeatingGroupTable.test.tsx
+++ b/src/layout/RepeatingGroup/Table/RepeatingGroupTable.test.tsx
@@ -149,7 +149,13 @@ describe('RepeatingGroupTable', () => {
     });
 
     it('should keep table header visible when editing a single row', async () => {
-      await render(undefined, {
+      const groupWithEditInTableAndStickyHeader = getFormLayoutRepeatingGroupMock({
+        id: 'mock-container-id',
+        stickyHeader: true,
+        tableColumns: { field1: { editInTable: true } },
+      });
+
+      await render(getLayout(groupWithEditInTableAndStickyHeader, components), {
         'some-group': [{ [ALTINN_ROW_ID]: uuidv4(), checkBoxBinding: 'option.value', prop1: 'test row 0' }],
       });
       expect(document.getElementById('group-mock-container-id-table-header')).toBeInTheDocument();

--- a/src/layout/RepeatingGroup/Table/RepeatingGroupTable.test.tsx
+++ b/src/layout/RepeatingGroup/Table/RepeatingGroupTable.test.tsx
@@ -174,7 +174,7 @@ describe('RepeatingGroupTable', () => {
       });
 
       await render(getLayout(groupWithEditInTableAndStickyHeader, components), {
-        'some-group': [{ [ALTINN_ROW_ID]: uuidv4(), checkBoxBinding: 'option.value', prop1: 'test row 0' }],
+        'some-group': [{ [ALTINN_ROW_ID]: uuidv4(), checkboxBinding: 'option.value', prop1: 'test row 0' }],
       });
       expect(document.getElementById('group-mock-container-id-table-header')).toBeInTheDocument();
       await userEvent.click(screen.getAllByRole('button', { name: /rediger/i })[0]);
@@ -189,7 +189,7 @@ describe('RepeatingGroupTable', () => {
       });
 
       await render(getLayout(groupWithoutEditInTable, components), {
-        'some-group': [{ [ALTINN_ROW_ID]: uuidv4(), checkBoxBinding: 'option.value', prop1: 'test row 0' }],
+        'some-group': [{ [ALTINN_ROW_ID]: uuidv4(), checkboxBinding: 'option.value', prop1: 'test row 0' }],
       });
 
       expect(document.getElementById('group-mock-container-id-table-header')).toBeInTheDocument();
@@ -337,10 +337,10 @@ describe('RepeatingGroupTable', () => {
     layout = getLayout(group, components),
     formData: Record<string, unknown> = {
       'some-group': [
-        { [ALTINN_ROW_ID]: uuidv4(), checkBoxBinding: 'option.value', prop1: 'test row 0' },
-        { [ALTINN_ROW_ID]: uuidv4(), checkBoxBinding: 'option.value', prop1: 'test row 1' },
-        { [ALTINN_ROW_ID]: uuidv4(), checkBoxBinding: 'option.value', prop1: 'test row 2' },
-        { [ALTINN_ROW_ID]: uuidv4(), checkBoxBinding: 'option.value', prop1: 'test row 3' },
+        { [ALTINN_ROW_ID]: uuidv4(), checkboxBinding: 'option.value', prop1: 'test row 0' },
+        { [ALTINN_ROW_ID]: uuidv4(), checkboxBinding: 'option.value', prop1: 'test row 1' },
+        { [ALTINN_ROW_ID]: uuidv4(), checkboxBinding: 'option.value', prop1: 'test row 2' },
+        { [ALTINN_ROW_ID]: uuidv4(), checkboxBinding: 'option.value', prop1: 'test row 3' },
       ],
     },
     extraTextResources: { id: string; value: string }[] = [],

--- a/src/layout/RepeatingGroup/Table/RepeatingGroupTable.test.tsx
+++ b/src/layout/RepeatingGroup/Table/RepeatingGroupTable.test.tsx
@@ -148,6 +148,16 @@ describe('RepeatingGroupTable', () => {
       expect(screen.getByTestId('editIndex')).toHaveTextContent('0');
     });
 
+    it('should keep table header visible when editing a single row', async () => {
+      await render(undefined, {
+        'some-group': [{ [ALTINN_ROW_ID]: uuidv4(), checkBoxBinding: 'option.value', prop1: 'test row 0' }],
+      });
+      expect(document.getElementById('group-mock-container-id-table-header')).toBeInTheDocument();
+      await userEvent.click(screen.getAllByRole('button', { name: /rediger/i })[0]);
+      expect(screen.getByTestId('editIndex')).toHaveTextContent('0');
+      expect(document.getElementById('group-mock-container-id-table-header')).toBeInTheDocument();
+    });
+
     it('should render EditableCell when editInTable is enabled for a column', async () => {
       const groupWithEditInTable = getFormLayoutRepeatingGroupMock({
         id: 'mock-container-id',
@@ -242,7 +252,17 @@ describe('RepeatingGroupTable', () => {
     });
   });
 
-  const render = async (layout = getLayout(group, components)) =>
+  const render = async (
+    layout = getLayout(group, components),
+    formData: Record<string, unknown> = {
+      'some-group': [
+        { [ALTINN_ROW_ID]: uuidv4(), checkBoxBinding: 'option.value', prop1: 'test row 0' },
+        { [ALTINN_ROW_ID]: uuidv4(), checkBoxBinding: 'option.value', prop1: 'test row 1' },
+        { [ALTINN_ROW_ID]: uuidv4(), checkBoxBinding: 'option.value', prop1: 'test row 2' },
+        { [ALTINN_ROW_ID]: uuidv4(), checkBoxBinding: 'option.value', prop1: 'test row 3' },
+      ],
+    },
+  ) =>
     await renderWithInstanceAndLayout({
       renderer: (
         <RepeatingGroupProvider baseComponentId={group.id}>
@@ -273,14 +293,7 @@ describe('RepeatingGroupTable', () => {
             },
           ],
         }),
-        fetchFormData: async () => ({
-          'some-group': [
-            { [ALTINN_ROW_ID]: uuidv4(), checkBoxBinding: 'option.value', prop1: 'test row 0' },
-            { [ALTINN_ROW_ID]: uuidv4(), checkBoxBinding: 'option.value', prop1: 'test row 1' },
-            { [ALTINN_ROW_ID]: uuidv4(), checkBoxBinding: 'option.value', prop1: 'test row 2' },
-            { [ALTINN_ROW_ID]: uuidv4(), checkBoxBinding: 'option.value', prop1: 'test row 3' },
-          ],
-        }),
+        fetchFormData: async () => formData,
       },
     });
 });

--- a/src/layout/RepeatingGroup/Table/RepeatingGroupTable.test.tsx
+++ b/src/layout/RepeatingGroup/Table/RepeatingGroupTable.test.tsx
@@ -166,7 +166,7 @@ describe('RepeatingGroupTable', () => {
       expect(screen.getByTestId('editIndex')).toHaveTextContent('0');
     });
 
-    it('should keep table header visible when editing a single row', async () => {
+    it('should keep table header visible when editing a single row with editInTable', async () => {
       const groupWithEditInTableAndStickyHeader = getFormLayoutRepeatingGroupMock({
         id: 'mock-container-id',
         stickyHeader: true,
@@ -180,6 +180,22 @@ describe('RepeatingGroupTable', () => {
       await userEvent.click(screen.getAllByRole('button', { name: /rediger/i })[0]);
       expect(screen.getByTestId('editIndex')).toHaveTextContent('0');
       expect(document.getElementById('group-mock-container-id-table-header')).toBeInTheDocument();
+    });
+
+    it('should hide table header when editing a single row without editInTable', async () => {
+      const groupWithoutEditInTable = getFormLayoutRepeatingGroupMock({
+        id: 'mock-container-id',
+        stickyHeader: true,
+      });
+
+      await render(getLayout(groupWithoutEditInTable, components), {
+        'some-group': [{ [ALTINN_ROW_ID]: uuidv4(), checkBoxBinding: 'option.value', prop1: 'test row 0' }],
+      });
+
+      expect(document.getElementById('group-mock-container-id-table-header')).toBeInTheDocument();
+      await userEvent.click(screen.getAllByRole('button', { name: /rediger/i })[0]);
+      expect(screen.getByTestId('editIndex')).toHaveTextContent('0');
+      expect(document.getElementById('group-mock-container-id-table-header')).not.toBeInTheDocument();
     });
 
     it('should render EditableCell when editInTable is enabled for a column', async () => {
@@ -235,7 +251,7 @@ describe('RepeatingGroupTable', () => {
         tableHeaders: ['field1', 'field2', 'field3', 'field4'],
         ...extra,
       });
-      await render(getLayout(groupWithExtraRows, components), extraRowTextResources);
+      await render(getLayout(groupWithExtraRows, components), undefined, extraRowTextResources);
 
       expect(screen.getByText('Extra0')).toBeInTheDocument();
       expect(screen.queryByText('Extra1Hidden')).not.toBeInTheDocument();

--- a/src/layout/RepeatingGroup/Table/RepeatingGroupTable.tsx
+++ b/src/layout/RepeatingGroup/Table/RepeatingGroupTable.tsx
@@ -61,9 +61,14 @@ export function RepeatingGroupTable(): React.JSX.Element | null {
     .filter((index) => index !== -1);
 
   const numRows = rowsToDisplay.length;
+  const firstRowId = numRows >= 1 ? rowsToDisplay[0].uuid : undefined;
 
   const isEmpty = numRows === 0;
-  const showTableHeader = numRows > 0;
+  const isEditingFirstRow = RepGroupContext.useIsEditingRow(firstRowId);
+  const hasColumnsWithEditInTable =
+    tableColumns && Object.keys(tableColumns).some((colId) => tableColumns[colId].editInTable);
+  const showTableHeader =
+    numRows > 0 && (hasColumnsWithEditInTable || !(numRows == 1 && firstRowId !== undefined && isEditingFirstRow));
 
   const showDeleteButtonColumns = new Set<boolean>();
   const showEditButtonColumns = new Set<boolean>();

--- a/src/layout/RepeatingGroup/Table/RepeatingGroupTable.tsx
+++ b/src/layout/RepeatingGroup/Table/RepeatingGroupTable.tsx
@@ -57,11 +57,9 @@ export function RepeatingGroupTable(): React.JSX.Element | null {
     .filter((index) => index !== -1);
 
   const numRows = rowsToDisplay.length;
-  const firstRowId = numRows >= 1 ? rowsToDisplay[0].uuid : undefined;
 
   const isEmpty = numRows === 0;
-  const isEditingFirstRow = RepGroupContext.useIsEditingRow(firstRowId);
-  const showTableHeader = numRows > 0 && !(numRows == 1 && firstRowId !== undefined && isEditingFirstRow);
+  const showTableHeader = numRows > 0;
 
   const showDeleteButtonColumns = new Set<boolean>();
   const showEditButtonColumns = new Set<boolean>();


### PR DESCRIPTION
## Description

Fixed an issue where RepeatingGroup table headers disappeared when editing the only row in the table.


<details><summary> AFTER</summary> 


https://github.com/user-attachments/assets/cc56bd03-d64b-4ee2-8254-1199f1a8bd65



</details>

## Related Is

- closes #4121 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table header visibility during inline cell editing; headers now remain visible when columns support inline editing, even when editing the first row of a single-row table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->