### PR TITLE
fix: make Summary2 selectable in developer tools

### DIFF
--- a/src/layout/Summary2/SummaryComponent2/ComponentSummary.tsx
+++ b/src/layout/Summary2/SummaryComponent2/ComponentSummary.tsx
@@ -97,12 +97,16 @@ interface SummaryFlexProps extends PropsWithChildren {
 function SummaryFlexInternal({ targetBaseId, children, className }: Omit<SummaryFlexProps, 'content'>) {
   const { pageBreak, grid, type } = useItemFor(targetBaseId);
   const indexedId = useIndexedId(targetBaseId);
+  const summary2BaseId = useSummaryProp('id');
+  const summary2NodeId = useSummaryProp('nodeId');
 
   return (
     <Flex
       item
       className={cn(pageBreakStyles(pageBreak), classes.summaryItem, className)}
       size={grid}
+      data-componentbaseid={summary2BaseId}
+      data-componentid={summary2NodeId}
       data-summary-target={indexedId}
       data-summary-target-type={type}
     >

--- a/src/layout/Summary2/SummaryComponent2/SummaryComponent2.test.tsx
+++ b/src/layout/Summary2/SummaryComponent2/SummaryComponent2.test.tsx
@@ -80,6 +80,24 @@ describe('SummaryComponent', () => {
     expect(screen.getByTestId('summary-single-value-component')).toBeInTheDocument();
   });
 
+  test('should expose the Summary2 component identifiers on rendered summary content', async () => {
+    await render({
+      summary2Config: {
+        type: 'Summary2',
+        hideEmptyFields: false,
+        id: 'Summary2',
+        target: {
+          id: 'Input',
+          type: 'component',
+        },
+      },
+    });
+
+    const summaryItem = screen.getByTestId('summary-single-value-component').closest('[data-componentid]');
+    expect(summaryItem).toHaveAttribute('data-componentid', 'mySummary2');
+    expect(summaryItem).toHaveAttribute('data-componentbaseid', 'mySummary2');
+  });
+
   test('should not render component if its set to hide if empty', async () => {
     await render({
       summary2Config: {

--- a/src/layout/Summary2/summaryStoreContext.tsx
+++ b/src/layout/Summary2/summaryStoreContext.tsx
@@ -2,6 +2,7 @@ import React, { createContext, useContext } from 'react';
 import type { PropsWithChildren } from 'react';
 
 import { useLayoutLookups } from 'src/features/form/layout/LayoutsContext';
+import { useIndexedId } from 'src/utils/layout/DataModelLocation';
 import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { ISummaryOverridesCommon } from 'src/layout/common.generated';
 import type { CompSummaryOverrides, CompTypes } from 'src/layout/layout';
@@ -10,17 +11,18 @@ import type { CompSummary2External } from 'src/layout/Summary2/config.generated'
 type Summary2State = Pick<
   CompSummary2External,
   'id' | 'hideEmptyFields' | 'showPageInAccordion' | 'overrides' | 'isCompact'
->;
+> & { nodeId: string };
 const StoreContext = createContext<Summary2State | null>(null);
 
 export function Summary2StoreProvider({ children, baseComponentId }: PropsWithChildren<{ baseComponentId: string }>) {
+  const nodeId = useIndexedId(baseComponentId);
   const { id, hideEmptyFields, showPageInAccordion, overrides, isCompact } = useItemWhenType(
     baseComponentId,
     'Summary2',
   );
 
   return (
-    <StoreContext.Provider value={{ id, hideEmptyFields, showPageInAccordion, overrides, isCompact }}>
+    <StoreContext.Provider value={{ id, nodeId, hideEmptyFields, showPageInAccordion, overrides, isCompact }}>
       {children}
     </StoreContext.Provider>
   );


### PR DESCRIPTION
## Description

Makes rendered `Summary2` content selectable with both picker buttons in the developer tools.

`Summary2` renders without the generic component wrapper, so its rendered summary items did not expose the `data-componentid` and `data-componentbaseid` attributes consumed by the pickers. This change carries the indexed `Summary2` node ID through the summary context and adds both identifiers to the existing summary item element. It does not add a wrapper or change the layout.

Screenshots are not applicable because the fix only adds developer-tool selector metadata and has no visual output.

## Related Issue(s)

Reported through a support request.

## Verification/QA

- Manual functionality testing
  - [ ] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [x] No manual testing done/necessary; the selector contract is covered by the regression test
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM structure or visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  - [x] No documentation change is needed for this developer-tool bug fix
  - [ ] I will do that later/have created an issue
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [ ] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [ ] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [x] I don't have permissions to add labels, please help me out

Commands run:

```text
yarn test -- SummaryComponent2.test.tsx --runInBand
yarn lint
yarn tsc
yarn build
```

All commands above passed. The full test suite is left to CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Summary components now expose component and node identifiers through rendered element attributes, improving traceability and integration with external tooling.

* **Tests**
  * Added coverage confirming Summary2 renders the expected component identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->