### PR TITLE
Fix/grid label disappearing on 400 percent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,49 @@ The app has a complex provider tree with many nested contexts. When making chang
 
 There are many usages of `any` or type casting (`as type`) in the codebase. This skips TypeScript completely and is, in most cases, not what we want. We would like to improve the typing by avoiding this moving forward whilst also refactoring and improving existing types by removing such casts and `any`s.
 
+#### Control flow: prefer guard clauses
+
+Handle each case as a flat guard clause that returns early (or `continue`/`return` inside loops) instead of nesting `if`/`else if`/`else`. Each case stays one short, independent block, so the code reads top-to-bottom like its step-by-step comment.
+
+```ts
+// Before: nested branches, the main case buried in the final `else`
+function useMobileRows(rows: GridRow[] | undefined): MobileRow[] {
+  const hiddenInRows = useHiddenInRows(rows);
+
+  const result: MobileRow[] = [];
+  let headerCells: GridCell[] = [];
+  (rows ?? []).forEach((row, index) => {
+    if (row.header) {
+      headerCells = row.cells;
+    } else if (isGridRowHidden(row, hiddenInRows)) {
+      // skip
+    } else {
+      result.push({ row, headerCells, index });
+    }
+  });
+  return result;
+}
+
+// After: one guard per case, main case un-nested, code mirrors the comment
+function useMobileRows(rows: GridRow[] | undefined): MobileRow[] {
+  const hiddenInRows = useHiddenInRows(rows);
+
+  const result: MobileRow[] = [];
+  let headerCells: GridCell[] = [];
+  (rows ?? []).forEach((row, index) => {
+    if (row.header) {
+      headerCells = row.cells;
+      return;
+    }
+    if (isGridRowHidden(row, hiddenInRows)) {
+      return;
+    }
+    result.push({ row, headerCells, index });
+  });
+  return result;
+}
+```
+
 #### TanStack Query best practices
 
 Use objects for managing query keys and functions and `queryOptions` for sharing these across the system and central management.

--- a/src/layout/Grid/Grid.module.css
+++ b/src/layout/Grid/Grid.module.css
@@ -97,9 +97,6 @@ Altinn, and making sure they are consistent. */
   gap: 16px;
 }
 
-/* Read-only "column title / value" pair (e.g. "Krav" + requirement text), rendered as a description list.
-   The explicit margin/padding resets override the global `ol, ul, dl { padding-left: 1.5rem }` rule in index.css
-   and the user-agent `dd { margin-inline-start: 40px }`, so the label and value line up flush-left with the field. */
 .mobileCell {
   display: flex;
   flex-direction: column;

--- a/src/layout/Grid/Grid.module.css
+++ b/src/layout/Grid/Grid.module.css
@@ -90,3 +90,19 @@ Altinn, and making sure they are consistent. */
   gap: 24px;
   flex-direction: column;
 }
+
+.mobileRow {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.mobileRowHeading {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.mobileRowHeadingText {
+  font-weight: 500;
+}

--- a/src/layout/Grid/Grid.module.css
+++ b/src/layout/Grid/Grid.module.css
@@ -94,15 +94,26 @@ Altinn, and making sure they are consistent. */
 .mobileRow {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 16px;
 }
 
-.mobileRowHeading {
+/* Read-only "column title / value" pair (e.g. "Krav" + requirement text), rendered as a description list.
+   The explicit margin/padding resets override the global `ol, ul, dl { padding-left: 1.5rem }` rule in index.css
+   and the user-agent `dd { margin-inline-start: 40px }`, so the label and value line up flush-left with the field. */
+.mobileCell {
   display: flex;
-  align-items: center;
-  gap: 4px;
+  flex-direction: column;
+  gap: var(--ds-size-1, 4px);
+  margin: 0;
+  padding: 0;
 }
 
-.mobileRowHeadingText {
-  font-weight: 500;
+.mobileCellLabel {
+  margin: 0;
+  padding: 0;
+}
+
+.mobileCellText {
+  margin: 0;
+  padding: 0;
 }

--- a/src/layout/Grid/GridComponent.test.tsx
+++ b/src/layout/Grid/GridComponent.test.tsx
@@ -206,25 +206,53 @@ describe('GridComponent', () => {
       expect(screen.queryByRole('columnheader')).not.toBeInTheDocument();
     });
 
-    it('keeps each row category text visible and associates it with the field', async () => {
+    it('renders the column title as a label and the row text as a description-list value', async () => {
       await renderMobile(kravSvarRows);
 
-      // The category text from each body row must remain visible
-      expect(screen.getByText('Setter brukeren i sentrum')).toBeInTheDocument();
-      expect(screen.getByText('Tilrettelegger for gjenbruk')).toBeInTheDocument();
+      // The category text from each body row must remain visible inside a <dd> value
+      const firstValue = screen.getByText('Setter brukeren i sentrum');
+      const secondValue = screen.getByText('Tilrettelegger for gjenbruk');
+      expect(firstValue.closest('dd')).toBeInTheDocument();
+      expect(secondValue.closest('dd')).toBeInTheDocument();
 
-      // Each field is wrapped in a group labelled by its row's category text
-      const firstGroup = screen.getByRole('group', { name: 'Setter brukeren i sentrum' });
+      // The column title "Krav" is rendered as the term (<dt>) inside the same description list
+      const terms = screen.getAllByText('Krav');
+      expect(terms).toHaveLength(2);
+      terms.forEach((term) => expect(term.closest('dt')).toBeInTheDocument());
+      expect(firstValue.closest('dl')).toContainElement(terms[0]);
+      expect(secondValue.closest('dl')).toContainElement(terms[1]);
+    });
+
+    it('associates the read-only requirement text with its answer field via a labelled group', async () => {
+      await renderMobile(kravSvarRows);
+
+      // Each field is wrapped in a group whose accessible name carries the column title + requirement text,
+      // so a screen reader announces the category together with the field.
+      const firstGroup = screen.getByRole('group', { name: 'Krav Setter brukeren i sentrum' });
       expect(within(firstGroup).getByRole('textbox')).toBeInTheDocument();
 
-      const secondGroup = screen.getByRole('group', { name: 'Tilrettelegger for gjenbruk' });
+      const secondGroup = screen.getByRole('group', { name: 'Krav Tilrettelegger for gjenbruk' });
       expect(within(secondGroup).getByRole('textbox')).toBeInTheDocument();
     });
 
-    it('does not render the redundant column-title header row as repeated context', async () => {
+    it('does not render the header row as its own standalone stacked row', async () => {
       await renderMobile(kravSvarRows);
-      // 'Krav' is only present in the header row, which should not be rendered on mobile
+      // The header titles only appear as per-row labels, never as a separate group/row of bare column titles
+      expect(screen.queryByRole('group', { name: 'Krav' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('group', { name: 'Svar' })).not.toBeInTheDocument();
+    });
+
+    it('renders category text without a column-title label when there is no header row', async () => {
+      await renderMobile([
+        {
+          cells: [{ text: 'Setter brukeren i sentrum' }, { component: 'answer-1' }],
+        },
+      ]);
+
+      // No header row -> no <dt> label; the text is still associated with the field via the group
       expect(screen.queryByText('Krav')).not.toBeInTheDocument();
+      const group = screen.getByRole('group', { name: 'Setter brukeren i sentrum' });
+      expect(within(group).getByRole('textbox')).toBeInTheDocument();
     });
 
     it('hides rows whose only component is hidden', async () => {

--- a/src/layout/Grid/GridComponent.test.tsx
+++ b/src/layout/Grid/GridComponent.test.tsx
@@ -1,9 +1,13 @@
 import React from 'react';
 
-import { screen } from '@testing-library/react';
+import { jest } from '@jest/globals';
+import { screen, within } from '@testing-library/react';
 
+import { defaultDataTypeMock } from 'src/__mocks__/getLayoutSetsMock';
+import * as useDeviceWidths from 'src/hooks/useDeviceWidths';
 import { RenderGrid } from 'src/layout/Grid/GridComponent';
 import { renderGenericComponentTest } from 'src/test/renderWithProviders';
+import type { GridRow } from 'src/layout/common.generated';
 import type { CompExternalExact } from 'src/layout/layout';
 
 describe('GridComponent', () => {
@@ -148,5 +152,124 @@ describe('GridComponent', () => {
     expect(cells.length).toBeGreaterThanOrEqual(1);
     const firstCell = cells[0];
     expect(firstCell).toHaveAttribute('colspan', '3');
+  });
+
+  describe('mobile layout', () => {
+    const renderMobile = async (rows: GridRow[]) => {
+      jest.spyOn(useDeviceWidths, 'useIsMobile').mockReturnValue(true);
+      return await renderGenericComponentTest({
+        type: 'Grid',
+        renderer: (props) => <RenderGrid {...props} />,
+        component: { rows } as CompExternalExact<'Grid'>,
+        queries: {
+          fetchLayouts: async () => ({
+            FormLayout: {
+              data: {
+                layout: [
+                  { id: 'my-test-component-id', type: 'Grid', rows },
+                  {
+                    id: 'answer-1',
+                    type: 'TextArea',
+                    textResourceBindings: { title: 'Svar' },
+                    dataModelBindings: { simpleBinding: { dataType: defaultDataTypeMock, field: 'answer1' } },
+                  },
+                  {
+                    id: 'answer-2',
+                    type: 'TextArea',
+                    textResourceBindings: { title: 'Svar' },
+                    dataModelBindings: { simpleBinding: { dataType: defaultDataTypeMock, field: 'answer2' } },
+                  },
+                ],
+              },
+            },
+          }),
+        },
+      });
+    };
+
+    const kravSvarRows: GridRow[] = [
+      {
+        header: true,
+        cells: [{ text: 'Krav' }, { text: 'Svar' }],
+      },
+      {
+        cells: [{ text: 'Setter brukeren i sentrum' }, { component: 'answer-1' }],
+      },
+      {
+        cells: [{ text: 'Tilrettelegger for gjenbruk' }, { component: 'answer-2' }],
+      },
+    ];
+
+    it('does not render the desktop table on mobile', async () => {
+      await renderMobile(kravSvarRows);
+      expect(screen.queryByRole('table')).not.toBeInTheDocument();
+      expect(screen.queryByRole('columnheader')).not.toBeInTheDocument();
+    });
+
+    it('keeps each row category text visible and associates it with the field', async () => {
+      await renderMobile(kravSvarRows);
+
+      // The category text from each body row must remain visible
+      expect(screen.getByText('Setter brukeren i sentrum')).toBeInTheDocument();
+      expect(screen.getByText('Tilrettelegger for gjenbruk')).toBeInTheDocument();
+
+      // Each field is wrapped in a group labelled by its row's category text
+      const firstGroup = screen.getByRole('group', { name: 'Setter brukeren i sentrum' });
+      expect(within(firstGroup).getByRole('textbox')).toBeInTheDocument();
+
+      const secondGroup = screen.getByRole('group', { name: 'Tilrettelegger for gjenbruk' });
+      expect(within(secondGroup).getByRole('textbox')).toBeInTheDocument();
+    });
+
+    it('does not render the redundant column-title header row as repeated context', async () => {
+      await renderMobile(kravSvarRows);
+      // 'Krav' is only present in the header row, which should not be rendered on mobile
+      expect(screen.queryByText('Krav')).not.toBeInTheDocument();
+    });
+
+    it('hides rows whose only component is hidden', async () => {
+      const rows: GridRow[] = [
+        {
+          cells: [{ text: 'Visible requirement' }, { component: 'answer-1' }],
+        },
+        {
+          cells: [{ text: 'Hidden requirement' }, { component: 'answer-2' }],
+        },
+      ];
+
+      jest.spyOn(useDeviceWidths, 'useIsMobile').mockReturnValue(true);
+      await renderGenericComponentTest({
+        type: 'Grid',
+        renderer: (props) => <RenderGrid {...props} />,
+        component: { rows } as CompExternalExact<'Grid'>,
+        queries: {
+          fetchLayouts: async () => ({
+            FormLayout: {
+              data: {
+                layout: [
+                  { id: 'my-test-component-id', type: 'Grid', rows },
+                  {
+                    id: 'answer-1',
+                    type: 'TextArea',
+                    textResourceBindings: { title: 'Svar' },
+                    dataModelBindings: { simpleBinding: { dataType: defaultDataTypeMock, field: 'answer1' } },
+                  },
+                  {
+                    id: 'answer-2',
+                    type: 'TextArea',
+                    hidden: true,
+                    textResourceBindings: { title: 'Svar' },
+                    dataModelBindings: { simpleBinding: { dataType: defaultDataTypeMock, field: 'answer2' } },
+                  },
+                ],
+              },
+            },
+          }),
+        },
+      });
+
+      expect(screen.getByText('Visible requirement')).toBeInTheDocument();
+      expect(screen.queryByText('Hidden requirement')).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/layout/Grid/GridComponent.tsx
+++ b/src/layout/Grid/GridComponent.tsx
@@ -499,28 +499,34 @@ interface MobileGridProps extends PropsFromGenericComponent<'Grid'> {
 
 interface MobileRow {
   row: GridRow;
-  /** Column titles from the nearest header row above this row; used as each cell's label. */
   headerCells: GridCell[];
   index: number;
 }
 
 /**
- * Flattens grid rows for the stacked mobile view: drops header rows and hidden rows, and tags each
- * remaining body row with the column titles from the closest header row above it (a grid can have
- * several header sections). Those titles are rendered as the per-cell labels (e.g. "Krav").
+ * Picks the rows to show in the stacked mobile view. Walking top to bottom:
+ * 1. Header row: not shown; its cells become the column titles for the rows below.
+ * 2. Hidden row: skipped.
+ * 3. Body row: kept, tagged with the current column titles (later shown as each cell's label).
  */
 function useMobileRows(rows: GridRow[] | undefined): MobileRow[] {
   const hiddenInRows = useHiddenInRows(rows);
 
   const result: MobileRow[] = [];
   let headerCells: GridCell[] = [];
-  for (const [index, row] of (rows ?? []).entries()) {
+  (rows ?? []).forEach((row, index) => {
+    // 1. Header row: keep its cells as the column titles for the rows below, then move on.
     if (row.header) {
-      headerCells = row.cells; // titles now in effect for the rows below
-    } else if (!isGridRowHidden(row, hiddenInRows)) {
-      result.push({ row, headerCells, index });
+      headerCells = row.cells;
+      return;
     }
-  }
+    // 2. Hidden row: skip.
+    if (isGridRowHidden(row, hiddenInRows)) {
+      return;
+    }
+    // 3. Body row: keep, tagged with the current column titles.
+    result.push({ row, headerCells, index });
+  });
   return result;
 }
 

--- a/src/layout/Grid/GridComponent.tsx
+++ b/src/layout/Grid/GridComponent.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useId, useMemo } from 'react';
 import type { PropsWithChildren } from 'react';
 
-import { Table } from '@digdir/designsystemet-react';
+import { Label as DesignsystemetLabel, Table } from '@digdir/designsystemet-react';
 import cn from 'classnames';
 
 import { ConditionalWrapper } from 'src/app-components/ConditionalWrapper/ConditionalWrapper';
@@ -36,6 +36,7 @@ import { useIsHidden } from 'src/utils/layout/hidden';
 import { useExpressionDataSources } from 'src/utils/layout/useExpressionDataSources';
 import { useLabel } from 'src/utils/layout/useLabel';
 import { useItemFor, useItemWhenType } from 'src/utils/layout/useNodeItem';
+import { typedBoolean } from 'src/utils/typing';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type {
   GridCell,
@@ -505,8 +506,18 @@ function MobileGrid({ baseComponentId, overrideDisplay, hiddenColumnIndices }: M
     overrideDisplay,
   });
 
-  // Header rows only carry column titles, which are redundant in the stacked mobile view. Hidden rows must stay hidden.
-  const visibleRows = (rows ?? []).filter((row) => !row.header && !isGridRowHidden(row, hiddenInRows));
+  // Header rows are not rendered as their own stacked row (that would just repeat the column titles). Instead we carry
+  // the nearest preceding header row's column titles into each body row as a per-cell prefix (e.g. "Krav: <text>"), so
+  // the category is preserved. Hidden rows must stay hidden.
+  const rowsToRender: { row: GridRow; headerCells: GridCell[]; key: number }[] = [];
+  let currentHeaderCells: GridCell[] = [];
+  (rows ?? []).forEach((row, rowIdx) => {
+    if (row.header) {
+      currentHeaderCells = row.cells;
+    } else if (!isGridRowHidden(row, hiddenInRows)) {
+      rowsToRender.push({ row, headerCells: currentHeaderCells, key: rowIdx });
+    }
+  });
 
   return (
     <Fieldset
@@ -517,10 +528,11 @@ function MobileGrid({ baseComponentId, overrideDisplay, hiddenColumnIndices }: M
       help={getHelpTextComponent()}
       className={css.mobileFieldset}
     >
-      {visibleRows.map((row, rowIdx) => (
+      {rowsToRender.map(({ row, headerCells, key }) => (
         <MobileGridRow
-          key={rowIdx}
+          key={key}
           row={row}
+          headerCells={headerCells}
           hiddenColumnIndices={hiddenColumnIndices}
         />
       ))}
@@ -530,31 +542,59 @@ function MobileGrid({ baseComponentId, overrideDisplay, hiddenColumnIndices }: M
 
 interface MobileGridRowProps {
   row: GridRow;
+  headerCells: GridCell[];
   hiddenColumnIndices: number[];
 }
 
+interface ContextItem {
+  cell: GridCell;
+  cellIdx: number;
+  /** Text-resource id of the column title (from the header row), rendered as the cell's label. */
+  header: string | undefined;
+  headerId: string | undefined;
+  valueId: string;
+}
+
 /**
- * Renders a single grid row stacked for mobile/high-zoom. Any leading text/labelFrom cells become the row's
- * heading/context, and the row's component cell(s) are grouped beneath it and programmatically associated with that
- * context via `aria-labelledby` so the category is announced together with each field.
+ * Renders a single grid row stacked for mobile/high-zoom. Each read-only text/labelFrom cell renders as a
+ * `<dl>` where the column title (e.g. "Krav") is the `<dt>` label and the cell value is the `<dd>` text — a
+ * WCAG-compliant name/value relationship. The row's component cell(s) (which carry their own label, e.g. "Svar")
+ * are rendered beneath, and the whole row is a `role="group"` programmatically associated with the read-only
+ * context via `aria-labelledby`, so a screen reader announces the category together with each field.
  */
-function MobileGridRow({ row, hiddenColumnIndices }: MobileGridRowProps) {
+function MobileGridRow({ row, headerCells, hiddenColumnIndices }: MobileGridRowProps) {
   const rowId = useId();
 
   const visibleCells = row.cells
     .map((cell, cellIdx) => ({ cell, cellIdx }))
     .filter(({ cell, cellIdx }) => !hiddenColumnIndices.includes(cellIdx) && !isGridCellEmpty(cell));
 
-  const contextCells = visibleCells.filter(({ cell }) => isGridCellText(cell) || isGridCellLabelFrom(cell));
+  const contextItems: ContextItem[] = visibleCells
+    .filter(({ cell }) => isGridCellText(cell) || isGridCellLabelFrom(cell))
+    .map(({ cell, cellIdx }) => {
+      const headerCell = headerCells[cellIdx];
+      const header = isGridCellText(headerCell) && headerCell.text ? headerCell.text : undefined;
+      return {
+        cell,
+        cellIdx,
+        header,
+        headerId: header ? `${rowId}-hdr-${cellIdx}` : undefined,
+        valueId: `${rowId}-val-${cellIdx}`,
+      };
+    });
+
   const componentCells = visibleCells.filter(({ cell }) => isGridCellNode(cell));
 
-  const labelledBy = contextCells.map(({ cellIdx }) => `${rowId}-ctx-${cellIdx}`).join(' ') || undefined;
+  const labelledBy =
+    contextItems
+      .flatMap(({ headerId, valueId }) => [headerId, valueId])
+      .filter(typedBoolean)
+      .join(' ') || undefined;
 
-  const context = contextCells.map(({ cell, cellIdx }) => (
+  const context = contextItems.map((item) => (
     <MobileContextCell
-      key={cellIdx}
-      id={`${rowId}-ctx-${cellIdx}`}
-      cell={cell}
+      key={item.cellIdx}
+      {...item}
     />
   ));
 
@@ -571,11 +611,11 @@ function MobileGridRow({ row, hiddenColumnIndices }: MobileGridRowProps) {
 
   // No interactive cells: just the (descriptive) text, nothing to group or associate.
   if (!componentCells.length) {
-    return contextCells.length ? <div className={css.mobileRow}>{context}</div> : null;
+    return contextItems.length ? <div className={css.mobileRow}>{context}</div> : null;
   }
 
   // No context: the component(s) keep their own labels; no extra grouping needed.
-  if (!contextCells.length) {
+  if (!contextItems.length) {
     return <div className={css.mobileRow}>{components}</div>;
   }
 
@@ -591,12 +631,14 @@ function MobileGridRow({ row, hiddenColumnIndices }: MobileGridRowProps) {
   );
 }
 
-function MobileContextCell({ id, cell }: { id: string; cell: GridCell }) {
+function MobileContextCell({ cell, header, headerId, valueId }: ContextItem) {
   if (isGridCellLabelFrom(cell)) {
     return (
       <MobileLabelContext
-        id={id}
         labelFrom={cell.labelFrom}
+        header={header}
+        headerId={headerId}
+        valueId={valueId}
       />
     );
   }
@@ -604,8 +646,10 @@ function MobileContextCell({ id, cell }: { id: string; cell: GridCell }) {
   if (isGridCellText(cell)) {
     return (
       <MobileTextContext
-        id={id}
         cell={cell}
+        header={header}
+        headerId={headerId}
+        valueId={valueId}
       />
     );
   }
@@ -613,27 +657,71 @@ function MobileContextCell({ id, cell }: { id: string; cell: GridCell }) {
   return null;
 }
 
-function MobileTextContext({ id, cell }: { id: string; cell: GridCellText }) {
-  const { elementAsString } = useLanguage();
+interface ContextCellProps {
+  header: string | undefined;
+  headerId: string | undefined;
+  valueId: string;
+}
+
+/** Renders the column title (e.g. "Krav") as a non-interactive label, matching the styling of form-field labels. */
+function ColumnTitleLabel({ header, headerId }: { header: string; headerId: string | undefined }) {
   return (
-    <div
-      id={id}
-      className={css.mobileRowHeading}
+    <DesignsystemetLabel
+      asChild
+      weight='medium'
     >
-      <span className={css.mobileRowHeadingText}>
-        <Lang id={cell.text} />
-      </span>
+      <dt
+        id={headerId}
+        className={css.mobileCellLabel}
+      >
+        <Lang id={header} />
+      </dt>
+    </DesignsystemetLabel>
+  );
+}
+
+function MobileTextContext({ cell, header, headerId, valueId }: ContextCellProps & { cell: GridCellText }) {
+  const { elementAsString } = useLanguage();
+  const value = (
+    <>
+      <Lang id={cell.text} />
       {cell.help && (
         <HelpTextContainer
           title={elementAsString(<Lang id={cell.text} />)}
           helpText={<Lang id={cell.help} />}
         />
       )}
-    </div>
+    </>
+  );
+
+  if (!header) {
+    return (
+      <p
+        id={valueId}
+        className={css.mobileCellText}
+      >
+        {value}
+      </p>
+    );
+  }
+
+  return (
+    <dl className={css.mobileCell}>
+      <ColumnTitleLabel
+        header={header}
+        headerId={headerId}
+      />
+      <dd
+        id={valueId}
+        className={css.mobileCellText}
+      >
+        {value}
+      </dd>
+    </dl>
   );
 }
 
-function MobileLabelContext({ id, labelFrom }: { id: string; labelFrom: string }) {
+function MobileLabelContext({ labelFrom, header, headerId, valueId }: ContextCellProps & { labelFrom: string }) {
   const item = useItemFor(labelFrom);
   const trb = item.textResourceBindings;
   const required = 'required' in item && item.required;
@@ -641,18 +729,39 @@ function MobileLabelContext({ id, labelFrom }: { id: string; labelFrom: string }
   const help = trb && 'help' in trb ? trb.help : undefined;
   const description = trb && 'description' in trb && typeof trb.description === 'string' ? trb.description : undefined;
 
+  const value = (
+    <LabelContent
+      id={useIndexedId(labelFrom)}
+      label={title}
+      required={required}
+      help={help}
+      description={description}
+    />
+  );
+
+  if (!header) {
+    return (
+      <div
+        id={valueId}
+        className={css.mobileCellText}
+      >
+        {value}
+      </div>
+    );
+  }
+
   return (
-    <div
-      id={id}
-      className={css.mobileRowHeading}
-    >
-      <LabelContent
-        id={useIndexedId(labelFrom)}
-        label={title}
-        required={required}
-        help={help}
-        description={description}
+    <dl className={css.mobileCell}>
+      <ColumnTitleLabel
+        header={header}
+        headerId={headerId}
       />
-    </div>
+      <dd
+        id={valueId}
+        className={css.mobileCellText}
+      >
+        {value}
+      </dd>
+    </dl>
   );
 }

--- a/src/layout/Grid/GridComponent.tsx
+++ b/src/layout/Grid/GridComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useId, useMemo } from 'react';
 import type { PropsWithChildren } from 'react';
 
 import { Table } from '@digdir/designsystemet-react';
@@ -21,10 +21,12 @@ import { GenericComponent } from 'src/layout/GenericComponent';
 import css from 'src/layout/Grid/Grid.module.css';
 import {
   getGridCellHiddenExpr,
+  isGridCellEmpty,
   isGridCellLabelFrom,
   isGridCellNode,
   isGridCellText,
-  useBaseIdsFromGrid,
+  isGridRowHidden,
+  useHiddenInRows,
   useIsGridRowHidden,
 } from 'src/layout/Grid/tools';
 import { getColumnStyles } from 'src/utils/formComponentUtils';
@@ -37,6 +39,7 @@ import { useItemFor, useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type {
   GridCell,
+  GridCellText,
   GridRow,
   IGridColumnProperties,
   ITableColumnFormatting,
@@ -130,7 +133,12 @@ export function RenderGrid(props: PropsFromGenericComponent<'Grid'>) {
   );
 
   if (isMobile) {
-    return <MobileGrid {...props} />;
+    return (
+      <MobileGrid
+        {...props}
+        hiddenColumnIndices={hiddenColumnIndices}
+      />
+    );
   }
 
   return (
@@ -484,13 +492,21 @@ function CellWithLabel({
   );
 }
 
-function MobileGrid({ baseComponentId, overrideDisplay }: PropsFromGenericComponent<'Grid'>) {
-  const baseIds = useBaseIdsFromGrid(baseComponentId);
+interface MobileGridProps extends PropsFromGenericComponent<'Grid'> {
+  hiddenColumnIndices: number[];
+}
+
+function MobileGrid({ baseComponentId, overrideDisplay, hiddenColumnIndices }: MobileGridProps) {
+  const { rows } = useItemWhenType(baseComponentId, 'Grid');
+  const hiddenInRows = useHiddenInRows(rows);
 
   const { labelText, getDescriptionComponent, getHelpTextComponent } = useLabel({
     baseComponentId,
     overrideDisplay,
   });
+
+  // Header rows only carry column titles, which are redundant in the stacked mobile view. Hidden rows must stay hidden.
+  const visibleRows = (rows ?? []).filter((row) => !row.header && !isGridRowHidden(row, hiddenInRows));
 
   return (
     <Fieldset
@@ -501,12 +517,142 @@ function MobileGrid({ baseComponentId, overrideDisplay }: PropsFromGenericCompon
       help={getHelpTextComponent()}
       className={css.mobileFieldset}
     >
-      {baseIds.map((childId) => (
-        <GenericComponent
-          key={childId}
-          baseComponentId={childId}
+      {visibleRows.map((row, rowIdx) => (
+        <MobileGridRow
+          key={rowIdx}
+          row={row}
+          hiddenColumnIndices={hiddenColumnIndices}
         />
       ))}
     </Fieldset>
+  );
+}
+
+interface MobileGridRowProps {
+  row: GridRow;
+  hiddenColumnIndices: number[];
+}
+
+/**
+ * Renders a single grid row stacked for mobile/high-zoom. Any leading text/labelFrom cells become the row's
+ * heading/context, and the row's component cell(s) are grouped beneath it and programmatically associated with that
+ * context via `aria-labelledby` so the category is announced together with each field.
+ */
+function MobileGridRow({ row, hiddenColumnIndices }: MobileGridRowProps) {
+  const rowId = useId();
+
+  const visibleCells = row.cells
+    .map((cell, cellIdx) => ({ cell, cellIdx }))
+    .filter(({ cell, cellIdx }) => !hiddenColumnIndices.includes(cellIdx) && !isGridCellEmpty(cell));
+
+  const contextCells = visibleCells.filter(({ cell }) => isGridCellText(cell) || isGridCellLabelFrom(cell));
+  const componentCells = visibleCells.filter(({ cell }) => isGridCellNode(cell));
+
+  const labelledBy = contextCells.map(({ cellIdx }) => `${rowId}-ctx-${cellIdx}`).join(' ') || undefined;
+
+  const context = contextCells.map(({ cell, cellIdx }) => (
+    <MobileContextCell
+      key={cellIdx}
+      id={`${rowId}-ctx-${cellIdx}`}
+      cell={cell}
+    />
+  ));
+
+  const components = componentCells.map(({ cell, cellIdx }) => {
+    const componentId = isGridCellNode(cell) ? cell.component : undefined;
+    return componentId ? (
+      <GenericComponent
+        key={cellIdx}
+        baseComponentId={componentId}
+        overrideDisplay={{ rowReadOnly: row.readOnly }}
+      />
+    ) : null;
+  });
+
+  // No interactive cells: just the (descriptive) text, nothing to group or associate.
+  if (!componentCells.length) {
+    return contextCells.length ? <div className={css.mobileRow}>{context}</div> : null;
+  }
+
+  // No context: the component(s) keep their own labels; no extra grouping needed.
+  if (!contextCells.length) {
+    return <div className={css.mobileRow}>{components}</div>;
+  }
+
+  return (
+    <div
+      className={css.mobileRow}
+      role='group'
+      aria-labelledby={labelledBy}
+    >
+      {context}
+      {components}
+    </div>
+  );
+}
+
+function MobileContextCell({ id, cell }: { id: string; cell: GridCell }) {
+  if (isGridCellLabelFrom(cell)) {
+    return (
+      <MobileLabelContext
+        id={id}
+        labelFrom={cell.labelFrom}
+      />
+    );
+  }
+
+  if (isGridCellText(cell)) {
+    return (
+      <MobileTextContext
+        id={id}
+        cell={cell}
+      />
+    );
+  }
+
+  return null;
+}
+
+function MobileTextContext({ id, cell }: { id: string; cell: GridCellText }) {
+  const { elementAsString } = useLanguage();
+  return (
+    <div
+      id={id}
+      className={css.mobileRowHeading}
+    >
+      <span className={css.mobileRowHeadingText}>
+        <Lang id={cell.text} />
+      </span>
+      {cell.help && (
+        <HelpTextContainer
+          title={elementAsString(<Lang id={cell.text} />)}
+          helpText={<Lang id={cell.help} />}
+        />
+      )}
+    </div>
+  );
+}
+
+function MobileLabelContext({ id, labelFrom }: { id: string; labelFrom: string }) {
+  const item = useItemFor(labelFrom);
+  const trb = item.textResourceBindings;
+  const required = 'required' in item && item.required;
+  const title = trb && 'title' in trb ? trb.title : undefined;
+  const help = trb && 'help' in trb ? trb.help : undefined;
+  const description = trb && 'description' in trb && typeof trb.description === 'string' ? trb.description : undefined;
+
+  return (
+    <div
+      id={id}
+      className={css.mobileRowHeading}
+    >
+      <LabelContent
+        id={useIndexedId(labelFrom)}
+        label={title}
+        required={required}
+        help={help}
+        description={description}
+      />
+    </div>
   );
 }

--- a/src/layout/Grid/GridComponent.tsx
+++ b/src/layout/Grid/GridComponent.tsx
@@ -497,26 +497,40 @@ interface MobileGridProps extends PropsFromGenericComponent<'Grid'> {
   hiddenColumnIndices: number[];
 }
 
+interface MobileRow {
+  row: GridRow;
+  /** Column titles from the nearest header row above this row; used as each cell's label. */
+  headerCells: GridCell[];
+  index: number;
+}
+
+/**
+ * Flattens grid rows for the stacked mobile view: drops header rows and hidden rows, and tags each
+ * remaining body row with the column titles from the closest header row above it (a grid can have
+ * several header sections). Those titles are rendered as the per-cell labels (e.g. "Krav").
+ */
+function useMobileRows(rows: GridRow[] | undefined): MobileRow[] {
+  const hiddenInRows = useHiddenInRows(rows);
+
+  const result: MobileRow[] = [];
+  let headerCells: GridCell[] = [];
+  for (const [index, row] of (rows ?? []).entries()) {
+    if (row.header) {
+      headerCells = row.cells; // titles now in effect for the rows below
+    } else if (!isGridRowHidden(row, hiddenInRows)) {
+      result.push({ row, headerCells, index });
+    }
+  }
+  return result;
+}
+
 function MobileGrid({ baseComponentId, overrideDisplay, hiddenColumnIndices }: MobileGridProps) {
   const { rows } = useItemWhenType(baseComponentId, 'Grid');
-  const hiddenInRows = useHiddenInRows(rows);
+  const mobileRows = useMobileRows(rows);
 
   const { labelText, getDescriptionComponent, getHelpTextComponent } = useLabel({
     baseComponentId,
     overrideDisplay,
-  });
-
-  // Header rows are not rendered as their own stacked row (that would just repeat the column titles). Instead we carry
-  // the nearest preceding header row's column titles into each body row as a per-cell prefix (e.g. "Krav: <text>"), so
-  // the category is preserved. Hidden rows must stay hidden.
-  const rowsToRender: { row: GridRow; headerCells: GridCell[]; key: number }[] = [];
-  let currentHeaderCells: GridCell[] = [];
-  (rows ?? []).forEach((row, rowIdx) => {
-    if (row.header) {
-      currentHeaderCells = row.cells;
-    } else if (!isGridRowHidden(row, hiddenInRows)) {
-      rowsToRender.push({ row, headerCells: currentHeaderCells, key: rowIdx });
-    }
   });
 
   return (
@@ -528,9 +542,9 @@ function MobileGrid({ baseComponentId, overrideDisplay, hiddenColumnIndices }: M
       help={getHelpTextComponent()}
       className={css.mobileFieldset}
     >
-      {rowsToRender.map(({ row, headerCells, key }) => (
+      {mobileRows.map(({ row, headerCells, index }) => (
         <MobileGridRow
-          key={key}
+          key={index}
           row={row}
           headerCells={headerCells}
           hiddenColumnIndices={hiddenColumnIndices}
@@ -546,7 +560,7 @@ interface MobileGridRowProps {
   hiddenColumnIndices: number[];
 }
 
-interface ContextItem {
+interface ReadOnlyCell {
   cell: GridCell;
   cellIdx: number;
   /** Text-resource id of the column title (from the header row), rendered as the cell's label. */
@@ -555,12 +569,34 @@ interface ContextItem {
   valueId: string;
 }
 
+/** Pairs a read-only cell with its column title and the element ids used for the screen-reader association. */
+function toReadOnlyCell(cell: GridCell, cellIdx: number, headerCell: GridCell, rowId: string): ReadOnlyCell {
+  const header = isGridCellText(headerCell) && headerCell.text ? headerCell.text : undefined;
+  return {
+    cell,
+    cellIdx,
+    header,
+    headerId: header ? `${rowId}-hdr-${cellIdx}` : undefined,
+    valueId: `${rowId}-val-${cellIdx}`,
+  };
+}
+
+/** The `aria-labelledby` value tying a row's field(s) to its read-only title/value text. */
+function ariaLabelledBy(cells: ReadOnlyCell[]): string | undefined {
+  return (
+    cells
+      .flatMap(({ headerId, valueId }) => [headerId, valueId])
+      .filter(typedBoolean)
+      .join(' ') || undefined
+  );
+}
+
 /**
- * Renders a single grid row stacked for mobile/high-zoom. Each read-only text/labelFrom cell renders as a
- * `<dl>` where the column title (e.g. "Krav") is the `<dt>` label and the cell value is the `<dd>` text — a
- * WCAG-compliant name/value relationship. The row's component cell(s) (which carry their own label, e.g. "Svar")
- * are rendered beneath, and the whole row is a `role="group"` programmatically associated with the read-only
- * context via `aria-labelledby`, so a screen reader announces the category together with each field.
+ * Renders one grid row, stacked for mobile/high-zoom:
+ * 1. Read-only text cells become a `<dl>`: column title (e.g. "Spørsmål") as `<dt>`, cell value as `<dd>`.
+ * 2. Component cells render below, keeping their own label (e.g. "Svar").
+ * 3. The row is a `role="group"` linked to its text via `aria-labelledby`, so screen readers read the
+ *    category together with the field.
  */
 function MobileGridRow({ row, headerCells, hiddenColumnIndices }: MobileGridRowProps) {
   const rowId = useId();
@@ -569,72 +605,55 @@ function MobileGridRow({ row, headerCells, hiddenColumnIndices }: MobileGridRowP
     .map((cell, cellIdx) => ({ cell, cellIdx }))
     .filter(({ cell, cellIdx }) => !hiddenColumnIndices.includes(cellIdx) && !isGridCellEmpty(cell));
 
-  const contextItems: ContextItem[] = visibleCells
+  // 1. Read-only text/labelFrom cells -> title/value pairs.
+  const readOnlyCells = visibleCells
     .filter(({ cell }) => isGridCellText(cell) || isGridCellLabelFrom(cell))
-    .map(({ cell, cellIdx }) => {
-      const headerCell = headerCells[cellIdx];
-      const header = isGridCellText(headerCell) && headerCell.text ? headerCell.text : undefined;
-      return {
-        cell,
-        cellIdx,
-        header,
-        headerId: header ? `${rowId}-hdr-${cellIdx}` : undefined,
-        valueId: `${rowId}-val-${cellIdx}`,
-      };
-    });
+    .map(({ cell, cellIdx }) => toReadOnlyCell(cell, cellIdx, headerCells[cellIdx], rowId));
 
-  const componentCells = visibleCells.filter(({ cell }) => isGridCellNode(cell));
+  // 2. Component cells -> the actual fields (each keeps its own label).
+  const fieldCells = visibleCells.filter(({ cell }) => isGridCellNode(cell));
 
-  const labelledBy =
-    contextItems
-      .flatMap(({ headerId, valueId }) => [headerId, valueId])
-      .filter(typedBoolean)
-      .join(' ') || undefined;
-
-  const context = contextItems.map((item) => (
-    <MobileContextCell
-      key={item.cellIdx}
-      {...item}
+  const readOnlyNodes = readOnlyCells.map((cell) => (
+    <MobileReadOnlyCell
+      key={cell.cellIdx}
+      {...cell}
     />
   ));
-
-  const components = componentCells.map(({ cell, cellIdx }) => {
-    const componentId = isGridCellNode(cell) ? cell.component : undefined;
-    return componentId ? (
+  const fieldNodes = fieldCells.map(({ cell, cellIdx }) =>
+    isGridCellNode(cell) && cell.component ? (
       <GenericComponent
         key={cellIdx}
-        baseComponentId={componentId}
+        baseComponentId={cell.component}
         overrideDisplay={{ rowReadOnly: row.readOnly }}
       />
-    ) : null;
-  });
+    ) : null,
+  );
 
-  // No interactive cells: just the (descriptive) text, nothing to group or associate.
-  if (!componentCells.length) {
-    return contextItems.length ? <div className={css.mobileRow}>{context}</div> : null;
+  // Only text, or only fields: render as-is, no group needed.
+  if (!fieldCells.length) {
+    return readOnlyCells.length ? <div className={css.mobileRow}>{readOnlyNodes}</div> : null;
+  }
+  if (!readOnlyCells.length) {
+    return <div className={css.mobileRow}>{fieldNodes}</div>;
   }
 
-  // No context: the component(s) keep their own labels; no extra grouping needed.
-  if (!contextItems.length) {
-    return <div className={css.mobileRow}>{components}</div>;
-  }
-
+  // 3. Both: group the fields with their read-only title/value text for screen readers.
   return (
     <div
       className={css.mobileRow}
       role='group'
-      aria-labelledby={labelledBy}
+      aria-labelledby={ariaLabelledBy(readOnlyCells)}
     >
-      {context}
-      {components}
+      {readOnlyNodes}
+      {fieldNodes}
     </div>
   );
 }
 
-function MobileContextCell({ cell, header, headerId, valueId }: ContextItem) {
+function MobileReadOnlyCell({ cell, header, headerId, valueId }: ReadOnlyCell) {
   if (isGridCellLabelFrom(cell)) {
     return (
-      <MobileLabelContext
+      <MobileLabelFromCell
         labelFrom={cell.labelFrom}
         header={header}
         headerId={headerId}
@@ -645,7 +664,7 @@ function MobileContextCell({ cell, header, headerId, valueId }: ContextItem) {
 
   if (isGridCellText(cell)) {
     return (
-      <MobileTextContext
+      <MobileTextCell
         cell={cell}
         header={header}
         headerId={headerId}
@@ -657,7 +676,7 @@ function MobileContextCell({ cell, header, headerId, valueId }: ContextItem) {
   return null;
 }
 
-interface ContextCellProps {
+interface ReadOnlyCellProps {
   header: string | undefined;
   headerId: string | undefined;
   valueId: string;
@@ -680,7 +699,7 @@ function ColumnTitleLabel({ header, headerId }: { header: string; headerId: stri
   );
 }
 
-function MobileTextContext({ cell, header, headerId, valueId }: ContextCellProps & { cell: GridCellText }) {
+function MobileTextCell({ cell, header, headerId, valueId }: ReadOnlyCellProps & { cell: GridCellText }) {
   const { elementAsString } = useLanguage();
   const value = (
     <>
@@ -721,7 +740,7 @@ function MobileTextContext({ cell, header, headerId, valueId }: ContextCellProps
   );
 }
 
-function MobileLabelContext({ labelFrom, header, headerId, valueId }: ContextCellProps & { labelFrom: string }) {
+function MobileLabelFromCell({ labelFrom, header, headerId, valueId }: ReadOnlyCellProps & { labelFrom: string }) {
   const item = useItemFor(labelFrom);
   const trb = item.textResourceBindings;
   const required = 'required' in item && item.required;

--- a/src/layout/Grid/tools.ts
+++ b/src/layout/Grid/tools.ts
@@ -60,7 +60,7 @@ function useIsHiddenInRow(row: GridRow) {
   return useIsHiddenMulti(baseIds);
 }
 
-function useHiddenInRows(rows: GridRows | undefined) {
+export function useHiddenInRows(rows: GridRows | undefined) {
   const baseIds =
     rows
       ?.map((row) => row.cells.map((cell) => (isGridCellNode(cell) && cell.component ? cell.component : undefined)))

--- a/test/e2e/integration/component-library/grid.ts
+++ b/test/e2e/integration/component-library/grid.ts
@@ -51,21 +51,20 @@ describe('Grid summary test', () => {
   });
 
   it('keeps row category text visible and associated with the field on mobile/400% zoom', () => {
-    cy.gotoNavPage('GridLabelBugPage');
+    cy.gotoNavPage('Grid');
     cy.viewport('samsung-s10');
 
-    // The desktop table should collapse into the stacked mobile view
-    cy.get('#grid-label-bug-textarea').should('be.visible');
-    cy.get('#grid-label-bug-textarea table').should('not.exist');
+    // The desktop grid table should collapse into the stacked mobile view
+    cy.get('#grid-example-common-fields').should('be.visible');
+    cy.get('#grid-example-common-fields table').should('not.exist');
 
-    // Each "Krav" category text must remain visible (it used to be dropped on mobile)
-    cy.contains('Setter brukeren i sentrum for tjenesteutviklingen').should('be.visible');
-    cy.contains('Sikrer personvern og informasjonssikkerhet').should('be.visible');
+    // The column title ("Row number") is rendered as a <dt> label and the row's read-only text as its
+    // <dd> value - this text used to be dropped entirely on mobile.
+    cy.get('#grid-example-common-fields').find('dt').should('contain.text', 'Row number');
+    cy.get('#grid-example-common-fields').find('dd').should('contain.text', 'Row 1');
 
-    // The category text is programmatically associated with its answer field: the field lives inside a group
-    // labelled by the column title + row text (this text is unique to the textarea grid).
-    cy.findByRole('group', { name: 'Krav Sikrer personvern og informasjonssikkerhet' })
-      .findByRole('textbox')
-      .should('exist');
+    // The category text is programmatically associated with its answer field: the input lives inside a
+    // group labelled by the column title + row text.
+    cy.findByRole('group', { name: 'Row number Row 1' }).findByRole('textbox').should('exist');
   });
 });

--- a/test/e2e/integration/component-library/grid.ts
+++ b/test/e2e/integration/component-library/grid.ts
@@ -63,8 +63,8 @@ describe('Grid summary test', () => {
     cy.contains('Sikrer personvern og informasjonssikkerhet').should('be.visible');
 
     // The category text is programmatically associated with its answer field: the field lives inside a group
-    // labelled by the category text (this text is unique to the textarea grid).
-    cy.findByRole('group', { name: 'Sikrer personvern og informasjonssikkerhet' })
+    // labelled by the column title + row text (this text is unique to the textarea grid).
+    cy.findByRole('group', { name: 'Krav Sikrer personvern og informasjonssikkerhet' })
       .findByRole('textbox')
       .should('exist');
   });

--- a/test/e2e/integration/component-library/grid.ts
+++ b/test/e2e/integration/component-library/grid.ts
@@ -49,4 +49,23 @@ describe('Grid summary test', () => {
         .should('have.length', 5);
     }
   });
+
+  it('keeps row category text visible and associated with the field on mobile/400% zoom', () => {
+    cy.gotoNavPage('GridLabelBugPage');
+    cy.viewport('samsung-s10');
+
+    // The desktop table should collapse into the stacked mobile view
+    cy.get('#grid-label-bug-textarea').should('be.visible');
+    cy.get('#grid-label-bug-textarea table').should('not.exist');
+
+    // Each "Krav" category text must remain visible (it used to be dropped on mobile)
+    cy.contains('Setter brukeren i sentrum for tjenesteutviklingen').should('be.visible');
+    cy.contains('Sikrer personvern og informasjonssikkerhet').should('be.visible');
+
+    // The category text is programmatically associated with its answer field: the field lives inside a group
+    // labelled by the category text (this text is unique to the textarea grid).
+    cy.findByRole('group', { name: 'Sikrer personvern og informasjonssikkerhet' })
+      .findByRole('textbox')
+      .should('exist');
+  });
 });


### PR DESCRIPTION
Description
  
On narrow viewports and at high browser zoom (e.g. 400%, which Altinn treats as "mobile"), the Grid component collapses its table into a stacked layout. 

Previously this hid the header labels:

<img width="1124" height="874" alt="Screenshot 2026-06-15 at 16 51 10" src="https://github.com/user-attachments/assets/44ba2ed4-ddc3-4011-bbc9-06ab225ed408" />

  
Now:

<img width="951" height="967" alt="Screenshot 2026-06-15 at 16 42 40" src="https://github.com/user-attachments/assets/674a8b02-7937-4661-b448-750b75057d9b" />


  
The stacked layout dropped all read-only text columns — so for a typical "Label / Answer" grid, the requirement text disappeared entirely. 

  This change reworks the Grid's mobile layout so each row keeps its context:
  
  - The column title (e.g. "Krav") is rendered as a label and the row's read-only text (e.g. "Setter brukeren i sentrum…") as its value, using a description list (`<dl>/<dt>/<dd>`) for a correct, programmatic name/value relationship.
  - Input fields keep their own real `<label>`

  Related Issue(s)

  - closes [#{issue number} <!-- WCAG 1.4.10 – Grid mister kategori-tekst på mobil / 400 % zoom -->](https://github.com/Altinn/altinn-studio/issues/18943)
  
  Verification/QA

  - Manual functionality testing
    - [x] I have tested these changes manually
    - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
    - [ ] No testing done/necessary
  - Automated tests   
    - [x] Unit test(s) have been added/updated
    - [x] Cypress E2E test(s) have been added/updated
    - [ ] No automatic tests are needed here (no functional changes/additions)
    - [ ] I want someone to help me make some tests
  - UU/WCAG (follow these guidelines until we have our own)
    - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
    - [x] I want someone to help me perform accessibility testing <!-- SR announcement behavior was analyzed and structured for it, but not yet verified on a real screen reader
  -->
    - [ ] No testing done/necessary (no DOM/visual changes)
  - User documentation @ altinn-studio-docs
    - [ ] Has been added/updated
    - [x] No functionality has been changed/added, so no documentation is needed
    - [ ] I will do that later/have created an issue
  - Support in Altinn Studio
    - [ ] Issue(s) created for support in Studio
    - [x] This change/feature does not require any changes to Altinn Studio
  - Sprint board
    - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
    - [ ] I don't have permissions to do that, please help me out
  - Labels
    - [x] I have added a kind/* and backport* label to this PR for proper release notes grouping <!-- suggested: kind/bug + backport -->
    - [ ] I don't have permissions to add labels, please help me out
  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced the Grid mobile layout to render read-only cell details in a stacked definition-list style with clearer label/value separation and improved spacing.
  * Improved per-row accessibility semantics for screen readers by grouping related details consistently.

* **Tests**
  * Expanded mobile unit tests to verify mobile-specific markup, omission rules, and visibility behavior.
  * Added a Cypress e2e test confirming the correct mobile rendering and accessibility associations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->