### PR TITLE
fix: Dropdown in table missing form label (a11y)

### DIFF
--- a/src/layout/Dropdown/DropdownComponent.tsx
+++ b/src/layout/Dropdown/DropdownComponent.tsx
@@ -110,7 +110,6 @@ export function DropdownComponent({ baseComponentId, overrideDisplay }: PropsFro
           selected={formatSelectedValue(selectedValues, options)}
           onSelectedChange={(option) => handleChange(option ? [option.value] : [])}
           onBlur={() => debounce}
-          name={overrideDisplay?.renderedInTable ? langAsString(textResourceBindings?.title) : undefined}
           className={cn(comboboxClasses.container, classes.showCaretsWithoutClear, { [classes.readOnly]: readOnly })}
           style={{ width: '100%' }}
         >


### PR DESCRIPTION
WCAG issue: https://github.com/Altinn/app-frontend-react/issues/4065


## Description

When a `Dropdown` is rendered inside a table, WAVE reported two accessibility errors:
- **Select missing label** (empty dropdown)
- **Missing form label** (after selecting a value)

before:

<img width="1045" height="572" alt="Screenshot 2026-06-11 at 14 46 59" src="https://github.com/user-attachments/assets/8aad33da-842e-4dd0-98db-01d9bbc9491c" />

After:

<img width="1042" height="402" alt="Screenshot 2026-06-11 at 14 47 43" src="https://github.com/user-attachments/assets/b23954ab-998c-4a9a-bbee-e8ae3c506464" />


### Root cause

The Design System `Suggestion` component renders a hidden native `<select name=... id="${id}-select">` **only when a `name` prop is passed**, and that `<select>` has no associated label. `DropdownComponent` passed `name` only in table mode (`overrideDisplay.renderedInTable`), so the unlabeled control existed exclusively in tables — exactly where the bug appeared.

The `<select>` serves no functional purpose here (form data is managed via `FD` state, not native form submission), and the visible combobox input already gets its accessible name from the visually-hidden `<DSLabel htmlFor={id}>` and `aria-label`.

### Fix

Remove the `name` prop from the Dropdown's `Suggestion`, eliminating the hidden unlabeled `<select>`. This mirrors `MultipleSelect`, which never passes `name` and has no such error.

## Testing

Easy way to test:

Put this layout in `component-library/App/ui/ComponentLayouts/layouts/DropdownPage.json` app:

```
{
  "$schema": "https://altinncdn.no/toolkits/altinn-app-frontend/4/schemas/json/layout/layout.schema.v1.json",
  "data": {
    "hidden": false,
    "layout": [
      {
        "id": "DropdownPage-NavigationBar",
        "type": "NavigationBar"
      },
      {
        "id": "DropdownPage-Header",
        "type": "Header",
        "size": "h2",
        "textResourceBindings": {
          "title": "RadioButtonsPage"
        }
      },
      {
        "id": "DropdownPage-Header-Component",
        "type": "Header",
        "size": "h3",
        "textResourceBindings": {
          "title": "Header.Component"
        }
      },
      {
        "id": "DropdownPage-RadioButtons",
        "type": "Dropdown",
        "dataModelBindings": {
          "simpleBinding": "dropdown"
        },
        "textResourceBindings": {
          "title": "DropdownPage.Dropdown.title"
        },
        "options": [
          {
            "label": "Bil",
            "value": "bil"
          },
          {
            "label": "Moped",
            "value": "moped"
          },
          {
            "label": "Traktor",
            "value": "traktor"
          },
          {
            "label": "Båt",
            "value": "baat"
          }
        ],
        "required": false
      },
      {
        "id": "DropdownPage-Table-Header",
        "type": "Header",
        "size": "h3",
        "textResourceBindings": {
          "title": "Dropdown in table (accessibility test)"
        }
      },
      {
        "id": "DropdownPage-Table",
        "type": "RepeatingGroup",
        "textResourceBindings": {
          "title": "Vehicles",
          "description": "Add a row, then check the dropdown cell with the WAVE extension (both empty and with a value selected)."
        },
        "dataModelBindings": {
          "group": "repeatingGroup"
        },
        "edit": {
          "mode": "onlyTable"
        },
        "tableHeaders": [
          "DropdownPage-Table-Dropdown"
        ],
        "children": [
          "DropdownPage-Table-Dropdown"
        ]
      },
      {
        "id": "DropdownPage-Table-Dropdown",
        "type": "Dropdown",
        "dataModelBindings": {
          "simpleBinding": "repeatingGroup.name"
        },
        "textResourceBindings": {
          "title": "Vehicle"
        },
        "options": [
          {
            "label": "Bil",
            "value": "bil"
          },
          {
            "label": "Moped",
            "value": "moped"
          },
          {
            "label": "Traktor",
            "value": "traktor"
          },
          {
            "label": "Båt",
            "value": "baat"
          }
        ],
        "required": false
      },
      {
        "id": "DropdownPage-Header-Summary",
        "type": "Header",
        "size": "h3",
        "textResourceBindings": {
          "title": "Header.Summary"
        }
      },
      {
        "id": "DropdownPage-Summary",
        "type": "Summary",
        "componentRef": "DropdownPage-RadioButtons",
        "largeGroup": false
      },
      {
        "id": "DropdownPage-Header-Summary2",
        "type": "Header",
        "size": "h3",
        "textResourceBindings": {
          "title": "Header.Summary2"
        }
      },
      {
        "id": "DropdownPage-Summary2",
        "type": "Summary2",
        "hidden": false,
        "target": {
          "type": "component",
          "id": "DropdownPage-RadioButtons"
        }
      },
      {
        "id": "DropdownPage-NavigationButtons",
        "showBackButton": true,
        "textResourceBindings": {},
        "type": "NavigationButtons"
      }
    ]
  }
}
```

Then follow these instructions:

  1. Start the app component-library 
  1. And make sure the OLD, non-monorepo app-localtest is running so you can reach the app locally.
  2. Start the frontend — in app-frontend-react:  yarn start
  3. Open the app in Chrome via localtest (http://local.altinn.cloud/... → the component-library app) and
  start a new instance.
  4. Navigate to the Dropdown page using the left navigation/menu.
  5. Scroll to "Dropdown in table (accessibility test)" and click Add new to create a row. You'll see a
  Dropdown rendered inside the table cell.
  6. Run WAVE (click the WAVE extension icon) while the dropdown cell is empty → confirm there is no
  "Select missing label" error on that cell.
  7. Select a value (e.g. Bil), then re-run WAVE → confirm there is no "Missing form label" error.
  8. (Optional baseline) git checkout main, restart, repeat steps 6–7
  — you should see the errors appear. git checkout this branch again to restore the fix

