### PR TITLE
feat: use the new logout endpoint (v4-apps)

### DIFF
--- a/src/utils/urls/urlHelper.test.ts
+++ b/src/utils/urls/urlHelper.test.ts
@@ -165,10 +165,10 @@ describe('Shared urlHelper.ts', () => {
   });
 
   test('logoutUrlAltinn() returning correct environments', () => {
-    expect(logoutUrlAltinn(hostTT)).toBe('https://tt02.altinn.no/ui/authentication/LogOut');
-    expect(logoutUrlAltinn(hostAT)).toBe('https://at21.altinn.cloud/ui/authentication/LogOut');
-    expect(logoutUrlAltinn(hostYT)).toBe('https://yt01.altinn.cloud/ui/authentication/LogOut');
-    expect(logoutUrlAltinn(hostProd)).toBe('https://altinn.no/ui/authentication/LogOut');
+    expect(logoutUrlAltinn(hostTT)).toBe('https://platform.tt02.altinn.no/authentication/api/v1/logout');
+    expect(logoutUrlAltinn(hostAT)).toBe('https://platform.at21.altinn.cloud/authentication/api/v1/logout');
+    expect(logoutUrlAltinn(hostYT)).toBe('https://platform.yt01.altinn.cloud/authentication/api/v1/logout');
+    expect(logoutUrlAltinn(hostProd)).toBe('https://platform.altinn.no/authentication/api/v1/logout');
     expect(logoutUrlAltinn(hostDocker)).toBe('http://local.altinn.cloud/');
     expect(logoutUrlAltinn(hostPodman)).toBe('http://local.altinn.cloud:8000/');
     expect(logoutUrlAltinn(hostStudio)).toBe(undefined);

--- a/src/utils/urls/urlHelper.ts
+++ b/src/utils/urls/urlHelper.ts
@@ -104,15 +104,15 @@ export const returnUrlToAllForms = (host: string): string | undefined => {
 };
 
 export function logoutUrlAltinn(host: string): string | undefined {
-  if (host.match(localRegex)) {
+  if (isLocalEnvironment(host)) {
     return `http://${host}/`;
   }
 
-  const baseUrl = returnBaseUrlToAltinn(host);
-  if (!baseUrl) {
+  const altinnHost = extractAltinnHost(host);
+  if (!altinnHost) {
     return;
   }
-  return `${baseUrl}ui/authentication/LogOut`;
+  return `https://platform.${altinnHost}/authentication/api/v1/logout`;
 }
 
 export function customEncodeURI(uri: string): string {


### PR DESCRIPTION
## Description

Switches the "Logg ut"-link in the app header from the legacy Altinn 2 endpoint to the new Altinn 3 platform endpoint.                                                                                                                                                                                                           
   
  - **Before**: `https://{altinnHost}/ui/authentication/LogOut`                                                                                                                                                                                                                                                                    
  - **After**: `https://platform.{altinnHost}/authentication/api/v1/logout`
                                                                                                                                                                                                                                                                                                                                   
  ## Changes                                                           

  - `src/utils/urls/urlHelper.ts` — `logoutUrlAltinn(host)` now builds the URL against the platform host (`platform.<env>.altinn.<no|cloud>`) and uses `extractAltinnHost` directly. Local-environment fallback (`http://local.altinn.cloud[:port]/`) and the `undefined` return for unknown hosts are unchanged.                  
  - `src/utils/urls/urlHelper.test.ts` — Updated expected URLs for `logoutUrlAltinn` across prod / TT02 / AT21 / YT01.
                                                                                                                                                                                                                                                                                                                                   
  The single callsite (`src/components/presentation/AppHeader/AppHeaderMenu.tsx`) is untouched — it consumes `logoutUrlAltinn(window.location.host)` and picks up the new URL automatically.                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                   
  ## Resulting URLs per environment                                                                                                                                                                                                                                                                                                
                                                                       
  | Host the app runs on | Logout URL |                                                                                                                                                                                                                                                                                            
  |---|---|                                                            
  | `*.apps.altinn.no` (prod) | `https://platform.altinn.no/authentication/api/v1/logout` |
  | `*.apps.tt02.altinn.no` (TT02) | `https://platform.tt02.altinn.no/authentication/api/v1/logout` |                                                                                                                                                                                                                              
  | `*.apps.at21.altinn.cloud` (AT21) | `https://platform.at21.altinn.cloud/authentication/api/v1/logout` |
  | `*.apps.yt01.altinn.cloud` (YT01) | `https://platform.yt01.altinn.cloud/authentication/api/v1/logout` |                                                                                                                                                                                                                        
  | `local.altinn.cloud[:port]` | `http://local.altinn.cloud[:port]/` (unchanged) |                                                                                                                                                                                                                                                
  | Unknown (studio etc.) | `undefined` (unchanged) |         

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- Closes the v4 part of following issue: https://github.com/Altinn/altinn-studio/issues/18676

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated logout endpoint configuration to use new authentication API endpoints across all environments (TT/AT/YT/Prod).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->