### PR TITLE
feat: use new A3 endpoints for change reportee and redirect (v4)

### DIFF
--- a/src/utils/urls/urlHelper.test.ts
+++ b/src/utils/urls/urlHelper.test.ts
@@ -82,16 +82,16 @@ describe('Shared urlHelper.ts', () => {
   test('returnUrlToArchive() returning correct environments without dialogId', () => {
     const partyId = 12345;
     expect(returnUrlToArchive(hostTT, partyId)).toBe(
-      'https://tt02.altinn.no/accessmanagement/api/v1/reportee/changeandredirect?partyId=12345&goTo=https%3A%2F%2Faf.tt02.altinn.no%2F',
+      'https://am.ui.tt02.altinn.no/accessmanagement/api/v1/reportee/changeandredirect?partyId=12345&goTo=https%3A%2F%2Faf.tt02.altinn.no%2F',
     );
     expect(returnUrlToArchive(hostAT, partyId)).toBe(
-      'https://at21.altinn.cloud/accessmanagement/api/v1/reportee/changeandredirect?partyId=12345&goTo=https%3A%2F%2Faf.at21.altinn.cloud%2F',
+      'https://am.ui.at21.altinn.cloud/accessmanagement/api/v1/reportee/changeandredirect?partyId=12345&goTo=https%3A%2F%2Faf.at21.altinn.cloud%2F',
     );
     expect(returnUrlToArchive(hostYT, partyId)).toBe(
-      'https://yt01.altinn.cloud/accessmanagement/api/v1/reportee/changeandredirect?partyId=12345&goTo=https%3A%2F%2Faf.yt01.altinn.cloud%2F',
+      'https://am.ui.yt01.altinn.cloud/accessmanagement/api/v1/reportee/changeandredirect?partyId=12345&goTo=https%3A%2F%2Faf.yt01.altinn.cloud%2F',
     );
     expect(returnUrlToArchive(hostProd, partyId)).toBe(
-      'https://altinn.no/accessmanagement/api/v1/reportee/changeandredirect?partyId=12345&goTo=https%3A%2F%2Faf.altinn.no%2F',
+      'https://am.ui.altinn.no/accessmanagement/api/v1/reportee/changeandredirect?partyId=12345&goTo=https%3A%2F%2Faf.altinn.no%2F',
     );
     expect(returnUrlToArchive(hostDocker, partyId)).toBe('http://local.altinn.cloud/');
     expect(returnUrlToArchive(hostPodman, partyId)).toBe('http://local.altinn.cloud:8000/');
@@ -104,16 +104,16 @@ describe('Shared urlHelper.ts', () => {
     const partyId = 12345;
     const dialogId = '123e4567-e89b-12d3-a456-426614174000';
     expect(returnUrlToArchive(hostTT, partyId, dialogId)).toBe(
-      'https://tt02.altinn.no/accessmanagement/api/v1/reportee/changeandredirect?partyId=12345&goTo=https%3A%2F%2Faf.tt02.altinn.no%2Finbox%2F123e4567-e89b-12d3-a456-426614174000',
+      'https://am.ui.tt02.altinn.no/accessmanagement/api/v1/reportee/changeandredirect?partyId=12345&goTo=https%3A%2F%2Faf.tt02.altinn.no%2Finbox%2F123e4567-e89b-12d3-a456-426614174000',
     );
     expect(returnUrlToArchive(hostAT, partyId, dialogId)).toBe(
-      'https://at21.altinn.cloud/accessmanagement/api/v1/reportee/changeandredirect?partyId=12345&goTo=https%3A%2F%2Faf.at21.altinn.cloud%2Finbox%2F123e4567-e89b-12d3-a456-426614174000',
+      'https://am.ui.at21.altinn.cloud/accessmanagement/api/v1/reportee/changeandredirect?partyId=12345&goTo=https%3A%2F%2Faf.at21.altinn.cloud%2Finbox%2F123e4567-e89b-12d3-a456-426614174000',
     );
     expect(returnUrlToArchive(hostYT, partyId, dialogId)).toBe(
-      'https://yt01.altinn.cloud/accessmanagement/api/v1/reportee/changeandredirect?partyId=12345&goTo=https%3A%2F%2Faf.yt01.altinn.cloud%2Finbox%2F123e4567-e89b-12d3-a456-426614174000',
+      'https://am.ui.yt01.altinn.cloud/accessmanagement/api/v1/reportee/changeandredirect?partyId=12345&goTo=https%3A%2F%2Faf.yt01.altinn.cloud%2Finbox%2F123e4567-e89b-12d3-a456-426614174000',
     );
     expect(returnUrlToArchive(hostProd, partyId, dialogId)).toBe(
-      'https://altinn.no/accessmanagement/api/v1/reportee/changeandredirect?partyId=12345&goTo=https%3A%2F%2Faf.altinn.no%2Finbox%2F123e4567-e89b-12d3-a456-426614174000',
+      'https://am.ui.altinn.no/accessmanagement/api/v1/reportee/changeandredirect?partyId=12345&goTo=https%3A%2F%2Faf.altinn.no%2Finbox%2F123e4567-e89b-12d3-a456-426614174000',
     );
     expect(returnUrlToArchive(hostDocker, partyId, dialogId)).toBe('http://local.altinn.cloud/');
     expect(returnUrlToArchive(hostPodman, partyId, dialogId)).toBe('http://local.altinn.cloud:8000/');

--- a/src/utils/urls/urlHelper.test.ts
+++ b/src/utils/urls/urlHelper.test.ts
@@ -82,16 +82,16 @@ describe('Shared urlHelper.ts', () => {
   test('returnUrlToArchive() returning correct environments without dialogId', () => {
     const partyId = 12345;
     expect(returnUrlToArchive(hostTT, partyId)).toBe(
-      'https://tt02.altinn.no/ui/Reportee/ChangeReporteeAndRedirect?goTo=https%3A%2F%2Faf.tt02.altinn.no%2F&R=12345',
+      'https://tt02.altinn.no/accessmanagement/api/v1/reportee/changeandredirect?partyId=12345&goTo=https%3A%2F%2Faf.tt02.altinn.no%2F',
     );
     expect(returnUrlToArchive(hostAT, partyId)).toBe(
-      'https://at21.altinn.cloud/ui/Reportee/ChangeReporteeAndRedirect?goTo=https%3A%2F%2Faf.at21.altinn.cloud%2F&R=12345',
+      'https://at21.altinn.cloud/accessmanagement/api/v1/reportee/changeandredirect?partyId=12345&goTo=https%3A%2F%2Faf.at21.altinn.cloud%2F',
     );
     expect(returnUrlToArchive(hostYT, partyId)).toBe(
-      'https://yt01.altinn.cloud/ui/Reportee/ChangeReporteeAndRedirect?goTo=https%3A%2F%2Faf.yt01.altinn.cloud%2F&R=12345',
+      'https://yt01.altinn.cloud/accessmanagement/api/v1/reportee/changeandredirect?partyId=12345&goTo=https%3A%2F%2Faf.yt01.altinn.cloud%2F',
     );
     expect(returnUrlToArchive(hostProd, partyId)).toBe(
-      'https://altinn.no/ui/Reportee/ChangeReporteeAndRedirect?goTo=https%3A%2F%2Faf.altinn.no%2F&R=12345',
+      'https://altinn.no/accessmanagement/api/v1/reportee/changeandredirect?partyId=12345&goTo=https%3A%2F%2Faf.altinn.no%2F',
     );
     expect(returnUrlToArchive(hostDocker, partyId)).toBe('http://local.altinn.cloud/');
     expect(returnUrlToArchive(hostPodman, partyId)).toBe('http://local.altinn.cloud:8000/');
@@ -104,16 +104,16 @@ describe('Shared urlHelper.ts', () => {
     const partyId = 12345;
     const dialogId = '123e4567-e89b-12d3-a456-426614174000';
     expect(returnUrlToArchive(hostTT, partyId, dialogId)).toBe(
-      'https://tt02.altinn.no/ui/Reportee/ChangeReporteeAndRedirect?goTo=https%3A%2F%2Faf.tt02.altinn.no%2Finbox%2F123e4567-e89b-12d3-a456-426614174000&R=12345',
+      'https://tt02.altinn.no/accessmanagement/api/v1/reportee/changeandredirect?partyId=12345&goTo=https%3A%2F%2Faf.tt02.altinn.no%2Finbox%2F123e4567-e89b-12d3-a456-426614174000',
     );
     expect(returnUrlToArchive(hostAT, partyId, dialogId)).toBe(
-      'https://at21.altinn.cloud/ui/Reportee/ChangeReporteeAndRedirect?goTo=https%3A%2F%2Faf.at21.altinn.cloud%2Finbox%2F123e4567-e89b-12d3-a456-426614174000&R=12345',
+      'https://at21.altinn.cloud/accessmanagement/api/v1/reportee/changeandredirect?partyId=12345&goTo=https%3A%2F%2Faf.at21.altinn.cloud%2Finbox%2F123e4567-e89b-12d3-a456-426614174000',
     );
     expect(returnUrlToArchive(hostYT, partyId, dialogId)).toBe(
-      'https://yt01.altinn.cloud/ui/Reportee/ChangeReporteeAndRedirect?goTo=https%3A%2F%2Faf.yt01.altinn.cloud%2Finbox%2F123e4567-e89b-12d3-a456-426614174000&R=12345',
+      'https://yt01.altinn.cloud/accessmanagement/api/v1/reportee/changeandredirect?partyId=12345&goTo=https%3A%2F%2Faf.yt01.altinn.cloud%2Finbox%2F123e4567-e89b-12d3-a456-426614174000',
     );
     expect(returnUrlToArchive(hostProd, partyId, dialogId)).toBe(
-      'https://altinn.no/ui/Reportee/ChangeReporteeAndRedirect?goTo=https%3A%2F%2Faf.altinn.no%2Finbox%2F123e4567-e89b-12d3-a456-426614174000&R=12345',
+      'https://altinn.no/accessmanagement/api/v1/reportee/changeandredirect?partyId=12345&goTo=https%3A%2F%2Faf.altinn.no%2Finbox%2F123e4567-e89b-12d3-a456-426614174000',
     );
     expect(returnUrlToArchive(hostDocker, partyId, dialogId)).toBe('http://local.altinn.cloud/');
     expect(returnUrlToArchive(hostPodman, partyId, dialogId)).toBe('http://local.altinn.cloud:8000/');

--- a/src/utils/urls/urlHelper.ts
+++ b/src/utils/urls/urlHelper.ts
@@ -25,6 +25,10 @@ function buildArbeidsflateUrl(altinnHost: string): string {
   return `https://af.${altinnHost}/`;
 }
 
+function buildAccessManagementBaseUrl(altinnHost: string): string {
+  return `https://am.ui.${altinnHost}/`;
+}
+
 function redirectAndChangeParty(goTo: string, partyId: number): string {
   return `accessmanagement/api/v1/reportee/changeandredirect?partyId=${partyId}&goTo=${encodeURIComponent(goTo)}`;
 }
@@ -42,9 +46,8 @@ function buildArbeidsflateRedirectUrl(host: string, partyId?: number, dialogId?:
     return `http://${host}/`;
   }
 
-  const baseUrl = returnBaseUrlToAltinn(host);
   const altinnHost = extractAltinnHost(host);
-  if (!baseUrl || !altinnHost) {
+  if (!altinnHost) {
     return undefined;
   }
 
@@ -56,7 +59,8 @@ function buildArbeidsflateRedirectUrl(host: string, partyId?: number, dialogId?:
   }
 
   // Use access management changeandredirect endpoint to switch party and redirect to A3 arbeidsflate
-  return `${baseUrl}${redirectAndChangeParty(targetUrl, partyId)}`;
+  const amBaseUrl = buildAccessManagementBaseUrl(altinnHost);
+  return `${amBaseUrl}${redirectAndChangeParty(targetUrl, partyId)}`;
 }
 
 export const getMessageBoxUrl = (partyId?: number, dialogId?: string): string | undefined =>

--- a/src/utils/urls/urlHelper.ts
+++ b/src/utils/urls/urlHelper.ts
@@ -26,7 +26,7 @@ function buildArbeidsflateUrl(altinnHost: string): string {
 }
 
 function redirectAndChangeParty(goTo: string, partyId: number): string {
-  return `ui/Reportee/ChangeReporteeAndRedirect?goTo=${encodeURIComponent(goTo)}&R=${partyId}`;
+  return `accessmanagement/api/v1/reportee/changeandredirect?partyId=${partyId}&goTo=${encodeURIComponent(goTo)}`;
 }
 
 export const returnBaseUrlToAltinn = (host: string): string | undefined => {
@@ -55,7 +55,7 @@ function buildArbeidsflateRedirectUrl(host: string, partyId?: number, dialogId?:
     return targetUrl;
   }
 
-  // Use A2 redirect mechanism with A3 arbeidsflate URL to maintain party context
+  // Use access management changeandredirect endpoint to switch party and redirect to A3 arbeidsflate
   return `${baseUrl}${redirectAndChangeParty(targetUrl, partyId)}`;
 }
 


### PR DESCRIPTION
## Description


This PR updates how navigation back to the inbox is handled by switching to the new endpoint available in Altinn 3.

The change ensures alignment with the updated access management flow and replaces the previous endpoint with the new, supported alternative.

The new endpoint was introduced here:
https://github.com/Altinn/altinn-access-management-frontend/pull/2167

### Test App
This build can be testet with the app "redirect-inbox-simple-app". 
https://altinn.studio/repos/ttd/redirect-inbox-simple-app

### TT02
https://ttd.apps.tt02.altinn.no/ttd/redirect-inbox-simple-app/#/instance/51432356/804fd79a-58f7-4bb2-9174-a2e3aacc27c1/Task_1/Side1

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- Closes partial: https://github.com/Altinn/altinn-studio/issues/18675 (v4 support)

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually (tt02)
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated test assertions to match the revised redirect URL format in the reportee change workflow.

* **Refactor**
  * Adjusted redirect URL construction to use the new access-management redirect format and encoded target parameters for party-switching flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->