### PR TITLE
fix: Avoid error when switching frontend version if it also exists in comment in html-file

### DIFF
--- a/src/features/devtools/components/VersionSwitcher/VersionSwitcher.tsx
+++ b/src/features/devtools/components/VersionSwitcher/VersionSwitcher.tsx
@@ -6,6 +6,7 @@ import axios from 'axios';
 
 import { Button } from 'src/app-components/Button/Button';
 import { Spinner } from 'src/app-components/loading/Spinner/Spinner';
+import { replaceFrontendVersion } from 'src/features/devtools/components/VersionSwitcher/versionSwitcherUtils';
 import comboboxClasses from 'src/styles/combobox.module.css';
 import { optionFilter } from 'src/utils/options';
 import { appFrontendCDNPath, appPath, frontendVersionsCDN } from 'src/utils/urls/appUrlHelper';
@@ -38,14 +39,15 @@ export const VersionSwitcher = () => {
   });
 
   const onClick = () => {
-    if (selectedVersion) {
-      const newDoc = html
-        .replace(/src=".*\/altinn-app-frontend.js"/, `src="${selectedVersion}/altinn-app-frontend.js"`)
-        .replace(/href=".*\/altinn-app-frontend.css"/, `href="${selectedVersion}/altinn-app-frontend.css"`);
-      document.open();
-      document.write(newDoc);
-      document.close();
+    if (!selectedVersion) {
+      return;
     }
+
+    const newDoc = replaceFrontendVersion(html, selectedVersion);
+
+    document.open();
+    document.write(newDoc);
+    document.close();
   };
 
   if (isVersionsLoading || isHtmlLoading || !versions) {

--- a/src/features/devtools/components/VersionSwitcher/versionSwitcherUtils.test.ts
+++ b/src/features/devtools/components/VersionSwitcher/versionSwitcherUtils.test.ts
@@ -11,11 +11,6 @@ describe('versionSwitcherUtils', () => {
   <base href="https://ttd.apps.tt02.altinn.no/ttd/signering-brukerstyrt/"></head>
 
   <body style="background: rgb(255, 255, 255);">
-    <script>
-      const appId = window.location.pathname.split('/');
-      window.org = appId[1];
-      window.app = appId[2];
-    </script>
     <!-- <script src="https://altinncdn.no/toolkits/altinn-app-frontend/4.31.3-preview.1/altinn-app-frontend.js"></script> -->
     <script src="https://altinncdn.no/toolkits/altinn-app-frontend/4/altinn-app-frontend.js"></script>
   </body>
@@ -31,10 +26,6 @@ describe('versionSwitcherUtils', () => {
   <base href="https://ttd.apps.tt02.altinn.no/ttd/signering-brukerstyrt/"></head>
 
   <body style="background: rgb(255, 255, 255);">
-    <script>
-      window.org = appId[1];
-      window.app = appId[2];
-    </script>
     <!-- <script src="https://altinncdn.no/toolkits/altinn-app-frontend/4.60/altinn-app-frontend.js"></script> -->
     <script src="https://altinncdn.no/toolkits/altinn-app-frontend/4.60/altinn-app-frontend.js"></script>
   </body>

--- a/src/features/devtools/components/VersionSwitcher/versionSwitcherUtils.test.ts
+++ b/src/features/devtools/components/VersionSwitcher/versionSwitcherUtils.test.ts
@@ -1,0 +1,48 @@
+import { replaceFrontendVersion } from 'src/features/devtools/components/VersionSwitcher/versionSwitcherUtils';
+
+describe('versionSwitcherUtils', () => {
+  it('replaces the js and css asset urls with the selected version', () => {
+    const html = `
+<html lang="nb" dir="ltr" class="viewport-is-desktop"><head>
+  <meta charset="utf-8">
+
+  <!-- <link rel="stylesheet" type="text/css" href="https://altinncdn.no/toolkits/altinn-app-frontend/4.31.3-preview.1/altinn-app-frontend.css"> -->
+  <link rel="stylesheet" type="text/css" href="https://altinncdn.no/toolkits/altinn-app-frontend/4/altinn-app-frontend.css">
+  <base href="https://ttd.apps.tt02.altinn.no/ttd/signering-brukerstyrt/"></head>
+
+  <body style="background: rgb(255, 255, 255);">
+    <script>
+      const appId = window.location.pathname.split('/');
+      window.org = appId[1];
+      window.app = appId[2];
+    </script>
+    <!-- <script src="https://altinncdn.no/toolkits/altinn-app-frontend/4.31.3-preview.1/altinn-app-frontend.js"></script> -->
+    <script src="https://altinncdn.no/toolkits/altinn-app-frontend/4/altinn-app-frontend.js"></script>
+  </body>
+  </html>
+      `;
+
+    const expected = `
+<html lang="nb" dir="ltr" class="viewport-is-desktop"><head>
+  <meta charset="utf-8">
+
+  <!-- <link rel="stylesheet" type="text/css" href="https://altinncdn.no/toolkits/altinn-app-frontend/4.60/altinn-app-frontend.css"> -->
+  <link rel="stylesheet" type="text/css" href="https://altinncdn.no/toolkits/altinn-app-frontend/4.60/altinn-app-frontend.css">
+  <base href="https://ttd.apps.tt02.altinn.no/ttd/signering-brukerstyrt/"></head>
+
+  <body style="background: rgb(255, 255, 255);">
+    <script>
+      window.org = appId[1];
+      window.app = appId[2];
+    </script>
+    <!-- <script src="https://altinncdn.no/toolkits/altinn-app-frontend/4.60/altinn-app-frontend.js"></script> -->
+    <script src="https://altinncdn.no/toolkits/altinn-app-frontend/4.60/altinn-app-frontend.js"></script>
+  </body>
+  </html>
+      `;
+
+    const selectedVersion = 'https://altinncdn.no/toolkits/altinn-app-frontend/4.60';
+    const result = replaceFrontendVersion(html, selectedVersion);
+    expect(result).toBe(expected);
+  });
+});

--- a/src/features/devtools/components/VersionSwitcher/versionSwitcherUtils.ts
+++ b/src/features/devtools/components/VersionSwitcher/versionSwitcherUtils.ts
@@ -1,0 +1,15 @@
+/**
+ * Replaces the frontend version in the given HTML string with the selected version.
+ */
+export function replaceFrontendVersion(html: string, selectedVersion: string): string {
+  return (
+    html
+      .replace(/src=".*\/altinn-app-frontend.js"/g, `src="${selectedVersion}/altinn-app-frontend.js"`)
+      .replace(/href=".*\/altinn-app-frontend.css"/g, `href="${selectedVersion}/altinn-app-frontend.css"`)
+      // Remove the bootstrap's `const appId = ...` line (it may be indented). document.write() reuses
+      // the current JavaScript realm, so this `const` was already declared on the initial page load,
+      // and re-running it throws "Identifier 'appId' has already been declared". Dropping the line lets
+      // the existing binding be reused; it holds the same value since the URL is unchanged.
+      .replace(/^[ \t]*const appId.*\r?\n?/m, '')
+  );
+}

--- a/src/features/devtools/components/VersionSwitcher/versionSwitcherUtils.ts
+++ b/src/features/devtools/components/VersionSwitcher/versionSwitcherUtils.ts
@@ -2,14 +2,7 @@
  * Replaces the frontend version in the given HTML string with the selected version.
  */
 export function replaceFrontendVersion(html: string, selectedVersion: string): string {
-  return (
-    html
-      .replace(/src=".*\/altinn-app-frontend.js"/g, `src="${selectedVersion}/altinn-app-frontend.js"`)
-      .replace(/href=".*\/altinn-app-frontend.css"/g, `href="${selectedVersion}/altinn-app-frontend.css"`)
-      // Remove the bootstrap's `const appId = ...` line (it may be indented). document.write() reuses
-      // the current JavaScript realm, so this `const` was already declared on the initial page load,
-      // and re-running it throws "Identifier 'appId' has already been declared". Dropping the line lets
-      // the existing binding be reused; it holds the same value since the URL is unchanged.
-      .replace(/^[ \t]*const appId.*\r?\n?/m, '')
-  );
+  return html
+    .replace(/src=".*\/altinn-app-frontend.js"/g, `src="${selectedVersion}/altinn-app-frontend.js"`)
+    .replace(/href=".*\/altinn-app-frontend.css"/g, `href="${selectedVersion}/altinn-app-frontend.css"`);
 }

--- a/src/features/devtools/components/VersionSwitcher/versionSwitcherUtils.ts
+++ b/src/features/devtools/components/VersionSwitcher/versionSwitcherUtils.ts
@@ -3,6 +3,6 @@
  */
 export function replaceFrontendVersion(html: string, selectedVersion: string): string {
   return html
-    .replace(/src=".*\/altinn-app-frontend.js"/g, `src="${selectedVersion}/altinn-app-frontend.js"`)
-    .replace(/href=".*\/altinn-app-frontend.css"/g, `href="${selectedVersion}/altinn-app-frontend.css"`);
+    .replace(/src="[^"]*\/altinn-app-frontend\.js"/g, `src="${selectedVersion}/altinn-app-frontend.js"`)
+    .replace(/href="[^"]*\/altinn-app-frontend\.css"/g, `href="${selectedVersion}/altinn-app-frontend.css"`);
 }


### PR DESCRIPTION
If the html file loaded into the browser also contains a reference to the frontend in a comment, switching version from our internal dev tools would not work.

This is simply fixed by using replace all (/regexp/g) instead of just replace (/regexp/)

## Related Issue(s)

- closes #4289 

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified and improved the devtools version switcher with a cleaner, more maintainable approach for reliably updating frontend assets when switching between versions.

* **Tests**
  * Added comprehensive test coverage for version switching functionality to ensure stylesheet and script asset URLs update correctly across different selected versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->