### PR TITLE
added temp workflow

### DIFF
--- a/.github/workflows/cypress-percy-baseline.yml
+++ b/.github/workflows/cypress-percy-baseline.yml
@@ -1,0 +1,153 @@
+name: Cypress
+
+on:
+  push:
+    branches: [chore/percy-baseline]
+    paths:
+      - 'src/**'
+      - 'test/**'
+      - 'yarn.lock'
+      - '.github/workflows/cypress.yml'
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'test/**'
+      - 'yarn.lock'
+      - '.github/workflows/cypress.yml'
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+  workflow_dispatch:
+
+jobs:
+  install:
+    name: Install
+    runs-on: ubuntu-latest
+    container:
+      image: cypress/browsers:node-22.13.1-chrome-133.0.6943.53-1-ff-135.0-edge-132.0.2957.140-1@sha256:914c9814a9567f32660203db7ecd610b8f8fede6e9103885728b3bd3f6dca4ff
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install dependencies
+        run: yarn --immutable
+
+      - name: Cypress install
+        uses: cypress-io/github-action@dace029018fcdf86e0df89a31bc3cfa5b32570d8 # v7.3.0
+        with:
+          # Disable running of tests within install job
+          runTests: false
+          build: yarn run build
+
+      - name: Save build folder
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dist
+          if-no-files-found: error
+          path: dist
+
+  cypress-run-internal:
+    name: Cypress Run Internal
+    if: |
+      github.repository_owner == 'Altinn' &&
+      (github.event_name != 'pull_request' && github.event.repository.fork == false) ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
+    runs-on: ubuntu-latest
+    container:
+      image: cypress/browsers:node-22.13.1-chrome-133.0.6943.53-1-ff-135.0-edge-132.0.2957.140-1@sha256:914c9814a9567f32660203db7ecd610b8f8fede6e9103885728b3bd3f6dca4ff
+    timeout-minutes: 120
+    needs: install
+    strategy:
+      fail-fast: false
+      matrix:
+        containers: [1, 2, 3, 4, 5, 6]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Download the build folder
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dist
+          path: dist
+
+      - name: Set Percy command based on PR draft status or main branch
+        shell: bash
+        run: |
+          if [ "${{ github.ref }}" == "refs/heads/main" ] || [ "${{ github.event.pull_request.draft }}" == "false" ]; then
+            echo "PERCY_COMMAND=percy exec --parallel -- npx" >> $GITHUB_ENV
+          fi
+
+      - name: Cypress run
+        env:
+          CYPRESS_PROJECT_ID: y2jhp6
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN_TEMP_AGAINST_MONOREPO }}
+          PERCY_PARALLEL_TOTAL: 6
+          PERCY_PARALLEL_NONCE: ${{ github.run_id }}-${{ github.run_attempt }}
+          PERCY_BRANCH: ${{ github.head_ref || github.ref_name }}
+          PERCY_TARGET_BRANCH: ${{ github.base_ref || 'main' }}
+          IS_PR_DRAFT: ${{ github.event.pull_request.draft }}
+        uses: cypress-io/github-action@dace029018fcdf86e0df89a31bc3cfa5b32570d8 # v7.3.0
+        with:
+          # quote the url to be safe against YML parsing surprises
+          start: 'npx http-server dist --cors="*" -p 8080'
+          wait-on: 'http://localhost:8080'
+          command-prefix: ${{ env.PERCY_COMMAND }}
+          record: true
+          parallel: true
+          group: altinn-app-frontend
+          tag: altinn-app-frontend
+          browser: chrome
+          ci-build-id: ${{ github.run_id }}-${{ github.run_attempt }}
+          spec: test/e2e/integration
+          env: environment=tt02
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: failure()
+        with:
+          name: logs
+          path: test/logs/*
+
+  cypress-run-external:
+    name: Cypress Run External
+    if: |
+      github.repository_owner == 'Altinn' &&
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true)
+
+    runs-on: ubuntu-latest
+    container:
+      image: cypress/browsers:node-22.13.1-chrome-133.0.6943.53-1-ff-135.0-edge-132.0.2957.140-1@sha256:914c9814a9567f32660203db7ecd610b8f8fede6e9103885728b3bd3f6dca4ff
+    timeout-minutes: 120
+    needs: install
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Download the build folder
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dist
+          path: dist
+
+      - name: Cypress run
+        uses: cypress-io/github-action@dace029018fcdf86e0df89a31bc3cfa5b32570d8 # v7.3.0
+        with:
+          start: 'npx http-server dist --cors="*" -p 8080'
+          browser: chrome
+          spec: test/e2e/integration
+          env: environment=tt02
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: failure()
+        with:
+          name: external-logs
+          path: |
+            test/logs/*
+            test/screenshots/*
+            test/videos/*

--- a/.github/workflows/cypress-percy-baseline.yml
+++ b/.github/workflows/cypress-percy-baseline.yml
@@ -7,13 +7,13 @@ on:
       - 'src/**'
       - 'test/**'
       - 'yarn.lock'
-      - '.github/workflows/cypress.yml'
+      - '.github/workflows/cypress-percy-baseline.yml'
   pull_request:
     paths:
       - 'src/**'
       - 'test/**'
       - 'yarn.lock'
-      - '.github/workflows/cypress.yml'
+      - '.github/workflows/cypress-percy-baseline.yml'
     types:
       - opened
       - reopened


### PR DESCRIPTION
## Description

Adds a workflow that will run a single time in order to establish a percy baseline in monorepo.

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [ ] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [ ] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [ ] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a new automated Cypress run for relevant code changes, including visual checks with Percy.
  * Improved coverage for both internal and forked pull request runs, with better failure logs and artifacts.
* **Chores**
  * Enabled manual triggering and expanded the workflow to run on additional relevant events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->