### PR TITLE
fix: Add accessible name to cancel signing dialog

### DIFF
--- a/src/language/texts/en.ts
+++ b/src/language/texts/en.ts
@@ -473,10 +473,11 @@ export function en() {
     'signing.delegation_error_panel_title': 'Could not grant access to form',
     'signing.delegation_error_panel_description':
       'One or more of the signees are invalid and have not been granted access to the form. Go back to try to correct the issue or contact the form owner.',
-    'signing.reject_modal_title': 'Cancel the signing process',
+    'signing.reject_modal_title': 'Cancel signing',
     'signing.reject_modal_description':
-      'By canceling the signing process, all signatures will be deleted, and all delegated access will be revoked.',
-    'signing.reject_modal_button': 'Cancel the signing process',
+      'All signatures will be deleted. Everyone you have delegated to will lose access. This cannot be undone.',
+    'signing.reject_modal_button': 'Cancel signing',
+    'signing.reject_modal_close_button': 'Continue signing',
     'signing.reject_modal_trigger_button': 'Cancel signing',
     'signing.wrong_task_error': 'The {0} component is only available in a signing task.',
     'signing.error_missing_signing_rights':

--- a/src/language/texts/nb.ts
+++ b/src/language/texts/nb.ts
@@ -474,10 +474,11 @@ export function nb() {
     'signing.delegation_error_panel_title': 'Kunne ikke gi tilgang til skjema',
     'signing.delegation_error_panel_description':
       'En eller flere av signatarene er ugyldige og har ikke fått tilgang til skjemaet. Gå tilbake for å prøve å rette opp feilen eller kontakt skjemaeier.',
-    'signing.reject_modal_title': 'Avbryt signeringsprosessen',
+    'signing.reject_modal_title': 'Avbryt signering',
     'signing.reject_modal_description':
-      'Ved å avbryte signeringsprosessen vil alle signaturer bli slettet og alle delegerte tilganger trukket tilbake.',
-    'signing.reject_modal_button': 'Avbryt signeringsprosessen',
+      'Alle signaturer blir slettet. Alle personer du har delegert til mister tilgang. Du kan ikke angre dette.',
+    'signing.reject_modal_button': 'Avbryt signering',
+    'signing.reject_modal_close_button': 'Fortsett signering',
     'signing.reject_modal_trigger_button': 'Avbryt signering',
     'signing.loading': 'Laster inn signeringsstatus...',
     'signing.wrong_task_error': '{0}-komponenten er kun tilgjengelig i et signeringssteg.',

--- a/src/language/texts/nn.ts
+++ b/src/language/texts/nn.ts
@@ -467,10 +467,11 @@ export function nn() {
     'signing.no_action_required_panel_description_has_signed': 'Alt i orden! Du kan no gå tilbake til innboksen din.',
     'signing.no_action_required_panel_description_not_signed': 'Du har ikkje tilgang til å signere dette skjemaet.',
     'signing.no_action_required_button': 'Gå til innboksen',
-    'signing.reject_modal_title': 'Avbryt signeringsprosessen',
+    'signing.reject_modal_title': 'Avbryt signering',
     'signing.reject_modal_description':
-      'Ved å avbryte signeringsprosessen blir alle signaturar sletta, og alle delegert tilgang trekt tilbake.',
-    'signing.reject_modal_button': 'Avbryt signeringsprosessen',
+      'Alle signaturar blir sletta. Alle personar du har delegert til mistar tilgang. Du kan ikkje angre dette.',
+    'signing.reject_modal_button': 'Avbryt signering',
+    'signing.reject_modal_close_button': 'Hald fram med signering',
     'signing.reject_modal_trigger_button': 'Avbryt signering',
     'signing.api_error_panel_title': 'Klarte ikkje hente signeringsstatus',
     'signing.api_error_panel_description':

--- a/src/layout/SigningActions/PanelSigning.tsx
+++ b/src/layout/SigningActions/PanelSigning.tsx
@@ -78,7 +78,9 @@ function setAutoFocus(node: HTMLElement | null) {
 
 function RejectButton({ baseComponentId }: RejectTextProps) {
   const modalRef = useRef<HTMLDialogElement>(null);
-  const titleId = `reject-modal-title-${useId()}`;
+  const reactId = useId();
+  const titleId = `reject-modal-title-${reactId}`;
+  const descId = `reject-modal-description-${reactId}`;
   const { mutate: processReject, isPending: isRejecting } = useProcessNext({ action: 'reject' });
   const { textResourceBindings } = useItemWhenType(baseComponentId, 'SigningActions');
 
@@ -106,6 +108,7 @@ function RejectButton({ baseComponentId }: RejectTextProps) {
         <Dialog.Block>
           <Heading
             id={titleId}
+            aria-describedby={descId}
             tabIndex={-1}
             ref={setAutoFocus}
           >
@@ -113,7 +116,7 @@ function RejectButton({ baseComponentId }: RejectTextProps) {
           </Heading>
         </Dialog.Block>
         <Dialog.Block>
-          <Paragraph>
+          <Paragraph id={descId}>
             <Lang id={modalDescription} />
           </Paragraph>
         </Dialog.Block>

--- a/src/layout/SigningActions/PanelSigning.tsx
+++ b/src/layout/SigningActions/PanelSigning.tsx
@@ -117,7 +117,7 @@ function RejectButton({ baseComponentId }: RejectTextProps) {
             <Lang id={modalDescription} />
           </Paragraph>
         </Dialog.Block>
-        <Dialog.Block>
+        <Dialog.Block className={classes.dialogButtonContainer}>
           <Button
             color='danger'
             disabled={isRejecting}

--- a/src/layout/SigningActions/PanelSigning.tsx
+++ b/src/layout/SigningActions/PanelSigning.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useId, useRef } from 'react';
 import type { PropsWithChildren, ReactElement } from 'react';
 
 import { Dialog, Heading, Paragraph } from '@digdir/designsystemet-react';
@@ -70,6 +70,7 @@ type RejectTextProps = {
 
 function RejectButton({ baseComponentId }: RejectTextProps) {
   const modalRef = useRef<HTMLDialogElement>(null);
+  const titleId = `${baseComponentId}-reject-modal-title-${useId()}`;
   const { mutate: processReject, isPending: isRejecting } = useProcessNext({ action: 'reject' });
   const { textResourceBindings } = useItemWhenType(baseComponentId, 'SigningActions');
 
@@ -90,11 +91,12 @@ function RejectButton({ baseComponentId }: RejectTextProps) {
         </Button>
       </Dialog.Trigger>
       <Dialog
+        aria-labelledby={titleId}
         modal
         ref={modalRef}
       >
         <Dialog.Block>
-          <Heading>
+          <Heading id={titleId}>
             <Lang id={modalTitle} />
           </Heading>
         </Dialog.Block>

--- a/src/layout/SigningActions/PanelSigning.tsx
+++ b/src/layout/SigningActions/PanelSigning.tsx
@@ -68,9 +68,17 @@ type RejectTextProps = {
   baseComponentId: string;
 };
 
+/**
+ * Moves focus to the dialog title on open, so screen readers announce it
+ * We don't use node.focus() since the dialog's content is always mounted (the native <dialog> stays in the DOM while closed)
+ */
+function setAutoFocus(node: HTMLElement | null) {
+  node?.setAttribute('autofocus', '');
+}
+
 function RejectButton({ baseComponentId }: RejectTextProps) {
   const modalRef = useRef<HTMLDialogElement>(null);
-  const titleId = `${baseComponentId}-reject-modal-title-${useId()}`;
+  const titleId = `reject-modal-title-${useId()}`;
   const { mutate: processReject, isPending: isRejecting } = useProcessNext({ action: 'reject' });
   const { textResourceBindings } = useItemWhenType(baseComponentId, 'SigningActions');
 
@@ -96,7 +104,11 @@ function RejectButton({ baseComponentId }: RejectTextProps) {
         ref={modalRef}
       >
         <Dialog.Block>
-          <Heading id={titleId}>
+          <Heading
+            id={titleId}
+            tabIndex={-1}
+            ref={setAutoFocus}
+          >
             <Lang id={modalTitle} />
           </Heading>
         </Dialog.Block>

--- a/src/layout/SigningActions/PanelSigning.tsx
+++ b/src/layout/SigningActions/PanelSigning.tsx
@@ -87,6 +87,7 @@ function RejectButton({ baseComponentId }: RejectTextProps) {
   const modalTitle = textResourceBindings?.rejectModalTitle ?? 'signing.reject_modal_title';
   const modalDescription = textResourceBindings?.rejectModalDescription ?? 'signing.reject_modal_description';
   const modalButton = textResourceBindings?.rejectModalButton ?? 'signing.reject_modal_button';
+  const modalCloseButton = textResourceBindings?.rejectModalCloseButton ?? 'signing.reject_modal_close_button';
   const modalTriggerButton = textResourceBindings?.rejectModalTriggerButton ?? 'signing.reject_modal_trigger_button';
 
   return (
@@ -135,7 +136,7 @@ function RejectButton({ baseComponentId }: RejectTextProps) {
             size='md'
             onClick={() => modalRef.current?.close()}
           >
-            <Lang id='general.close' />
+            <Lang id={modalCloseButton} />
           </Button>
         </Dialog.Block>
       </Dialog>

--- a/src/layout/SigningActions/SigningActions.module.css
+++ b/src/layout/SigningActions/SigningActions.module.css
@@ -31,6 +31,12 @@
   }
 }
 
+.dialogButtonContainer {
+  display: flex;
+  gap: var(--ds-size-4);
+  flex-wrap: wrap;
+}
+
 /* TODO: Remove this when we upgrade Designsystemet to @next */
 .checkbox {
   > * {

--- a/src/layout/SigningActions/config.ts
+++ b/src/layout/SigningActions/config.ts
@@ -171,6 +171,14 @@ export const Config = new CG.component({
   )
   .addTextResource(
     new CG.trb({
+      name: 'rejectModalCloseButton',
+      title: 'Reject modal close button',
+      description:
+        'The text to display in the button that closes the modal without rejecting the signing task, i.e. continuing the signing',
+    }),
+  )
+  .addTextResource(
+    new CG.trb({
       name: 'rejectModalTriggerButton',
       title: 'Reject modal trigger button',
       description: 'The text to display in the button that triggers the reject modal',


### PR DESCRIPTION
## Description

Fixes accessibility issues with the "reject signing" confirmation modal so it works correctly with screen readers, addressing issue #4295.

Changes
- Accessible name for the dialog — Added aria-labelledby on the <Dialog> pointing to the heading, so the modal has a proper accessible name when opened.
- Focus management — The dialog title now receives focus on open (via an autofocus attribute set on render), so screen readers announce the modal heading. This approach is used instead of node.focus() because the native <dialog> content stays mounted in the DOM while closed.
- Description association — Linked the heading to the description paragraph with aria-describedby so the supporting text is announced alongside the title.
- Button spacing — Wrapped the action buttons in a flex container (dialogButtonContainer) with consistent gap and wrapping for better layout. Used styling in DeletePopoverWarning as inspiration
- After discussion with @olavflar , we decided to also change the text a bit, and added an extra text entry for the close button

Illustration of changes to button layout.
Before : 
<img width="804" height="402" alt="image" src="https://github.com/user-attachments/assets/59bd020c-08e2-474f-ab28-9b60a6acee77" />

After : 
<img width="688" height="306" alt="image" src="https://github.com/user-attachments/assets/790021a2-ce58-4c93-84b1-1cdeff90620a" />


## Related Issue(s)

- closes #4295 

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary of changes

* **Improvements**
  * Enhanced accessibility for the signing reject/cancel confirmation dialog with stable label/description IDs, improved screen reader support, and focus moved to the dialog title on open.
  * Updated modal close/continue button labeling to use dedicated “continue signing” wording.
  * Refreshed the dialog’s action button layout with improved flex spacing and wrapping.
  * Updated English, Norwegian Bokmål, and Nynorsk copy for the signing cancel/reject flow to reflect the outcome more clearly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->