### PR TITLE
fix required indicator when using onlyTable in repeatingGroup

### DIFF
--- a/src/layout/RepeatingGroup/Table/RepeatingGroupTableTitle.tsx
+++ b/src/layout/RepeatingGroup/Table/RepeatingGroupTableTitle.tsx
@@ -3,10 +3,12 @@ import React from 'react';
 import { ExprVal } from 'src/features/expressions/types';
 import { useLayoutLookups } from 'src/features/form/layout/LayoutsContext';
 import { Lang } from 'src/features/language/Lang';
+import { useRepeatingGroupComponentId } from 'src/layout/RepeatingGroup/Providers/RepeatingGroupContext';
 import classes from 'src/layout/RepeatingGroup/RepeatingGroup.module.css';
 import { useColumnStylesRepeatingGroups } from 'src/utils/formComponentUtils';
 import { useEvalExpression } from 'src/utils/layout/generator/useEvalExpression';
 import { useLabel } from 'src/utils/layout/useLabel';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { EvalExprOptions } from 'src/features/expressions';
 import type { IGroupColumnFormatting } from 'src/layout/RepeatingGroup/config.generated';
 
@@ -22,15 +24,19 @@ export const RepeatingGroupTableTitle = ({ baseComponentId, columnSettings }: IP
     baseComponentId,
     overrideDisplay: undefined,
   });
+  const groupComponentId = useRepeatingGroupComponentId();
+  const { edit } = useItemWhenType(groupComponentId, 'RepeatingGroup');
   const editInTable = columnSettings[baseComponentId]?.editInTable;
+  const isOnlyTable = edit?.mode === 'onlyTable';
+  const showIndicators = editInTable || (isOnlyTable && editInTable !== false);
   return (
     <span
       className={classes.contentFormatting}
       style={style}
     >
       <Lang id={tableTitle} />
-      {editInTable && getRequiredComponent()}
-      {editInTable && getOptionalComponent()}
+      {showIndicators && getRequiredComponent()}
+      {showIndicators && getOptionalComponent()}
     </span>
   );
 };


### PR DESCRIPTION
## Description
The required indicator now displays in `repeatingGroup` when `onlyTable` is set to true.

Manually tested in app mat/akvakultur-driftsplan. 

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [x] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved visibility of required and optional field indicators in repeating group table editing mode. Indicators now properly display when tables are set to edit-only mode, providing users with better visual feedback about field requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->