### PR TITLE
test: fixed party-selection.ts cypress test that fails in tt02

### DIFF
--- a/test/e2e/integration/frontend-test/party-selection.ts
+++ b/test/e2e/integration/frontend-test/party-selection.ts
@@ -1,11 +1,17 @@
 import texts from 'test/e2e/fixtures/texts.json';
 import { AppFrontend } from 'test/e2e/pageobjects/app-frontend';
-import { cyMockResponses, CyPartyMocks, removeAllButOneOrg } from 'test/e2e/pageobjects/party-mocks';
+import { cyMockResponses, CyPartyMocks, removeAllButKeepOrg } from 'test/e2e/pageobjects/party-mocks';
 import { cyUserCredentials } from 'test/e2e/support/auth';
 
 import type { IParty } from 'src/types/shared';
 
 const appFrontend = new AppFrontend();
+
+// Org numbers the accountant test user only represents as accountant — no instantiate rights, so
+// instantiation returns 403.
+const NonInstantiableOrgForAccountant = {
+  AldrendeOppstemtTigerAS: '213611372',
+} as const;
 
 describe('Party selection', () => {
   it('Party selection filtering and search', () => {
@@ -249,15 +255,19 @@ describe('Party selection', () => {
   it('Should be possible to select another party if instantiation fails, and go back to party selection and instantiate again', () => {
     cy.allowFailureOnEnd();
     const user = cyUserCredentials.accountant.firstName;
+    // Pin a specific org by number instead of taking the first one — the tt02 party list order is
+    // not stable, and an org the user *can* instantiate for may otherwise end up first.
     cyMockResponses({
       allowedToInstantiate: (parties) =>
         // Removing all other users as well, since one of the users are not allowed to instantiate on tt02
-        removeAllButOneOrg(parties).filter((party) => party.orgNumber || party.name.includes(user)),
+        removeAllButKeepOrg(parties, NonInstantiableOrgForAccountant.AldrendeOppstemtTigerAS).filter(
+          (party) => party.orgNumber || party.name.includes(user),
+        ),
       doNotPromptForParty: false,
     });
     cy.startAppInstance(appFrontend.apps.frontendTest, { cyUser: 'accountant' });
 
-    // Select the first organisation. This is not allowed to instantiate in this app, so it will throw an error.
+    // Select the organisation. This is not allowed to instantiate in this app, so it will throw an error.
     cy.findAllByText(/org\.nr\. \d+/)
       .first()
       .click();

--- a/test/e2e/pageobjects/party-mocks.ts
+++ b/test/e2e/pageobjects/party-mocks.ts
@@ -180,3 +180,16 @@ export function removeAllButOneOrg(parties: IParty[]): IParty[] {
   }
   return toKeep;
 }
+
+export function removeAllButKeepOrg(parties: IParty[], orgNumber: string): IParty[] {
+  // Keep one specific organisation (by org number) plus all persons. Pinning a specific org by
+  // number, instead of just taking the first one. This avoids depending on the order of the tt02
+  // party list, which is not stable. Falls back to the first org when this specific org is not
+  // present, e.g. in docker/podman/localtest environments that have entirely different test data.
+  const org = parties.find((party) => party.partyTypeName === PartyType.Organisation && party.orgNumber === orgNumber);
+  if (!org) {
+    return removeAllButOneOrg(parties);
+  }
+  const persons = parties.filter((party) => party.partyTypeName === PartyType.Person);
+  return [org, ...persons];
+}


### PR DESCRIPTION
## Description

Cypress-testen `party-selection.ts` =>  _"Du mangler rettigheter for å se denne tjenesten"_ begynte å feile på tt02:

  ```
  expected [data-testid="AltinnError"] to contain text
  "Du mangler rettigheter for å se denne tjenesten", but the text was ''
  ```

  Siste grønne kjøring på `main` var 21. mai, første røde 26. mai, uten noen relevant kode-merge imellom. `frontend-test`-appen  er heller ikke endret (publisert v208, 13.01.2026).

Endret til å ta et mer eksplisitt valg av hvilken org vi forsøker å instansiere for. Det ser ut til at testbrukeren har fått tilgang til en ekstra org som den kan representere, og som den også har rettigheter til å instansiere for. Dermed kan .first() og removeAllButOneOrg ende opp med å velge en org brukeren faktisk har tilgang til å instansiere for, og vi får derfor ikke det forventede resultatet.

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->
