### PR TITLE
chore: bytt A2 /ui/Profile-lenker til A3-URL-er i språkfiler

### DIFF
--- a/src/features/instantiate/containers/PartySelection.tsx
+++ b/src/features/instantiate/containers/PartySelection.tsx
@@ -17,6 +17,7 @@ import { AltinnAppTheme } from 'src/theme/altinnAppTheme';
 import { changeBodyBackground } from 'src/utils/bodyStyling';
 import { HttpStatusCodes } from 'src/utils/network/networking';
 import { capitalizeName } from 'src/utils/stringHelper';
+import { getHostname } from 'src/utils/urls/appUrlHelper';
 import type { IParty } from 'src/types/shared';
 
 const useStyles = makeStyles((theme) => ({
@@ -202,7 +203,10 @@ export const PartySelection = () => {
           {langAsString('party_selection.why_seeing_this')}
         </Typography>
         <Typography variant='body1'>
-          {lang(appOverride ? 'party_selection.seeing_this_override' : 'party_selection.seeing_this_preference')}
+          {lang(
+            appOverride ? 'party_selection.seeing_this_override' : 'party_selection.seeing_this_preference',
+            appOverride ? undefined : [getHostname()],
+          )}
         </Typography>
       </Grid>
     );

--- a/src/language/texts/en.ts
+++ b/src/language/texts/en.ts
@@ -197,7 +197,7 @@ export function en() {
       authorization_error_ask:
         'If you are representing a person it is the one you are representing that can give you the required rights to start this service. If you are you representing an organization you have to ask for the required rights from persons with access delegation rights within your organization.',
       authorization_error_check_rights:
-        '<a href="https://{0}/ui/Profile/" target="_blank">See who has rights to delegate access under "Others with rights within the organization"</a>.',
+        '<a href="https://am.ui.{0}/accessmanagement/ui" target="_blank">See who has rights to delegate access under "Others with rights within the organization"</a>.',
       authorization_error_info_rights:
         '<a href="https://{0}/hjelp/profil/roller-og-rettigheter/" target="_blank">Learn more about roles and rights</a>.',
       authorization_error_info_customer_service: 'You can also contact customer service at {0}.',
@@ -243,7 +243,7 @@ export function en() {
       show_sub_unit: 'Show sub units',
       why_seeing_this: 'Why am I seeing this?',
       seeing_this_preference:
-        'You can change your [profile settings](https://altinn.no/ui/Profile) to not get prompted for party selection each time you start a new instance. You can find this setting under **Profile** > **Advanced settings** > **Do not ask what party I represent each time I start to fill in a new form**.',
+        'You can change your [profile settings](https://af.{0}/profile/parties) to not get prompted for party selection each time you start a new instance. You can find this setting under **Profile** > **Parties**.',
       seeing_this_override: 'This app has been configured to always prompt you for party selection.',
     },
     helptext: {

--- a/src/language/texts/nb.ts
+++ b/src/language/texts/nb.ts
@@ -199,7 +199,7 @@ export function nb(): FixedLanguageList {
       authorization_error_ask:
         'Om du representerer en person, er det den du representerer som kan gi deg rettighet til å starte tjenesten. Representerer du en organisasjon er det de som har rollen tilgangsstyring innad i organisasjonen som kan gi deg rettighet.',
       authorization_error_check_rights:
-        '<a href="https://{0}/ui/Profile/" target="_blank">Se hvem som har rollen tilgangsstyring under "Andre med rettigheter til virksomheten"</a>.',
+        '<a href="https://am.ui.{0}/accessmanagement/ui" target="_blank">Se hvem som har rollen tilgangsstyring under "Andre med rettigheter til virksomheten"</a>.',
       authorization_error_info_rights:
         '<a href="https://{0}/hjelp/profil/roller-og-rettigheter/" target="_blank">Her finner du mer informasjon om roller og rettigheter</a>.',
       authorization_error_info_customer_service: 'Du kan også kontakte oss på brukerservice {0}.',
@@ -246,7 +246,7 @@ export function nb(): FixedLanguageList {
       show_sub_unit: 'Vis underenheter',
       why_seeing_this: 'Hvorfor ser jeg dette?',
       seeing_this_preference:
-        'Du kan endre [profilinnstillingene](https://altinn.no/ui/Profile) dine for å ikke bli spurt om aktør hver gang du starter utfylling av et nytt skjema. Du finner denne innstillingen under **Profil** > **Avanserte innstillinger** > **Jeg ønsker ikke å bli spurt om aktør hver gang jeg starter utfylling av et nytt skjema**.',
+        'Du kan endre [profilinnstillingene](https://af.{0}/profile/parties) dine for å ikke bli spurt om aktør hver gang du starter utfylling av et nytt skjema. Du finner denne innstillingen under **Profil** > **Aktører**.',
       seeing_this_override: 'Denne appen er satt opp til å alltid spørre om aktør.',
     },
     helptext: {

--- a/src/language/texts/nn.ts
+++ b/src/language/texts/nn.ts
@@ -199,7 +199,7 @@ export function nn(): FixedLanguageList {
       authorization_error_ask:
         'Om du representerer ein person, er det den du representerer som kan gi deg dei naudsynte rettane til å starte tenesta. Representerer du ein organisasjon er det personar som har rolla tilgangsstyring innad i organisasjonen som kan gi deg dei naudsynte rettane.',
       authorization_error_check_rights:
-        '<a href="https://{0}/ui/Profile/" target="_blank">Sjå kven som har rolla tilgangsstyring under "Andre med rettar til verksemda"</a>.',
+        '<a href="https://am.ui.{0}/accessmanagement/ui" target="_blank">Sjå kven som har rolla tilgangsstyring under "Andre med rettar til verksemda"</a>.',
       authorization_error_info_rights:
         '<a href="https://{0}/hjelp/profil/roller-og-rettigheter/" target="_blank">Her finn du meir informasjon om roller og rettar</a>.',
       authorization_error_info_customer_service: 'Du kan også kontakte oss på brukarservice {0}.',
@@ -246,7 +246,7 @@ export function nn(): FixedLanguageList {
       show_sub_unit: 'Vis undereiningar',
       why_seeing_this: 'Kvifor ser eg dette?',
       seeing_this_preference:
-        'Du kan endra [profilinnstillingane](https://altinn.no/ui/Profile) dine for å ikkje bli spurt om aktør kvar gong du startar utfylling av eit nytt skjema. Du finn denne innstillinga under **Profil** > **Avanserte innstillingar** > **Eg ønskjer ikkje å bli spurt om aktør kvar gong eg startar utfylling av eit nytt skjema**.',
+        'Du kan endra [profilinnstillingane](https://af.{0}/profile/parties) dine for å ikkje bli spurt om aktør kvar gong du startar utfylling av eit nytt skjema. Du finn denne innstillinga under **Profil** > **Aktørar**.',
       seeing_this_override: 'Denne appen er sett opp til å alltid spørja om aktør.',
     },
     helptext: {


### PR DESCRIPTION
## Description

 ## Oppsummering
  - `instantiate.authorization_error_check_rights`: bytter `https://{0}/ui/Profile/` → `https://am.ui.{0}/accessmanagement/ui` (A3 tilgangsstyring).
  - `party_selection.seeing_this_preference`: bytter hardkodet `https://altinn.no/ui/Profile` til miljø-bevisst `https://af.{0}/profile/parties`, og forenkler brødsmulen til **Profil > Aktører** (nb) /
  **Aktørar** (nn) / **Parties** (en).
  - `PartySelection.tsx`: importerer `getHostname` og sender det som `{0}`-parameter til `lang()`.



## Related Issue(s)

- https://github.com/Altinn/altinn-studio/issues/18695 (closes for v3-apps)

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->
