### PR TITLE
Add retry for fetching paymentInformation

### DIFF
--- a/src/features/payment/PaymentInformationProvider.tsx
+++ b/src/features/payment/PaymentInformationProvider.tsx
@@ -26,11 +26,17 @@ export function usePaymentInformationQueryDef(
 
   const selectedLanguage = useCurrentLanguage();
 
+  // Returning from the hosted payment page races with the payment webhook that advances the process.
+  // The endpoint can briefly fail (e.g. while the data element is momentarily locked, or a transient
+  // 5xx/network blip) — retry a few times so a single bad response doesn't strand the user on the
+  // error page before the backend has settled. Mirrors the instance-data query's retry policy.
   if (appSupportsPaymentWebhooks(altinnNugetVersion)) {
     return {
       queryKey: ['fetchPaymentInfoForTask', instanceId, selectedLanguage],
       queryFn: instanceId ? () => fetchPaymentInformationForTask(instanceId, selectedLanguage, taskId) : skipToken,
       enabled: enabled && !!instanceId,
+      retry: 3,
+      retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
     };
   } else {
     return {
@@ -38,6 +44,8 @@ export function usePaymentInformationQueryDef(
       queryFn: instanceId ? () => fetchPaymentInformation(instanceId, selectedLanguage) : skipToken,
       enabled: enabled && !!instanceId,
       gcTime: 0,
+      retry: 3,
+      retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
     };
   }
 }


### PR DESCRIPTION
## Description

Adds retry with exponential backoff to the payment information query (`GET …/payment`), mirroring the existing instance-data query policy (`retry: 3`).

Returning from the hosted payment page races with the payment webhook that advances the process. In that window the endpoint can briefly fail (a momentarily locked data element, or a transient 5xx/network blip). With no retry, a single bad response immediately rendered the `DisplayError` page and stranded the user after a completed payment. Retrying a few times lets the backend settle before any error surfaces.

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [x] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced payment processing reliability by implementing automatic retry logic to handle temporary service disruptions without interrupting transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->