### PR TITLE
fix: overlap of edit button and help icon in the summary component

### DIFF
--- a/src/layout/Header/HeaderComponent.module.css
+++ b/src/layout/Header/HeaderComponent.module.css
@@ -1,0 +1,5 @@
+.header {
+  display: flex;
+  align-items: center;
+  gap: var(--ds-size-2);
+}

--- a/src/layout/Header/HeaderComponent.tsx
+++ b/src/layout/Header/HeaderComponent.tsx
@@ -6,6 +6,7 @@ import { HelpTextContainer } from 'src/components/form/HelpTextContainer';
 import { Lang } from 'src/features/language/Lang';
 import { useLanguage } from 'src/features/language/useLanguage';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
+import classes from 'src/layout/Header/HeaderComponent.module.css';
 import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 
@@ -42,23 +43,22 @@ export const HeaderComponent = ({ baseComponentId }: PropsFromGenericComponent<'
   const { id, size, textResourceBindings } = useItemWhenType(baseComponentId, 'Header');
   const { langAsString } = useLanguage();
   return (
-    <ComponentStructureWrapper
-      baseComponentId={baseComponentId}
-      style={{ display: 'flex' }}
-    >
-      <Heading
-        id={id}
-        {...getHeaderProps(size)}
-      >
-        <Lang id={textResourceBindings?.title} />
-      </Heading>
-      {textResourceBindings?.help && (
-        <HelpTextContainer
+    <ComponentStructureWrapper baseComponentId={baseComponentId}>
+      <div className={classes.header}>
+        <Heading
           id={id}
-          helpText={<Lang id={textResourceBindings.help} />}
-          title={langAsString(textResourceBindings?.title)}
-        />
-      )}
+          {...getHeaderProps(size)}
+        >
+          <Lang id={textResourceBindings?.title} />
+        </Heading>
+        {textResourceBindings?.help && (
+          <HelpTextContainer
+            id={id}
+            helpText={<Lang id={textResourceBindings.help} />}
+            title={langAsString(textResourceBindings?.title)}
+          />
+        )}
+      </div>
     </ComponentStructureWrapper>
   );
 };

--- a/src/layout/Summary/SummaryContent.module.css
+++ b/src/layout/Summary/SummaryContent.module.css
@@ -5,6 +5,8 @@
 .label {
   font-weight: 600;
   grid-area: label;
+  overflow-wrap: anywhere;
+  min-width: 0;
 }
 .labelError {
   color: var(--colors-primary-red);
@@ -17,6 +19,7 @@
 .container {
   display: grid;
   width: 100%;
+  column-gap: var(--ds-size-2);
   grid-template-columns: 1fr auto;
   grid-template-areas:
     'label btn'


### PR DESCRIPTION
## Description
The help icon and edit marker would occasionally overlap the title in the summary component.

Before: 
<img width="579" height="147" alt="image" src="https://github.com/user-attachments/assets/792753bf-dc82-444c-bf7f-a7daab5e4990" />
(Using 200% zoom:)
<img width="1869" height="317" alt="image" src="https://github.com/user-attachments/assets/acea265e-84b7-4359-9eeb-01ae08293efd" />

After: 
<img width="554" height="161" alt="image" src="https://github.com/user-attachments/assets/9fb45076-2ebc-4828-bbc2-b9f84ba26785" />

(200% zoom:)
<img width="1850" height="460" alt="image" src="https://github.com/user-attachments/assets/e48cbb0c-3bea-430d-aa98-64773003f62f" />

<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes [#19181](https://github.com/Altinn/altinn-studio/issues/19181)

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [x] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved header layout with better vertical alignment and spacing
  * Enhanced label text wrapping to prevent overflow and improve readability
  * Refined spacing adjustments throughout the summary section

<!-- end of auto-generated comment: release notes by coderabbit.ai -->