### PR TITLE
fix: ensure to redirect auth-level when 403 with RequiredAuthenticationLevel

### DIFF
--- a/src/features/instantiate/containers/InstantiateContainer.tsx
+++ b/src/features/instantiate/containers/InstantiateContainer.tsx
@@ -10,6 +10,7 @@ import { useSelectedParty } from 'src/features/party/PartiesProvider';
 import { AltinnPalette } from 'src/theme/altinnAppTheme';
 import { changeBodyBackground } from 'src/utils/bodyStyling';
 import { isAxiosError } from 'src/utils/isAxiosError';
+import { isAuthenticationRedirectError } from 'src/utils/maybeAuthenticationRedirect';
 import { HttpStatusCodes } from 'src/utils/network/networking';
 
 export const InstantiateContainer = () => {
@@ -23,6 +24,10 @@ export const InstantiateContainer = () => {
       instantiation.instantiate(party.partyId);
     }
   }, [instantiation, party]);
+
+  if (isAuthenticationRedirectError(instantiation.error)) {
+    return <Loader reason='authentication-redirect' />;
+  }
 
   if (isAxiosError(instantiation.error) && instantiation.error.response?.status === HttpStatusCodes.Forbidden) {
     if (isInstantiationValidationResult(instantiation.error.response?.data)) {

--- a/src/features/instantiate/useInstantiation.tsx
+++ b/src/features/instantiate/useInstantiation.tsx
@@ -38,12 +38,14 @@ export function useInstantiation() {
     mutationKey: ['instantiate'],
     mutationFn: (args: InstantiationArgs) =>
       typeof args === 'number' ? doInstantiate(args, currentLanguage) : doInstantiateWithPrefill(args, currentLanguage),
-    onError: (error: HttpClientError) => {
+    onError: async (error: HttpClientError) => {
       window.logError(`Instantiation failed:\n`, error);
+
+      // If the instantiation failed because the user is authenticated with a too low security level, the backend
+      // responds with 403 and a RequiredAuthenticationLevel. We then redirect to step-up authentication instead of
+      // falling through to a generic "missing roles" error page. No-op for any other error.
       if (isAxiosError(error)) {
-        // If the instantiation failed because the user is authenticated with a too low security level, redirect to
-        // step-up authentication instead of falling through to a generic "missing roles" error page.
-        maybeAuthenticationRedirect(error).then();
+        await maybeAuthenticationRedirect(error);
       }
     },
     onSuccess: async (data) => {

--- a/src/features/instantiate/useInstantiation.tsx
+++ b/src/features/instantiate/useInstantiation.tsx
@@ -7,6 +7,8 @@ import type { AxiosError } from 'axios';
 import { useAppMutations } from 'src/core/contexts/AppQueriesProvider';
 import { instanceQueries } from 'src/features/instance/InstanceContext';
 import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
+import { isAxiosError } from 'src/utils/isAxiosError';
+import { maybeAuthenticationRedirect } from 'src/utils/maybeAuthenticationRedirect';
 import type { IInstance } from 'src/types/shared';
 import type { HttpClientError } from 'src/utils/network/sharedNetworking';
 
@@ -38,6 +40,11 @@ export function useInstantiation() {
       typeof args === 'number' ? doInstantiate(args, currentLanguage) : doInstantiateWithPrefill(args, currentLanguage),
     onError: (error: HttpClientError) => {
       window.logError(`Instantiation failed:\n`, error);
+      if (isAxiosError(error)) {
+        // If the instantiation failed because the user is authenticated with a too low security level, redirect to
+        // step-up authentication instead of falling through to a generic "missing roles" error page.
+        maybeAuthenticationRedirect(error).then();
+      }
     },
     onSuccess: async (data) => {
       const [instanceOwnerPartyId, instanceGuid] = data.id.split('/');

--- a/src/features/instantiate/useInstantiation.tsx
+++ b/src/features/instantiate/useInstantiation.tsx
@@ -7,7 +7,6 @@ import type { AxiosError } from 'axios';
 import { useAppMutations } from 'src/core/contexts/AppQueriesProvider';
 import { instanceQueries } from 'src/features/instance/InstanceContext';
 import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
-import { isAxiosError } from 'src/utils/isAxiosError';
 import { maybeAuthenticationRedirect } from 'src/utils/maybeAuthenticationRedirect';
 import type { IInstance } from 'src/types/shared';
 import type { HttpClientError } from 'src/utils/network/sharedNetworking';
@@ -41,12 +40,8 @@ export function useInstantiation() {
     onError: async (error: HttpClientError) => {
       window.logError(`Instantiation failed:\n`, error);
 
-      // If the instantiation failed because the user is authenticated with a too low security level, the backend
-      // responds with 403 and a RequiredAuthenticationLevel. We then redirect to step-up authentication instead of
-      // falling through to a generic "missing roles" error page. No-op for any other error.
-      if (isAxiosError(error)) {
-        await maybeAuthenticationRedirect(error);
-      }
+      // Redirect to step-up authentication if the error is a too-low auth level. No-op otherwise.
+      await maybeAuthenticationRedirect(error);
     },
     onSuccess: async (data) => {
       const [instanceOwnerPartyId, instanceGuid] = data.id.split('/');

--- a/src/utils/maybeAuthenticationRedirect.ts
+++ b/src/utils/maybeAuthenticationRedirect.ts
@@ -1,17 +1,33 @@
-import type { AxiosError } from 'axios';
-
+import { isAxiosError } from 'src/utils/isAxiosError';
 import { putWithoutConfig } from 'src/utils/network/networking';
 import { invalidateCookieUrl, redirectToUpgrade } from 'src/utils/urls/appUrlHelper';
 
-export async function maybeAuthenticationRedirect(error: AxiosError): Promise<boolean> {
-  if (error.response && error.response.status === 403 && error.response.data) {
-    const reqAuthLevel = error.response.data['RequiredAuthenticationLevel'];
-    if (reqAuthLevel) {
-      await putWithoutConfig(invalidateCookieUrl);
-      redirectToUpgrade(reqAuthLevel);
+function getRequiredAuthenticationLevel(error: unknown): string | undefined {
+  if (isAxiosError(error) && error.response?.status === 403 && error.response.data) {
+    return error.response.data['RequiredAuthenticationLevel'];
+  }
+  return undefined;
+}
 
-      return true;
-    }
+export function isAuthenticationRedirectError(error: unknown): boolean {
+  return !!getRequiredAuthenticationLevel(error);
+}
+
+async function invalidateExistingAuthCookie(): Promise<void> {
+  try {
+    await putWithoutConfig(invalidateCookieUrl);
+  } catch (e) {
+    window.logError('Failed to invalidate auth cookie before step-up redirect:\n', e);
+  }
+}
+
+export async function maybeAuthenticationRedirect(error: unknown): Promise<boolean> {
+  const reqAuthLevel = getRequiredAuthenticationLevel(error);
+  if (reqAuthLevel) {
+    await invalidateExistingAuthCookie();
+    redirectToUpgrade(reqAuthLevel);
+
+    return true;
   }
 
   return false;


### PR DESCRIPTION
## Feil ved for lavt sikkerhetsnivå ved instansiering

Når en bruker forsøkte å opprette en instans, men var innlogget med et lavere sikkerhetsnivå enn tjenesten krevde (for eksempel nivå 3 når nivå 4 var påkrevd), fikk brukeren feilaktig meldingen **"Du mangler rettigheter for å se denne tjenesten"** (`MissingRolesError`).

Backend håndterte situasjonen korrekt og svarte med **403 Forbidden** samt informasjon om hvilket autentiseringsnivå som var påkrevd:

```json
{
  "RequiredAuthenticationLevel": "4"
}
```

Problemet var at instansieringsflyten ikke utførte den nødvendige sjekken for step-up-autentisering (`maybeAuthenticationRedirect`).

Resultatet var at brukeren ble sendt til en generell feilside for manglende rettigheter, i stedet for å bli videresendt til ID-porten for å autentisere seg på riktig sikkerhetsnivå.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed authentication redirect handling during instantiation failures to properly trigger step-up authentication when required.
  * Enhanced error handling to correctly identify and process authentication-related errors with appropriate redirect flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->