### PR TITLE
feat: Support lists in expressions

### DIFF
--- a/schemas/json/layout/expression.schema.v1.json
+++ b/schemas/json/layout/expression.schema.v1.json
@@ -46,6 +46,7 @@
         { "$ref": "#/definitions/strict-string" },
         { "$ref": "#/definitions/strict-boolean" },
         { "$ref": "#/definitions/strict-number" },
+        { "$ref": "#/definitions/strict-list" },
         { "$ref": "#/definitions/func-if" }
       ]
     },
@@ -141,6 +142,17 @@
         { "$ref": "#/definitions/func-stringLength" },
         { "$ref": "#/definitions/func-stringIndexOf" },
         { "$ref": "#/definitions/func-countDataElements" }
+      ]
+    },
+    "list": {
+      "title": "Any expression returning a list",
+      "$ref": "#/definitions/strict-list"
+    },
+    "strict-list": {
+      "title": "Any expression returning a list (strict)",
+      "anyOf": [
+        { "$ref": "#/definitions/func-dataModel" },
+        { "$ref": "#/definitions/func-list" }
       ]
     },
     "func-if": {
@@ -680,6 +692,15 @@
         { "$ref": "#/definitions/string" }
       ],
       "additionalItems": false
+    },
+    "func-list": {
+      "title": "Create a list",
+      "description": "This function creates a list from its arguments.",
+      "type": "array",
+      "items": [
+        { "const": "list" }
+      ],
+      "additionalItems": { "$ref": "#/definitions/any" }
     },
     "compare-operator": {
       "title": "Comparison operator",

--- a/src/codegen/dataTypes/GenerateExpressionOr.ts
+++ b/src/codegen/dataTypes/GenerateExpressionOr.ts
@@ -10,6 +10,7 @@ const toTsMap: { [key in ExprVal]: string } = {
   [ExprVal.Number]: 'ExprValToActualOrExpr<ExprVal.Number>',
   [ExprVal.String]: 'ExprValToActualOrExpr<ExprVal.String>',
   [ExprVal.Date]: 'ExprValToActualOrExpr<ExprVal.Date>',
+  [ExprVal.List]: 'ExprValToActualOrExpr<ExprVal.List>',
 };
 
 const toSchemaMap: { [key in ExprVal]: JSONSchema7 } = {
@@ -18,6 +19,7 @@ const toSchemaMap: { [key in ExprVal]: JSONSchema7 } = {
   [ExprVal.Number]: { $ref: 'expression.schema.v1.json#/definitions/number' },
   [ExprVal.String]: { $ref: 'expression.schema.v1.json#/definitions/string' },
   [ExprVal.Date]: { $ref: 'expression.schema.v1.json#/definitions/string' },
+  [ExprVal.List]: { $ref: 'expression.schema.v1.json#/definitions/list' },
 };
 
 type TypeMap<Val extends ExprVal> = Val extends ExprVal.Boolean

--- a/src/features/expressions/expression-functions.ts
+++ b/src/features/expressions/expression-functions.ts
@@ -7,7 +7,7 @@ import { exprCastValue } from 'src/features/expressions';
 import { Decimal } from 'src/features/expressions/Decimal';
 import { ExprRuntimeError, NodeRelationNotFound } from 'src/features/expressions/errors';
 import { ExprVal } from 'src/features/expressions/types';
-import { addError } from 'src/features/expressions/validation';
+import { addError, isValidValue } from 'src/features/expressions/validation';
 import { makeIndexedId } from 'src/features/form/layout/utils/makeIndexedId';
 import { CodeListPending } from 'src/features/options/CodeListsProvider';
 import { buildAuthContext } from 'src/utils/authContext';
@@ -21,6 +21,7 @@ import type {
   ExprFunctionName,
   ExprFunctions,
   ExprValToActual,
+  ValidValue,
 } from 'src/features/expressions/types';
 import type { ValidationContext } from 'src/features/expressions/validation';
 import type { IDataModelReference } from 'src/layout/common.generated';
@@ -318,6 +319,11 @@ export const ExprFunctionDefinitions = {
   lowerCaseFirst: {
     args: args(required(ExprVal.String)),
     returns: ExprVal.String,
+    needs: noSources,
+  },
+  list: {
+    args: args(rest(ExprVal.Any)),
+    returns: ExprVal.List,
     needs: noSources,
   },
   _experimentalSelectAndMap: {
@@ -794,6 +800,9 @@ export const ExprFunctionImplementations: { [K in ExprFunctionName]: Implementat
     }
     return string.charAt(0).toLowerCase() + string.slice(1);
   },
+  list(...items): ValidValue[] {
+    return items;
+  },
   _experimentalSelectAndMap(path, propertyToSelect, prepend, append, appendToLastElement = true) {
     if (path === null || propertyToSelect == null) {
       throw new ExprRuntimeError(this.expr, this.path, `Cannot lookup dataModel null`);
@@ -900,7 +909,7 @@ function pickSimpleValue(
   if (value === ContextNotProvided) {
     return null;
   }
-  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+  if (isValidValue(value)) {
     return value;
   }
   return null;

--- a/src/features/expressions/index.ts
+++ b/src/features/expressions/index.ts
@@ -10,6 +10,7 @@ import {
 } from 'src/features/expressions/errors';
 import { ExprFunctionDefinitions, ExprFunctionImplementations } from 'src/features/expressions/expression-functions';
 import { ExprVal } from 'src/features/expressions/types';
+import { isValidArray } from 'src/features/expressions/validation';
 import { type ExpressionDataSources } from 'src/utils/layout/useExpressionDataSources';
 import type {
   ExprConfig,
@@ -307,7 +308,7 @@ export const ExprTypes: {
   },
   [ExprVal.Any]: {
     nullable: true,
-    accepts: [ExprVal.Boolean, ExprVal.String, ExprVal.Number, ExprVal.Any],
+    accepts: [ExprVal.Boolean, ExprVal.String, ExprVal.Number, ExprVal.Any, ExprVal.List],
     impl: (arg) => arg,
   },
   [ExprVal.Date]: {
@@ -323,6 +324,17 @@ export const ExprTypes: {
       }
 
       throw new UnexpectedType(this.expr, this.path, 'date', arg);
+    },
+  },
+  [ExprVal.List]: {
+    nullable: false,
+    accepts: [ExprVal.List, ExprVal.Any],
+    impl(arg) {
+      if (isValidArray(arg)) {
+        return arg;
+      } else {
+        throw new UnexpectedType(this.expr, this.path, 'list', arg);
+      }
     },
   },
 };

--- a/src/features/expressions/shared-tests/functions/dataModel/array-is-null.json
+++ b/src/features/expressions/shared-tests/functions/dataModel/array-is-null.json
@@ -1,5 +1,5 @@
 {
-  "name": "Looking up an array returns null",
+  "name": "Looking up an array with objects returns null",
   "expression": ["dataModel", "a"],
   "expects": null,
   "dataModels": [

--- a/src/features/expressions/shared-tests/functions/dataModel/lookup-list.json
+++ b/src/features/expressions/shared-tests/functions/dataModel/lookup-list.json
@@ -1,0 +1,57 @@
+{
+  "name": "Lookup a list value",
+  "dataModels": [
+    {
+      "dataElement": {
+        "id": "00dd7417-5b4e-402a-bb73-007537071f1d",
+        "dataType": "default"
+      },
+      "data": {
+        "numberList": [1, 2],
+        "stringList": ["Lorem", "ipsum"],
+        "booleanList": [true, false],
+        "nullList": [null, null],
+        "multidimensionalList": [[[1, 2], [3, 4]], [[5, 6], [7, 8]]],
+        "emptyList": [],
+        "differentTypesList": [1, "string", true, null, []]
+      }
+    }
+  ],
+  "testCases": [
+    {
+      "name": "Number list lookup",
+      "expression": ["dataModel", "numberList"],
+      "expects": [1, 2]
+    },
+    {
+      "name": "String list lookup",
+      "expression": ["dataModel", "stringList"],
+      "expects": ["Lorem", "ipsum"]
+    },
+    {
+      "name": "Boolean list lookup",
+      "expression": ["dataModel", "booleanList"],
+      "expects": [true, false]
+    },
+    {
+      "name": "Null list lookup",
+      "expression": ["dataModel", "nullList"],
+      "expects": [null, null]
+    },
+    {
+      "name": "Multi-dimensional list lookup",
+      "expression": ["dataModel", "multidimensionalList"],
+      "expects": [[[1, 2], [3, 4]], [[5, 6], [7, 8]]]
+    },
+    {
+      "name": "Empty list lookup",
+      "expression": ["dataModel", "emptyList"],
+      "expects": []
+    },
+    {
+      "name": "Lookup of list with different types",
+      "expression": ["dataModel", "differentTypesList"],
+      "expects": [1, "string", true, null, []]
+    }
+  ]
+}

--- a/src/features/expressions/shared-tests/functions/list/list.json
+++ b/src/features/expressions/shared-tests/functions/list/list.json
@@ -1,0 +1,35 @@
+{
+  "name": "List tests",
+  "testCases": [
+    {
+      "name": "Returns the list",
+      "expression": ["list", 1, 2],
+      "expects": [1, 2]
+    },
+    {
+      "name": "Supports empty lists",
+      "expression": ["list"],
+      "expects": []
+    },
+    {
+      "name": "Supports lists with different types",
+      "expression": ["list", 1, "string", true, null],
+      "expects": [1, "string", true, null]
+    },
+    {
+      "name": "Supports nested lists",
+      "expression": ["list", ["list", 1, 2], ["list", 3, 4]],
+      "expects": [[1, 2], [3, 4]]
+    },
+    {
+      "name": "Does not evaluate the final expression when the result happens to be a valid expression",
+      "expression": ["list", "equals", 1, 1],
+      "expects": ["equals", 1, 1]
+    },
+    {
+      "name": "Evaluates expressions inside arguments",
+      "expression": ["list", ["equals", 1, 1]],
+      "expects": [true]
+    }
+  ]
+}

--- a/src/features/expressions/types.ts
+++ b/src/features/expressions/types.ts
@@ -14,6 +14,7 @@ export enum ExprVal {
   String = '__string__',
   Number = '__number__',
   Date = '__date__', // Actually just a string, but must be parsable as a date (ane lets us work with Date internally)
+  List = '__list__',
   Any = '__any__',
 }
 
@@ -25,9 +26,11 @@ export type ExprValToActual<T extends ExprVal = ExprVal> = T extends ExprVal.Dat
       ? number
       : T extends ExprVal.Boolean
         ? boolean
-        : T extends ExprVal.Any
-          ? string | number | boolean | null
-          : unknown;
+        : T extends ExprVal.List
+          ? ValidValue[]
+          : T extends ExprVal.Any
+            ? ValidValue
+            : unknown;
 
 /**
  * This type replaces ExprVal with the actual value type, or expression that returns that type.
@@ -132,3 +135,5 @@ export interface ExprDateExtensions {
 }
 
 export type ExprDate = Date & { exprDateExtensions: ExprDateExtensions };
+
+export type ValidValue = string | number | boolean | null | ValidValue[];

--- a/src/features/expressions/validation.ts
+++ b/src/features/expressions/validation.ts
@@ -5,7 +5,13 @@ import {
 } from 'src/features/expressions/expression-functions';
 import { prettyErrors } from 'src/features/expressions/prettyErrors';
 import { ExprVal } from 'src/features/expressions/types';
-import type { AnyExprArg, Expression, ExprFunctionName, ExprValToActualOrExpr } from 'src/features/expressions/types';
+import type {
+  AnyExprArg,
+  Expression,
+  ExprFunctionName,
+  ExprValToActualOrExpr,
+  ValidValue,
+} from 'src/features/expressions/types';
 
 export enum ValidationErrorMessage {
   InvalidType = 'Invalid type "%s"',
@@ -322,3 +328,17 @@ export const ExprValidation = {
    */
   throwIfInvalid,
 };
+
+export function isValidValue(value: unknown): value is ValidValue {
+  return (
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean' ||
+    value === null ||
+    isValidArray(value)
+  );
+}
+
+export function isValidArray(value: unknown): value is ValidValue[] {
+  return Array.isArray(value) && value.every(isValidValue);
+}


### PR DESCRIPTION
## Description
This pull request adds list support to our expression language in frontend. This includes the following:
- A `list` function that creates a list
- Recognising arrays as valid types
- Allowing the `dataModel` function to return a list

## Related Issue(s)
- #4189

## Verification/QA
- Manual functionality testing
  - [x] I have tested these changes manually
- Automated tests
  - [x] Unit test(s) have been added/updated
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [x] No testing done/necessary (no DOM/visual changes)
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [x] Has been added/updated: https://github.com/Altinn/altinn-studio-docs/pull/2894
- Support in Altinn Studio
  - [x] Issue(s) created for support in Studio: The JSON Schema in the expression editor must be updated. This is a part of #4189.
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
