### PR TITLE
Adding search functionality for orgNr in party selection

### DIFF
--- a/src/__mocks__/getPartyMock.ts
+++ b/src/__mocks__/getPartyMock.ts
@@ -4,7 +4,7 @@ import type { IParty } from 'src/types/shared';
 export const getPartyMock = (overrides?: Partial<IParty>): IParty => ({
   partyId: 12345,
   name: 'Ola Privatperson',
-  ssn: '01017512345',
+  ssn: '010175*****',
   partyTypeName: PartyType.Person,
   orgNumber: null,
   unitType: undefined,

--- a/src/features/instantiate/containers/PartySelection.test.tsx
+++ b/src/features/instantiate/containers/PartySelection.test.tsx
@@ -10,7 +10,7 @@ import { useSelectedParty, useSelectedPartyIsValid } from 'src/features/party/Pa
 import { renderWithDefaultProviders } from 'src/test/renderWithProviders';
 
 const deletedParty = getPartyMock({
-  ssn: '01017512347',
+  ssn: '050575*****',
   partyId: 12347,
   name: 'Petter Nordmann',
   isDeleted: true,
@@ -18,17 +18,17 @@ const deletedParty = getPartyMock({
 
 // Need at least 9 parties to test pagination (twice)
 const parties = [
-  getPartyMock(),
+  getPartyMock({ ssn: '010175*****' }),
   getServiceOwnerPartyMock(),
   getPartyWithSubunitMock().org,
-  getPartyMock({ ssn: '01017512346', partyId: 12346, name: 'Kari Nordmann' }),
+  getPartyMock({ ssn: '020275*****', partyId: 12346, name: 'Kari Nordmann' }),
   deletedParty,
-  getPartyMock({ ssn: '01017512348', partyId: 12348, name: 'Per Nordmann' }),
-  getPartyMock({ ssn: '01017512349', partyId: 12349, name: 'Lise Nordmann' }),
-  getPartyMock({ ssn: '01017512350', partyId: 12350, name: 'Anne Nordmann' }),
-  getPartyMock({ ssn: '01017512351', partyId: 12351, name: 'Hans Nordmann' }),
-  getPartyMock({ ssn: '01017512352', partyId: 12352, name: 'Knut Nordmann' }),
-  getPartyMock({ ssn: '01017512353', partyId: 12353, name: 'Bjørn Nordmann' }),
+  getPartyMock({ ssn: '030375*****', partyId: 12348, name: 'Per Nordmann' }),
+  getPartyMock({ ssn: '040475*****', partyId: 12349, name: 'Lise Nordmann' }),
+  getPartyMock({ ssn: '060675*****', partyId: 12350, name: 'Anne Nordmann' }),
+  getPartyMock({ ssn: '070775*****', partyId: 12351, name: 'Hans Nordmann' }),
+  getPartyMock({ ssn: '080875*****', partyId: 12352, name: 'Knut Nordmann' }),
+  getPartyMock({ ssn: '090975*****', partyId: 12353, name: 'Bjørn Nordmann' }),
 ];
 
 function TestWrapper(props: PropsWithChildren) {
@@ -80,6 +80,26 @@ describe('PartySelection', () => {
     expect(screen.queryByRole('button', { name: /last flere/i })).not.toBeInTheDocument();
   });
 
+  it('should find an organisation when searching for an org number containing whitespace', async () => {
+    const user = userEvent.setup({ delay: null });
+    await render();
+
+    await user.type(screen.getByRole('textbox', { name: /søk/i }), '974 760 673');
+
+    expect(screen.getAllByTestId('AltinnParty-PartyWrapper')).toHaveLength(1);
+    expect(screen.getByRole('button', { name: 'Brønnøysundregistrene org.nr. 974760673' })).toBeInTheDocument();
+  });
+
+  it('should find a person when searching for an SSN containing whitespace', async () => {
+    const user = userEvent.setup({ delay: null });
+    await render();
+
+    await user.type(screen.getByRole('textbox', { name: /søk/i }), '01 01 75');
+
+    expect(screen.getAllByTestId('AltinnParty-PartyWrapper')).toHaveLength(1);
+    expect(screen.getByRole('button', { name: 'Ola Privatperson personnr. 010175*****' })).toBeInTheDocument();
+  });
+
   it('sub-unit filter should work', async () => {
     const user = userEvent.setup({ delay: null });
     await render();
@@ -113,13 +133,13 @@ describe('PartySelection', () => {
 
     expect(screen.getByRole('checkbox', { name: /vis slettede/i })).toBeChecked();
     expect(screen.getAllByTestId('AltinnParty-PartyWrapper')).toHaveLength(1);
-    expect(screen.getByRole('button', { name: 'Petter Nordmann (slettet) personnr. 010175*****' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Petter Nordmann (slettet) personnr. 050575*****' })).toBeInTheDocument();
   });
 
   describe('selecting parties', () => {
     const testCases = [
       {
-        parties: [getPartyMock({ ssn: '01017512346', partyId: 12346, name: 'Kari Nordmann' })],
+        parties: [getPartyMock({ ssn: '010175*****', partyId: 12346, name: 'Kari Nordmann' })],
         expectedPartyId: 12346,
         partyName: 'Kari Nordmann personnr. 010175*****',
       },

--- a/src/features/instantiate/containers/PartySelection.test.tsx
+++ b/src/features/instantiate/containers/PartySelection.test.tsx
@@ -100,6 +100,19 @@ describe('PartySelection', () => {
     expect(screen.getByRole('button', { name: 'Ola Privatperson personnr. 010175*****' })).toBeInTheDocument();
   });
 
+  it('should not find parties when searching for letters together with matching numbers', async () => {
+    const user = userEvent.setup({ delay: null });
+    await render();
+    const searchInput = screen.getByRole('textbox', { name: /søk/i });
+
+    await user.type(searchInput, 'abc010175');
+    expect(screen.queryAllByTestId('AltinnParty-PartyWrapper')).toHaveLength(0);
+
+    await user.clear(searchInput);
+    await user.type(searchInput, 'abc974760673');
+    expect(screen.queryAllByTestId('AltinnParty-PartyWrapper')).toHaveLength(0);
+  });
+
   it('sub-unit filter should work', async () => {
     const user = userEvent.setup({ delay: null });
     await render();

--- a/src/features/instantiate/containers/PartySelection.tsx
+++ b/src/features/instantiate/containers/PartySelection.tsx
@@ -64,8 +64,14 @@ export const PartySelection = () => {
     navigate('/');
   };
 
+  const numberFilterString = filterString.replace(/\D/g, '');
+  const hasNumberFilter = numberFilterString.length > 0 && numberFilterString.match(/^\d+$/);
   const filteredParties = partiesAllowedToInstantiate.filter(
-    (party) => party.name.toUpperCase().includes(filterString.toUpperCase()) && !(party.isDeleted && !showDeleted),
+    (party) =>
+      (party.name.toUpperCase().includes(filterString.toUpperCase()) ||
+        (hasNumberFilter &&
+          (party.ssn?.includes(numberFilterString) || party.orgNumber?.includes(numberFilterString)))) &&
+      !(party.isDeleted && !showDeleted),
   );
 
   const hasMoreParties = filteredParties.length > numberOfPartiesShown;

--- a/src/features/instantiate/containers/PartySelection.tsx
+++ b/src/features/instantiate/containers/PartySelection.tsx
@@ -64,7 +64,7 @@ export const PartySelection = () => {
     navigate('/');
   };
 
-  const numberFilterString = filterString.replace(/\D/g, '');
+  const numberFilterString = filterString.replace(/\s+/g, '');
   const hasNumberFilter = numberFilterString.length > 0 && numberFilterString.match(/^\d+$/);
   const filteredParties = partiesAllowedToInstantiate.filter(
     (party) =>

--- a/test/e2e/support/apps/signing-test/signing-login.ts
+++ b/test/e2e/support/apps/signing-test/signing-login.ts
@@ -24,7 +24,7 @@ export function signingTestLogin(user: User) {
     if (!instanceSuffix && Cypress.env('type') !== 'localtest') {
       const org = Tenor.orgs.overflodigSlemTigerAS;
       cy.findByText('Hvem vil du sende inn for?').should('be.visible');
-      cy.findByRole('textbox', { name: 'Søk etter aktør' }).type(org.name);
+      cy.findByRole('textbox', { name: 'Søk etter aktør' }).type(org.orgNr);
       cy.findByRole('button', { name: new RegExp(`org.nr. ${org.orgNr}`) }).click();
     }
 


### PR DESCRIPTION
## Description

This adds missing functionality (which was so severe I'm agreeing with calling this a bug) in the party selection view. This should now support searching for org numbers + ssn, even with whitespace.

## Related Issue(s)

- closes https://github.com/Altinn/altinn-studio/issues/19124

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced party search to support numeric identifier queries
  * Personal identifiers now masked in the system

* **Tests**
  * Added test coverage for numeric search functionality with whitespace handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->