### PR TITLE
fix: fixed align tabel title

### DIFF
--- a/src/layout/RepeatingGroup/Table/RepeatingGroupTable.test.tsx
+++ b/src/layout/RepeatingGroup/Table/RepeatingGroupTable.test.tsx
@@ -209,6 +209,8 @@ describe('RepeatingGroupTable', () => {
       const layout = getLayout(groupWithNumericColumn, componentsWithNumericInput);
       await render(layout);
       expect(screen.getByRole('columnheader', { name: 'Title1' })).toHaveStyle({ '--cell-text-alignment': 'left' });
+    });
+
     async function renderExtraRowsWithHiddenSecondColumn(
       extra: Pick<Partial<CompRepeatingGroupExternal>, 'rowsBefore' | 'rowsAfter'>,
     ) {

--- a/src/layout/RepeatingGroup/Table/RepeatingGroupTable.test.tsx
+++ b/src/layout/RepeatingGroup/Table/RepeatingGroupTable.test.tsx
@@ -174,6 +174,24 @@ describe('RepeatingGroupTable', () => {
       const field1Inputs = inputs.filter((input) => input.getAttribute('id')?.includes('field1'));
       expect(field1Inputs.length).toBeGreaterThan(0);
     });
+
+    it('should align numeric editInTable header to left', async () => {
+      const groupWithNumericColumn = getFormLayoutRepeatingGroupMock({
+        id: 'mock-container-id',
+        tableColumns: { field1: { editInTable: true } },
+      });
+      const componentsWithNumericInput: CompExternal[] = components.map((component) =>
+        component.id === 'field1'
+          ? {
+              ...component,
+              formatting: { number: { thousandSeparator: ' ' } },
+            }
+          : component,
+      );
+      const layout = getLayout(groupWithNumericColumn, componentsWithNumericInput);
+      await render(layout);
+      expect(screen.getByRole('columnheader', { name: 'Title1' })).toHaveStyle({ '--cell-text-alignment': 'left' });
+    });
   });
 
   describe('mobile view', () => {

--- a/src/layout/RepeatingGroup/Table/RepeatingGroupTable.tsx
+++ b/src/layout/RepeatingGroup/Table/RepeatingGroupTable.tsx
@@ -300,7 +300,7 @@ function TitleCell({
   baseComponentId: string;
   columnSettings: IGroupColumnFormatting;
 }) {
-  const style = useColumnStylesRepeatingGroups(baseComponentId, columnSettings, { isTitle: true });
+  const style = useColumnStylesRepeatingGroups(baseComponentId, columnSettings, true);
 
   return (
     <Table.HeaderCell

--- a/src/layout/RepeatingGroup/Table/RepeatingGroupTable.tsx
+++ b/src/layout/RepeatingGroup/Table/RepeatingGroupTable.tsx
@@ -300,16 +300,12 @@ function TitleCell({
   baseComponentId: string;
   columnSettings: IGroupColumnFormatting;
 }) {
-  const style = useColumnStylesRepeatingGroups(baseComponentId, columnSettings, { deriveAlignmentText: false });
-  const headerStyle = {
-    ...style,
-    '--cell-text-alignment': columnSettings[baseComponentId]?.alignText ?? 'left',
-  } as React.CSSProperties;
+  const style = useColumnStylesRepeatingGroups(baseComponentId, columnSettings, { isTitle: true });
 
   return (
     <Table.HeaderCell
       className={classes.tableCellFormatting}
-      style={headerStyle}
+      style={style}
     >
       <RepeatingGroupTableTitle
         baseComponentId={baseComponentId}

--- a/src/layout/RepeatingGroup/Table/RepeatingGroupTable.tsx
+++ b/src/layout/RepeatingGroup/Table/RepeatingGroupTable.tsx
@@ -300,12 +300,16 @@ function TitleCell({
   baseComponentId: string;
   columnSettings: IGroupColumnFormatting;
 }) {
-  const style = useColumnStylesRepeatingGroups(baseComponentId, columnSettings);
+  const style = useColumnStylesRepeatingGroups(baseComponentId, columnSettings, { deriveAlignmentText: false });
+  const headerStyle = {
+    ...style,
+    '--cell-text-alignment': columnSettings[baseComponentId]?.alignText ?? 'left',
+  } as React.CSSProperties;
 
   return (
     <Table.HeaderCell
       className={classes.tableCellFormatting}
-      style={style}
+      style={headerStyle}
     >
       <RepeatingGroupTableTitle
         baseComponentId={baseComponentId}

--- a/src/layout/RepeatingGroup/Table/RepeatingGroupTableTitle.tsx
+++ b/src/layout/RepeatingGroup/Table/RepeatingGroupTableTitle.tsx
@@ -16,11 +16,7 @@ interface IProps {
 }
 
 export const RepeatingGroupTableTitle = ({ baseComponentId, columnSettings }: IProps) => {
-  const style = useColumnStylesRepeatingGroups(baseComponentId, columnSettings);
-  const titleStyle = {
-    ...style,
-    '--cell-text-alignment': columnSettings[baseComponentId]?.alignText ?? 'left',
-  } as React.CSSProperties;
+  const style = useColumnStylesRepeatingGroups(baseComponentId, columnSettings, { isTitle: true });
   const tableTitle = useTableTitle(baseComponentId);
   const { getRequiredComponent, getOptionalComponent } = useLabel({
     baseComponentId,
@@ -30,7 +26,7 @@ export const RepeatingGroupTableTitle = ({ baseComponentId, columnSettings }: IP
   return (
     <span
       className={classes.contentFormatting}
-      style={titleStyle}
+      style={style}
     >
       <Lang id={tableTitle} />
       {editInTable && getRequiredComponent()}

--- a/src/layout/RepeatingGroup/Table/RepeatingGroupTableTitle.tsx
+++ b/src/layout/RepeatingGroup/Table/RepeatingGroupTableTitle.tsx
@@ -16,7 +16,7 @@ interface IProps {
 }
 
 export const RepeatingGroupTableTitle = ({ baseComponentId, columnSettings }: IProps) => {
-  const style = useColumnStylesRepeatingGroups(baseComponentId, columnSettings, { isTitle: true });
+  const style = useColumnStylesRepeatingGroups(baseComponentId, columnSettings, true);
   const tableTitle = useTableTitle(baseComponentId);
   const { getRequiredComponent, getOptionalComponent } = useLabel({
     baseComponentId,

--- a/src/layout/RepeatingGroup/Table/RepeatingGroupTableTitle.tsx
+++ b/src/layout/RepeatingGroup/Table/RepeatingGroupTableTitle.tsx
@@ -17,6 +17,10 @@ interface IProps {
 
 export const RepeatingGroupTableTitle = ({ baseComponentId, columnSettings }: IProps) => {
   const style = useColumnStylesRepeatingGroups(baseComponentId, columnSettings);
+  const titleStyle = {
+    ...style,
+    '--cell-text-alignment': columnSettings[baseComponentId]?.alignText ?? 'left',
+  } as React.CSSProperties;
   const tableTitle = useTableTitle(baseComponentId);
   const { getRequiredComponent, getOptionalComponent } = useLabel({
     baseComponentId,
@@ -26,7 +30,7 @@ export const RepeatingGroupTableTitle = ({ baseComponentId, columnSettings }: IP
   return (
     <span
       className={classes.contentFormatting}
-      style={style}
+      style={titleStyle}
     >
       <Lang id={tableTitle} />
       {editInTable && getRequiredComponent()}

--- a/src/utils/formComponentUtils.ts
+++ b/src/utils/formComponentUtils.ts
@@ -122,7 +122,7 @@ export const pageBreakStyles = (pageBreak: ExprResolved<IPageBreak> | undefined)
   };
 };
 
-function useTextAlignment(baseComponentId: string, isTitle?: boolean): 'left' | 'center' | 'right' {
+function useTextAlignment(baseComponentId: string, isTitle: boolean): 'left' | 'center' | 'right' {
   const component = useLayoutLookups().getComponent(baseComponentId);
   const formatting = component.type === 'Input' ? component.formatting : undefined;
   if (!formatting || isTitle) {
@@ -137,9 +137,8 @@ function useTextAlignment(baseComponentId: string, isTitle?: boolean): 'left' | 
 export function useColumnStylesRepeatingGroups(
   baseComponentId: string,
   columnSettings: IGroupColumnFormatting | undefined,
-  options?: { isTitle?: boolean },
+  isTitle = false,
 ) {
-  const isTitle = options?.isTitle ?? false;
   const textAlignment = useTextAlignment(baseComponentId, isTitle);
   const column = columnSettings && columnSettings[baseComponentId];
   if (!column) {

--- a/src/utils/formComponentUtils.ts
+++ b/src/utils/formComponentUtils.ts
@@ -122,10 +122,10 @@ export const pageBreakStyles = (pageBreak: ExprResolved<IPageBreak> | undefined)
   };
 };
 
-function useTextAlignment(baseComponentId: string): 'left' | 'center' | 'right' {
+function useTextAlignment(baseComponentId: string, isTitle?: boolean): 'left' | 'center' | 'right' {
   const component = useLayoutLookups().getComponent(baseComponentId);
   const formatting = component.type === 'Input' ? component.formatting : undefined;
-  if (!formatting) {
+  if (!formatting || isTitle) {
     return 'left';
   }
   if (formatting.align) {
@@ -137,18 +137,17 @@ function useTextAlignment(baseComponentId: string): 'left' | 'center' | 'right' 
 export function useColumnStylesRepeatingGroups(
   baseComponentId: string,
   columnSettings: IGroupColumnFormatting | undefined,
-  options?: { deriveAlignmentText?: boolean },
+  options?: { isTitle?: boolean },
 ) {
-  const textAlignment = useTextAlignment(baseComponentId);
+  const isTitle = options?.isTitle ?? false;
+  const textAlignment = useTextAlignment(baseComponentId, isTitle);
   const column = columnSettings && columnSettings[baseComponentId];
   if (!column) {
     return;
   }
 
   const columnCopy = { ...column };
-  if (options?.deriveAlignmentText !== false) {
-    columnCopy.alignText = columnCopy.alignText ?? textAlignment;
-  }
+  columnCopy.alignText = columnCopy.alignText ?? textAlignment;
   return getColumnStyles(columnCopy);
 }
 

--- a/src/utils/formComponentUtils.ts
+++ b/src/utils/formComponentUtils.ts
@@ -137,6 +137,7 @@ function useTextAlignment(baseComponentId: string): 'left' | 'center' | 'right' 
 export function useColumnStylesRepeatingGroups(
   baseComponentId: string,
   columnSettings: IGroupColumnFormatting | undefined,
+  options?: { deriveAlignmentText?: boolean },
 ) {
   const textAlignment = useTextAlignment(baseComponentId);
   const column = columnSettings && columnSettings[baseComponentId];
@@ -145,8 +146,9 @@ export function useColumnStylesRepeatingGroups(
   }
 
   const columnCopy = { ...column };
-  columnCopy.alignText = columnCopy.alignText ?? textAlignment;
-
+  if (options?.deriveAlignmentText !== false) {
+    columnCopy.alignText = columnCopy.alignText ?? textAlignment;
+  }
   return getColumnStyles(columnCopy);
 }
 


### PR DESCRIPTION
## Description

`useColumnStylesRepeatingGroups` now takes a boolean `isTitle` props, and passes it to `useTextAlignment` so header/title alignment is handled centrally in one place.
This keeps numeric right-alignment for data cells while ensuring header titles default to left unless explicitly configured via alignText.

## Related Issue(s)

- closes #4122 


<img width="761" height="169" alt="Screenshot 2026-04-23 at 13 43 24" src="https://github.com/user-attachments/assets/2b79663b-0c10-4a82-8a84-699569ea2305" />



## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inconsistent text alignment in repeating-group table headers and titles so column headers and titles respect per-column alignment (defaults to left for title/header when appropriate).

* **Tests**
  * Added a test ensuring numeric/editable table columns render left-aligned headers to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->