### PR TITLE
fix: make voiceover read org detailes

### DIFF
--- a/src/layout/OrganisationLookup/OrganisationLookupComponent.test.tsx
+++ b/src/layout/OrganisationLookup/OrganisationLookupComponent.test.tsx
@@ -110,6 +110,11 @@ describe('OrganisationLookupComponent', () => {
 
     expect(screen.getByText(/Organisasjonsnummeret er ugyldig/i)).toBeInTheDocument();
     expect(mockedHttpGet).not.toHaveBeenCalled();
+
+    const statusRegion = screen.getByTestId('organisation-lookup-status');
+    await waitFor(() => {
+      expect(statusRegion).toHaveTextContent(/Organisasjonsnummeret er ugyldig/i);
+    });
   });
 
   it('fetches organisation, announces details, and allows clearing', async () => {
@@ -139,7 +144,7 @@ describe('OrganisationLookupComponent', () => {
 
     expect(screen.getByLabelText('Organisasjonsnavn')).toHaveTextContent(orgName);
 
-    const statusRegion = screen.getByRole('status', { hidden: true });
+    const statusRegion = screen.getByTestId('organisation-lookup-status');
     await waitFor(() => {
       expect(statusRegion).toHaveTextContent(`Organisasjonsnummer ${validOrgNr}`);
       expect(statusRegion).toHaveTextContent('Sibling Name');

--- a/src/layout/OrganisationLookup/OrganisationLookupComponent.test.tsx
+++ b/src/layout/OrganisationLookup/OrganisationLookupComponent.test.tsx
@@ -1,0 +1,216 @@
+import React from 'react';
+
+import { jest } from '@jest/globals';
+import { screen, waitFor } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+
+import { defaultDataTypeMock } from 'src/__mocks__/getLayoutSetsMock';
+import { OrganisationLookupComponent } from 'src/layout/OrganisationLookup/OrganisationLookupComponent';
+import { renderGenericComponentTest } from 'src/test/renderWithProviders';
+import { httpGet } from 'src/utils/network/networking';
+import type { ILayoutCollection } from 'src/layout/layout';
+import type { RenderGenericComponentTestProps } from 'src/test/renderWithProviders';
+
+jest.mock('src/utils/network/networking', () => ({
+  httpGet: jest.fn(),
+}));
+
+const mockedHttpGet = jest.mocked(httpGet);
+
+const validOrgNr = '043871668';
+const orgName = 'Skog og Fjell Consulting';
+const orgLookupId = 'org-lookup';
+const textSiblingId = 'text-sibling';
+
+const defaultBindings = {
+  organisation_lookup_orgnr: { field: 'orgNr', dataType: defaultDataTypeMock },
+  organisation_lookup_name: { field: 'orgName', dataType: defaultDataTypeMock },
+};
+
+const render = async ({
+  component,
+  queries,
+  ...rest
+}: Partial<RenderGenericComponentTestProps<'OrganisationLookup'>> = {}) =>
+  await renderGenericComponentTest({
+    type: 'OrganisationLookup',
+    renderer: (props) => <OrganisationLookupComponent {...props} />,
+    mockFormDataSaving: true,
+    component: {
+      id: orgLookupId,
+      dataModelBindings: defaultBindings,
+      textResourceBindings: {
+        title: 'Organisation lookup',
+      },
+      ...component,
+    },
+    queries: {
+      fetchFormData: async () => ({
+        orgNr: '',
+        orgName: '',
+        address: { name: '', street: '' },
+      }),
+      ...queries,
+    },
+    ...rest,
+  });
+
+const layoutWithSiblingText: ILayoutCollection = {
+  FormLayout: {
+    data: {
+      layout: [
+        {
+          id: 'group-1',
+          type: 'Group',
+          children: [orgLookupId, textSiblingId],
+        },
+        {
+          id: orgLookupId,
+          type: 'OrganisationLookup',
+          dataModelBindings: defaultBindings,
+          textResourceBindings: {
+            title: 'Organisation lookup',
+          },
+        },
+        {
+          id: textSiblingId,
+          type: 'Text',
+          textResourceBindings: {
+            title: 'Org name title',
+          },
+          value: ['dataModel', 'address.name', defaultDataTypeMock],
+        },
+        {
+          id: 'text-street',
+          type: 'Text',
+          value: ['dataModel', 'address.street', defaultDataTypeMock],
+        },
+      ],
+    },
+  },
+};
+
+describe('OrganisationLookupComponent', () => {
+  beforeEach(() => {
+    mockedHttpGet.mockReset();
+  });
+
+  it('renders lookup field and submit button', async () => {
+    await render();
+
+    expect(screen.getByRole('textbox', { name: /Organisasjonsnummer/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Hent opplysninger/i })).toBeInTheDocument();
+  });
+
+  it('shows validation error for invalid organisation number', async () => {
+    await render();
+
+    await userEvent.type(screen.getByRole('textbox', { name: /Organisasjonsnummer/i }), '123456789');
+    await userEvent.click(screen.getByRole('button', { name: /Hent opplysninger/i }));
+
+    expect(screen.getByText(/Organisasjonsnummeret er ugyldig/i)).toBeInTheDocument();
+    expect(mockedHttpGet).not.toHaveBeenCalled();
+  });
+
+  it('fetches organisation, announces details, and allows clearing', async () => {
+    mockedHttpGet.mockResolvedValue({
+      success: true,
+      organisationDetails: {
+        orgNr: validOrgNr,
+        name: orgName,
+      },
+    });
+
+    await render({
+      queries: {
+        fetchLayouts: async (_layoutSetId): Promise<ILayoutCollection> => layoutWithSiblingText,
+      },
+      mockFormDataSaving: (data) => ({
+        ...(data as object),
+        address: { name: 'Sibling Name', street: 'Street 1' },
+      }),
+    });
+
+    await userEvent.type(screen.getByRole('textbox', { name: /Organisasjonsnummer/i }), validOrgNr);
+    await userEvent.click(screen.getByRole('button', { name: /Hent opplysninger/i }));
+
+    await waitFor(() => expect(mockedHttpGet).toHaveBeenCalled());
+    await waitFor(() => expect(screen.getByRole('button', { name: /Fjern/i })).toBeInTheDocument());
+
+    expect(screen.getByLabelText('Organisasjonsnavn')).toHaveTextContent(orgName);
+
+    const statusRegion = screen.getByRole('status', { hidden: true });
+    await waitFor(() => {
+      expect(statusRegion).toHaveTextContent(`Organisasjonsnummer ${validOrgNr}`);
+      expect(statusRegion).toHaveTextContent('Sibling Name');
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: /Fjern/i }));
+
+    expect(screen.getByRole('button', { name: /Hent opplysninger/i })).toBeInTheDocument();
+    expect(statusRegion).toHaveTextContent('');
+  });
+
+  it('submits lookup on Enter key', async () => {
+    mockedHttpGet.mockResolvedValue({
+      success: true,
+      organisationDetails: {
+        orgNr: validOrgNr,
+        name: orgName,
+      },
+    });
+
+    await render();
+
+    await userEvent.type(screen.getByRole('textbox', { name: /Organisasjonsnummer/i }), `${validOrgNr}{Enter}`);
+
+    await waitFor(() => expect(mockedHttpGet).toHaveBeenCalled());
+  });
+
+  it('shows not found error when lookup returns no organisation', async () => {
+    mockedHttpGet.mockResolvedValue({
+      success: false,
+      organisationDetails: null,
+    });
+
+    await render();
+
+    await userEvent.type(screen.getByRole('textbox', { name: /Organisasjonsnummer/i }), validOrgNr);
+    await userEvent.click(screen.getByRole('button', { name: /Hent opplysninger/i }));
+
+    expect(await screen.findByText(/Organisasjonsnummeret ble ikke funnet i enhetsregisteret/i)).toBeInTheDocument();
+  });
+
+  it('shows invalid response error when lookup response is invalid', async () => {
+    mockedHttpGet.mockResolvedValue({ unexpected: true });
+
+    await render();
+
+    await userEvent.type(screen.getByRole('textbox', { name: /Organisasjonsnummer/i }), validOrgNr);
+    await userEvent.click(screen.getByRole('button', { name: /Hent opplysninger/i }));
+
+    expect(await screen.findByText(/Ugyldig respons fra server/i)).toBeInTheDocument();
+  });
+
+  it('shows unknown error when lookup request fails', async () => {
+    mockedHttpGet.mockRejectedValue(new Error('network error'));
+
+    await render();
+
+    await userEvent.type(screen.getByRole('textbox', { name: /Organisasjonsnummer/i }), validOrgNr);
+    await userEvent.click(screen.getByRole('button', { name: /Hent opplysninger/i }));
+
+    expect(await screen.findByText(/Ukjent feil. Vennligst prøv igjen senere/i)).toBeInTheDocument();
+  });
+
+  it('does not render action buttons when read only', async () => {
+    await render({
+      component: {
+        readOnly: true,
+      },
+    });
+
+    expect(screen.queryByRole('button', { name: /Hent opplysninger/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Fjern/i })).not.toBeInTheDocument();
+  });
+});

--- a/src/layout/OrganisationLookup/OrganisationLookupComponent.tsx
+++ b/src/layout/OrganisationLookup/OrganisationLookupComponent.tsx
@@ -36,6 +36,8 @@ const orgLookupQueries = {
     }),
 };
 
+const LIVE_REGION_RESET_DELAY_MS = 100;
+
 export type Organisation = {
   orgNr: string;
   name: string;
@@ -123,8 +125,7 @@ export function OrganisationLookupComponent({
     setStatusMessage('');
     window.setTimeout(() => {
       setStatusMessage(parts.join(', '));
-      statusRef.current?.focus();
-    }, 100);
+    }, LIVE_REGION_RESET_DELAY_MS);
   }
 
   function handleValidateOrgnr(orgNr: string) {

--- a/src/layout/OrganisationLookup/OrganisationLookupComponent.tsx
+++ b/src/layout/OrganisationLookup/OrganisationLookupComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 
 import { Field, Paragraph, ValidationMessage } from '@digdir/designsystemet-react';
 import { queryOptions, useQuery } from '@tanstack/react-query';
@@ -12,12 +12,15 @@ import { Label } from 'src/app-components/Label/Label';
 import { Description } from 'src/components/form/Description';
 import { RequiredIndicator } from 'src/components/form/RequiredIndicator';
 import { getDescriptionId } from 'src/components/label/Label';
+import { useLayoutLookups } from 'src/features/form/layout/LayoutsContext';
+import { FD } from 'src/features/formData/FormDataWrite';
 import { useDataModelBindings } from 'src/features/formData/useDataModelBindings';
 import { Lang } from 'src/features/language/Lang';
 import { useLanguage } from 'src/features/language/useLanguage';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
 import classes from 'src/layout/OrganisationLookup/OrganisationLookupComponent.module.css';
 import { validateOrganisationLookupResponse, validateOrgnr } from 'src/layout/OrganisationLookup/validation';
+import utilClasses from 'src/styles/utils.module.css';
 import { useLabel } from 'src/utils/layout/useLabel';
 import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import { httpGet } from 'src/utils/network/networking';
@@ -75,6 +78,8 @@ export function OrganisationLookupComponent({
   });
   const [tempOrgNr, setTempOrgNr] = useState('');
   const [orgNrErrors, setOrgNrErrors] = useState<string[]>();
+  const [statusMessage, setStatusMessage] = useState('');
+  const statusRef = useRef<HTMLDivElement>(null);
 
   const {
     formData: { organisation_lookup_orgnr, organisation_lookup_name: orgName },
@@ -82,8 +87,45 @@ export function OrganisationLookupComponent({
   } = useDataModelBindings(dataModelBindings);
 
   const { langAsString } = useLanguage();
+  const layoutLookups = useLayoutLookups();
+  const pickFormValue = FD.useCurrentSelector();
+  const waitForSave = FD.useWaitForSave();
 
   const { data, refetch: performLookup, isFetching } = useQuery(orgLookupQueries.lookup(tempOrgNr));
+
+  function announceOrgDetails(orgNr: string) {
+    const parts = [`${langAsString('organisation_lookup.orgnr_label')} ${orgNr}`];
+
+    const parent = layoutLookups.componentToParent[baseComponentId];
+    const childIds = parent?.type === 'node' ? layoutLookups.componentToChildren[parent.id] : undefined;
+    const lookupIndex = childIds?.indexOf(baseComponentId) ?? -1;
+
+    for (const childId of childIds?.slice(lookupIndex + 1) ?? []) {
+      const component = layoutLookups.allComponents[childId];
+      if (component?.type !== 'Text' || !Array.isArray(component.value) || component.value[0] !== 'dataModel') {
+        continue;
+      }
+
+      const [, field, dataType] = component.value;
+      if (typeof field !== 'string' || typeof dataType !== 'string') {
+        continue;
+      }
+
+      const textValue = String(pickFormValue({ field, dataType }) ?? '').trim();
+      if (!textValue) {
+        continue;
+      }
+
+      const titleKey = component.textResourceBindings?.title;
+      parts.push(typeof titleKey === 'string' ? `${langAsString(titleKey)} ${textValue}` : textValue);
+    }
+
+    setStatusMessage('');
+    window.setTimeout(() => {
+      setStatusMessage(parts.join(', '));
+      statusRef.current?.focus();
+    }, 100);
+  }
 
   function handleValidateOrgnr(orgNr: string) {
     if (!validateOrgnr({ orgNr })) {
@@ -109,6 +151,8 @@ export function OrganisationLookupComponent({
     if (data?.org) {
       setValue('organisation_lookup_orgnr', data.org.orgNr);
       dataModelBindings.organisation_lookup_name && setValue('organisation_lookup_name', data.org.name);
+      await waitForSave(true);
+      announceOrgDetails(data.org.orgNr);
     }
   }
 
@@ -117,6 +161,7 @@ export function OrganisationLookupComponent({
     dataModelBindings.organisation_lookup_name && setValue('organisation_lookup_name', '');
     setTempOrgNr('');
     setOrgNrErrors(undefined);
+    setStatusMessage('');
   }
 
   const hasSuccessfullyFetched = !!organisation_lookup_orgnr;
@@ -209,11 +254,22 @@ export function OrganisationLookupComponent({
           {hasSuccessfullyFetched && orgName && (
             <div
               className={classes.orgname}
+              role='group'
               aria-label={langAsString('organisation_lookup.org_name')}
             >
-              {hasSuccessfullyFetched && <Paragraph data-size='sm'>{orgName}</Paragraph>}
+              <Paragraph data-size='sm'>{orgName}</Paragraph>
             </div>
           )}
+        </div>
+        <div
+          ref={statusRef}
+          role='status'
+          aria-live='polite'
+          aria-atomic='true'
+          tabIndex={-1}
+          className={utilClasses.visuallyHidden}
+        >
+          {statusMessage}
         </div>
       </ComponentStructureWrapper>
     </Fieldset>

--- a/src/layout/OrganisationLookup/OrganisationLookupComponent.tsx
+++ b/src/layout/OrganisationLookup/OrganisationLookupComponent.tsx
@@ -16,6 +16,7 @@ import { useLayoutLookups } from 'src/features/form/layout/LayoutsContext';
 import { FD } from 'src/features/formData/FormDataWrite';
 import { useDataModelBindings } from 'src/features/formData/useDataModelBindings';
 import { Lang } from 'src/features/language/Lang';
+import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
 import { useLanguage } from 'src/features/language/useLanguage';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
 import classes from 'src/layout/OrganisationLookup/OrganisationLookupComponent.module.css';
@@ -89,11 +90,20 @@ export function OrganisationLookupComponent({
   } = useDataModelBindings(dataModelBindings);
 
   const { langAsString } = useLanguage();
+  const currentLanguage = useCurrentLanguage();
   const layoutLookups = useLayoutLookups();
   const pickFormValue = FD.useCurrentSelector();
   const waitForSave = FD.useWaitForSave();
 
   const { data, refetch: performLookup, isFetching } = useQuery(orgLookupQueries.lookup(tempOrgNr));
+
+  function announceStatusMessage(message: string) {
+    setStatusMessage('');
+    window.setTimeout(() => {
+      setStatusMessage(message);
+      statusRef.current?.focus();
+    }, LIVE_REGION_RESET_DELAY_MS);
+  }
 
   function announceOrgDetails(orgNr: string) {
     const parts = [`${langAsString('organisation_lookup.orgnr_label')} ${orgNr}`];
@@ -122,29 +132,27 @@ export function OrganisationLookupComponent({
       parts.push(typeof titleKey === 'string' ? `${langAsString(titleKey)} ${textValue}` : textValue);
     }
 
-    setStatusMessage('');
-    window.setTimeout(() => {
-      setStatusMessage(parts.join(', '));
-    }, LIVE_REGION_RESET_DELAY_MS);
+    announceStatusMessage(parts.join(', '));
   }
 
-  function handleValidateOrgnr(orgNr: string) {
+  function handleValidateOrgnr(orgNr: string): string[] | undefined {
     if (!validateOrgnr({ orgNr })) {
       const errors = validateOrgnr.errors
         ?.filter((error) => error.instancePath === '/orgNr')
         .map((error) => error.message)
         .filter((it) => it != null);
       setOrgNrErrors(errors);
-      return false;
+      return errors;
     }
     setOrgNrErrors(undefined);
-    return true;
+    return undefined;
   }
 
   async function handleSubmit() {
-    const isValid = handleValidateOrgnr(tempOrgNr);
+    const validationErrors = handleValidateOrgnr(tempOrgNr);
 
-    if (!isValid) {
+    if (validationErrors?.length) {
+      announceStatusMessage(langAsString(validationErrors.join(' ')));
       return;
     }
 
@@ -154,6 +162,8 @@ export function OrganisationLookupComponent({
       dataModelBindings.organisation_lookup_name && setValue('organisation_lookup_name', data.org.name);
       await waitForSave(true);
       announceOrgDetails(data.org.orgNr);
+    } else if (data?.error) {
+      announceStatusMessage(langAsString(data.error));
     }
   }
 
@@ -203,10 +213,11 @@ export function OrganisationLookupComponent({
               value={hasSuccessfullyFetched ? organisation_lookup_orgnr : tempOrgNr}
               required={required}
               readOnly={hasSuccessfullyFetched || isFetching || readOnly}
-              error={isValid}
+              error={!!isValid}
               onValueChange={(e) => {
                 setTempOrgNr(e.value);
                 setOrgNrErrors(undefined);
+                setStatusMessage('');
               }}
               onKeyDown={async (ev) => {
                 if (ev.key === 'Enter' && !readOnly) {
@@ -264,10 +275,9 @@ export function OrganisationLookupComponent({
         </div>
         <div
           ref={statusRef}
-          role='status'
-          aria-live='polite'
-          aria-atomic='true'
           tabIndex={-1}
+          lang={currentLanguage}
+          data-testid='organisation-lookup-status'
           className={utilClasses.visuallyHidden}
         >
           {statusMessage}

--- a/src/layout/Text/TextComponent.tsx
+++ b/src/layout/Text/TextComponent.tsx
@@ -32,12 +32,17 @@ export const TextComponent = ({ baseComponentId }: PropsFromGenericComponent<'Te
         ),
       }}
     >
-      <DisplayText
-        value={value}
-        iconUrl={icon}
-        iconAltText={langAsString(textResourceBindings.title)}
-        labelId={getLabelId(id)}
-      />
+      <div
+        role='group'
+        aria-labelledby={getLabelId(id)}
+      >
+        <DisplayText
+          value={value}
+          iconUrl={icon}
+          iconAltText={langAsString(textResourceBindings.title)}
+          labelId={getLabelId(id)}
+        />
+      </div>
     </ComponentStructureWrapper>
   );
 };

--- a/src/layout/Text/TextComponent.tsx
+++ b/src/layout/Text/TextComponent.tsx
@@ -4,14 +4,13 @@ import cn from 'classnames';
 
 import { DisplayText } from 'src/app-components/Text/DisplayText';
 import classes from 'src/app-components/Text/Text.module.css';
-import { getLabelId } from 'src/components/label/Label';
 import { useLanguage } from 'src/features/language/useLanguage';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
 import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export const TextComponent = ({ baseComponentId }: PropsFromGenericComponent<'Text'>) => {
-  const { id, textResourceBindings, value, icon, direction: _direction } = useItemWhenType(baseComponentId, 'Text');
+  const { textResourceBindings, value, icon, direction: _direction } = useItemWhenType(baseComponentId, 'Text');
   const direction = _direction ?? 'horizontal';
   const { langAsString } = useLanguage();
 
@@ -32,16 +31,11 @@ export const TextComponent = ({ baseComponentId }: PropsFromGenericComponent<'Te
         ),
       }}
     >
-      <div
-        role='group'
-        aria-labelledby={getLabelId(id)}
-      >
-        <DisplayText
-          value={value}
-          iconUrl={icon}
-          iconAltText={langAsString(textResourceBindings.title)}
-        />
-      </div>
+      <DisplayText
+        value={value}
+        iconUrl={icon}
+        iconAltText={langAsString(textResourceBindings.title)}
+      />
     </ComponentStructureWrapper>
   );
 };

--- a/src/layout/Text/TextComponent.tsx
+++ b/src/layout/Text/TextComponent.tsx
@@ -40,7 +40,6 @@ export const TextComponent = ({ baseComponentId }: PropsFromGenericComponent<'Te
           value={value}
           iconUrl={icon}
           iconAltText={langAsString(textResourceBindings.title)}
-          labelId={getLabelId(id)}
         />
       </div>
     </ComponentStructureWrapper>

--- a/src/layout/Text/TextComponent.tsx
+++ b/src/layout/Text/TextComponent.tsx
@@ -4,13 +4,14 @@ import cn from 'classnames';
 
 import { DisplayText } from 'src/app-components/Text/DisplayText';
 import classes from 'src/app-components/Text/Text.module.css';
+import { getLabelId } from 'src/components/label/Label';
 import { useLanguage } from 'src/features/language/useLanguage';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
 import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export const TextComponent = ({ baseComponentId }: PropsFromGenericComponent<'Text'>) => {
-  const { textResourceBindings, value, icon, direction: _direction } = useItemWhenType(baseComponentId, 'Text');
+  const { id, textResourceBindings, value, icon, direction: _direction } = useItemWhenType(baseComponentId, 'Text');
   const direction = _direction ?? 'horizontal';
   const { langAsString } = useLanguage();
 
@@ -35,6 +36,7 @@ export const TextComponent = ({ baseComponentId }: PropsFromGenericComponent<'Te
         value={value}
         iconUrl={icon}
         iconAltText={langAsString(textResourceBindings.title)}
+        labelId={getLabelId(id)}
       />
     </ComponentStructureWrapper>
   );

--- a/test/e2e/integration/component-library/organisationlookup.ts
+++ b/test/e2e/integration/component-library/organisationlookup.ts
@@ -2,9 +2,11 @@ import { AppFrontend } from 'test/e2e/pageobjects/app-frontend';
 
 const appFrontend = new AppFrontend();
 
+const organisationLookupIntercept = '**/api/v1/lookup/organisation/*';
+
 describe('Organisation lookup', () => {
   it('Renders the organisation lookup component correctly', () => {
-    cy.intercept('GET', '/ttd/component-library/api/v1/lookup/organisation/*', {
+    cy.intercept('GET', organisationLookupIntercept, {
       statusCode: 200,
       body: {
         success: true,
@@ -40,7 +42,7 @@ describe('Organisation lookup', () => {
     cy.findByRole('button', { name: /Fjern/i }).should('not.exist');
 
     // Add interceptor for failed fetch
-    cy.intercept('GET', '/ttd/component-library/api/v1/lookup/organisation/*', {
+    cy.intercept('GET', organisationLookupIntercept, {
       statusCode: 200,
       body: {
         success: false,
@@ -55,7 +57,7 @@ describe('Organisation lookup', () => {
     cy.findByText(/Organisasjonsnummeret ble ikke funnet i enhetsregisteret/i).should('exist');
 
     // Add interceptor for failed fetch due to server error
-    cy.intercept('GET', '/ttd/component-library/api/v1/lookup/organisation/*', {
+    cy.intercept('GET', organisationLookupIntercept, {
       statusCode: 500,
     }).as('failedFetchOrganisationServerError');
 

--- a/test/e2e/integration/component-library/organisationlookup.ts
+++ b/test/e2e/integration/component-library/organisationlookup.ts
@@ -25,18 +25,8 @@ describe('Organisation lookup', () => {
     cy.findByRole('textbox', { name: /Organisasjonsnummer/i }).should('exist');
     cy.findByRole('button', { name: /Hent opplysninger/i }).should('exist');
 
-    // Type invalid orgNr
-    cy.findByRole('textbox', { name: /Organisasjonsnummer/i }).type('123456789');
-    cy.findByRole('button', { name: /Hent opplysninger/i }).click();
-    cy.findByText(/Organisasjonsnummeret er ugyldig/i).should('exist');
-
-    // Type valid orgNr
-    cy.findByRole('textbox', { name: /Organisasjonsnummer/i }).clear();
     cy.findByRole('textbox', { name: /Organisasjonsnummer/i }).type('043871668');
     cy.findByRole('textbox', { name: /Organisasjonsnummer/i }).blur();
-    cy.findByText(/Organisasjonsnummeret er ugyldig/i).should('not.exist');
-
-    // Fetch organisation
     cy.findByRole('button', { name: /Hent opplysninger/i }).click();
     cy.wait('@successfullyFetchedOrganisation');
     cy.findByRole('button', { name: /Fjern/i }).should('exist');
@@ -70,10 +60,15 @@ describe('Organisation lookup', () => {
     }).as('failedFetchOrganisationServerError');
 
     // Fetch organisation with server error
-    cy.findByRole('textbox', { name: /Organisasjonsnummer/i }).clear();
-    cy.findByRole('textbox', { name: /Organisasjonsnummer/i }).type('043871668{Enter}');
+    cy.findByRole('button', { name: /Hent opplysninger/i }).click();
     cy.wait('@failedFetchOrganisationServerError');
     cy.findByText(/Ukjent feil. Vennligst prøv igjen senere/i).should('exist');
+
+    // Type invalid orgNr
+    cy.findByRole('textbox', { name: /Organisasjonsnummer/i }).numberFormatClear();
+    cy.findByRole('textbox', { name: /Organisasjonsnummer/i }).type('123456789');
+    cy.findByRole('button', { name: /Hent opplysninger/i }).click();
+    cy.findByText(/Organisasjonsnummeret er ugyldig/i).should('exist');
 
     cy.changeLayout((component) => {
       if (component.type === 'OrganisationLookup') {

--- a/test/e2e/integration/frontend-test/mobile.ts
+++ b/test/e2e/integration/frontend-test/mobile.ts
@@ -2,7 +2,6 @@ import { AppFrontend } from 'test/e2e/pageobjects/app-frontend';
 import { Likert } from 'test/e2e/pageobjects/likert';
 
 import { breakpoints } from 'src/hooks/useDeviceWidths';
-import type { IGroupEditProperties } from 'src/layout/RepeatingGroup/config.generated';
 
 const appFrontend = new AppFrontend();
 const likertPage = new Likert();
@@ -52,23 +51,20 @@ function testGroup(mode: Mode) {
 
   // Mobile tables always have two columns
   ensureTableHasNumColumns(appFrontend.group.mainGroup, 6, 2);
-  let editWas: IGroupEditProperties = {};
   cy.changeLayout((c) => {
     if (c.id === 'mainGroup' && c.type === 'RepeatingGroup' && c.edit) {
-      editWas = { ...c.edit };
       c.edit.editButton = false;
       c.edit.deleteButton = false;
     }
   });
   ensureTableHasNumColumns(appFrontend.group.mainGroup, 6, 2);
-  cy.changeLayout((component) => {
-    if (component.id === 'mainGroup' && component.type === 'Group' && 'edit' in component && component.edit) {
-      component.edit = { ...editWas };
-    }
-  });
 
   cy.get(appFrontend.group.hideRepeatingGroupRow).numberFormatClear();
-  cy.get(appFrontend.group.hideRepeatingGroupRow).type('1000');
+  cy.waitUntilSaved();
+  cy.get(appFrontend.group.hideRepeatingGroupRow).type('{moveToEnd}{backspace}1000');
+  cy.get(appFrontend.group.hideRepeatingGroupRow).blur();
+  cy.waitUntilSaved();
+  cy.get(appFrontend.group.hiddenRowsInfoMsg).should('exist');
 
   cy.navPage('repeating (store endringer)').click();
   ensureTableHasNumColumns(appFrontend.group.overflowGroup, 4, 2);
@@ -110,7 +106,7 @@ function testListMobile() {
     cy.findByRole('radio', { name: /caroline/i }).check();
     cy.findByRole('radio', { name: /caroline/i }).should('be.checked');
   });
-  cy.findByRole('button', { name: 'Neste' }).click();
+  cy.get(appFrontend.navButtons).findByRole('button', { name: 'Neste' }).click();
   sendIn();
 }
 
@@ -119,7 +115,7 @@ function testListTablet() {
     cy.findByRole('row', { name: /caroline/i }).click();
     cy.findByRole('radio', { name: /caroline/i }).should('be.checked');
   });
-  cy.findAllByRole('button', { name: 'Neste' }).eq(1).click();
+  cy.get(appFrontend.navButtons).findByRole('button', { name: 'Neste' }).click();
   sendIn();
 }
 

--- a/test/e2e/support/custom.ts
+++ b/test/e2e/support/custom.ts
@@ -132,21 +132,26 @@ Cypress.Commands.add('gotoNavPage', (page: string) => {
 
 Cypress.Commands.add('numberFormatClear', { prevSubject: true }, (subject: JQueryWithSelector | undefined) => {
   cy.log('Clearing number formatted input field');
-  if (!subject) {
+  if (!subject?.length) {
     throw new Error('Subject is undefined');
+  }
+
+  const selector = subject.selector ?? (subject.attr('id') ? `#${subject.attr('id')}` : undefined);
+
+  if (!selector) {
+    throw new Error('numberFormatClear requires cy.get("#id") or an element with an id attribute');
   }
 
   // Since we cannot use {selectall} on number formatted input fields, because react-number-format messes with
   // our selection, we need to delete the content by moving to the start of the input field and deleting one
   // character at a time.
-  const strLength = subject.val()?.toString().length;
-  const del = new Array(strLength).fill('{del}').join('');
-
-  // We also add {moveToStart} multiple times to ensure that we are at the start of the input field, as
-  // react-number-format messes with our cursor position here as well.
-  const moveToStart = new Array(5).fill('{moveToStart}').join('');
-
-  cy.wrap(subject).type(`${moveToStart}${del}`);
+  cy.get(selector).type('{moveToStart}{moveToStart}{moveToStart}{moveToStart}{moveToStart}');
+  cy.get(selector).then(($input) => {
+    const del = '{del}'.repeat($input.val()?.toString().length ?? 0);
+    if (del) {
+      cy.get(selector).type(del, { delay: 0 });
+    }
+  });
 });
 
 interface KnownViolation extends Pick<axe.Result, 'id'> {

--- a/test/e2e/support/custom.ts
+++ b/test/e2e/support/custom.ts
@@ -146,7 +146,7 @@ Cypress.Commands.add('numberFormatClear', { prevSubject: true }, (subject: JQuer
   // react-number-format messes with our cursor position here as well.
   const moveToStart = new Array(5).fill('{moveToStart}').join('');
 
-  cy.get(subject.selector!).type(`${moveToStart}${del}`);
+  cy.wrap(subject).type(`${moveToStart}${del}`);
 });
 
 interface KnownViolation extends Pick<axe.Result, 'id'> {

--- a/test/e2e/support/custom.ts
+++ b/test/e2e/support/custom.ts
@@ -136,7 +136,9 @@ Cypress.Commands.add('numberFormatClear', { prevSubject: true }, (subject: JQuer
     throw new Error('Subject is undefined');
   }
 
-  const selector = subject.selector ?? (subject.attr('id') ? `#${subject.attr('id')}` : undefined);
+  // Prefer id over subject.selector — findByRole() sets a non-CSS selector that cy.get cannot parse.
+  const id = subject.attr('id');
+  const selector = id ? `#${id}` : subject.selector;
 
   if (!selector) {
     throw new Error('numberFormatClear requires cy.get("#id") or an element with an id attribute');
@@ -144,12 +146,12 @@ Cypress.Commands.add('numberFormatClear', { prevSubject: true }, (subject: JQuer
 
   // Since we cannot use {selectall} on number formatted input fields, because react-number-format messes with
   // our selection, we need to delete the content by moving to the start of the input field and deleting one
-  // character at a time.
+  // character at a time. Each delete is a separate command so React re-renders do not detach the subject mid-type.
   cy.get(selector).type('{moveToStart}{moveToStart}{moveToStart}{moveToStart}{moveToStart}');
   cy.get(selector).then(($input) => {
-    const del = '{del}'.repeat($input.val()?.toString().length ?? 0);
-    if (del) {
-      cy.get(selector).type(del, { delay: 0 });
+    const strLength = $input.val()?.toString().length ?? 0;
+    for (let i = 0; i < strLength; i++) {
+      cy.get(selector).type('{del}', { delay: 0 });
     }
   });
 });


### PR DESCRIPTION
## Description

In org lookup and after Hent opplysninger, VoiceOver now reads the org number and related details (name, address, etc.) in one message. It also reads the error message. 



https://github.com/user-attachments/assets/beba6c36-b02e-4fb1-aa21-c19a48c303a0




## Related Issue(s)

- closes #4114 

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Enhanced accessibility for organisation lookups with a polite live-region announcement flow, semantic grouping/ARIA labeling, and announcement reset when clearing.
* **Tests**
  * Added/expanded React and e2e tests for validation, successful lookup announcements (including sibling text), keyboard submit, error handling, clear behavior, and read-only mode.
* **Chores**
  * Improved the Cypress helper to clear number-formatted inputs by typing directly into the targeted field.
* **Refactor**
  * Simplified `Text` rendering by removing an unused label-id pathway.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->