### PR TITLE
fix: readOnly for PersonLookup and OrganisationLookup

### DIFF
--- a/src/layout/OrganisationLookup/OrganisationLookupComponent.tsx
+++ b/src/layout/OrganisationLookup/OrganisationLookupComponent.tsx
@@ -68,7 +68,7 @@ export function OrganisationLookupComponent({
   baseComponentId,
   overrideDisplay,
 }: PropsFromGenericComponent<'OrganisationLookup'>) {
-  const { id, dataModelBindings, required } = useItemWhenType(baseComponentId, 'OrganisationLookup');
+  const { id, dataModelBindings, required, readOnly } = useItemWhenType(baseComponentId, 'OrganisationLookup');
   const { labelText, getHelpTextComponent, getDescriptionComponent } = useLabel({
     baseComponentId,
     overrideDisplay,
@@ -156,7 +156,7 @@ export function OrganisationLookupComponent({
               aria-label={langAsString('organisation_lookup.orgnr_label')}
               value={hasSuccessfullyFetched ? organisation_lookup_orgnr : tempOrgNr}
               required={required}
-              readOnly={hasSuccessfullyFetched || isFetching}
+              readOnly={hasSuccessfullyFetched || isFetching || readOnly}
               error={isValid}
               onValueChange={(e) => {
                 setTempOrgNr(e.value);
@@ -177,7 +177,7 @@ export function OrganisationLookupComponent({
               </ValidationMessage>
             )}
           </Field>
-          <div className={classes.submit}>
+          {!readOnly && <div className={classes.submit}>
             {!hasSuccessfullyFetched ? (
               <Button
                 onClick={handleSubmit}
@@ -195,7 +195,7 @@ export function OrganisationLookupComponent({
                 <Lang id='organisation_lookup.clear_button' />
               </Button>
             )}
-          </div>
+          </div>}
           {data?.error && (
             <ValidationMessage
               data-size='sm'

--- a/src/layout/OrganisationLookup/OrganisationLookupComponent.tsx
+++ b/src/layout/OrganisationLookup/OrganisationLookupComponent.tsx
@@ -177,25 +177,27 @@ export function OrganisationLookupComponent({
               </ValidationMessage>
             )}
           </Field>
-          {!readOnly && <div className={classes.submit}>
-            {!hasSuccessfullyFetched ? (
-              <Button
-                onClick={handleSubmit}
-                variant='secondary'
-                isLoading={isFetching}
-              >
-                <Lang id='organisation_lookup.submit_button' />
-              </Button>
-            ) : (
-              <Button
-                variant='secondary'
-                color='danger'
-                onClick={handleClear}
-              >
-                <Lang id='organisation_lookup.clear_button' />
-              </Button>
-            )}
-          </div>}
+          {!readOnly && (
+            <div className={classes.submit}>
+              {!hasSuccessfullyFetched ? (
+                <Button
+                  onClick={handleSubmit}
+                  variant='secondary'
+                  isLoading={isFetching}
+                >
+                  <Lang id='organisation_lookup.submit_button' />
+                </Button>
+              ) : (
+                <Button
+                  variant='secondary'
+                  color='danger'
+                  onClick={handleClear}
+                >
+                  <Lang id='organisation_lookup.clear_button' />
+                </Button>
+              )}
+            </div>
+          )}
           {data?.error && (
             <ValidationMessage
               data-size='sm'

--- a/src/layout/OrganisationLookup/OrganisationLookupComponent.tsx
+++ b/src/layout/OrganisationLookup/OrganisationLookupComponent.tsx
@@ -163,7 +163,7 @@ export function OrganisationLookupComponent({
                 setOrgNrErrors(undefined);
               }}
               onKeyDown={async (ev) => {
-                if (ev.key === 'Enter') {
+                if (ev.key === 'Enter' && !readOnly) {
                   await handleSubmit();
                 }
               }}

--- a/src/layout/PersonLookup/PersonLookupComponent.tsx
+++ b/src/layout/PersonLookup/PersonLookupComponent.tsx
@@ -305,25 +305,27 @@ export function PersonLookupComponent({ baseComponentId, overrideDisplay }: Prop
                 />
               ))}
           </Field>
-          {!readOnly && <div className={classes.submit}>
-            {!hasSuccessfullyFetched ? (
-              <Button
-                onClick={handleSubmit}
-                variant='secondary'
-                isLoading={isFetching}
-              >
-                <Lang id='person_lookup.submit_button' />
-              </Button>
-            ) : (
-              <Button
-                variant='secondary'
-                color='danger'
-                onClick={handleClear}
-              >
-                <Lang id='person_lookup.clear_button' />
-              </Button>
-            )}
-          </div>}
+          {!readOnly && (
+            <div className={classes.submit}>
+              {!hasSuccessfullyFetched ? (
+                <Button
+                  onClick={handleSubmit}
+                  variant='secondary'
+                  isLoading={isFetching}
+                >
+                  <Lang id='person_lookup.submit_button' />
+                </Button>
+              ) : (
+                <Button
+                  variant='secondary'
+                  color='danger'
+                  onClick={handleClear}
+                >
+                  <Lang id='person_lookup.clear_button' />
+                </Button>
+              )}
+            </div>
+          )}
           {data?.error && (
             <ValidationMessage
               data-size='sm'

--- a/src/layout/PersonLookup/PersonLookupComponent.tsx
+++ b/src/layout/PersonLookup/PersonLookupComponent.tsx
@@ -80,7 +80,7 @@ async function fetchPerson(
 }
 
 export function PersonLookupComponent({ baseComponentId, overrideDisplay }: PropsFromGenericComponent<'PersonLookup'>) {
-  const { id, dataModelBindings, required } = useItemWhenType(baseComponentId, 'PersonLookup');
+  const { id, dataModelBindings, required, readOnly } = useItemWhenType(baseComponentId, 'PersonLookup');
   const { labelText, getDescriptionComponent, getHelpTextComponent } = useLabel({
     baseComponentId,
     overrideDisplay,
@@ -226,7 +226,7 @@ export function PersonLookupComponent({ baseComponentId, overrideDisplay }: Prop
               aria-label={langAsString('person_lookup.ssn_label')}
               value={hasSuccessfullyFetched ? person_lookup_ssn : tempSsn}
               required={required}
-              readOnly={hasSuccessfullyFetched}
+              readOnly={hasSuccessfullyFetched || readOnly}
               error={invalidSsn}
               onValueChange={(e) => {
                 setTempSsn(e.value);
@@ -280,7 +280,7 @@ export function PersonLookupComponent({ baseComponentId, overrideDisplay }: Prop
               value={hasSuccessfullyFetched ? displayName : tempName}
               type='text'
               required={required}
-              readOnly={hasSuccessfullyFetched}
+              readOnly={hasSuccessfullyFetched || readOnly}
               error={invalidName}
               onChange={(e) => {
                 setTempName(e.target.value);
@@ -305,7 +305,7 @@ export function PersonLookupComponent({ baseComponentId, overrideDisplay }: Prop
                 />
               ))}
           </Field>
-          <div className={classes.submit}>
+          {!readOnly && <div className={classes.submit}>
             {!hasSuccessfullyFetched ? (
               <Button
                 onClick={handleSubmit}
@@ -323,7 +323,7 @@ export function PersonLookupComponent({ baseComponentId, overrideDisplay }: Prop
                 <Lang id='person_lookup.clear_button' />
               </Button>
             )}
-          </div>
+          </div>}
           {data?.error && (
             <ValidationMessage
               data-size='sm'

--- a/src/layout/PersonLookup/PersonLookupComponent.tsx
+++ b/src/layout/PersonLookup/PersonLookupComponent.tsx
@@ -226,14 +226,14 @@ export function PersonLookupComponent({ baseComponentId, overrideDisplay }: Prop
               aria-label={langAsString('person_lookup.ssn_label')}
               value={hasSuccessfullyFetched ? person_lookup_ssn : tempSsn}
               required={required}
-              readOnly={hasSuccessfullyFetched || readOnly}
+              readOnly={hasSuccessfullyFetched || isFetching || readOnly}
               error={invalidSsn}
               onValueChange={(e) => {
                 setTempSsn(e.value);
                 setSsnErrors(undefined);
               }}
               onKeyDown={async (ev) => {
-                if (ev.key === 'Enter') {
+                if (ev.key === 'Enter' && !readOnly) {
                   await handleSubmit();
                 }
               }}
@@ -280,14 +280,14 @@ export function PersonLookupComponent({ baseComponentId, overrideDisplay }: Prop
               value={hasSuccessfullyFetched ? displayName : tempName}
               type='text'
               required={required}
-              readOnly={hasSuccessfullyFetched || readOnly}
+              readOnly={hasSuccessfullyFetched || isFetching || readOnly}
               error={invalidName}
               onChange={(e) => {
                 setTempName(e.target.value);
                 setNameError(undefined);
               }}
               onKeyDown={async (ev) => {
-                if (ev.key === 'Enter') {
+                if (ev.key === 'Enter' && !readOnly) {
                   await handleSubmit();
                 }
               }}


### PR DESCRIPTION
## Description
FIxes readOnly for PersonLookup and OrganisationLookup


https://github.com/user-attachments/assets/ef189922-8a69-4b5e-ab46-2d136813bf88


<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes #4119 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [x] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Lookup components correctly enforce read-only: inputs are disabled when read-only or during active lookup, action buttons are hidden in read-only mode, and Enter-key submission is disabled when read-only. Existing interactive lookup, validation, and submit/clear behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->