### PR TITLE
fix: mask ssn in frontend

### DIFF
--- a/src/components/altinnParty.test.tsx
+++ b/src/components/altinnParty.test.tsx
@@ -32,7 +32,7 @@ describe('altinnParty', () => {
     const handleSelectParty = jest.fn();
     await render({ onSelectParty: handleSelectParty });
 
-    const party = screen.getByText(/personnr\. 01017512345/i);
+    const party = screen.getByText(/personnr\. 010175\*\*\*\*\*/i);
 
     await user.click(party);
 

--- a/src/components/altinnParty.tsx
+++ b/src/components/altinnParty.tsx
@@ -10,6 +10,7 @@ import classes from 'src/components/altinnParty.module.css';
 import { Lang } from 'src/features/language/Lang';
 import { useLanguage } from 'src/features/language/useLanguage';
 import { PartyType } from 'src/types/shared';
+import { maskSsn } from 'src/utils/maskSsn';
 import type { IParty } from 'src/types/shared';
 
 export interface IAltinnPartyProps {
@@ -161,7 +162,7 @@ export function AltinnParty({ party, onSelectParty, showSubUnits }: IAltinnParty
         <Paragraph className={classes.partyInfo}>
           {isOrg
             ? `${langAsString('party_selection.unit_org_number')} ${party.orgNumber}`
-            : `${langAsString('party_selection.unit_personal_number')} ${party.ssn}`}
+            : `${langAsString('party_selection.unit_personal_number')} ${maskSsn(party.ssn)}`}
         </Paragraph>
       </Flex>
       {renderSubunits()}

--- a/src/features/instantiate/containers/PartySelection.test.tsx
+++ b/src/features/instantiate/containers/PartySelection.test.tsx
@@ -113,7 +113,7 @@ describe('PartySelection', () => {
 
     expect(screen.getByRole('checkbox', { name: /vis slettede/i })).toBeChecked();
     expect(screen.getAllByTestId('AltinnParty-PartyWrapper')).toHaveLength(1);
-    expect(screen.getByRole('button', { name: 'Petter Nordmann (slettet) personnr. 01017512347' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Petter Nordmann (slettet) personnr. 010175*****' })).toBeInTheDocument();
   });
 
   describe('selecting parties', () => {
@@ -121,7 +121,7 @@ describe('PartySelection', () => {
       {
         parties: [getPartyMock({ ssn: '01017512346', partyId: 12346, name: 'Kari Nordmann' })],
         expectedPartyId: 12346,
-        partyName: 'Kari Nordmann personnr. 01017512346',
+        partyName: 'Kari Nordmann personnr. 010175*****',
       },
       {
         parties: [getServiceOwnerPartyMock()],

--- a/src/features/pdf/PDFWrapper.test.tsx
+++ b/src/features/pdf/PDFWrapper.test.tsx
@@ -85,7 +85,7 @@ describe('PDFWrapper', () => {
     await waitFor(() => expect(result.container.querySelector('#readyForPrint')).not.toBeNull(), { timeout: 5000 });
 
     expect(screen.queryByText('Avsender:')).not.toBeNull();
-    expect(screen.queryByText('01017512345-Ola Privatperson')).not.toBeNull();
+    expect(screen.queryByText('010175*****-Ola Privatperson')).not.toBeNull();
   });
 
   it('should render PDF with correct sender for service owner', async () => {
@@ -94,7 +94,7 @@ describe('PDFWrapper', () => {
     await waitFor(() => expect(result.container.querySelector('#readyForPrint')).not.toBeNull(), { timeout: 5000 });
 
     expect(screen.queryByText('Avsender:')).not.toBeNull();
-    expect(screen.queryByText('01017512345-Ola Privatperson')).toBeNull();
+    expect(screen.queryByText('010175*****-Ola Privatperson')).toBeNull();
     expect(screen.queryByText('974760673-Brønnøysundregistrene')).not.toBeNull();
   });
 

--- a/src/features/process/confirm/containers/ConfirmPage.test.tsx
+++ b/src/features/process/confirm/containers/ConfirmPage.test.tsx
@@ -12,6 +12,7 @@ import { ConfirmPage, type IConfirmPageProps } from 'src/features/process/confir
 import { doProcessNext } from 'src/queries/queries';
 import { renderWithInstanceAndLayout } from 'src/test/renderWithProviders';
 import { IProcess } from 'src/types/shared';
+import { maskSsn } from 'src/utils/maskSsn';
 
 jest.mock('src/features/instance/useProcessQuery', () => ({
   ...jest.requireActual<typeof import('src/features/instance/useProcessQuery')>(
@@ -44,7 +45,7 @@ describe('ConfirmPage', () => {
       renderer: () => <ConfirmPage {...props} />,
     });
 
-    const ssn = screen.getByText(personParty.ssn ?? '', { exact: false });
+    const ssn = screen.getByText(maskSsn(personParty.ssn), { exact: false });
     expect(ssn).toBeInTheDocument();
     const name = screen.getByText(personParty.name, { exact: false });
     expect(name).toBeInTheDocument();

--- a/src/features/process/confirm/helpers/returnConfirmSummaryObject.test.ts
+++ b/src/features/process/confirm/helpers/returnConfirmSummaryObject.test.ts
@@ -17,7 +17,7 @@ describe('returnConfirmSummaryObject', () => {
 
     expect(result).toEqual({
       'confirm.sender': {
-        value: '01017512345-Ola Privatperson',
+        value: '010175*****-Ola Privatperson',
       },
     });
   });
@@ -35,7 +35,7 @@ describe('returnConfirmSummaryObject', () => {
 
     expect(result).toEqual({
       'confirm.sender': {
-        value: '01017512345-Ola Privatperson',
+        value: '010175*****-Ola Privatperson',
       },
     });
   });
@@ -113,7 +113,7 @@ describe('returnConfirmSummaryObject', () => {
 
     expect(result).toEqual({
       'Some custom value': {
-        value: '01017512345-Ola Privatperson',
+        value: '010175*****-Ola Privatperson',
       },
     });
   });

--- a/src/features/process/confirm/helpers/returnConfirmSummaryObject.ts
+++ b/src/features/process/confirm/helpers/returnConfirmSummaryObject.ts
@@ -1,3 +1,4 @@
+import { maskSsn } from 'src/utils/maskSsn';
 import type { SummaryDataObject } from 'src/components/table/AltinnSummaryTable';
 import type { IUseLanguage } from 'src/features/language/useLanguage';
 import type { IParty } from 'src/types/shared';
@@ -11,7 +12,7 @@ export function getInstanceSender(instanceOwnerParty?: IParty): string {
   if (!instanceOwnerParty) {
     return '';
   }
-  const identifier = instanceOwnerParty.ssn ?? instanceOwnerParty.orgNumber;
+  const identifier = instanceOwnerParty.ssn ? maskSsn(instanceOwnerParty.ssn) : instanceOwnerParty.orgNumber;
   return identifier ? `${identifier}-${instanceOwnerParty.name}` : instanceOwnerParty.name;
 }
 

--- a/src/layout/InstanceInformation/InstanceInformationComponent.tsx
+++ b/src/layout/InstanceInformation/InstanceInformationComponent.tsx
@@ -15,6 +15,7 @@ import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper'
 import { toTimeZonedDate } from 'src/utils/dateUtils';
 import { useExternalItem } from 'src/utils/layout/hooks';
 import { useLabel } from 'src/utils/layout/useLabel';
+import { maskSsn } from 'src/utils/maskSsn';
 import type { SummaryDataObject } from 'src/components/table/AltinnSummaryTable';
 import type { IUseLanguage } from 'src/features/language/useLanguage';
 import type { CompInternal } from 'src/layout/layout';
@@ -74,7 +75,7 @@ export function InstanceInformation({ elements }: Pick<CompInternal<'InstanceInf
   const instanceDateSent =
     lastChanged && dateSent !== false && formatDate(toTimeZonedDate(formatISO(lastChanged)), PrettyDateAndTime);
 
-  const identifier = instanceOwnerParty?.ssn ?? instanceOwnerParty?.orgNumber;
+  const identifier = instanceOwnerParty?.ssn ? maskSsn(instanceOwnerParty.ssn) : instanceOwnerParty?.orgNumber;
   const instanceSender =
     sender !== false &&
     instanceOwnerParty &&

--- a/src/utils/maskSsn.ts
+++ b/src/utils/maskSsn.ts
@@ -1,0 +1,12 @@
+/**
+ * Hides everything after the 6-digit birth date of a fødselsnummer.
+ * E.g. "12345678901" -> "123456*****". Works whether the backend sends the full
+ * number or just the birth date, and won't double-mask an already-masked value.
+ * This is an extra safety net for display, backend should also avoid sending the full number.
+ */
+export function maskSsn(ssn: string | null | undefined): string {
+  if (!ssn) {
+    return '';
+  }
+  return `${ssn.slice(0, 6)}*****`;
+}


### PR DESCRIPTION
## Description

Display the ssn as masked with digit stars instead of the last 5 numbers.


<img width="1206" height="512" alt="image" src="https://github.com/user-attachments/assets/753ec1e7-24ce-4508-a348-f4f715ed2c27" />


<!---
  Provide a general summary of your changes in the title above.
  Describe your change(s) in detail here.
  Remember that the title and description should include a non-technical summary readable
  for service owners browsing our release notes.
-->

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Personal SSN masking has been implemented across the application. In all views displaying personal identification information—including party selection, confirmation pages, and instance summaries—SSN values now appear in masked format (showing the first 6 digits followed by asterisks, e.g., 010175*****) rather than the complete number.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->