### PR TITLE
fix: fileuploadWithTag auto focus on edit window when file is uploaded

### DIFF
--- a/src/language/texts/en.ts
+++ b/src/language/texts/en.ts
@@ -78,6 +78,8 @@ export function en() {
     'form_filler.file_uploader_list_header_status': 'Status',
     'form_filler.file_uploader_list_header_delete_sr': 'Delete',
     'form_filler.file_uploader_list_status_done': 'Uploaded',
+    'form_filler.file_uploader_attachment_uploaded_sr':
+      'The attachment {0} has been uploaded. You can now add a description for the attachment.',
     'form_filler.file_uploader_status_scanning': 'Scanning...',
     'form_filler.file_uploader_status_infected': 'Infected',
     'form_filler.file_uploader_infected_file_alert': 'The file {0} is infected with malware and cannot be used.',

--- a/src/language/texts/nb.ts
+++ b/src/language/texts/nb.ts
@@ -78,6 +78,8 @@ export function nb() {
     'form_filler.file_uploader_list_header_name': 'Navn',
     'form_filler.file_uploader_list_header_status': 'Status',
     'form_filler.file_uploader_list_status_done': 'Ferdig lastet',
+    'form_filler.file_uploader_attachment_uploaded_sr':
+      'Vedlegget {0} er lastet opp. Du kan nå legge til en beskrivelse av vedlegget.',
     'form_filler.file_uploader_status_scanning': 'Skanner...',
     'form_filler.file_uploader_status_infected': 'Infisert',
     'form_filler.file_uploader_infected_file_alert':

--- a/src/language/texts/nn.ts
+++ b/src/language/texts/nn.ts
@@ -78,6 +78,8 @@ export function nn() {
     'form_filler.file_uploader_list_header_name': 'Namn',
     'form_filler.file_uploader_list_header_status': 'Status',
     'form_filler.file_uploader_list_status_done': 'Ferdig lasta',
+    'form_filler.file_uploader_attachment_uploaded_sr':
+      'Vedlegget {0} er lasta opp. Du kan no leggje til ei skildring av vedlegget.',
     'form_filler.file_uploader_status_scanning': 'Skannar...',
     'form_filler.file_uploader_status_infected': 'Infisert',
     'form_filler.file_uploader_infected_file_alert':

--- a/src/layout/FileUploadWithTag/EditWindowComponent.tsx
+++ b/src/layout/FileUploadWithTag/EditWindowComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useState } from 'react';
 
 import { EXPERIMENTAL_Suggestion as Suggestion } from '@digdir/designsystemet-react';
 import deepEqual from 'fast-deep-equal';
@@ -25,6 +25,10 @@ import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import { optionFilter } from 'src/utils/options';
 import type { IAttachment } from 'src/features/attachments';
 import type { IOptionInternal } from 'src/features/options/castOptionsToStrings';
+
+function focusOnMount(node: HTMLDivElement | null) {
+  node?.focus();
+}
 
 export interface EditWindowProps {
   baseComponentId: string;
@@ -91,19 +95,13 @@ export function EditWindowComponent({
   const isLoading = attachment.updating || !attachment.uploaded || isFetching || options?.length === 0;
   const uniqueId = isAttachmentUploaded(attachment) ? attachment.data.id : attachment.data.temporaryId;
 
-  // Focus on edit window when mounting the component. Temporary fix until we implement a new fileupload component, ref. https://github.com/Altinn/app-frontend-react/issues/4280#issuecomment-4716177309
-  const containerRef = useRef<HTMLDivElement>(null);
-  useEffect(() => {
-    containerRef.current?.focus();
-  }, []);
-
   const announceUploaded = isAttachmentUploaded(attachment)
     ? langAsString('form_filler.file_uploader_attachment_uploaded_sr', [attachment.data?.filename])
     : undefined;
 
   return (
     <div
-      ref={containerRef}
+      ref={focusOnMount}
       tabIndex={-1}
       role='group'
       aria-label={announceUploaded}

--- a/src/layout/FileUploadWithTag/EditWindowComponent.tsx
+++ b/src/layout/FileUploadWithTag/EditWindowComponent.tsx
@@ -97,14 +97,16 @@ export function EditWindowComponent({
     containerRef.current?.focus();
   }, []);
 
+  const announceUploaded = isAttachmentUploaded(attachment)
+    ? langAsString('form_filler.file_uploader_attachment_uploaded_sr', [attachment.data?.filename])
+    : undefined;
+
   return (
     <div
       ref={containerRef}
       tabIndex={-1}
       role='group'
-      aria-label={langAsString('form_filler.file_uploader_attachment_uploaded_sr', [
-        uploadedAttachment?.data.filename ?? '',
-      ])}
+      aria-label={announceUploaded}
       id={`attachment-edit-window-${uniqueId}`}
       className={classes.editContainer}
     >

--- a/src/layout/FileUploadWithTag/EditWindowComponent.tsx
+++ b/src/layout/FileUploadWithTag/EditWindowComponent.tsx
@@ -91,7 +91,7 @@ export function EditWindowComponent({
   const isLoading = attachment.updating || !attachment.uploaded || isFetching || options?.length === 0;
   const uniqueId = isAttachmentUploaded(attachment) ? attachment.data.id : attachment.data.temporaryId;
 
-  // Focus on the container when the edit window opens so screen reader users are taken to the new content. This is especially important for users to be aware of the upload status of the attachment, which is announced in the aria-label of the container.
+  // Focus on edit window when mounting the component.
   const containerRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     containerRef.current?.focus();

--- a/src/layout/FileUploadWithTag/EditWindowComponent.tsx
+++ b/src/layout/FileUploadWithTag/EditWindowComponent.tsx
@@ -91,7 +91,7 @@ export function EditWindowComponent({
   const isLoading = attachment.updating || !attachment.uploaded || isFetching || options?.length === 0;
   const uniqueId = isAttachmentUploaded(attachment) ? attachment.data.id : attachment.data.temporaryId;
 
-  // Focus on edit window when mounting the component.
+  // Focus on edit window when mounting the component. Temporary fix until we implement a new fileupload component, ref. https://github.com/Altinn/app-frontend-react/issues/4280#issuecomment-4716177309
   const containerRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     containerRef.current?.focus();

--- a/src/layout/FileUploadWithTag/EditWindowComponent.tsx
+++ b/src/layout/FileUploadWithTag/EditWindowComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import { EXPERIMENTAL_Suggestion as Suggestion } from '@digdir/designsystemet-react';
 import deepEqual from 'fast-deep-equal';
@@ -91,8 +91,20 @@ export function EditWindowComponent({
   const isLoading = attachment.updating || !attachment.uploaded || isFetching || options?.length === 0;
   const uniqueId = isAttachmentUploaded(attachment) ? attachment.data.id : attachment.data.temporaryId;
 
+  // Focus on the container when the edit window opens so screen reader users are taken to the new content. This is especially important for users to be aware of the upload status of the attachment, which is announced in the aria-label of the container.
+  const containerRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    containerRef.current?.focus();
+  }, []);
+
   return (
     <div
+      ref={containerRef}
+      tabIndex={-1}
+      role='group'
+      aria-label={langAsString('form_filler.file_uploader_attachment_uploaded_sr', [
+        uploadedAttachment?.data.filename ?? '',
+      ])}
       id={`attachment-edit-window-${uniqueId}`}
       className={classes.editContainer}
     >


### PR DESCRIPTION
## Description

This PR implements autofocus on edit window when `EditWindowComponent.tsx` mounts by using `useEffect` and `ref`, whereas screen reader reads that the file is uploaded. 

This is a temporary fix, because after summer we will implement a new file upload component when it is established in Designsystemet.



<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes #4280 

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [x] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced accessibility for file upload feature with improved screen reader support when attachments are successfully uploaded across English, Norwegian Bokmål, and Norwegian Nynorsk
  * Improved focus management and labeling in the edit window to provide better context for screen reader users

<!-- end of auto-generated comment: release notes by coderabbit.ai -->