### PR TITLE
Disabling keepalive request in PDF mode

### DIFF
--- a/src/core/auth/KeepAliveProvider.tsx
+++ b/src/core/auth/KeepAliveProvider.tsx
@@ -7,6 +7,7 @@ import { useAppQueries } from 'src/core/contexts/AppQueriesProvider';
 import { createContext } from 'src/core/contexts/context';
 import { useApplicationSettings } from 'src/features/applicationSettings/ApplicationSettingsProvider';
 import { useAllowAnonymous } from 'src/features/stateless/getAllowAnonymous';
+import { useIsPdf } from 'src/hooks/useIsPdf';
 import { getEnvironmentLoginUrl } from 'src/utils/urls/appUrlHelper';
 
 const ONE_MINUTE_IN_MILLISECONDS = 60000;
@@ -16,10 +17,10 @@ const redirectToLogin = (appOidcProvider: string | null): void => {
   window.location.href = getEnvironmentLoginUrl(appOidcProvider);
 };
 
-const useRefreshJwtTokenQuery = (appOidcProvider: string | null | undefined, allowAnonymous: boolean | undefined) => {
+const useRefreshJwtTokenQuery = (appOidcProvider: string | null | undefined, enabled: boolean) => {
   const { fetchRefreshJwtToken } = useAppQueries();
   const utils = useQuery({
-    enabled: allowAnonymous === false, // Only refresh token at page load if allowAnonymous === false
+    enabled,
     refetchOnWindowFocus: true,
     refetchInterval: TEN_MINUTE_IN_MILLISECONDS, // Refresh token every 10 minutes only if the tab is focused
 
@@ -48,8 +49,10 @@ const { Provider } = createContext<undefined>({
 export function KeepAliveProvider({ children }: PropsWithChildren) {
   const applicationSettings = useApplicationSettings();
   const allowAnonymous = useAllowAnonymous();
+  const isPdf = useIsPdf();
+  const enabled = allowAnonymous === false && !isPdf; // Only refresh token at page load if allowAnonymous === false
 
-  useRefreshJwtTokenQuery(applicationSettings?.appOidcProvider, allowAnonymous);
+  useRefreshJwtTokenQuery(applicationSettings?.appOidcProvider, enabled);
 
   return <Provider value={undefined}>{children}</Provider>;
 }

--- a/test/e2e/integration/frontend-test/pdf.ts
+++ b/test/e2e/integration/frontend-test/pdf.ts
@@ -52,6 +52,13 @@ describe('PDF', () => {
         cy.get('@allRequests.all').then((_intercepts) => {
           const intercepts = _intercepts as unknown as Interception[];
           expect(intercepts.length).to.be.greaterThan(10);
+
+          // We explicitly do not want keepAlive requests, since those should be disabled in PDF mode
+          expect(
+            intercepts.map((intercept) => intercept.request.url),
+            'PDF mode requests',
+          ).not.to.satisfy((urls: string[]) => urls.some((url) => url.includes('/api/authentication/keepAlive')));
+
           for (const intercept of intercepts) {
             const { request } = intercept;
             const reqInfo = `${intercept.browserRequestId} ${intercept.routeId} ${request.method} ${request.url.split(domain)[1]}`;


### PR DESCRIPTION
## Description

We've seen the keepAlive request fail in PDF mode, and there's no good reason for this request running in the PDF generator anyway. This change disables it.

## Related Issue(s)

- https://digdir.slack.com/archives/C0760NPT2BE/p1780912129396449
- https://digdir-samarbeid.slack.com/archives/C02EJ9HKQA3/p1780911939729589

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [x] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * JWT token refresh is now disabled while viewing PDF documents, reducing unnecessary background requests.

* **Tests**
  * Enhanced PDF mode tests to verify the keep-alive endpoint is not called during PDF viewing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->