### PR TITLE
Fix focus- and SR-issues in repeating group

### DIFF
--- a/src/language/texts/en.ts
+++ b/src/language/texts/en.ts
@@ -207,6 +207,7 @@ export function en() {
       'One of the rows is incorrectly filled out. This has to bee fixed before the schema can be submitted.',
     'group.row_popover_delete_message': 'Are you sure you want to delete this row?',
     'group.row_popover_delete_button_confirm': 'Yes, delete the row',
+    'group.row_deleted_sr': 'Row deleted, {0} remaining',
     'iframe_component.unsupported_browser_title': 'Your browser is unsupported',
     'iframe_component.unsupported_browser':
       'Your browser does not support iframes that use srcdoc. This may result in not being able to see all the content intended to be displayed here. We recommend trying a different browser.',

--- a/src/language/texts/nb.ts
+++ b/src/language/texts/nb.ts
@@ -208,6 +208,7 @@ export function nb() {
     'group.row_error': 'En av radene er ikke fylt ut riktig, dette må fikses før skjema kan sendes inn',
     'group.row_popover_delete_message': 'Er du sikker på at du vil slette denne raden?',
     'group.row_popover_delete_button_confirm': 'Ja, slett raden',
+    'group.row_deleted_sr': 'Rad slettet, {0} gjenstår',
     'iframe_component.unsupported_browser_title': 'Nettleseren din støttes ikke',
     'iframe_component.unsupported_browser':
       'Nettleseren du bruker støtter ikke iframes som benytter seg av srcdoc. Dette kan føre til at du ikke ser all innholdet som er ment å vises her. Vi anbefaler deg å prøve en annen nettleser.',

--- a/src/language/texts/nn.ts
+++ b/src/language/texts/nn.ts
@@ -208,6 +208,7 @@ export function nn() {
     'group.row_error': 'Ei av radene er ikkje fylt ut riktig. Dette må bli retta før skjema kan sendast inn.',
     'group.row_popover_delete_message': 'Er du sikker på at du vil sletta denne rada?',
     'group.row_popover_delete_button_confirm': 'Ja, slett rada',
+    'group.row_deleted_sr': 'Rad sletta, {0} står att',
     'iframe_component.unsupported_browser_title': 'Nettlesaren din støttas ikkje',
     'iframe_component.unsupported_browser':
       'Nettlesaren di støttar ikkje iframes som brukar srcdoc. Dette kan føre til at du ikkje ser all innhaldet som er meint å visast her. Vi anbefalar deg å prøve ein annan nettlesar.',

--- a/src/layout/RepeatingGroup/Container/RepeatingGroupContainer.test.tsx
+++ b/src/layout/RepeatingGroup/Container/RepeatingGroupContainer.test.tsx
@@ -16,6 +16,7 @@ import {
   useRepeatingGroupRowState,
   useRepeatingGroupSelector,
 } from 'src/layout/RepeatingGroup/Providers/RepeatingGroupContext';
+import { RepeatingGroupsFocusProvider } from 'src/layout/RepeatingGroup/Providers/RepeatingGroupFocusContext';
 import { mockMediaQuery } from 'src/test/mockMediaQuery';
 import { renderWithInstanceAndLayout } from 'src/test/renderWithProviders';
 import type { ILayout } from 'src/layout/layout';
@@ -100,8 +101,10 @@ async function render({ container, numRows = 3, validationIssues = [] }: IRender
   return await renderWithInstanceAndLayout({
     renderer: (
       <RepeatingGroupProvider baseComponentId={group.id}>
-        <LeakEditIndex />
-        <RepeatingGroupContainer />
+        <RepeatingGroupsFocusProvider>
+          <LeakEditIndex />
+          <RepeatingGroupContainer />
+        </RepeatingGroupsFocusProvider>
       </RepeatingGroupProvider>
     ),
     queries: {
@@ -207,6 +210,91 @@ describe('RepeatingGroupContainer', () => {
     expect(within(editContainer).queryByText('Title2')).not.toBeInTheDocument();
     expect(within(editContainer).getByText('Title3')).toBeInTheDocument();
     expect(within(editContainer).getByText('Title4')).toBeInTheDocument();
+  });
+
+  it('moves focus to the top of the edit container when navigating between multiPage pages', async () => {
+    await render({
+      container: {
+        edit: {
+          ...mockContainer.edit,
+          multiPage: true,
+        },
+        children: ['0:field1', '0:field2', '1:field3', '1:field4'],
+      },
+    });
+
+    // Open the first row for editing (shows page 0 with field1/field2)
+    await userEvent.click(screen.getAllByRole('button', { name: /Rediger/i })[0]);
+    const editContainer = screen.getByTestId('group-edit-container');
+
+    // Navigate forward: focus should move to the first field on the new page, not stay on the button.
+    await userEvent.click(within(editContainer).getByRole('button', { name: /Neste/i }));
+    await waitFor(() => expect(document.activeElement).toHaveAccessibleName(/Title3/));
+
+    // Navigate back: focus should move to the first field on the previous page.
+    await userEvent.click(within(editContainer).getByRole('button', { name: /Tilbake/i }));
+    await waitFor(() => expect(document.activeElement).toHaveAccessibleName(/Title1/));
+  });
+
+  it("moves focus to the same row's edit button after saving and closing", async () => {
+    await render({ numRows: 3 });
+
+    // Open the second row (index 1) for editing
+    await userEvent.click(screen.getAllByRole('button', { name: /Rediger/i })[1]);
+
+    const editContainer = screen.getByTestId('group-edit-container');
+    await userEvent.click(within(editContainer).getByRole('button', { name: /Lagre og lukk/i }));
+
+    // Focus returns to the edit button of the same row (index 1), not the next row.
+    await waitFor(() => {
+      expect(document.activeElement).toHaveAccessibleName(/Rediger/);
+      expect(document.activeElement?.closest('[data-row-num]')).toHaveAttribute('data-row-num', '1');
+    });
+  });
+
+  it('moves focus to the first field of the next edit container after save and open next', async () => {
+    await render({
+      container: {
+        edit: {
+          ...mockContainer.edit,
+          saveAndNextButton: true,
+        },
+      },
+      numRows: 3,
+    });
+
+    // Open the first row, then save and open next
+    await userEvent.click(screen.getAllByRole('button', { name: /Rediger/i })[0]);
+    const editContainer = screen.getByTestId('group-edit-container');
+    await userEvent.click(within(editContainer).getByRole('button', { name: /Lagre og åpne neste/i }));
+
+    // Focus moves to the first field in the next row's edit container, not its edit button.
+    await waitFor(() => expect(document.activeElement).toHaveAccessibleName(/Title1/));
+  });
+
+  it('does not move focus to the edit button when validation blocks saving', async () => {
+    await render({
+      container: {
+        validateOnSaveRow: ['All'],
+      },
+      validationIssues: [
+        {
+          customTextKey: 'Feltet er feil',
+          field: 'Group[0].prop1',
+          dataElementId: defaultMockDataElementId,
+          severity: BackendValidationSeverity.Error,
+          source: 'custom',
+        } as BackendValidationIssue,
+      ],
+    });
+
+    await userEvent.click(screen.getAllByRole('button', { name: /Rediger/i })[0]);
+    await userEvent.click(screen.getAllByRole('button', { name: /Lagre og lukk/i })[1]);
+
+    await waitFor(() => expect(screen.getByText(/feltet er feil/i)).toBeInTheDocument());
+    // The row stays open and focus must remain inside the edit container, not jump to the edit button.
+    const editContainer = screen.getByTestId('group-edit-container');
+    expect(editContainer.contains(document.activeElement)).toBe(true);
   });
 
   it('should trigger validate when saving if validateOnSaveRow is set', async () => {
@@ -330,6 +418,36 @@ describe('RepeatingGroupContainer', () => {
 
     const closeButtons = screen.getAllByText('New close text');
     expect(closeButtons).toHaveLength(1);
+  });
+
+  it('should notify screen readers via a live region when a row is deleted', async () => {
+    await render({ numRows: 3 });
+
+    const status = screen.getByRole('status');
+    expect(status).toBeEmptyDOMElement();
+
+    await userEvent.click(screen.getAllByRole('button', { name: /Slett/i })[0]);
+    await waitFor(() => expect(status).toHaveTextContent('Rad slettet, 2 gjenstår'));
+
+    // The message must change on consecutive deletions; screen readers do not reliably re-announce
+    // identical live-region text, so a repeated identical message would go unread.
+    await userEvent.click(screen.getAllByRole('button', { name: /Slett/i })[0]);
+    await waitFor(() => expect(status).toHaveTextContent('Rad slettet, 1 gjenstår'));
+  });
+
+  it('should move focus to the previous row after deletion instead of letting it fall back to the page', async () => {
+    await render({ numRows: 3 });
+
+    // Delete the second row; focus should move to the first (previous) row.
+    await userEvent.click(screen.getAllByRole('button', { name: /Slett/i })[1]);
+
+    // Focus must land on an actionable element in the remaining previous row, not on document.body
+    // (which would make the screen reader announce the page title and skip the deletion message).
+    await waitFor(() => {
+      expect(document.activeElement).not.toBe(document.body);
+      expect(document.activeElement?.tagName).toBe('BUTTON');
+      expect(document.activeElement?.closest('[data-row-num]')).toHaveAttribute('data-row-num', '0');
+    });
   });
 
   it('should display textResourceBindings.save_button as save button if present', async () => {

--- a/src/layout/RepeatingGroup/Container/RepeatingGroupContainer.tsx
+++ b/src/layout/RepeatingGroup/Container/RepeatingGroupContainer.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useEffect } from 'react';
 import type { JSX } from 'react';
 
 import { PlusIcon } from '@navikt/aksel-icons';
@@ -74,18 +74,15 @@ function RowDeletionAnnouncement() {
   const { numVisibleRows } = useRepeatingGroupRowState();
   const [message, setMessage] = React.useState('');
 
-  // Only announce when the count actually increases. Initializing the ref to the current count means a
-  // remount (e.g. the group being hidden then shown again) with a non-zero count announces nothing.
+  // Only announce when the count actually increases.
   const lastAnnouncedCount = React.useRef(deletedRowsCount);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (deletedRowsCount <= lastAnnouncedCount.current) {
       return;
     }
     lastAnnouncedCount.current = deletedRowsCount;
-    // Include the remaining row count so the message text differs between consecutive deletions.
-    // Screen readers do not reliably re-announce live-region text that is identical to the
-    // previous announcement.
+    // Include the remaining row count so the message gets re-announced on later deletions
     setMessage(langAsString('group.row_deleted_sr', [numVisibleRows]));
   }, [deletedRowsCount, numVisibleRows, langAsString]);
 

--- a/src/layout/RepeatingGroup/Container/RepeatingGroupContainer.tsx
+++ b/src/layout/RepeatingGroup/Container/RepeatingGroupContainer.tsx
@@ -23,6 +23,7 @@ import {
 import { useRepeatingGroupsFocusContext } from 'src/layout/RepeatingGroup/Providers/RepeatingGroupFocusContext';
 import { RepeatingGroupTable } from 'src/layout/RepeatingGroup/Table/RepeatingGroupTable';
 import { RepGroupHooks } from 'src/layout/RepeatingGroup/utils';
+import utilClasses from 'src/styles/utils.module.css';
 import { DataModelLocationProvider, useIndexedId } from 'src/utils/layout/DataModelLocation';
 import { useIsHidden } from 'src/utils/layout/hidden';
 import { useDataModelBindingsFor, useExternalItem } from 'src/utils/layout/hooks';
@@ -61,10 +62,43 @@ export const RepeatingGroupContainer = forwardRef((_, ref: React.ForwardedRef<HT
       >
         <AllComponentValidations baseComponentId={baseComponentId} />
       </Flex>
+      <RowDeletionAnnouncement />
     </Flex>
   );
 });
 RepeatingGroupContainer.displayName = 'RepeatingGroupContainer';
+
+function RowDeletionAnnouncement() {
+  const { langAsString } = useLanguage();
+  const deletedRowsCount = useRepeatingGroupSelector((state) => state.deletedRowsCount);
+  const { numVisibleRows } = useRepeatingGroupRowState();
+  const [message, setMessage] = React.useState('');
+
+  // Only announce when the count actually increases. Initializing the ref to the current count means a
+  // remount (e.g. the group being hidden then shown again) with a non-zero count announces nothing.
+  const lastAnnouncedCount = React.useRef(deletedRowsCount);
+
+  React.useEffect(() => {
+    if (deletedRowsCount <= lastAnnouncedCount.current) {
+      return;
+    }
+    lastAnnouncedCount.current = deletedRowsCount;
+    // Include the remaining row count so the message text differs between consecutive deletions.
+    // Screen readers do not reliably re-announce live-region text that is identical to the
+    // previous announcement.
+    setMessage(langAsString('group.row_deleted_sr', [numVisibleRows]));
+  }, [deletedRowsCount, numVisibleRows, langAsString]);
+
+  return (
+    <div
+      role='status'
+      aria-live='polite'
+      className={utilClasses.visuallyHidden}
+    >
+      {message}
+    </div>
+  );
+}
 
 function ModeOnlyTable() {
   return (
@@ -180,7 +214,7 @@ export const alignStyle = (align: ButtonPosition): React.CSSProperties => {
 
 function AddButton() {
   const { lang, langAsString } = useLanguage();
-  const { triggerFocus } = useRepeatingGroupsFocusContext();
+  const { triggerFocus, registerAddButton } = useRepeatingGroupsFocusContext();
   const baseComponentId = useRepeatingGroupComponentId();
   const addRow = RepGroupContext.useAddRow();
   const { visibleRows } = useRepeatingGroupRowState();
@@ -218,6 +252,7 @@ function AddButton() {
 
   return (
     <Button
+      ref={registerAddButton}
       textAlign={addButton?.textAlign}
       fullWidth={fullWidth}
       id={`add-button-${id}`}
@@ -226,13 +261,6 @@ function AddButton() {
       onClick={async () => {
         const newRow = await addRow();
         newRow.index !== undefined && triggerFocus(newRow.index);
-      }}
-      onKeyUp={async (event: React.KeyboardEvent<HTMLButtonElement>) => {
-        const allowedKeys = ['enter', ' ', 'spacebar'];
-        if (allowedKeys.includes(event.key.toLowerCase())) {
-          const newRow = await addRow();
-          newRow.index !== undefined && triggerFocus(newRow.index);
-        }
       }}
       variant='secondary'
       disabled={currentlyAddingRow}

--- a/src/layout/RepeatingGroup/EditContainer/RepeatingGroupsEditContainer.tsx
+++ b/src/layout/RepeatingGroup/EditContainer/RepeatingGroupsEditContainer.tsx
@@ -18,7 +18,10 @@ import {
   useRepeatingGroupComponentId,
   useRepeatingGroupRowState,
 } from 'src/layout/RepeatingGroup/Providers/RepeatingGroupContext';
-import { useRepeatingGroupsFocusContext } from 'src/layout/RepeatingGroup/Providers/RepeatingGroupFocusContext';
+import {
+  useDeleteRowAndFocus,
+  useRepeatingGroupsFocusContext,
+} from 'src/layout/RepeatingGroup/Providers/RepeatingGroupFocusContext';
 import classes from 'src/layout/RepeatingGroup/RepeatingGroup.module.css';
 import { RepGroupHooks } from 'src/layout/RepeatingGroup/utils';
 import { useIndexedId } from 'src/utils/layout/DataModelLocation';
@@ -60,9 +63,9 @@ function RepeatingGroupsEditContainerInternal({
 }): JSX.Element | null {
   const baseComponentId = useRepeatingGroupComponentId();
   const closeForEditing = RepGroupContext.useCloseForEditing();
-  const deleteRow = RepGroupContext.useDeleteRow();
+  const deleteRow = useDeleteRowAndFocus();
   const openNextForEditing = RepGroupContext.useOpenNextForEditing();
-  const { visibleRows } = useRepeatingGroupRowState();
+  const { visibleRows, editableRows } = useRepeatingGroupRowState();
   const childIds = RepGroupHooks.useChildIdsWithMultiPage(baseComponentId);
 
   const editingRowIndex = visibleRows.find((r) => r.uuid === editId)?.index;
@@ -82,7 +85,7 @@ function RepeatingGroupsEditContainerInternal({
   const textsForRow = rowWithExpressions?.textResourceBindings;
   const editForRow = rowWithExpressions?.edit;
   const { textResourceBindings, edit: editForGroup, tableColumns } = useItemWhenType(baseComponentId, 'RepeatingGroup');
-  const { refSetter } = useRepeatingGroupsFocusContext();
+  const { refSetter, focusEditContainer, focusEditButton } = useRepeatingGroupsFocusContext();
   const texts = {
     ...textResourceBindings,
     ...textsForRow,
@@ -187,7 +190,14 @@ function RepeatingGroupsEditContainerInternal({
                   <Button
                     variant='secondary'
                     color='second'
-                    onClick={() => prevMultiPage()}
+                    onClick={() => {
+                      prevMultiPage();
+                      if (editingRowIndex !== undefined) {
+                        // Wait for the new page to render, then move focus to the top of the edit
+                        // container instead of leaving it on this navigation button.
+                        requestAnimationFrame(() => focusEditContainer(editingRowIndex));
+                      }
+                    }}
                   >
                     <ChevronLeftIcon
                       fontSize='1rem'
@@ -202,7 +212,14 @@ function RepeatingGroupsEditContainerInternal({
                   <Button
                     variant='secondary'
                     color='second'
-                    onClick={() => nextMultiPage()}
+                    onClick={() => {
+                      nextMultiPage();
+                      if (editingRowIndex !== undefined) {
+                        // Wait for the new page to render, then move focus to the top of the edit
+                        // container instead of leaving it on this navigation button.
+                        requestAnimationFrame(() => focusEditContainer(editingRowIndex));
+                      }
+                    }}
                   >
                     <Lang id={texts.multipage_next_button ? texts.multipage_next_button : 'general.next'} />
                     <ChevronRightIcon
@@ -224,7 +241,20 @@ function RepeatingGroupsEditContainerInternal({
               <Flex item>
                 <Button
                   id={`next-button-grp-${id}`}
-                  onClick={() => openNextForEditing()}
+                  onClick={async () => {
+                    // Capture the next editable row before opening it, then move focus to the top of
+                    // its edit container (not the next row's edit button) once it has rendered.
+                    const currentEditableIndex = editableRows.findIndex((r) => r.uuid === editId);
+                    const nextEditableRow = editableRows[currentEditableIndex + 1];
+                    const opened = await openNextForEditing();
+                    if (opened) {
+                      requestAnimationFrame(() =>
+                        // If there is no next editable row, openNextForEditing closes this one
+                        // instead; fall back to this row's edit button like save and close.
+                        nextEditableRow ? focusEditContainer(nextEditableRow.index) : focusEditButton(row.index),
+                      );
+                    }
+                  }}
                   variant='primary'
                   color='first'
                 >
@@ -236,7 +266,14 @@ function RepeatingGroupsEditContainerInternal({
               <Flex item>
                 <Button
                   id={`save-button-${id}`}
-                  onClick={() => closeForEditing({ index: row.index, uuid: row.uuid })}
+                  onClick={async () => {
+                    const closed = await closeForEditing({ index: row.index, uuid: row.uuid });
+                    // Move focus back to this row's edit button rather than letting it fall to the
+                    // next row (or the page body) when the edit container unmounts.
+                    if (closed) {
+                      requestAnimationFrame(() => focusEditButton(row.index));
+                    }
+                  }}
                   variant={saveAndNextButtonVisible ? 'secondary' : 'primary'}
                   color='first'
                 >

--- a/src/layout/RepeatingGroup/EditContainer/RepeatingGroupsEditContainer.tsx
+++ b/src/layout/RepeatingGroup/EditContainer/RepeatingGroupsEditContainer.tsx
@@ -242,15 +242,13 @@ function RepeatingGroupsEditContainerInternal({
                 <Button
                   id={`next-button-grp-${id}`}
                   onClick={async () => {
-                    // Capture the next editable row before opening it, then move focus to the top of
-                    // its edit container (not the next row's edit button) once it has rendered.
+                    // Move focus to the top of its edit container
                     const currentEditableIndex = editableRows.findIndex((r) => r.uuid === editId);
                     const nextEditableRow = editableRows[currentEditableIndex + 1];
                     const opened = await openNextForEditing();
                     if (opened) {
                       requestAnimationFrame(() =>
-                        // If there is no next editable row, openNextForEditing closes this one
-                        // instead; fall back to this row's edit button like save and close.
+                        // Fall back to focusing this row's edit button like save and close.
                         nextEditableRow ? focusEditContainer(nextEditableRow.index) : focusEditButton(row.index),
                       );
                     }
@@ -268,8 +266,7 @@ function RepeatingGroupsEditContainerInternal({
                   id={`save-button-${id}`}
                   onClick={async () => {
                     const closed = await closeForEditing({ index: row.index, uuid: row.uuid });
-                    // Move focus back to this row's edit button rather than letting it fall to the
-                    // next row (or the page body) when the edit container unmounts.
+                    // Move focus back to this row's edit button
                     if (closed) {
                       requestAnimationFrame(() => focusEditButton(row.index));
                     }

--- a/src/layout/RepeatingGroup/Providers/RepeatingGroupContext.tsx
+++ b/src/layout/RepeatingGroup/Providers/RepeatingGroupContext.tsx
@@ -26,6 +26,7 @@ interface Store {
   deletingIds: string[];
   addingIds: string[];
   currentPage: number | undefined;
+  deletedRowsCount: number;
 }
 
 interface ZustandHiddenMethods {
@@ -205,6 +206,7 @@ function newStore({ baseComponentId, getRows, editMode, pagination }: NewStorePr
     deletingIds: [],
     addingIds: [],
     currentPage: pagination ? 0 : undefined,
+    deletedRowsCount: 0,
 
     closeForEditing: (row) => {
       set((state) => {
@@ -286,11 +288,13 @@ function newStore({ baseComponentId, getRows, editMode, pagination }: NewStorePr
           return state;
         }
         const deletingIds = [...state.deletingIds.slice(0, i), ...state.deletingIds.slice(i + 1)];
+        const deletedRowsCount = successful ? state.deletedRowsCount + 1 : state.deletedRowsCount;
         if (isEditing && successful) {
-          return { editingId: undefined, deletingIds };
+          return { editingId: undefined, deletingIds, deletedRowsCount };
         }
         return {
           deletingIds,
+          deletedRowsCount,
           editingId: isEditing && successful ? undefined : state.editingId,
         };
       });
@@ -441,22 +445,26 @@ export const RepGroupContext = {
     const rawOpenNextForEditing = ZStore.useStaticSelector((state) => state.openNextForEditing);
     const maybeValidateRow = useMaybeValidateRow();
 
-    return async () => {
+    // Returns true when the next row was opened, false when validation blocked it (row stays open).
+    return async (): Promise<boolean> => {
       if (await maybeValidateRow()) {
-        return;
+        return false;
       }
       rawOpenNextForEditing();
+      return true;
     };
   },
   useCloseForEditing() {
     const rawCloseForEditing = ZStore.useStaticSelector((state) => state.closeForEditing);
     const maybeValidateRow = useMaybeValidateRow();
 
-    return async (row: BaseRow) => {
+    // Returns true when the row was closed, false when validation blocked it (row stays open).
+    return async (row: BaseRow): Promise<boolean> => {
       if (await maybeValidateRow()) {
-        return;
+        return false;
       }
       rawCloseForEditing(row);
+      return true;
     };
   },
   useChangePage() {

--- a/src/layout/RepeatingGroup/Providers/RepeatingGroupFocusContext.tsx
+++ b/src/layout/RepeatingGroup/Providers/RepeatingGroupFocusContext.tsx
@@ -10,10 +10,12 @@ import { FD } from 'src/features/formData/FormDataWrite';
 import {
   RepGroupContext,
   useRepeatingGroupComponentId,
+  useRepeatingGroupRowState,
 } from 'src/layout/RepeatingGroup/Providers/RepeatingGroupContext';
 import { useIntermediateItem } from 'src/utils/layout/hooks';
 import { getBaseComponentId, splitDashedKey } from 'src/utils/splitDashedKey';
 import type { ParentRef } from 'src/features/form/layout/makeLayoutLookups';
+import type { BaseRow } from 'src/utils/layout/types';
 
 type FocusableHTMLElement =
   | HTMLButtonElement
@@ -25,9 +27,20 @@ type FocusableHTMLElement =
 export type RefSetter = (rowIndex: number, key: string, div: HTMLElement | null) => void;
 export type FocusTrigger = (rowIndex: number) => void;
 
+// Key used when registering the whole table row as a focus target. This gives read-only tables
+// (where the cells contain no focusable elements) something to focus, e.g. after deleting a row.
+const ROW_CONTAINER_KEY = 'row';
+// Keys used to register the row's edit button and its edit container as focus targets.
+const EDIT_BUTTON_KEY = 'editButton';
+const EDIT_CONTAINER_KEY = 'editContainer';
+
 interface Context {
   refSetter: RefSetter;
   triggerFocus: FocusTrigger;
+  focusEditContainer: (rowIndex: number) => void;
+  focusEditButton: (rowIndex: number) => void;
+  registerAddButton: (node: HTMLElement | null) => void;
+  focusAddButton: () => void;
 }
 
 const { Provider, useCtx } = createContext<Context>({
@@ -36,6 +49,10 @@ const { Provider, useCtx } = createContext<Context>({
   default: {
     refSetter: () => undefined,
     triggerFocus: () => undefined,
+    focusEditContainer: () => undefined,
+    focusEditButton: () => undefined,
+    registerAddButton: () => undefined,
+    focusAddButton: () => undefined,
   },
 });
 
@@ -44,6 +61,9 @@ export const useRepeatingGroupsFocusContext = () => useCtx();
 export function RepeatingGroupsFocusProvider({ children }: PropsWithChildren) {
   const elementRefs = useMemo(() => new Map<string, HTMLElement | null>(), []);
   const waitingForFocus = useRef<number | null>(null);
+  const waitingForEditContainer = useRef<number | null>(null);
+  const waitingForEditButton = useRef<number | null>(null);
+  const addButtonRef = useRef<HTMLElement | null>(null);
 
   useNavigateToRepeatingGroupPageAndFocusRow();
 
@@ -54,10 +74,17 @@ export function RepeatingGroupsFocusProvider({ children }: PropsWithChildren) {
       return;
     }
 
-    for (const [key, element] of elementRefs.entries()) {
-      if (!key.startsWith(`${rowIndex}-`)) {
-        continue;
-      }
+    // Prefer specific row content (editable cells, edit container) and fall back to the row
+    // container last, so we only focus an action button when there is nothing else to focus.
+    const prefix = `${rowIndex}-`;
+    const rowContainerKey = `${rowIndex}-${ROW_CONTAINER_KEY}`;
+    const matching = Array.from(elementRefs.entries()).filter(([key]) => key.startsWith(prefix));
+    const ordered = [
+      ...matching.filter(([key]) => key !== rowContainerKey),
+      ...matching.filter(([key]) => key === rowContainerKey),
+    ];
+
+    for (const [, element] of ordered) {
       const firstFocusableChild = element && findFirstFocusableElement(element);
       if (firstFocusableChild) {
         firstFocusableChild.focus();
@@ -76,12 +103,107 @@ export function RepeatingGroupsFocusProvider({ children }: PropsWithChildren) {
         waitingForFocus.current = null;
         triggerFocus(rowIndex);
       }
+      if (key === EDIT_CONTAINER_KEY && waitingForEditContainer.current === rowIndex) {
+        waitingForEditContainer.current = null;
+        focusEditContainer(rowIndex);
+      }
+      if (key === EDIT_BUTTON_KEY && waitingForEditButton.current === rowIndex) {
+        waitingForEditButton.current = null;
+        focusEditButton(rowIndex);
+      }
     } else {
       elementRefs.delete(`${rowIndex}-${key}`);
     }
   };
 
-  return <Provider value={{ refSetter, triggerFocus }}>{children}</Provider>;
+  // Move focus to the first focusable element inside the edit container of a row. Used when
+  // navigating between multiPage pages and when opening the next row for editing, so focus follows
+  // to the top of the edit container instead of being left behind on the button that was pressed.
+  const focusEditContainer = (rowIndex: number) => {
+    const element = elementRefs.get(`${rowIndex}-${EDIT_CONTAINER_KEY}`);
+    const firstFocusableChild = element && findFirstFocusableElement(element);
+    if (firstFocusableChild) {
+      waitingForEditContainer.current = null;
+      firstFocusableChild.focus();
+      return;
+    }
+    // The edit container isn't mounted yet (e.g. opening a row on another page); focus it once it
+    // registers via refSetter.
+    waitingForEditContainer.current = rowIndex;
+  };
+
+  // Move focus to a row's edit button, e.g. back to the same row after closing its edit container.
+  const focusEditButton = (rowIndex: number) => {
+    const element = elementRefs.get(`${rowIndex}-${EDIT_BUTTON_KEY}`);
+    if (element) {
+      waitingForEditButton.current = null;
+      element.focus();
+      return;
+    }
+    // The edit button isn't mounted yet (e.g. the table is remounting after closing in hideTable
+    // mode); focus it once it registers via refSetter.
+    waitingForEditButton.current = rowIndex;
+  };
+
+  const registerAddButton = (node: HTMLElement | null) => {
+    addButtonRef.current = node;
+  };
+
+  const focusAddButton = () => {
+    addButtonRef.current?.focus();
+  };
+
+  return (
+    <Provider
+      value={{ refSetter, triggerFocus, focusEditContainer, focusEditButton, registerAddButton, focusAddButton }}
+    >
+      {children}
+    </Provider>
+  );
+}
+
+export function getRowToFocusAfterDeletion(visibleRows: BaseRow[], deletedUuid: string): number | null {
+  const sorted = [...visibleRows].sort((a, b) => a.index - b.index);
+  const position = sorted.findIndex((row) => row.uuid === deletedUuid);
+  if (position === -1) {
+    return null;
+  }
+
+  const previousRow = sorted[position - 1];
+  if (previousRow) {
+    return previousRow.index;
+  }
+
+  const nextRow = sorted[position + 1];
+  if (nextRow) {
+    // The next row shifts down by one index once the (first) row is removed.
+    return nextRow.index - 1;
+  }
+
+  return null;
+}
+
+export function useDeleteRowAndFocus() {
+  const deleteRow = RepGroupContext.useDeleteRow();
+  const { triggerFocus, focusAddButton } = useRepeatingGroupsFocusContext();
+  const { visibleRows } = useRepeatingGroupRowState();
+
+  return async (row: BaseRow): Promise<boolean> => {
+    const focusTarget = getRowToFocusAfterDeletion(visibleRows, row.uuid);
+    const successful = await deleteRow(row);
+    if (successful) {
+      // Wait for the row to be removed and the remaining rows to re-render (and re-register their
+      // refs under their shifted indices) before moving focus, mirroring `useFocusWhenRemoved`.
+      requestAnimationFrame(() => {
+        if (focusTarget === null) {
+          focusAddButton();
+        } else {
+          triggerFocus(focusTarget);
+        }
+      });
+    }
+    return successful;
+  };
 }
 
 function isFocusable(element: HTMLElement): element is FocusableHTMLElement {

--- a/src/layout/RepeatingGroup/Providers/RepeatingGroupFocusContext.tsx
+++ b/src/layout/RepeatingGroup/Providers/RepeatingGroupFocusContext.tsx
@@ -27,8 +27,8 @@ type FocusableHTMLElement =
 export type RefSetter = (rowIndex: number, key: string, div: HTMLElement | null) => void;
 export type FocusTrigger = (rowIndex: number) => void;
 
-// Key used when registering the whole table row as a focus target. This gives read-only tables
-// (where the cells contain no focusable elements) something to focus, e.g. after deleting a row.
+// Key used when registering the whole table row as a focus target. This gives read-only tables after deleting a row
+// something to focus.
 const ROW_CONTAINER_KEY = 'row';
 // Keys used to register the row's edit button and its edit container as focus targets.
 const EDIT_BUTTON_KEY = 'editButton';
@@ -117,8 +117,7 @@ export function RepeatingGroupsFocusProvider({ children }: PropsWithChildren) {
   };
 
   // Move focus to the first focusable element inside the edit container of a row. Used when
-  // navigating between multiPage pages and when opening the next row for editing, so focus follows
-  // to the top of the edit container instead of being left behind on the button that was pressed.
+  // navigating between multiPage pages and when opening the next row for editing
   const focusEditContainer = (rowIndex: number) => {
     const element = elementRefs.get(`${rowIndex}-${EDIT_CONTAINER_KEY}`);
     const firstFocusableChild = element && findFirstFocusableElement(element);
@@ -127,12 +126,10 @@ export function RepeatingGroupsFocusProvider({ children }: PropsWithChildren) {
       firstFocusableChild.focus();
       return;
     }
-    // The edit container isn't mounted yet (e.g. opening a row on another page); focus it once it
-    // registers via refSetter.
     waitingForEditContainer.current = rowIndex;
   };
 
-  // Move focus to a row's edit button, e.g. back to the same row after closing its edit container.
+  // Move focus to a row's edit button
   const focusEditButton = (rowIndex: number) => {
     const element = elementRefs.get(`${rowIndex}-${EDIT_BUTTON_KEY}`);
     if (element) {
@@ -140,8 +137,6 @@ export function RepeatingGroupsFocusProvider({ children }: PropsWithChildren) {
       element.focus();
       return;
     }
-    // The edit button isn't mounted yet (e.g. the table is remounting after closing in hideTable
-    // mode); focus it once it registers via refSetter.
     waitingForEditButton.current = rowIndex;
   };
 
@@ -192,8 +187,7 @@ export function useDeleteRowAndFocus() {
     const focusTarget = getRowToFocusAfterDeletion(visibleRows, row.uuid);
     const successful = await deleteRow(row);
     if (successful) {
-      // Wait for the row to be removed and the remaining rows to re-render (and re-register their
-      // refs under their shifted indices) before moving focus, mirroring `useFocusWhenRemoved`.
+      // Wait for the row to be removed and the remaining rows to re-render before moving focus
       requestAnimationFrame(() => {
         if (focusTarget === null) {
           focusAddButton();

--- a/src/layout/RepeatingGroup/Table/RepeatingGroupTableRow.tsx
+++ b/src/layout/RepeatingGroup/Table/RepeatingGroupTableRow.tsx
@@ -21,7 +21,10 @@ import {
   RepGroupContext,
   useRepeatingGroupComponentId,
 } from 'src/layout/RepeatingGroup/Providers/RepeatingGroupContext';
-import { useRepeatingGroupsFocusContext } from 'src/layout/RepeatingGroup/Providers/RepeatingGroupFocusContext';
+import {
+  useDeleteRowAndFocus,
+  useRepeatingGroupsFocusContext,
+} from 'src/layout/RepeatingGroup/Providers/RepeatingGroupFocusContext';
 import classes from 'src/layout/RepeatingGroup/RepeatingGroup.module.css';
 import { useTableComponentIds } from 'src/layout/RepeatingGroup/useTableComponentIds';
 import { RepGroupHooks } from 'src/layout/RepeatingGroup/utils';
@@ -92,7 +95,7 @@ export function RepeatingGroupTableRow({
   const { refSetter } = useRepeatingGroupsFocusContext();
 
   const baseComponentId = useRepeatingGroupComponentId();
-  const deleteRow = RepGroupContext.useDeleteRow();
+  const deleteRow = useDeleteRowAndFocus();
   const toggleEditing = RepGroupContext.useToggleEditing();
   const indexedId = useIndexedId(baseComponentId);
   const langTools = useLanguage();
@@ -126,6 +129,7 @@ export function RepeatingGroupTableRow({
 
   return (
     <Table.Row
+      ref={(node) => refSetter(index, 'row', node)}
       className={cn({ [classes.tableRowError]: rowHasErrors }, className)}
       data-row-num={index}
       data-row-uuid={uuid}
@@ -226,6 +230,7 @@ export function RepeatingGroupTableRow({
                         editButtonText={editButtonText}
                         rowHasErrors={rowHasErrors}
                         compactButtons={compactButtons}
+                        buttonRef={(node) => refSetter(index, 'editButton', node)}
                       />
                     )}
                     {editForRow?.deleteButton !== false && displayDeleteColumn && (
@@ -271,6 +276,7 @@ export function RepeatingGroupTableRow({
                     editButtonText={editButtonText}
                     rowHasErrors={rowHasErrors}
                     compactButtons={compactButtons}
+                    buttonRef={(node) => refSetter(index, 'editButton', node)}
                   />
                 </div>
               </Table.Cell>
@@ -314,6 +320,7 @@ export function RepeatingGroupTableRow({
                 editButtonText={editButtonText}
                 rowHasErrors={rowHasErrors}
                 compactButtons={compactButtons}
+                buttonRef={(node) => refSetter(index, 'editButton', node)}
               />
             )}
             {editForRow?.deleteButton !== false && (
@@ -367,6 +374,7 @@ function EditElement({
   rowHasErrors,
   uuid,
   compactButtons,
+  buttonRef,
 }: {
   ariaExpanded: boolean;
   indexedId: string;
@@ -376,11 +384,13 @@ function EditElement({
   editButtonText: string;
   rowHasErrors: boolean;
   compactButtons: boolean;
+  buttonRef?: (node: HTMLButtonElement | null) => void;
 }) {
   const ariaLabel = useAriaLabel(editButtonText);
   const showText = compactButtons ? ariaExpanded : ariaExpanded || !mobileViewSmall;
   return (
     <Button
+      ref={buttonRef}
       aria-expanded={ariaExpanded}
       aria-controls={ariaExpanded ? `group-edit-container-${indexedId}-${uuid}` : undefined}
       variant='tertiary'


### PR DESCRIPTION
## Description

- Screen reader not notified when a row is deleted
    - Added a visually-hidden aria-live status region driven by a deletedRowsCount counter at the single endDeletingRow choke point, covering both delete entry points.
- Focus fell to the page body after deletion (page title read, preempting the announcement)
  -  Focus now moves to the previous row (race-free), or the Add button when no rows remain; registered the table row as a focus target for read-only tables.
- multiPage navigation left focus on the Next/Back button
  - Focus now moves to the top (first field) of the edit container in both directions.
- Save & Close focus target 
  - Now returns focus to the same row's edit button instead of the next row's.
- Save & Open Next focus target
  -  Now moves focus to the first field of the next row's edit container instead of the next row's edit button.

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [x] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added screen reader announcements for repeating-group row deletions, including updated remaining-row counts.
  * Enhanced keyboard focus management for multi-page editing and save flows, restoring focus to the appropriate edit controls and advancing focus after “save and next/close.”
  * Updated localized screen-reader text for row-deletion status in English, Bokmål, and Nynorsk.

* **Tests**
  * Added/extended accessibility tests covering live-region updates and focus movement across consecutive deletions and edit navigation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->