### PR TITLE
fix map with toolbar being editable in summary

### DIFF
--- a/src/layout/Map/Map.tsx
+++ b/src/layout/Map/Map.tsx
@@ -52,7 +52,7 @@ export function Map({ baseComponentId, className, readOnly, animate = true }: Ma
       scrollWheelZoom={!readOnly}
       attributionControl={false}
     >
-      {toolbar !== undefined && <MapEditGeometries baseComponentId={baseComponentId} />}
+      {toolbar !== undefined && !readOnly && <MapEditGeometries baseComponentId={baseComponentId} />}
       <MapLayers baseComponentId={baseComponentId} />
       <MapGeometries
         baseComponentId={baseComponentId}

--- a/src/layout/Map/features/geometries/fixed/MapGeometries.tsx
+++ b/src/layout/Map/features/geometries/fixed/MapGeometries.tsx
@@ -30,8 +30,8 @@ export function MapGeometries({ baseComponentId, readOnly }: MapGeometriesProps)
     return null;
   }
 
-  // if toolbar is defined, we want to render editable geometries separately
-  if (toolbar) {
+  // if toolbar is defined and map is editable, we want to render editable geometries separately
+  if (toolbar && !readOnly) {
     geometries = geometries?.filter((g) => !g.isEditable);
   }
 


### PR DESCRIPTION
## Description

If the map is in summary mode or readonly, the toolbar should not be rendered and the geometries should be rendered in the non-editable map layer.

<img width="935" height="699" alt="image" src="https://github.com/user-attachments/assets/c0cdff38-0d91-4fda-af6c-4cec585cd99d" />


<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes #4185

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [x] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Map editing toolbar behavior corrected to properly align with read-only mode state. Previously, editable geometries were displayed based only on toolbar presence. Now they are filtered based on both toolbar availability and edit mode setting. Maps in read-only mode now consistently prevent all geometry editing interactions through the toolbar interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/app-frontend-react/pull/4201)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->