### PR TITLE
[BACKPORT] refactor: use altinn 3 endpoint to increase auth level

### DIFF
--- a/src/features/instantiate/containers/InstantiateContainer.tsx
+++ b/src/features/instantiate/containers/InstantiateContainer.tsx
@@ -10,6 +10,7 @@ import { useSelectedParty } from 'src/features/party/PartiesProvider';
 import { AltinnPalette } from 'src/theme/altinnAppTheme';
 import { changeBodyBackground } from 'src/utils/bodyStyling';
 import { isAxiosError } from 'src/utils/isAxiosError';
+import { isAuthenticationRedirectError } from 'src/utils/maybeAuthenticationRedirect';
 import { HttpStatusCodes } from 'src/utils/network/networking';
 
 export const InstantiateContainer = () => {
@@ -23,6 +24,14 @@ export const InstantiateContainer = () => {
       instantiation.instantiate(party.partyId);
     }
   }, [instantiation, party]);
+
+  // A 403 with RequiredAuthenticationLevel triggers a step-up redirect (see useInstantiation.onError). Block further
+  // rendering with a loader until the browser navigates away, so we never flash the "missing roles" error page. After a
+  // successful step-up the level is raised, so a later 403 no longer carries RequiredAuthenticationLevel and the error
+  // page renders below instead.
+  if (isAuthenticationRedirectError(instantiation.error)) {
+    return <Loader reason='authentication-redirect' />;
+  }
 
   if (isAxiosError(instantiation.error) && instantiation.error.response?.status === HttpStatusCodes.Forbidden) {
     if (isInstantiationValidationResult(instantiation.error.response?.data)) {

--- a/src/features/instantiate/useInstantiation.tsx
+++ b/src/features/instantiate/useInstantiation.tsx
@@ -7,6 +7,7 @@ import type { AxiosError } from 'axios';
 import { useAppMutations } from 'src/core/contexts/AppQueriesProvider';
 import { instanceQueries } from 'src/features/instance/InstanceContext';
 import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
+import { maybeAuthenticationRedirect } from 'src/utils/maybeAuthenticationRedirect';
 import type { IInstance } from 'src/types/shared';
 import type { HttpClientError } from 'src/utils/network/sharedNetworking';
 
@@ -36,8 +37,13 @@ export function useInstantiation() {
     mutationKey: ['instantiate'],
     mutationFn: (args: InstantiationArgs) =>
       typeof args === 'number' ? doInstantiate(args, currentLanguage) : doInstantiateWithPrefill(args, currentLanguage),
-    onError: (error: HttpClientError) => {
+    onError: async (error: HttpClientError) => {
       window.logError(`Instantiation failed:\n`, error);
+
+      // If the instantiation failed because the user is authenticated with a too low security level, the backend
+      // responds with 403 and a RequiredAuthenticationLevel. We then redirect to step-up authentication instead of
+      // falling through to a generic "missing roles" error page. No-op for any other error.
+      await maybeAuthenticationRedirect(error);
     },
     onSuccess: async (data) => {
       const [instanceOwnerPartyId, instanceGuid] = data.id.split('/');

--- a/src/utils/maybeAuthenticationRedirect.ts
+++ b/src/utils/maybeAuthenticationRedirect.ts
@@ -1,17 +1,40 @@
-import type { AxiosError } from 'axios';
-
+import { isAxiosError } from 'src/utils/isAxiosError';
 import { putWithoutConfig } from 'src/utils/network/networking';
 import { invalidateCookieUrl, redirectToUpgrade } from 'src/utils/urls/appUrlHelper';
 
-export async function maybeAuthenticationRedirect(error: AxiosError): Promise<boolean> {
-  if (error.response && error.response.status === 403 && error.response.data) {
-    const reqAuthLevel = error.response.data['RequiredAuthenticationLevel'];
-    if (reqAuthLevel) {
-      await putWithoutConfig(invalidateCookieUrl);
-      redirectToUpgrade(reqAuthLevel);
+/**
+ * A 403 carrying a `RequiredAuthenticationLevel` means the user is authenticated, but with a too low security level.
+ * This is a synchronous guard so the render path can block further rendering (showing a loader) instead of flashing a
+ * generic "missing roles" error page while the asynchronous step-up redirect is in flight.
+ */
+export function isAuthenticationRedirectError(error: unknown): boolean {
+  return !!(
+    isAxiosError(error) &&
+    error.response?.status === 403 &&
+    error.response.data &&
+    error.response.data['RequiredAuthenticationLevel']
+  );
+}
 
-      return true;
-    }
+/**
+ * Kills the existing (too-low-level) auth cookie so the platform auth endpoint cannot short-circuit on the stale
+ * session and bounce us back at the same level. With no cookie it must go to ID-porten, which, together with the
+ * acr_values requirement on the redirect URL, forces a real step-up. Never throws: a failed invalidation must not
+ * block the redirect.
+ */
+async function invalidateExistingAuthCookie(): Promise<void> {
+  try {
+    await putWithoutConfig(invalidateCookieUrl);
+  } catch (e) {
+    window.logError('Failed to invalidate auth cookie before step-up redirect:\n', e);
+  }
+}
+export async function maybeAuthenticationRedirect(error: unknown): Promise<boolean> {
+  if (isAuthenticationRedirectError(error)) {
+    await invalidateExistingAuthCookie();
+    redirectToUpgrade();
+
+    return true;
   }
 
   return false;

--- a/src/utils/urls/appUrlHelper.test.ts
+++ b/src/utils/urls/appUrlHelper.test.ts
@@ -71,8 +71,8 @@ describe('Frontend urlHelper.ts', () => {
       );
     });
     it('should return the expected url for getUpgradeAuthLevelUrl', () => {
-      expect(getUpgradeAuthLevelUrl('overlord')).toBe(
-        'https://local.altinn.cloud/ui/authentication/upgrade?goTo=https%3A%2F%2Fplatform.local.altinn.cloud%2Fauthentication%2Fapi%2Fv1%2Fauthentication%3Fgoto%3Dhttps%3A%2F%2Flocal.altinn.cloud%2Fttd%2Ftest&reqAuthLevel=overlord',
+      expect(getUpgradeAuthLevelUrl()).toBe(
+        'https://platform.local.altinn.cloud/authentication/api/v1/authentication?goTo=https%3A%2F%2Flocal.altinn.cloud%2Fttd%2Ftest&acr_values=idporten-loa-high',
       );
     });
   });
@@ -98,16 +98,16 @@ describe('Frontend urlHelper.ts', () => {
     describe('util', () => {
       it('should return the expected url for getUpgradeAuthLevelUrl', () => {
         resetWindow();
-        expect(getUpgradeAuthLevelUrl('overlord')).toBe(
-          'https://altinn.no/ui/authentication/upgrade?goTo=https%3A%2F%2Fplatform.altinn.no%2Fauthentication%2Fapi%2Fv1%2Fauthentication%3Fgoto%3Dhttps%3A%2F%2Flocal.altinn.cloud%2Fttd%2Ftest&reqAuthLevel=overlord',
+        expect(getUpgradeAuthLevelUrl()).toBe(
+          'https://platform.altinn.no/authentication/api/v1/authentication?goTo=https%3A%2F%2Flocal.altinn.cloud%2Fttd%2Ftest&acr_values=idporten-loa-high',
         );
       });
       it('changes the window location', () => {
         resetWindow();
         expect(window.location.href).toBe('https://ttd.apps.altinn.no/ttd/test');
-        redirectToUpgrade('overlord');
+        redirectToUpgrade();
         expect(window.location.href).toBe(
-          'https://altinn.no/ui/authentication/upgrade?goTo=https%3A%2F%2Fplatform.altinn.no%2Fauthentication%2Fapi%2Fv1%2Fauthentication%3Fgoto%3Dhttps%3A%2F%2Flocal.altinn.cloud%2Fttd%2Ftest&reqAuthLevel=overlord',
+          'https://platform.altinn.no/authentication/api/v1/authentication?goTo=https%3A%2F%2Flocal.altinn.cloud%2Fttd%2Ftest&acr_values=idporten-loa-high',
         );
       });
     });

--- a/src/utils/urls/appUrlHelper.ts
+++ b/src/utils/urls/appUrlHelper.ts
@@ -130,13 +130,14 @@ export const getRedirectUrl = (returnUrl: string) => {
   return `${appPath}/api/v1/redirect?url=${encodedUriComponent}`;
 };
 
-export const getUpgradeAuthLevelUrl = (reqAuthLevel: string) => {
-  const redirect: string =
-    `https://platform.${getHostname()}` + `/authentication/api/v1/authentication?goto=${appPath}`;
-  return `https://${getHostname()}/ui/authentication/upgrade?goTo=${encodeURIComponent(
-    redirect,
-  )}&reqAuthLevel=${reqAuthLevel}`;
-};
+/**
+ * Builds the platform authentication URL that triggers a step-up to security level high (`idporten-loa-high`),
+ * returning the user to the app (`goTo`) once the higher level has been obtained.
+ */
+export const getUpgradeAuthLevelUrl = () =>
+  `https://platform.${getHostname()}/authentication/api/v1/authentication?goTo=${encodeURIComponent(
+    appPath,
+  )}&acr_values=idporten-loa-high`;
 
 export const getEnvironmentLoginUrl = (oidcProvider: string | null) => {
   // First split away the protocol 'https://' and take the last part. Then split on dots.
@@ -181,8 +182,8 @@ export const getHostname = () => {
   throw new Error('Unknown domain');
 };
 
-export const redirectToUpgrade = (reqAuthLevel: string) => {
-  window.location.href = getUpgradeAuthLevelUrl(reqAuthLevel);
+export const redirectToUpgrade = () => {
+  window.location.href = getUpgradeAuthLevelUrl();
 };
 
 export const getJsonSchemaUrl = () => `${appPath}/api/jsonschema/`;

--- a/test/e2e/integration/frontend-test/redirect.ts
+++ b/test/e2e/integration/frontend-test/redirect.ts
@@ -21,6 +21,62 @@ describe('Redirect', () => {
     cy.get('@instantiate.all').should('have.length', 1);
   });
 
+  it('User with too low authentication level is redirected to step-up authentication instead of the error page', () => {
+    cy.allowFailureOnEnd();
+
+    cy.intercept('GET', '**/api/v1/applicationmetadata', (req) => {
+      req.on('response', (res) => {
+        if (res.body && typeof res.body === 'object') {
+          res.body.onEntry = { show: 'new-instance' };
+        }
+      });
+    });
+
+    cy.intercept('POST', '**/instances**', {
+      statusCode: 403,
+      body: { RequiredAuthenticationLevel: 3 },
+    }).as('instantiate');
+
+    // Track the order in which the requests fire to assert cookie invalidation happens before step-up.
+    const callOrder: string[] = [];
+
+    cy.intercept('PUT', '**/api/authentication/invalidatecookie', (req) => {
+      callOrder.push('invalidateCookie');
+      req.reply({ statusCode: 200 });
+    }).as('invalidateCookie');
+
+    // The step-up sets window.location.href, which would put Cypress into "waiting for page load" indefinitely (the
+    // real target is a cross-origin platform endpoint). Match ONLY the step-up (login hits the same endpoint but never
+    // with acr_values) and 302 it to a static same-origin page so a load event fires and we stay on the app origin,
+    // while still capturing the request to assert its URL.
+    const baseUrl = Cypress.config('baseUrl');
+    if (!baseUrl || typeof baseUrl !== 'string') {
+      throw new Error('baseUrl is not configured');
+    }
+    const appOrigin = Cypress.env('type') === 'localtest' ? baseUrl : `https://ttd.apps.${new URL(baseUrl).host}`;
+    cy.intercept(
+      {
+        method: 'GET',
+        pathname: '/authentication/api/v1/authentication',
+        query: { acr_values: 'idporten-loa-high' },
+      },
+      (req) => {
+        callOrder.push('stepUp');
+        req.reply({ statusCode: 302, headers: { location: `${appOrigin}/ttd/frontend-test/login.html` } });
+      },
+    ).as('stepUp');
+
+    cy.startAppInstance(appFrontend.apps.frontendTest);
+
+    cy.wait('@invalidateCookie');
+
+    cy.wait('@stepUp').its('request.url').should('include', 'acr_values=idporten-loa-high');
+
+    cy.then(() => {
+      expect(callOrder).to.deep.equal(['invalidateCookie', 'stepUp']);
+    });
+  });
+
   it('User is redirected to unknown error page when a network call fails', () => {
     cy.allowFailureOnEnd();
     cy.intercept('GET', `**/applicationmetadata`, {


### PR DESCRIPTION
Backport

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authentication step-up redirect handling for users with insufficient authentication levels.

* **Bug Fixes**
  * Suppressed JWT keep-alive refresh on PDF pages.
  * Improved error handling during instantiation to prevent error page flashing during authentication redirects.

* **Improvements**
  * Added retry logic with exponential backoff for payment information queries to increase resilience.

* **Tests**
  * Added e2e test for authentication level step-up flows.
  * Enhanced PDF test assertions for keep-alive behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->