### PR TITLE
fix: fix radio buttons alignemnt in row and column mode

### DIFF
--- a/src/layout/RadioButtons/ControlledRadioGroup.module.css
+++ b/src/layout/RadioButtons/ControlledRadioGroup.module.css
@@ -4,14 +4,6 @@
   gap: var(--ds-size-6);
 }
 
-.inlineRadioGroupInTable {
-  margin-top: var(--ds-size-3);
-}
-
-.columnRadioGroupInTable {
-  margin-top: calc(var(--ds-size-1) * -2);
-}
-
 .legend {
   display: inline-flex;
 }

--- a/src/layout/RadioButtons/ControlledRadioGroup.module.css
+++ b/src/layout/RadioButtons/ControlledRadioGroup.module.css
@@ -4,6 +4,14 @@
   gap: var(--ds-size-6);
 }
 
+.inlineRadioGroupInTable {
+  margin-top: var(--ds-size-3);
+}
+
+.columnRadioGroupInTable {
+  margin-top: calc(var(--ds-size-1) * -2);
+}
+
 .legend {
   display: inline-flex;
 }

--- a/src/layout/RadioButtons/ControlledRadioGroup.tsx
+++ b/src/layout/RadioButtons/ControlledRadioGroup.tsx
@@ -109,7 +109,7 @@ export const ControlledRadioGroup = (props: PropsFromGenericComponent<'RadioButt
           )}
           <ConditionalWrapper
             condition={shouldDisplayHorizontally}
-            wrapper={(children) => <div className={cn(classes.inlineRadioGroup)}>{children}</div>}
+            wrapper={(children) => <div className={classes.inlineRadioGroup}>{children}</div>}
           >
             {calculatedOptions.map((option) => {
               const radioProps = getRadioProps({ value: option.value });

--- a/src/layout/RadioButtons/ControlledRadioGroup.tsx
+++ b/src/layout/RadioButtons/ControlledRadioGroup.tsx
@@ -14,6 +14,7 @@ import { useIsValid } from 'src/features/validation/selectors/isValid';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
 import classes from 'src/layout/RadioButtons/ControlledRadioGroup.module.css';
 import { useRadioButtons } from 'src/layout/RadioButtons/radioButtonsUtils';
+import utilClasses from 'src/styles/utils.module.css';
 import { shouldUseRowLayout } from 'src/utils/layout';
 import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
@@ -76,7 +77,6 @@ export const ControlledRadioGroup = (props: PropsFromGenericComponent<'RadioButt
   );
 
   const hideLabel = overrideDisplay?.renderedInTable === true && calculatedOptions.length === 1 && !showLabelsInTable;
-  const isRenderedInTable = overrideDisplay?.renderedInTable === true;
   const renderLegend = overrideDisplay?.renderLegend !== false;
   const fieldsetAriaLabel = !renderLegend ? langAsString(textResourceBindings?.title) : undefined;
   const shouldDisplayHorizontally = shouldUseRowLayout({
@@ -97,28 +97,19 @@ export const ControlledRadioGroup = (props: PropsFromGenericComponent<'RadioButt
       <div id={id}>
         <Fieldset
           role='radiogroup'
-          className={cn({
-            [classes.columnRadioGroupInTable]: isRenderedInTable && !shouldDisplayHorizontally,
-          })}
           aria-label={fieldsetAriaLabel}
         >
           {renderLegend && <Fieldset.Legend className={classes.legend}>{labelText}</Fieldset.Legend>}
-          {renderLegend && textResourceBindings?.description && (
-            <Fieldset.Description>
+          {textResourceBindings?.description && (
+            <Fieldset.Description
+              className={cn({ [utilClasses.visuallyHidden]: overrideDisplay?.renderLegend === false })}
+            >
               <Lang id={textResourceBindings?.description} />
             </Fieldset.Description>
           )}
           <ConditionalWrapper
             condition={shouldDisplayHorizontally}
-            wrapper={(children) => (
-              <div
-                className={cn(classes.inlineRadioGroup, {
-                  [classes.inlineRadioGroupInTable]: isRenderedInTable,
-                })}
-              >
-                {children}
-              </div>
-            )}
+            wrapper={(children) => <div className={cn(classes.inlineRadioGroup)}>{children}</div>}
           >
             {calculatedOptions.map((option) => {
               const radioProps = getRadioProps({ value: option.value });

--- a/src/layout/RadioButtons/ControlledRadioGroup.tsx
+++ b/src/layout/RadioButtons/ControlledRadioGroup.tsx
@@ -14,7 +14,6 @@ import { useIsValid } from 'src/features/validation/selectors/isValid';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
 import classes from 'src/layout/RadioButtons/ControlledRadioGroup.module.css';
 import { useRadioButtons } from 'src/layout/RadioButtons/radioButtonsUtils';
-import utilClasses from 'src/styles/utils.module.css';
 import { shouldUseRowLayout } from 'src/utils/layout';
 import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
@@ -77,6 +76,9 @@ export const ControlledRadioGroup = (props: PropsFromGenericComponent<'RadioButt
   );
 
   const hideLabel = overrideDisplay?.renderedInTable === true && calculatedOptions.length === 1 && !showLabelsInTable;
+  const isRenderedInTable = overrideDisplay?.renderedInTable === true;
+  const renderLegend = overrideDisplay?.renderLegend !== false;
+  const fieldsetAriaLabel = !renderLegend ? langAsString(textResourceBindings?.title) : undefined;
   const shouldDisplayHorizontally = shouldUseRowLayout({
     layout,
     optionsCount: calculatedOptions.length,
@@ -93,22 +95,30 @@ export const ControlledRadioGroup = (props: PropsFromGenericComponent<'RadioButt
   return (
     <ComponentStructureWrapper baseComponentId={baseComponentId}>
       <div id={id}>
-        <Fieldset role='radiogroup'>
-          <Fieldset.Legend
-            className={cn(classes.legend, { [utilClasses.visuallyHidden]: overrideDisplay?.renderLegend === false })}
-          >
-            {labelText}
-          </Fieldset.Legend>
-          {textResourceBindings?.description && (
-            <Fieldset.Description
-              className={cn({ [utilClasses.visuallyHidden]: overrideDisplay?.renderLegend === false })}
-            >
+        <Fieldset
+          role='radiogroup'
+          className={cn({
+            [classes.columnRadioGroupInTable]: isRenderedInTable && !shouldDisplayHorizontally,
+          })}
+          aria-label={fieldsetAriaLabel}
+        >
+          {renderLegend && <Fieldset.Legend className={classes.legend}>{labelText}</Fieldset.Legend>}
+          {renderLegend && textResourceBindings?.description && (
+            <Fieldset.Description>
               <Lang id={textResourceBindings?.description} />
             </Fieldset.Description>
           )}
           <ConditionalWrapper
             condition={shouldDisplayHorizontally}
-            wrapper={(children) => <div className={classes.inlineRadioGroup}>{children}</div>}
+            wrapper={(children) => (
+              <div
+                className={cn(classes.inlineRadioGroup, {
+                  [classes.inlineRadioGroupInTable]: isRenderedInTable,
+                })}
+              >
+                {children}
+              </div>
+            )}
           >
             {calculatedOptions.map((option) => {
               const radioProps = getRadioProps({ value: option.value });

--- a/src/layout/RepeatingGroup/RepeatingGroup.module.css
+++ b/src/layout/RepeatingGroup/RepeatingGroup.module.css
@@ -47,7 +47,7 @@ Altinn, and making sure they are consistent. */
 
 .repeatingGroupTable > tbody > tr > td {
   border-bottom-color: #dde3e5;
-  padding-top: 12px;
+  padding-top: 16px;
   padding-bottom: 12px;
   vertical-align: top;
 }

--- a/src/layout/RepeatingGroup/RepeatingGroup.module.css
+++ b/src/layout/RepeatingGroup/RepeatingGroup.module.css
@@ -47,9 +47,9 @@ Altinn, and making sure they are consistent. */
 
 .repeatingGroupTable > tbody > tr > td {
   border-bottom-color: #dde3e5;
-  padding-top: 16px;
+  padding-top: 12px;
   padding-bottom: 12px;
-  vertical-align: top;
+  vertical-align: -webkit-baseline-middle;
 }
 /* ==== */
 

--- a/src/layout/RepeatingGroup/Table/RepeatingGroupTableRow.tsx
+++ b/src/layout/RepeatingGroup/Table/RepeatingGroupTableRow.tsx
@@ -124,12 +124,7 @@ export function RepeatingGroupTableRow({
 
   return (
     <Table.Row
-      className={cn(
-        {
-          [classes.tableRowError]: rowHasErrors,
-        },
-        className,
-      )}
+      className={cn({ [classes.tableRowError]: rowHasErrors }, className)}
       data-row-num={index}
       data-row-uuid={uuid}
     >


### PR DESCRIPTION
## Description

Fixed alignment for radio buttons in row and column mode 


https://github.com/user-attachments/assets/16cbef54-f233-4919-b6b3-139eff074f50


## Related Issue(s)

- closes #4123 

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility support for radio button groups with enhanced screen reader handling
  * Fixed vertical alignment of content within table cells
<!-- end of auto-generated comment: release notes by coderabbit.ai -->