### PR TITLE
Fixing two flaky Cypress tests

### DIFF
--- a/test/e2e/integration/frontend-test/options.ts
+++ b/test/e2e/integration/frontend-test/options.ts
@@ -110,14 +110,10 @@ describe('Options', () => {
 
     cy.goto('changename');
 
-    // All options are fetched once at first (with 'undefined' in mapping, as no value for source has been set)
-    cy.get('@interceptOptions(references).all').should('have.length', 1);
-    cy.get('@interceptOptions(test).all').should('have.length', 1);
-
     // This field uses preselectedOptionIndex to select 'Altinn'
     cy.get(appFrontend.changeOfName.sources).should('have.value', 'Altinn');
 
-    // At that point our options have new mappings, so requests should have fired again
+    // At this point our options have new mappings, so requests should have fired again
     cy.get('@interceptOptions(references).all').should('have.length', 2);
     cy.get('@interceptOptions(test).all').should('have.length', 2);
 

--- a/test/e2e/integration/frontend-test/tabbing.ts
+++ b/test/e2e/integration/frontend-test/tabbing.ts
@@ -5,7 +5,15 @@ const appFrontend = new AppFrontend();
 
 describe('Tabbing', () => {
   it('Tab through the fields in change name form', () => {
+    cy.intercept('GET', '**/api/options/references?language=nb&source=altinn').as('fetchReferences');
     cy.goto('changename');
+
+    // Making extra sure we've finished waiting for the page to load. Sometimes, if we start too early (unrealistically
+    // early, compared to real users) the focus might have been reset before we get to simulate tabbing. This was
+    // somewhat flaky for a while.
+    cy.wait('@fetchReferences');
+    cy.waitUntilSaved();
+
     cy.get(appFrontend.changeOfName.newFirstName).focus().tab();
     cy.focused().should('have.text', 'Nytt mellomnavn');
     cy.tab();


### PR DESCRIPTION
## Description

I saw a few tests that were flaky:

1. `options.ts` - this test would sometimes fail because the length was `2` already when the page had loaded. That's because Cypress itself was too late to start the assertions, because `preselectedOptionIndex` works immediately when the page loads. Removing those assertions, since it's impossible for them to become `2` without having been `1` at some point anyway.
2. `tabbing.ts` - This test ran into a failure mode where the whole body would be focused. I saw this happened before `preselectedOptionIndex` and the option effects had run, so I'm adding some assertions to make it wait to begin tabbing until the page has properly loaded first.

## Related Issue(s)

- closes #{issue number}

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [x] No testing done/necessary
- Automated tests
  - [ ] Unit test(s) have been added/updated
  - [x] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  <!--- insert link to PR here -->
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
  <!--- insert link to issue here -->
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  <!--- insert link to issue(s) here -->
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out
  <!---
    Breaking changes:       kind/breaking-change
    New features:               kind/product-feature
    Bug fixes:                      kind/bug
    Dependencies:             kind/dependencies
    Other changes:            kind/other
    Not in release notes:  ignore-for-release

    Backport (to patch release): backport
    Do not backport:                   backport-ignore
  --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test reliability when loading reference options.
  * Reduced timing-related flakiness in the change-name form’s keyboard navigation test.
  * Updated option-selection test expectations to reflect refreshed option requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->