### PR TITLE
fix: added confirm popover and read it by voiceover

### DIFF
--- a/src/app-components/ConfirmPopover/ConfirmPopover.module.css
+++ b/src/app-components/ConfirmPopover/ConfirmPopover.module.css
@@ -1,0 +1,8 @@
+.message {
+  margin-bottom: var(--ds-size-3);
+}
+
+.buttonContainer {
+  display: flex;
+  gap: var(--ds-size-2);
+}

--- a/src/app-components/ConfirmPopover/ConfirmPopover.test.tsx
+++ b/src/app-components/ConfirmPopover/ConfirmPopover.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+
+import { Button } from '@digdir/designsystemet-react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { ConfirmPopover, type ConfirmPopoverProps } from 'src/app-components/ConfirmPopover/ConfirmPopover';
+
+if (typeof document.getAnimations !== 'function') {
+  document.getAnimations = () => [];
+}
+
+const message = 'Are you sure?';
+const confirmText = 'Yes, delete';
+const cancelText = 'Cancel';
+
+function renderConfirmPopover(props: Partial<ConfirmPopoverProps> = {}) {
+  const mergedProps: ConfirmPopoverProps = {
+    message,
+    confirmText,
+    cancelText,
+    onConfirm: jest.fn(),
+    onCancel: jest.fn(),
+    children: <Button>Delete</Button>,
+    ...props,
+  };
+  render(<ConfirmPopover {...mergedProps} />);
+  return mergedProps;
+}
+
+describe('ConfirmPopover', () => {
+  it('trigger the confirmation popover', () => {
+    renderConfirmPopover();
+    expect(screen.getByRole('button', { name: 'Delete' })).toHaveAttribute('popovertarget');
+    expect(screen.getByText(message)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: confirmText })).toBeInTheDocument();
+  });
+
+  it('calls onConfirm only after confirming', async () => {
+    const user = userEvent.setup();
+    const { onConfirm } = renderConfirmPopover();
+
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    expect(onConfirm).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole('button', { name: confirmText }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onCancel and does not confirm when cancelling', async () => {
+    const user = userEvent.setup();
+    const { onConfirm, onCancel } = renderConfirmPopover();
+
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('renders the provided cancel label', async () => {
+    const user = userEvent.setup();
+    renderConfirmPopover({ cancelText: 'No, keep it' });
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    expect(screen.getByRole('button', { name: 'No, keep it' })).toBeInTheDocument();
+  });
+});

--- a/src/app-components/ConfirmPopover/ConfirmPopover.tsx
+++ b/src/app-components/ConfirmPopover/ConfirmPopover.tsx
@@ -1,0 +1,87 @@
+import React, { useState } from 'react';
+import type { ReactNode } from 'react';
+
+import { Button, Popover } from '@digdir/designsystemet-react';
+
+import classes from 'src/app-components/ConfirmPopover/ConfirmPopover.module.css';
+
+export interface ConfirmPopoverProps {
+  children: ReactNode;
+  message: ReactNode;
+  confirmText: ReactNode;
+  cancelText: ReactNode;
+  onConfirm: () => void;
+  onCancel?: () => void;
+  color?: 'warning' | 'danger';
+  placement?: 'top' | 'bottom' | 'left' | 'right';
+  popoverId?: string;
+}
+
+export function ConfirmPopover({
+  children,
+  message,
+  confirmText,
+  cancelText,
+  onConfirm,
+  onCancel,
+  color = 'warning',
+  placement = 'left',
+  popoverId,
+}: ConfirmPopoverProps) {
+  const [open, setOpen] = useState(false);
+
+  function handleConfirm() {
+    onConfirm();
+    setOpen(false);
+  }
+
+  function handleCancel() {
+    setOpen(false);
+    onCancel?.();
+  }
+
+  return (
+    <Popover.TriggerContext>
+      <Popover.Trigger
+        asChild
+        onClick={() => setOpen(true)}
+      >
+        {children}
+      </Popover.Trigger>
+      <Popover
+        id={popoverId}
+        open={open}
+        onClose={() => setOpen(false)}
+        placement={placement}
+        data-color={color}
+      >
+        <div className={classes.message}>{message}</div>
+        <div className={classes.buttonContainer}>
+          <Button
+            data-size='sm'
+            color='danger'
+            type='button'
+            onMouseDown={(event) => {
+              event.preventDefault();
+              handleConfirm();
+            }}
+          >
+            {confirmText}
+          </Button>
+          <Button
+            data-size='sm'
+            variant='tertiary'
+            color='second'
+            type='button'
+            onMouseDown={(event) => {
+              event.preventDefault();
+              handleCancel();
+            }}
+          >
+            {cancelText}
+          </Button>
+        </div>
+      </Popover>
+    </Popover.TriggerContext>
+  );
+}

--- a/src/app-components/ConfirmPopover/ConfirmPopover.tsx
+++ b/src/app-components/ConfirmPopover/ConfirmPopover.tsx
@@ -61,10 +61,7 @@ export function ConfirmPopover({
             data-size='sm'
             color='danger'
             type='button'
-            onMouseDown={(event) => {
-              event.preventDefault();
-              handleConfirm();
-            }}
+            onClick={handleConfirm}
           >
             {confirmText}
           </Button>
@@ -73,10 +70,7 @@ export function ConfirmPopover({
             variant='tertiary'
             color='second'
             type='button'
-            onMouseDown={(event) => {
-              event.preventDefault();
-              handleCancel();
-            }}
+            onClick={handleCancel}
           >
             {cancelText}
           </Button>

--- a/src/app-components/Table/Table.tsx
+++ b/src/app-components/Table/Table.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import type { ReactElement } from 'react';
+import React, { type ReactElement, type ReactNode } from 'react';
 
 import { Button, Table } from '@digdir/designsystemet-react';
 import cn from 'classnames';
@@ -7,6 +6,7 @@ import { format, isValid, parseISO } from 'date-fns';
 import { pick } from 'dot-object';
 import type { JSONSchema7 } from 'json-schema';
 
+import { ConfirmPopover } from 'src/app-components/ConfirmPopover/ConfirmPopover';
 import { Spinner } from 'src/app-components/loading/Spinner/Spinner';
 import classes from 'src/app-components/Table/Table.module.css';
 import utilClasses from 'src/styles/utils.module.css';
@@ -20,12 +20,19 @@ interface Column<T> {
   enableInlineEditing?: boolean;
 }
 
+export interface TableActionButtonConfirm {
+  message: ReactNode;
+  confirmText: ReactNode;
+  cancelText: ReactNode;
+}
+
 export interface TableActionButton<T = unknown> {
   onClick: (rowIdx: number, rowData: T) => void;
   buttonText: React.ReactNode;
   icon: React.ReactNode;
   color?: 'first' | 'second' | 'success' | 'danger';
   variant?: 'tertiary' | 'primary' | 'secondary';
+  confirm?: TableActionButtonConfirm;
 }
 
 interface DataTableProps<T> {
@@ -193,18 +200,38 @@ export function AppTable<T>({
               {actionButtons && actionButtons.length > 0 && (
                 <Table.Cell>
                   <div className={classes.buttonContainer}>
-                    {actionButtons.map((button, idx) => (
-                      <Button
-                        key={idx}
-                        onClick={() => button.onClick(rowIndex, rowData)}
-                        data-size='sm'
-                        variant={button.variant ? button.variant : defaultButtonVariant}
-                        color={button.color ? button.color : 'second'}
-                      >
-                        {button.buttonText}
-                        {button.icon}
-                      </Button>
-                    ))}
+                    {actionButtons.map((button, idx) => {
+                      const { confirm } = button;
+                      const handleAction = () => button.onClick(rowIndex, rowData);
+                      const buttonElement = (
+                        <Button
+                          key={idx}
+                          onClick={confirm ? undefined : handleAction}
+                          data-size='sm'
+                          variant={button.variant ?? defaultButtonVariant}
+                          color={button.color ?? 'second'}
+                        >
+                          {button.buttonText}
+                          {button.icon}
+                        </Button>
+                      );
+
+                      if (!confirm) {
+                        return buttonElement;
+                      }
+
+                      return (
+                        <ConfirmPopover
+                          key={idx}
+                          message={confirm.message}
+                          confirmText={confirm.confirmText}
+                          cancelText={confirm.cancelText}
+                          onConfirm={handleAction}
+                        >
+                          {buttonElement}
+                        </ConfirmPopover>
+                      );
+                    })}
                   </div>
                 </Table.Cell>
               )}

--- a/src/layout/SimpleTable/SimpleTableComponent.tsx
+++ b/src/layout/SimpleTable/SimpleTableComponent.tsx
@@ -67,6 +67,11 @@ export function SimpleTableComponent({ baseComponentId, dataModelBindings }: Tab
       buttonText: <Lang id='general.delete' />,
       icon: <TrashIcon />,
       color: 'danger',
+      confirm: {
+        message: <Lang id='group.row_popover_delete_message' />,
+        confirmText: <Lang id='group.row_popover_delete_button_confirm' />,
+        cancelText: <Lang id='general.cancel' />,
+      },
     });
   }
 


### PR DESCRIPTION
## Description


https://github.com/user-attachments/assets/c248d8db-3a64-40df-9862-eb71688a34b2


## Related Issue(s)

- closes [#18944 ](https://github.com/Altinn/altinn-studio/issues/18944)

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added confirmation dialogs for destructive table actions such as delete operations. Users must now confirm these actions before they execute, improving safety and preventing accidental data loss or mistakes.

* **Tests**
  * Added comprehensive test coverage for the new confirmation dialog component to ensure reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->