### PR TITLE
chore: add track-and-prune for generated files to avoid unnecessary rewrites

### DIFF
--- a/src/codegen/run.ts
+++ b/src/codegen/run.ts
@@ -6,7 +6,7 @@ import { generateAllCommonTypes, generateCommonTypeScript } from 'src/codegen/Co
 import { LayoutSchemaV1 } from 'src/codegen/schemas/layout.schema.v1';
 import { LayoutSetsSchemaV1 } from 'src/codegen/schemas/layout-sets.schema.v1';
 import { LayoutSettingsSchemaV1 } from 'src/codegen/schemas/layoutSettings.schema.v1';
-import { saveFile, saveTsFile } from 'src/codegen/tools';
+import { getWrittenPaths, saveFile, saveTsFile } from 'src/codegen/tools';
 import type { ComponentConfig } from 'src/codegen/ComponentConfig';
 import type { SchemaFileProps } from 'src/codegen/SchemaFile';
 
@@ -30,17 +30,6 @@ async function findGeneratedFiles(root: string): Promise<string[]> {
     }
   }
   return found;
-}
-
-function expectedGeneratedPaths(sortedKeys: string[]): Set<string> {
-  return new Set<string>([
-    'src/layout/components.generated.ts',
-    'src/layout/common.generated.ts',
-    ...sortedKeys.flatMap((key) => [
-      `src/layout/${key}/config.generated.ts`,
-      `src/layout/${key}/config.def.generated.tsx`,
-    ]),
-  ]);
 }
 
 async function deleteOrphans(orphans: string[]): Promise<void> {
@@ -165,7 +154,7 @@ async function getComponentList(): Promise<[ComponentList, string[]]> {
 
   await Promise.all(promises);
 
-  const expected = expectedGeneratedPaths(sortedKeys);
-  const orphans = (await findGeneratedFiles('src/layout')).filter((file) => !expected.has(file));
+  const written = getWrittenPaths();
+  const orphans = (await findGeneratedFiles('src/layout')).filter((file) => !written.has(file));
   await deleteOrphans(orphans);
 })();

--- a/src/codegen/run.ts
+++ b/src/codegen/run.ts
@@ -12,6 +12,46 @@ import type { SchemaFileProps } from 'src/codegen/SchemaFile';
 
 type ComponentList = { [folder: string]: string };
 
+const GENERATED_FILE_PATTERN = /\.generated\.(ts|tsx)$/;
+
+function toPosixPath(p: string): string {
+  return p.split(path.sep).join('/');
+}
+
+async function findGeneratedFiles(root: string): Promise<string[]> {
+  const found: string[] = [];
+  const entries = await fs.readdir(root, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      found.push(...(await findGeneratedFiles(full)));
+    } else if (entry.isFile() && GENERATED_FILE_PATTERN.test(entry.name)) {
+      found.push(toPosixPath(full));
+    }
+  }
+  return found;
+}
+
+function expectedGeneratedPaths(sortedKeys: string[]): Set<string> {
+  return new Set<string>([
+    'src/layout/components.generated.ts',
+    'src/layout/common.generated.ts',
+    ...sortedKeys.flatMap((key) => [
+      `src/layout/${key}/config.generated.ts`,
+      `src/layout/${key}/config.def.generated.tsx`,
+    ]),
+  ]);
+}
+
+async function deleteOrphans(orphans: string[]): Promise<void> {
+  await Promise.all(
+    orphans.map(async (file) => {
+      console.log(`Removing orphaned ${file}`);
+      await fs.rm(file);
+    }),
+  );
+}
+
 async function getComponentList(): Promise<[ComponentList, string[]]> {
   const toDelete: string[] = [];
   const out: ComponentList = {};
@@ -124,4 +164,8 @@ async function getComponentList(): Promise<[ComponentList, string[]]> {
   );
 
   await Promise.all(promises);
+
+  const expected = expectedGeneratedPaths(sortedKeys);
+  const orphans = (await findGeneratedFiles('src/layout')).filter((file) => !expected.has(file));
+  await deleteOrphans(orphans);
 })();

--- a/src/codegen/tools.ts
+++ b/src/codegen/tools.ts
@@ -3,7 +3,14 @@ import { loadESLint } from 'eslint';
 import fs from 'node:fs/promises';
 import type { ESLint } from 'eslint';
 
+const writtenPaths = new Set<string>();
+
+export function getWrittenPaths(): ReadonlySet<string> {
+  return writtenPaths;
+}
+
 export async function saveFile(targetPath: string, _content: string, removeText?: RegExp, fileExisted?: boolean) {
+  writtenPaths.add(targetPath);
   const content = `${_content.trim()}\n`;
   try {
     const fd = await fs.open(targetPath, 'r+');
@@ -49,6 +56,7 @@ async function getESLint() {
 type TsResult = { result: string };
 
 export async function saveTsFile(targetPath: string, content: TsResult | Promise<TsResult>) {
+  writtenPaths.add(targetPath);
   const { result } = await content;
   const contentHash = crypto.createHash('sha256').update(result).digest('hex');
   const _fileExists = await fileExists(targetPath);


### PR DESCRIPTION

## Description

  A simpler "delete all `*.generated.*` before gen runs" would also work, but:

  - Defeats the hash-based skip in `saveTsFile`, every file gets re-linted and re-written every run.
  - `find -delete` isn't cross-platform (no PowerShell).

  Track-and-prune only touches files that are actually orphaned, so the happy path stays free.
<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

-  PR iteslf.

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced code generation cleanup by removing orphaned generated files from the layout directory, ensuring the generated artifact set remains accurate and consistent after each build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->