### PR TITLE
fix: make voicover read title and description out of the table

### DIFF
--- a/src/app-components/Table/Table.tsx
+++ b/src/app-components/Table/Table.tsx
@@ -33,6 +33,8 @@ interface DataTableProps<T> {
   schema?: JSONSchema7;
   columns: Column<T>[];
   caption?: React.ReactNode;
+  ariaLabel?: string;
+  tableTestId?: string;
   actionButtons?: TableActionButton<T>[];
   actionButtonHeader?: React.ReactNode;
   mobile?: boolean;
@@ -73,6 +75,8 @@ function formatValue(value: FormDataValue): string {
 
 export function AppTable<T>({
   caption,
+  ariaLabel,
+  tableTestId,
   data,
   columns,
   actionButtons,
@@ -93,6 +97,8 @@ export function AppTable<T>({
       className={cn(classes.table, tableClassName, { [classes.mobileTable]: mobile })}
       zebra={zebra}
       stickyHeader={stickyHeader}
+      aria-label={ariaLabel}
+      data-testid={tableTestId}
     >
       {caption}
       <Table.Head>

--- a/src/layout/SigningDocumentList/SigningDocumentListComponent.module.css
+++ b/src/layout/SigningDocumentList/SigningDocumentListComponent.module.css
@@ -1,0 +1,6 @@
+.downloadLink {
+  display: flex;
+  gap: 0.5rem;
+  white-space: nowrap;
+  text-decoration: none;
+}

--- a/src/layout/SigningDocumentList/SigningDocumentListComponent.test.tsx
+++ b/src/layout/SigningDocumentList/SigningDocumentListComponent.test.tsx
@@ -86,10 +86,15 @@ describe('SigningDocumentList', () => {
   it('should render correctly', () => {
     render(<SigningDocumentListComponent textResourceBindings={textResourceBindings} />);
 
-    screen.getByRole('table', { name: /Signing Document List/ });
+    screen.getByRole('heading', { name: /Signing Document List/ });
+    screen.getByText('description');
+    expect(screen.queryByRole('caption')).not.toBeInTheDocument();
+
+    screen.getByRole('table');
     screen.getByRole('columnheader', { name: 'signing_document_list.header_filename' });
     screen.getByRole('columnheader', { name: 'signing_document_list.header_attachment_type' });
     screen.getByRole('columnheader', { name: 'signing_document_list.header_size' });
+    screen.getByRole('columnheader', { name: 'signing_document_list.download' });
 
     expect(screen.getAllByRole('columnheader')).toHaveLength(4);
 
@@ -120,7 +125,8 @@ describe('SigningDocumentList', () => {
 
     render(<SigningDocumentListComponent textResourceBindings={textResourceBindings} />);
 
-    screen.getByRole('table', { name: /Signing Document List/ });
+    screen.getByRole('heading', { name: /Signing Document List/ });
+    screen.getByRole('table');
     screen.getByRole('columnheader', { name: 'signing_document_list.header_filename' });
     screen.getByRole('columnheader', { name: 'signing_document_list.header_attachment_type' });
     screen.getByRole('columnheader', { name: 'signing_document_list.header_size' });

--- a/src/layout/SigningDocumentList/SigningDocumentListComponent.test.tsx
+++ b/src/layout/SigningDocumentList/SigningDocumentListComponent.test.tsx
@@ -29,6 +29,10 @@ const mockDocumentList: SigningDocument[] = [
 
 jest.mock('src/utils/layout/useNodeItem', () => ({}));
 
+jest.mock('src/utils/layout/DataModelLocation', () => ({
+  useIndexedId: (baseId: string) => baseId,
+}));
+
 jest.mock('react-router-dom', () => ({
   useParams: jest.fn(() => ({
     partyId: 'partyId',
@@ -65,6 +69,7 @@ jest.mock('src/layout/SigningDocumentList/SigningDocumentListError', () => ({
 
 describe('SigningDocumentList', () => {
   const mockedUseDocumentList = jest.mocked(useDocumentList);
+  const baseComponentId = 'signing-document-list';
 
   const textResourceBindings: ITextResourceBindings<'SigningDocumentList'> = {
     title: 'Signing Document List',
@@ -84,7 +89,12 @@ describe('SigningDocumentList', () => {
   });
 
   it('should render correctly', () => {
-    render(<SigningDocumentListComponent textResourceBindings={textResourceBindings} />);
+    render(
+      <SigningDocumentListComponent
+        baseComponentId={baseComponentId}
+        textResourceBindings={textResourceBindings}
+      />,
+    );
 
     screen.getByRole('heading', { name: /Signing Document List/ });
     screen.getByText('description');
@@ -112,7 +122,12 @@ describe('SigningDocumentList', () => {
       error: new Error('API error'),
     } as unknown as ReturnType<typeof useDocumentList>);
 
-    render(<SigningDocumentListComponent textResourceBindings={textResourceBindings} />);
+    render(
+      <SigningDocumentListComponent
+        baseComponentId={baseComponentId}
+        textResourceBindings={textResourceBindings}
+      />,
+    );
 
     screen.getByText('API error');
   });
@@ -124,7 +139,12 @@ describe('SigningDocumentList', () => {
       error: null,
     } as unknown as ReturnType<typeof useDocumentList>);
 
-    render(<SigningDocumentListComponent textResourceBindings={textResourceBindings} />);
+    render(
+      <SigningDocumentListComponent
+        baseComponentId={baseComponentId}
+        textResourceBindings={textResourceBindings}
+      />,
+    );
 
     screen.getByRole('heading', { name: /Signing Document List/ });
     screen.getByRole('table', { name: /Signing Document List/ });

--- a/src/layout/SigningDocumentList/SigningDocumentListComponent.test.tsx
+++ b/src/layout/SigningDocumentList/SigningDocumentListComponent.test.tsx
@@ -90,7 +90,8 @@ describe('SigningDocumentList', () => {
     screen.getByText('description');
     expect(screen.queryByRole('caption')).not.toBeInTheDocument();
 
-    screen.getByRole('table');
+    screen.getByRole('table', { name: /Signing Document List/ });
+    expect(screen.getByTestId('signing-document-list')).toHaveAttribute('aria-label', 'Signing Document List');
     screen.getByRole('columnheader', { name: 'signing_document_list.header_filename' });
     screen.getByRole('columnheader', { name: 'signing_document_list.header_attachment_type' });
     screen.getByRole('columnheader', { name: 'signing_document_list.header_size' });
@@ -126,7 +127,7 @@ describe('SigningDocumentList', () => {
     render(<SigningDocumentListComponent textResourceBindings={textResourceBindings} />);
 
     screen.getByRole('heading', { name: /Signing Document List/ });
-    screen.getByRole('table');
+    screen.getByRole('table', { name: /Signing Document List/ });
     screen.getByRole('columnheader', { name: 'signing_document_list.header_filename' });
     screen.getByRole('columnheader', { name: 'signing_document_list.header_attachment_type' });
     screen.getByRole('columnheader', { name: 'signing_document_list.header_size' });

--- a/src/layout/SigningDocumentList/SigningDocumentListComponent.tsx
+++ b/src/layout/SigningDocumentList/SigningDocumentListComponent.tsx
@@ -68,6 +68,8 @@ export function SigningDocumentListComponent({
         isLoading={isLoading}
         headerClassName={classes.header}
         tableClassName={classes.table}
+        tableTestId='signing-document-list'
+        ariaLabel={textResourceBindings?.title ? langAsString(textResourceBindings.title) : undefined}
         data={data ?? []}
         emptyText={<Lang id='general.empty_table' />}
         columns={[

--- a/src/layout/SigningDocumentList/SigningDocumentListComponent.tsx
+++ b/src/layout/SigningDocumentList/SigningDocumentListComponent.tsx
@@ -44,8 +44,8 @@ export function SigningDocumentListComponent({
       {textResourceBindings?.title && (
         <div className={captionClasses.tableCaption}>
           <Heading
-            level={2}
-            data-size='lg'
+            level={3}
+            data-size='sm'
           >
             <Lang id={textResourceBindings.title} />
           </Heading>

--- a/src/layout/SigningDocumentList/SigningDocumentListComponent.tsx
+++ b/src/layout/SigningDocumentList/SigningDocumentListComponent.tsx
@@ -14,29 +14,30 @@ import { useLanguage } from 'src/features/language/useLanguage';
 import { getFileEnding, removeFileEnding } from 'src/layout/FileUpload/utils/fileEndings';
 import classes from 'src/layout/SigneeList/SigneeListComponent.module.css';
 import { useDocumentList } from 'src/layout/SigningDocumentList/api';
+import downloadClasses from 'src/layout/SigningDocumentList/SigningDocumentListComponent.module.css';
 import { SigningDocumentListError } from 'src/layout/SigningDocumentList/SigningDocumentListError';
 import utilClasses from 'src/styles/utils.module.css';
 import { getSizeWithUnit } from 'src/utils/attachmentsUtils';
+import { useIndexedId } from 'src/utils/layout/DataModelLocation';
 import type { ITextResourceBindings } from 'src/layout/layout';
 
-const tableLabelId = 'signing-document-list';
-
 export function SigningDocumentListComponent({
+  baseComponentId,
   textResourceBindings,
 }: {
+  baseComponentId: string;
   textResourceBindings: ITextResourceBindings<'SigningDocumentList'>;
 }) {
   const { instanceOwnerPartyId, instanceGuid } = useParams();
   const { langAsString } = useLanguage();
   const { altinnNugetVersion } = useApplicationMetadata();
+  const componentId = useIndexedId(baseComponentId);
 
   const { data, isLoading, error } = useDocumentList(instanceOwnerPartyId, instanceGuid, altinnNugetVersion);
 
   if (error) {
     return <SigningDocumentListError error={error} />;
   }
-
-  const downloadLabel = langAsString('signing_document_list.download');
 
   return (
     <>
@@ -51,13 +52,13 @@ export function SigningDocumentListComponent({
           {textResourceBindings.description && (
             <Description
               className={captionClasses.description}
-              componentId={tableLabelId}
+              componentId={componentId}
               description={<Lang id={textResourceBindings.description} />}
             />
           )}
           {textResourceBindings.help && (
             <HelpTextContainer
-              id={tableLabelId}
+              id={componentId}
               helpText={<Lang id={textResourceBindings.help} />}
             />
           )}
@@ -68,7 +69,7 @@ export function SigningDocumentListComponent({
         isLoading={isLoading}
         headerClassName={classes.header}
         tableClassName={classes.table}
-        tableTestId='signing-document-list'
+        tableTestId={baseComponentId}
         ariaLabel={textResourceBindings?.title ? langAsString(textResourceBindings.title) : undefined}
         data={data ?? []}
         emptyText={<Lang id='general.empty_table' />}
@@ -100,15 +101,17 @@ export function SigningDocumentListComponent({
             renderCell: (_, rowData) => getSizeWithUnit(rowData.size),
           },
           {
-            header: <span className={utilClasses.visuallyHidden}>{downloadLabel}</span>,
+            header: (
+              <span className={utilClasses.visuallyHidden}>{langAsString('signing_document_list.download')}</span>
+            ),
             accessors: [],
             renderCell: (_, rowData) => (
               <Link
                 href={rowData.url}
-                style={{ display: 'flex', gap: '0.5rem', whiteSpace: 'nowrap', textDecoration: 'none' }}
+                className={downloadClasses.downloadLink}
                 download
               >
-                {downloadLabel}
+                {langAsString('signing_document_list.download')}
                 <DownloadIcon fontSize='1.5rem' />
               </Link>
             ),

--- a/src/layout/SigningDocumentList/SigningDocumentListComponent.tsx
+++ b/src/layout/SigningDocumentList/SigningDocumentListComponent.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
 
-import { Link } from '@digdir/designsystemet-react';
+import { Heading, Link } from '@digdir/designsystemet-react';
 import { DownloadIcon } from '@navikt/aksel-icons';
 
 import { AppTable } from 'src/app-components/Table/Table';
-import { Caption } from 'src/components/form/caption/Caption';
+import captionClasses from 'src/components/form/caption/Caption.module.css';
+import { Description } from 'src/components/form/Description';
+import { HelpTextContainer } from 'src/components/form/HelpTextContainer';
 import { useApplicationMetadata } from 'src/features/applicationMetadata/ApplicationMetadataProvider';
 import { Lang } from 'src/features/language/Lang';
 import { useLanguage } from 'src/features/language/useLanguage';
@@ -13,8 +15,11 @@ import { getFileEnding, removeFileEnding } from 'src/layout/FileUpload/utils/fil
 import classes from 'src/layout/SigneeList/SigneeListComponent.module.css';
 import { useDocumentList } from 'src/layout/SigningDocumentList/api';
 import { SigningDocumentListError } from 'src/layout/SigningDocumentList/SigningDocumentListError';
+import utilClasses from 'src/styles/utils.module.css';
 import { getSizeWithUnit } from 'src/utils/attachmentsUtils';
 import type { ITextResourceBindings } from 'src/layout/layout';
+
+const tableLabelId = 'signing-document-list';
 
 export function SigningDocumentListComponent({
   textResourceBindings,
@@ -31,67 +36,83 @@ export function SigningDocumentListComponent({
     return <SigningDocumentListError error={error} />;
   }
 
+  const downloadLabel = langAsString('signing_document_list.download');
+
   return (
-    <AppTable
-      size='md'
-      isLoading={isLoading}
-      headerClassName={classes.header}
-      tableClassName={classes.table}
-      data={data ?? []}
-      emptyText={<Lang id='general.empty_table' />}
-      caption={
-        textResourceBindings?.title ? (
-          <Caption
-            title={<Lang id={textResourceBindings?.title} />}
-            description={textResourceBindings?.description && <Lang id={textResourceBindings?.description} />}
-            helpText={textResourceBindings?.help ? { text: textResourceBindings?.help } : undefined}
-            designSystemLabelProps={{ 'data-size': 'lg' }}
-          />
-        ) : undefined
-      }
-      columns={[
-        {
-          header: langAsString('signing_document_list.header_filename'),
-          accessors: [],
-          renderCell: (_, rowData) => (
-            <Link
-              href={rowData.url}
-              rel='noopener noreferrer'
-              title={rowData.filename}
-            >
-              <span className={classes.nameWrapper}>
-                <span className={classes.truncate}>{removeFileEnding(rowData.filename)}</span>
-                <span className={classes.extension}>{getFileEnding(rowData.filename)}</span>
-              </span>
-            </Link>
-          ),
-        },
-        {
-          header: langAsString('signing_document_list.header_attachment_type'),
-          accessors: [],
-          renderCell: (_, rowData) => rowData.attachmentTypes.map((it) => langAsString(it)).join(', '),
-        },
-        {
-          header: langAsString('signing_document_list.header_size'),
-          accessors: [],
-          renderCell: (_, rowData) => getSizeWithUnit(rowData.size),
-        },
-        {
-          header: null,
-          ariaLabel: langAsString('signing_document_list.download'),
-          accessors: [],
-          renderCell: (_, rowData) => (
-            <Link
-              href={rowData.url}
-              style={{ display: 'flex', gap: '0.5rem', whiteSpace: 'nowrap', textDecoration: 'none' }}
-              download
-            >
-              {langAsString('signing_document_list.download')}
-              <DownloadIcon fontSize='1.5rem' />
-            </Link>
-          ),
-        },
-      ]}
-    />
+    <>
+      {textResourceBindings?.title && (
+        <div className={captionClasses.tableCaption}>
+          <Heading
+            level={2}
+            data-size='lg'
+          >
+            <Lang id={textResourceBindings.title} />
+          </Heading>
+          {textResourceBindings.description && (
+            <Description
+              className={captionClasses.description}
+              componentId={tableLabelId}
+              description={<Lang id={textResourceBindings.description} />}
+            />
+          )}
+          {textResourceBindings.help && (
+            <HelpTextContainer
+              id={tableLabelId}
+              helpText={<Lang id={textResourceBindings.help} />}
+            />
+          )}
+        </div>
+      )}
+      <AppTable
+        size='md'
+        isLoading={isLoading}
+        headerClassName={classes.header}
+        tableClassName={classes.table}
+        data={data ?? []}
+        emptyText={<Lang id='general.empty_table' />}
+        columns={[
+          {
+            header: langAsString('signing_document_list.header_filename'),
+            accessors: [],
+            renderCell: (_, rowData) => (
+              <Link
+                href={rowData.url}
+                rel='noopener noreferrer'
+                title={rowData.filename}
+              >
+                <span className={classes.nameWrapper}>
+                  <span className={classes.truncate}>{removeFileEnding(rowData.filename)}</span>
+                  <span className={classes.extension}>{getFileEnding(rowData.filename)}</span>
+                </span>
+              </Link>
+            ),
+          },
+          {
+            header: langAsString('signing_document_list.header_attachment_type'),
+            accessors: [],
+            renderCell: (_, rowData) => rowData.attachmentTypes.map((it) => langAsString(it)).join(', '),
+          },
+          {
+            header: langAsString('signing_document_list.header_size'),
+            accessors: [],
+            renderCell: (_, rowData) => getSizeWithUnit(rowData.size),
+          },
+          {
+            header: <span className={utilClasses.visuallyHidden}>{downloadLabel}</span>,
+            accessors: [],
+            renderCell: (_, rowData) => (
+              <Link
+                href={rowData.url}
+                style={{ display: 'flex', gap: '0.5rem', whiteSpace: 'nowrap', textDecoration: 'none' }}
+                download
+              >
+                {downloadLabel}
+                <DownloadIcon fontSize='1.5rem' />
+              </Link>
+            ),
+          },
+        ]}
+      />
+    </>
   );
 }

--- a/src/layout/SigningDocumentList/index.tsx
+++ b/src/layout/SigningDocumentList/index.tsx
@@ -13,7 +13,12 @@ export class SigningDocumentList extends SigningDocumentListDef {
   render = forwardRef<HTMLElement, PropsFromGenericComponent<'SigningDocumentList'>>(
     function SigningDocumentListComponentRender(props, _): JSX.Element | null {
       const { textResourceBindings } = useItemWhenType(props.baseComponentId, 'SigningDocumentList');
-      return <SigningDocumentListComponent textResourceBindings={textResourceBindings} />;
+      return (
+        <SigningDocumentListComponent
+          baseComponentId={props.baseComponentId}
+          textResourceBindings={textResourceBindings}
+        />
+      );
     },
   );
 
@@ -30,6 +35,7 @@ export class SigningDocumentList extends SigningDocumentListDef {
         content={SummaryContains.SomeUserContent}
       >
         <SigningDocumentListComponent
+          baseComponentId={targetBaseComponentId}
           textResourceBindings={{
             ...textResourceBindings,
             title:


### PR DESCRIPTION
## Description



https://github.com/user-attachments/assets/36a3034c-fd23-4857-bf30-339f3b4bff28



## Related Issue(s)

- closes #4278 

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Refactor**
  * Improved the signing document list’s information hierarchy with explicit heading/description and an inline, localized caption.
* **Accessibility**
  * Enhanced table accessibility with consistent labeling support.
  * Updated the download column to use a localized, visually-hidden header label and consistent download link text styling.
* **Tests**
  * Refined accessibility and loading-state assertions, including stronger checks for headings, table labeling, and the download column header.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->