### PR TITLE
fixed screen reader issues in Alert component

### DIFF
--- a/src/layout/Alert/Alert.test.tsx
+++ b/src/layout/Alert/Alert.test.tsx
@@ -17,14 +17,20 @@ describe('Alert', () => {
     expect(screen.getByText(/body for alert/i)).toBeInTheDocument();
   });
 
-  it('should display as role="alert" when hidden is an expression', async () => {
-    await render({ title: 'title for alert', hidden: ['equals', 1, 2] });
+  it('should announce as role="status" for non-critical severities when hidden is an expression', async () => {
+    await render({ title: 'title for alert', severity: 'info', hidden: ['equals', 1, 2] });
+    expect(screen.getByRole('status', { name: /title for alert/i })).toBeInTheDocument();
+  });
+
+  it('should announce as role="alert" for critical severities when hidden is an expression', async () => {
+    await render({ title: 'title for alert', severity: 'danger', hidden: ['equals', 1, 2] });
     expect(screen.getByRole('alert', { name: /title for alert/i })).toBeInTheDocument();
   });
 
-  it('should not display as role="alert" when hidden is not set', async () => {
-    await render({ title: 'title for alert' });
+  it('should not announce as a live region when hidden is not set', async () => {
+    await render({ title: 'title for alert', severity: 'danger' });
     expect(screen.queryByRole('alert', { name: /title for alert/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('status', { name: /title for alert/i })).not.toBeInTheDocument();
   });
 });
 

--- a/src/layout/Alert/AlertBaseComponent.test.tsx
+++ b/src/layout/Alert/AlertBaseComponent.test.tsx
@@ -27,4 +27,26 @@ describe('Alert', () => {
     render({ children: 'Description for alert' });
     expect(screen.getByText(/description for alert/i)).toBeInTheDocument();
   });
+
+  it('should not set role or aria-live when not used as a screen reader alert', () => {
+    const { container } = render({ useAsAlert: false, title: 'Title for alert' });
+    const alert = container.firstElementChild;
+    expect(alert).not.toHaveAttribute('role');
+    expect(alert).not.toHaveAttribute('aria-live');
+  });
+
+  it.each(['warning', 'danger'] as const)('should use role="alert" for the critical severity "%s"', (severity) => {
+    render({ useAsAlert: true, severity, title: 'Title for alert' });
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+
+  it.each(['info', 'success'] as const)('should use role="status" for the non-critical severity "%s"', (severity) => {
+    render({ useAsAlert: true, severity, title: 'Title for alert' });
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('should not combine role with an explicit aria-live (avoids VoiceOver double-speak)', () => {
+    render({ useAsAlert: true, severity: 'danger', title: 'Title for alert' });
+    expect(screen.getByRole('alert')).not.toHaveAttribute('aria-live');
+  });
 });

--- a/src/layout/Alert/AlertBaseComponent.tsx
+++ b/src/layout/Alert/AlertBaseComponent.tsx
@@ -5,11 +5,15 @@ import { Alert as AlertDesignSystem } from '@digdir/designsystemet-react';
 import styles from 'src/layout/Alert/Alert.module.css';
 import type { AlertSeverity } from 'src/layout/Alert/config.generated';
 
-function calculateAriaLive(severity: AlertSeverity): 'polite' | 'assertive' {
+// Critical severities use role="alert" (implicit assertive live region), others use the less
+// intrusive role="status" (implicit polite live region). We deliberately do not also set aria-live:
+// combining it with role="alert"/"status" causes double announcements in VoiceOver on iOS.
+// See https://designsystemet.no/no/components/docs/alert/accessibility
+function calculateRole(severity: AlertSeverity): 'alert' | 'status' {
   if (severity === 'warning' || severity === 'danger') {
-    return 'assertive';
+    return 'alert';
   }
-  return 'polite';
+  return 'status';
 }
 
 export type AlertBaseComponentProps = {
@@ -24,8 +28,7 @@ export const AlertBaseComponent = ({ title, children, useAsAlert, severity, aria
   <AlertDesignSystem
     className={styles.container}
     data-color={severity}
-    role={useAsAlert ? 'alert' : undefined}
-    aria-live={useAsAlert ? calculateAriaLive(severity) : undefined}
+    role={useAsAlert ? calculateRole(severity) : undefined}
     aria-label={useAsAlert ? (ariaLabel ?? title) : undefined}
   >
     {title && <span className={styles.title}>{title}</span>}


### PR DESCRIPTION
 Description

  Improves screen reader behavior for the Alert component. Alerts that appear dynamically (for example,
  when a previously hidden alert becomes visible based on a rule) are now announced more correctly by
  assistive technology:
  
  - Informational and success alerts are announced politely (using role="status"), so they no longer
  interrupt the user unnecessarily, while warnings and errors continue to be announced immediately
  (using role="alert").
  - Removed a redundant aria-live attribute that was combined with role="alert". This combination
  caused some screen readers (notably VoiceOver on iOS) to read the alert twice.

  These changes align the Alert component with the Designsystemet accessibility guidance for alerts. No
  visual changes.
## Related Issue(s)

- closes https://github.com/Altinn/app-frontend-react/issues/4112

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [x] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [x] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced alert component accessibility with improved ARIA role handling for assistive technology users.

* **Tests**
  * Expanded test coverage for alert accessibility semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->