### PR TITLE
feat: added new property `buttonLayout` for vertical layout for edit/delet buttons

### DIFF
--- a/src/layout/RepeatingGroup/Table/RepeatingGroupTable.test.tsx
+++ b/src/layout/RepeatingGroup/Table/RepeatingGroupTable.test.tsx
@@ -333,6 +333,43 @@ describe('RepeatingGroupTable', () => {
     });
   });
 
+  describe('buttonLayout', () => {
+    const { setScreenWidth } = mockMediaQuery(992);
+    beforeEach(() => {
+      setScreenWidth(1337);
+    });
+
+    it('should render a single action column when buttonLayout is vertical', async () => {
+      const groupWithVerticalButtons = getFormLayoutRepeatingGroupMock({
+        id: 'mock-container-id',
+        edit: { buttonLayout: 'vertical' },
+      });
+      const layout = getLayout(groupWithVerticalButtons, components);
+      await render(layout);
+      const columnHeaders = screen.getAllByRole('columnheader');
+      expect(columnHeaders).toHaveLength(5);
+    });
+
+    it('should keep compact icon-only behavior in view mode when using vertical button layout', async () => {
+      const groupWithVerticalCompactButtons = getFormLayoutRepeatingGroupMock({
+        id: 'mock-container-id',
+        edit: { compactButtons: true, buttonLayout: 'vertical' },
+      });
+      const layout = getLayout(groupWithVerticalCompactButtons, components);
+      await render(layout);
+      const editButtons = screen.getAllByRole('button', { name: /Rediger/i });
+      const deleteButtons = screen.getAllByRole('button', { name: /Slett/i });
+      expect(editButtons).toHaveLength(4);
+      expect(deleteButtons).toHaveLength(4);
+      editButtons.forEach((button) => {
+        expect(button).not.toHaveTextContent('Rediger');
+      });
+      deleteButtons.forEach((button) => {
+        expect(button).not.toHaveTextContent('Slett');
+      });
+    });
+  });
+
   const render = async (
     layout = getLayout(group, components),
     formData: Record<string, unknown> = {

--- a/src/layout/RepeatingGroup/Table/RepeatingGroupTable.tsx
+++ b/src/layout/RepeatingGroup/Table/RepeatingGroupTable.tsx
@@ -190,6 +190,7 @@ export function RepeatingGroupTable(): React.JSX.Element | null {
               uuid={row.uuid}
               displayDeleteColumn={displayDeleteColumn}
               displayEditColumn={displayEditColumn}
+              columnCount={columnCount}
               useVerticalButtonLayout={useVerticalButtonLayout}
               tableIds={tableIdsWithoutHiddenColumns}
               hiddenColumns={hiddenColumns}
@@ -213,6 +214,7 @@ function RowToDisplay({
   dataModelBindings: { group },
   displayDeleteColumn,
   displayEditColumn,
+  columnCount,
   useVerticalButtonLayout,
   index,
   uuid,
@@ -223,6 +225,7 @@ function RowToDisplay({
   dataModelBindings: IDataModelBindings<'RepeatingGroup'>;
   displayDeleteColumn: boolean;
   displayEditColumn: boolean;
+  columnCount: number;
   useVerticalButtonLayout: boolean;
   tableIds: string[];
   hiddenColumns: string[];
@@ -230,9 +233,6 @@ function RowToDisplay({
   const component = useExternalItem(baseComponentId, 'RepeatingGroup');
   const mobileView = useIsMobileOrTablet();
   const isEditingRow = RepGroupContext.useIsEditingRow(uuid);
-  const columnCount = useVerticalButtonLayout
-    ? Number(displayEditColumn || displayDeleteColumn)
-    : Number(displayEditColumn) + Number(displayDeleteColumn);
   const editContainerColSpan = mobileView ? 2 : tableIds.length + 3 + columnCount;
 
   return (

--- a/src/layout/RepeatingGroup/Table/RepeatingGroupTable.tsx
+++ b/src/layout/RepeatingGroup/Table/RepeatingGroupTable.tsx
@@ -149,14 +149,18 @@ export function RepeatingGroupTable(): React.JSX.Element | null {
                 ))}
               </DataModelLocationProvider>
               {useVerticalButtonLayout ? (
-                columnCount > 0 && (
+                (displayEditColumn || displayDeleteColumn) && (
                   <Table.HeaderCell style={{ padding: 0 }}>
-                    <span className={utilClasses.visuallyHidden}>
-                      <Lang id='general.edit' />
-                    </span>
-                    <span className={utilClasses.visuallyHidden}>
-                      <Lang id='general.delete' />
-                    </span>
+                    {displayEditColumn && (
+                      <span className={utilClasses.visuallyHidden}>
+                        <Lang id='general.edit' />
+                      </span>
+                    )}
+                    {displayDeleteColumn && (
+                      <span className={utilClasses.visuallyHidden}>
+                        <Lang id='general.delete' />
+                      </span>
+                    )}
                   </Table.HeaderCell>
                 )
               ) : (

--- a/src/layout/RepeatingGroup/Table/RepeatingGroupTable.tsx
+++ b/src/layout/RepeatingGroup/Table/RepeatingGroupTable.tsx
@@ -83,10 +83,14 @@ export function RepeatingGroupTable(): React.JSX.Element | null {
   if (edit?.mode === 'onlyTable') {
     displayEditColumn = false;
   }
+  const useVerticalButtonLayout = edit?.buttonLayout === 'vertical';
+  const columnCount = useVerticalButtonLayout
+    ? Number(displayEditColumn || displayDeleteColumn)
+    : Number(displayEditColumn) + Number(displayDeleteColumn);
 
   const parent = useLayoutLookups().componentToParent[baseComponentId];
   const isNested = parent?.type === 'node';
-  const extraCells = [...(displayEditColumn ? [null] : []), ...(displayDeleteColumn ? [null] : [])];
+  const extraCells = Array.from({ length: columnCount }, () => null);
 
   return (
     <div
@@ -144,19 +148,34 @@ export function RepeatingGroupTable(): React.JSX.Element | null {
                   />
                 ))}
               </DataModelLocationProvider>
-              {displayEditColumn && (
-                <Table.HeaderCell style={{ padding: 0, paddingRight: '10px' }}>
-                  <span className={utilClasses.visuallyHidden}>
-                    <Lang id='general.edit' />
-                  </span>
-                </Table.HeaderCell>
-              )}
-              {displayDeleteColumn && (
-                <Table.HeaderCell style={{ padding: 0 }}>
-                  <span className={utilClasses.visuallyHidden}>
-                    <Lang id='general.delete' />
-                  </span>
-                </Table.HeaderCell>
+              {useVerticalButtonLayout ? (
+                columnCount > 0 && (
+                  <Table.HeaderCell style={{ padding: 0 }}>
+                    <span className={utilClasses.visuallyHidden}>
+                      <Lang id='general.edit' />
+                    </span>
+                    <span className={utilClasses.visuallyHidden}>
+                      <Lang id='general.delete' />
+                    </span>
+                  </Table.HeaderCell>
+                )
+              ) : (
+                <>
+                  {displayEditColumn && (
+                    <Table.HeaderCell style={{ padding: 0, paddingRight: '10px' }}>
+                      <span className={utilClasses.visuallyHidden}>
+                        <Lang id='general.edit' />
+                      </span>
+                    </Table.HeaderCell>
+                  )}
+                  {displayDeleteColumn && (
+                    <Table.HeaderCell style={{ padding: 0 }}>
+                      <span className={utilClasses.visuallyHidden}>
+                        <Lang id='general.delete' />
+                      </span>
+                    </Table.HeaderCell>
+                  )}
+                </>
               )}
             </Table.Row>
           </Table.Head>
@@ -171,6 +190,7 @@ export function RepeatingGroupTable(): React.JSX.Element | null {
               uuid={row.uuid}
               displayDeleteColumn={displayDeleteColumn}
               displayEditColumn={displayEditColumn}
+              useVerticalButtonLayout={useVerticalButtonLayout}
               tableIds={tableIdsWithoutHiddenColumns}
               hiddenColumns={hiddenColumns}
             />
@@ -193,6 +213,7 @@ function RowToDisplay({
   dataModelBindings: { group },
   displayDeleteColumn,
   displayEditColumn,
+  useVerticalButtonLayout,
   index,
   uuid,
   tableIds,
@@ -202,12 +223,18 @@ function RowToDisplay({
   dataModelBindings: IDataModelBindings<'RepeatingGroup'>;
   displayDeleteColumn: boolean;
   displayEditColumn: boolean;
+  useVerticalButtonLayout: boolean;
   tableIds: string[];
   hiddenColumns: string[];
 } & BaseRow) {
   const component = useExternalItem(baseComponentId, 'RepeatingGroup');
   const mobileView = useIsMobileOrTablet();
   const isEditingRow = RepGroupContext.useIsEditingRow(uuid);
+  const columnCount = useVerticalButtonLayout
+    ? Number(displayEditColumn || displayDeleteColumn)
+    : Number(displayEditColumn) + Number(displayDeleteColumn);
+  const editContainerColSpan = mobileView ? 2 : tableIds.length + 3 + columnCount;
+
   return (
     <DataModelLocationProvider
       groupBinding={group}
@@ -223,6 +250,7 @@ function RowToDisplay({
         mobileView={mobileView}
         displayDeleteColumn={displayDeleteColumn}
         displayEditColumn={displayEditColumn}
+        useVerticalButtonLayout={useVerticalButtonLayout}
         hiddenColumns={hiddenColumns}
       />
       {isEditingRow && (
@@ -234,7 +262,7 @@ function RowToDisplay({
         >
           <Table.Cell
             style={{ padding: 0, borderTop: 0 }}
-            colSpan={mobileView ? 2 : tableIds.length + 3 + (displayEditColumn ? 1 : 0) + (displayDeleteColumn ? 1 : 0)}
+            colSpan={editContainerColSpan}
           >
             {component.edit?.mode !== 'onlyTable' && <RepeatingGroupsEditContainer editId={uuid} />}
           </Table.Cell>

--- a/src/layout/RepeatingGroup/Table/RepeatingGroupTableRow.tsx
+++ b/src/layout/RepeatingGroup/Table/RepeatingGroupTableRow.tsx
@@ -385,7 +385,7 @@ function EditElement({
       aria-controls={ariaExpanded ? `group-edit-container-${indexedId}-${uuid}` : undefined}
       variant='tertiary'
       color='second'
-      icon={!ariaExpanded && mobileViewSmall}
+      icon={!ariaExpanded && (compactButtons || mobileViewSmall)}
       onClick={onClick}
       aria-label={ariaLabel}
       className={classes.tableButton}

--- a/src/layout/RepeatingGroup/Table/RepeatingGroupTableRow.tsx
+++ b/src/layout/RepeatingGroup/Table/RepeatingGroupTableRow.tsx
@@ -43,6 +43,7 @@ export interface IRepeatingGroupTableRowProps {
   mobileView: boolean;
   displayEditColumn: boolean;
   displayDeleteColumn: boolean;
+  useVerticalButtonLayout: boolean;
   hiddenColumns: string[];
 }
 
@@ -84,6 +85,7 @@ export function RepeatingGroupTableRow({
   mobileView,
   displayEditColumn,
   displayDeleteColumn,
+  useVerticalButtonLayout,
   hiddenColumns,
 }: IRepeatingGroupTableRowProps): JSX.Element | null {
   const mobileViewSmall = useIsMobile();
@@ -200,57 +202,102 @@ export function RepeatingGroupTableRow({
         </Table.Cell>
       )}
       {!mobileView ? (
-        <>
-          {editForRow?.editButton === false &&
-          editForRow?.deleteButton === false &&
-          (displayEditColumn || displayDeleteColumn) ? (
-            <Table.Cell
-              key={`editDelete-${uuid}`}
-              colSpan={displayEditColumn && displayDeleteColumn ? 2 : 1}
-            />
-          ) : null}
-          {editForRow?.editButton !== false && displayEditColumn && (
-            <Table.Cell
-              key={`edit-${uuid}`}
-              className={classes.buttonCell}
-              colSpan={displayDeleteColumn && editForRow?.deleteButton === false ? 2 : 1}
-            >
-              <div className={classes.buttonInCellWrapper}>
-                <EditElement
-                  mobileViewSmall={false}
-                  ariaExpanded={isEditingRow}
-                  indexedId={indexedId}
-                  uuid={uuid}
-                  onClick={() => toggleEditing({ index, uuid })}
-                  editButtonText={editButtonText}
-                  rowHasErrors={rowHasErrors}
-                  compactButtons={compactButtons}
-                />
-              </div>
-            </Table.Cell>
-          )}
-          {editForRow?.deleteButton !== false && displayDeleteColumn && (
-            <Table.Cell
-              key={`delete-${uuid}`}
-              className={cn(classes.buttonCell)}
-              colSpan={displayEditColumn && editForRow?.editButton === false ? 2 : 1}
-            >
-              <div className={classes.buttonInCellWrapper}>
-                <DeleteElement
-                  index={index}
-                  uuid={uuid}
-                  isDeletingRow={isDeletingRow}
-                  editForRow={editForRow}
-                  deleteButtonText={deleteButtonText}
-                  alertOnDeleteProps={alertOnDelete}
-                  langAsString={langAsString}
+        useVerticalButtonLayout ? (
+          <>
+            {editForRow?.editButton === false &&
+            editForRow?.deleteButton === false &&
+            (displayEditColumn || displayDeleteColumn) ? (
+              <Table.Cell key={`editDelete-${uuid}`} />
+            ) : null}
+            {(editForRow?.editButton !== false || editForRow?.deleteButton !== false) &&
+              (displayEditColumn || displayDeleteColumn) && (
+                <Table.Cell
+                  key={`actions-${uuid}`}
+                  className={classes.buttonCell}
                 >
-                  {compactButtons ? (isEditingRow ? deleteButtonText : null) : deleteButtonText}
-                </DeleteElement>
-              </div>
-            </Table.Cell>
-          )}
-        </>
+                  <div className={classes.buttonInCellWrapper}>
+                    {editForRow?.editButton !== false && displayEditColumn && (
+                      <EditElement
+                        mobileViewSmall={false}
+                        ariaExpanded={isEditingRow}
+                        indexedId={indexedId}
+                        uuid={uuid}
+                        onClick={() => toggleEditing({ index, uuid })}
+                        editButtonText={editButtonText}
+                        rowHasErrors={rowHasErrors}
+                        compactButtons={compactButtons}
+                      />
+                    )}
+                    {editForRow?.deleteButton !== false && displayDeleteColumn && (
+                      <DeleteElement
+                        index={index}
+                        uuid={uuid}
+                        isDeletingRow={isDeletingRow}
+                        editForRow={editForRow}
+                        deleteButtonText={deleteButtonText}
+                        alertOnDeleteProps={alertOnDelete}
+                        langAsString={langAsString}
+                      >
+                        {compactButtons ? (isEditingRow ? deleteButtonText : null) : deleteButtonText}
+                      </DeleteElement>
+                    )}
+                  </div>
+                </Table.Cell>
+              )}
+          </>
+        ) : (
+          <>
+            {editForRow?.editButton === false &&
+            editForRow?.deleteButton === false &&
+            (displayEditColumn || displayDeleteColumn) ? (
+              <Table.Cell
+                key={`editDelete-${uuid}`}
+                colSpan={displayEditColumn && displayDeleteColumn ? 2 : 1}
+              />
+            ) : null}
+            {editForRow?.editButton !== false && displayEditColumn && (
+              <Table.Cell
+                key={`edit-${uuid}`}
+                className={classes.buttonCell}
+                colSpan={displayDeleteColumn && editForRow?.deleteButton === false ? 2 : 1}
+              >
+                <div className={classes.buttonInCellWrapper}>
+                  <EditElement
+                    mobileViewSmall={false}
+                    ariaExpanded={isEditingRow}
+                    indexedId={indexedId}
+                    uuid={uuid}
+                    onClick={() => toggleEditing({ index, uuid })}
+                    editButtonText={editButtonText}
+                    rowHasErrors={rowHasErrors}
+                    compactButtons={compactButtons}
+                  />
+                </div>
+              </Table.Cell>
+            )}
+            {editForRow?.deleteButton !== false && displayDeleteColumn && (
+              <Table.Cell
+                key={`delete-${uuid}`}
+                className={cn(classes.buttonCell)}
+                colSpan={displayEditColumn && editForRow?.editButton === false ? 2 : 1}
+              >
+                <div className={classes.buttonInCellWrapper}>
+                  <DeleteElement
+                    index={index}
+                    uuid={uuid}
+                    isDeletingRow={isDeletingRow}
+                    editForRow={editForRow}
+                    deleteButtonText={deleteButtonText}
+                    alertOnDeleteProps={alertOnDelete}
+                    langAsString={langAsString}
+                  >
+                    {compactButtons ? (isEditingRow ? deleteButtonText : null) : deleteButtonText}
+                  </DeleteElement>
+                </div>
+              </Table.Cell>
+            )}
+          </>
+        )
       ) : (
         <Table.Cell
           className={cn(classes.buttonCell, classes.mobileTableCell)}

--- a/src/layout/RepeatingGroup/config.ts
+++ b/src/layout/RepeatingGroup/config.ts
@@ -224,6 +224,19 @@ export const Config = new CG.component({
                 'Text will still be shown when the row is in edit mode.',
             ),
         ),
+        new CG.prop(
+          'buttonLayout',
+          new CG.enum('horizontal', 'vertical')
+            .optional({ default: 'horizontal' })
+            .setTitle('Button layout')
+            .setDescription(
+              'In desktop table view, controls how the edit and delete buttons are laid out. ' +
+                '"horizontal" uses two table columns (edit and delete side by side). ' +
+                '"vertical" uses a single button column with edit above delete, saving horizontal space. ' +
+                'Does not apply to mobile/tablet layout. ' +
+                'Can be combined with compactButtons.',
+            ),
+        ),
       )
         .exportAs('IGroupEditProperties')
         .optional(),


### PR DESCRIPTION
## Description

This PR adds a new optional `edit.buttonLayout` property to RepeatingGroup so table row buttons can be arranged either horizontally (default) or vertically. 
When set to `"vertical"`, `edit` and `delete` buttons are rendered in a single column, which saves horizontal space in tables.

#### What changed
- Added buttonLayout to RepeatingGroup edit config:
       - Allowed values: `"horizontal" | "vertical"
`       - Default: `"horizontal"`
- Updated table header/body rendering to support:
       - two columns in horizontal mode
       - one combined action column in vertical mode
- Added tests for vertical action-column behavior and compact-buttons combination.
- Added [docs](https://github.com/Altinn/altinn-studio-docs/pull/2878) 

## Related Issue(s)

- closes #4125 

- [doce PR ](https://github.com/Altinn/altinn-studio-docs/pull/2878)



https://github.com/user-attachments/assets/b38652b0-5c0d-4233-9f18-8c03eb1fcbc5



## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Repeating group tables now support a vertical button layout option for edit/delete controls
  * Edit and delete buttons can be arranged vertically instead of horizontally in desktop table views
  * Compatible with compact buttons mode for icon-only displays

* **Tests**
  * Added test coverage for vertical button layout scenarios, including compact button configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->