### PR TITLE
fix: avoid Cypress socket errors in layout intercepts

### DIFF
--- a/test/e2e/support/custom.ts
+++ b/test/e2e/support/custom.ts
@@ -521,8 +521,8 @@ Cypress.Commands.add('moveProcessNext', () => {
 Cypress.Commands.add('interceptLayout', (taskName, mutator, wholeLayoutMutator, _options) => {
   const options = _options ?? { times: 1 };
   cy.intercept({ method: 'GET', url: `**/api/layouts/${taskName}`, ...options }, (req) => {
-    req.reply((res) => {
-      const set = JSON.parse(res.body);
+    req.on('before:response', (res) => {
+      const set = typeof res.body === 'string' ? JSON.parse(res.body) : res.body;
       if (mutator) {
         for (const layout of Object.values(set)) {
           (layout as ILayoutFile).data.layout.map(mutator);
@@ -531,7 +531,7 @@ Cypress.Commands.add('interceptLayout', (taskName, mutator, wholeLayoutMutator, 
       if (wholeLayoutMutator) {
         wholeLayoutMutator(set);
       }
-      res.send(JSON.stringify(set));
+      res.body = JSON.stringify(set);
     });
   }).as(`interceptLayout(${taskName})`);
 });


### PR DESCRIPTION
## Description

Updates the Cypress layout intercept helper used by several frontend tests so it mutates backend layout responses in the `before:response` hook instead of replying with a rewritten response.

This is intended to reduce sporadic PDF test failures where Cypress reports `Socket closed before finished writing response` for cancelled or abandoned intercepted requests. The error matches an open upstream Cypress issue: https://github.com/cypress-io/cypress/issues/26248.

The recurring failure has been observed in `test/e2e/integration/frontend-test/pdf.ts`, specifically the `"should generate PDF for changename step"` test. The failure has been seen repeatedly in tt02 runs for `GET **/api/layouts/changename`, while the other PDF tests have not shown the same pattern.

No application functionality is changed.

## Related Issue(s)

None.

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [x] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [x] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved the reliability of end-to-end layout interception during automated testing.
  * Made response handling more resilient when working with different response body formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->