### PR TITLE
fix(map): send referrer with tile requests

### DIFF
--- a/src/layout/Map/MapComponent.test.tsx
+++ b/src/layout/Map/MapComponent.test.tsx
@@ -174,7 +174,10 @@ describe('MapComponent', () => {
 
     const tiles = container.querySelectorAll<HTMLImageElement>('img.leaflet-tile');
     expect(tiles.length).toBeGreaterThan(0);
-    tiles.forEach((tile) => expect(tile.getAttribute('alt')).toBe(''));
+    tiles.forEach((tile) => {
+      expect(tile.getAttribute('alt')).toBe('');
+      expect(tile.referrerPolicy).toBe('strict-origin-when-cross-origin');
+    });
   });
 
   it('should have expression support for latitude and longitude in centerLocation', async () => {

--- a/src/layout/Map/features/layers/MapLayers.tsx
+++ b/src/layout/Map/features/layers/MapLayers.tsx
@@ -13,6 +13,7 @@ function OurTileLayer({ layer }: { layer: MapTileLayer }) {
       subdomains={layer.subdomains ?? []}
       minZoom={layer.minZoom ?? 0}
       maxZoom={layer.maxZoom ?? 18}
+      referrerPolicy='strict-origin-when-cross-origin'
     />
   );
 }


### PR DESCRIPTION
## Description

OpenStreetMap tiles could be blocked when an app's page-level referrer policy removed the identifying `Referer` header. This sets a referrer policy on raster tile images so the browser sends the app origin to the tile provider. It also covers local HTTP apps requesting the existing HTTPS OpenStreetMap tile URL.

## Related Issue(s)

- Closes #4337

## Verification/QA

- Manual functionality testing
  - [x] I have tested these changes manually
  - [ ] Creator of the original issue (or service owner) has been contacted for manual testing (or will be contacted when released in alpha)
  - [ ] No testing done/necessary
- Automated tests
  - [x] Unit test(s) have been added/updated
  - [ ] Cypress E2E test(s) have been added/updated
  - [ ] No automatic tests are needed here (no functional changes/additions)
  - [ ] I want someone to help me make some tests
- UU/WCAG ([follow these guidelines](https://aksel.nav.no/god-praksis/artikler/utvikling?tema=universell-utforming) until we have our own)
  - [ ] I have tested with a screen reader/keyboard navigation/automated wcag validator
  - [x] No testing done/necessary (no DOM/visual changes)
  - [ ] I want someone to help me perform accessibility testing
- User documentation @ [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs)
  - [ ] Has been added/updated
  - [x] No functionality has been changed/added, so no documentation is needed
  - [ ] I will do that later/have created an issue
- Support in Altinn Studio
  - [ ] Issue(s) created for support in Studio
  - [x] This change/feature does not require any changes to Altinn Studio
- Sprint board
  - [x] The original issue (or this PR itself) has been added to the Team Apps project and to the current sprint board
  - [ ] I don't have permissions to do that, please help me out
- Labels
  - [x] I have added a `kind/*` and `backport*` label to this PR for proper release notes grouping
  - [ ] I don't have permissions to add labels, please help me out

### Checks run

- `yarn test MapComponent.test.tsx --runInBand`
- `yarn tsc`
- staged-file ESLint pre-commit hook


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Map tiles now use a stricter referrer policy to improve privacy when loading map imagery.
- **Tests**
  - Added coverage to verify the map tile referrer policy is applied correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->